### PR TITLE
Add Contributing Guidelines

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,49 @@
+# Contributing
+
+We love pull requests. Here's a quick guide.
+
+## Getting Started
+
+* Make sure you have a [GitHub account](https://github.com/signup/free)
+* Fork the repository on GitHub
+
+## Making Changes
+
+* Edit existing docs using GitHub's inline markdown editor or clone your fork, edit locally, commit changes, and push to your fork
+
+## Adding a New Guide
+
+* Copy the guide_template.md at the root of this repo into source/_guides/guide-section/guide-name.md
+
+## Submitting a pull request
+
+When you're done making changes, [submit a pull request!][pr] 
+[pr]: https://github.com/pantheon-systems/documentation/compare/
+
+At this point you're waiting on us. We like to at least comment on pull requests
+within three business days (and, typically, one business day). We may suggest
+some changes or improvements or alternatives.
+
+Some things that will increase the chance that your pull request is accepted:
+
+* Follow our [style guide][style].
+* Write a [good commit message][commit].
+* Build and test locally to make sure everything looks good. Refer to [README](https://github.com/pantheon-systems/documentation/blob/master/README.md) for instructions.
+
+[style]: https://docs.getpantheon.com/style-guide.html
+[commit]: http://chris.beams.io/posts/git-commit/
+
+## Working with images
+
+See [Image Management](https://github.com/pantheon-systems/documentation/blob/master/source/assets/images/readme.md)
+
+# Additional Resources
+
+* [General GitHub documentation](http://help.github.com/)
+* [GitHub pull request documentation](http://help.github.com/send-pull-requests/)
+* #pantheon IRC channel on freenode.org
+
+
+####TODO
+- [ ] Identify contribution types
+- [ ] Create contribution examples


### PR DESCRIPTION
Added detail and moved from Sculpin source to root of repo, so
when a contributor creates an issue or opens a pull request they'll
see "Please review the guidelines for contributing to this repository."
per https://github.com/blog/1184-contributing-guidelines

Closes #14
