### PR TITLE
Single edit to FileZilla doc so it is CMS agnostic.

### DIFF
--- a/source/docs/articles/local/filezilla.md
+++ b/source/docs/articles/local/filezilla.md
@@ -42,7 +42,7 @@ Select to accept the server's host key for the current session so it is stored i
 **SSH Key-Based:** Once you are logged in you are directed to the root directory of your appserver. On the left side you will see your local computer and on the right you will have access to your site's appserver.  
 
 
-**Password-Based:** To get to the Drupal root simply navigate to the `code` directory and you will be able to continue managing your files as normal.
+**Password-Based:** To get to the site's root simply navigate to the `code` directory and you will be able to continue managing your files as normal.
 
  ![enter your password](https://www.getpantheon.com/sites/default/files/docs/desk_images/50376)
 


### PR DESCRIPTION
The diff is not populating correctly within GitHub. This edit was done on line 46. 
From: To get to the Drupal root simply navigate to the `code` directory
To: To get to the site's root simply navigate to the `code` directory
