### PR TITLE
Minor edit to send grid info

### DIFF
--- a/source/docs/articles/sites/code/email.md
+++ b/source/docs/articles/sites/code/email.md
@@ -15,7 +15,7 @@ Pantheon does not host inboxes for you. We recommend making use of an externally
 For outgoing email, your site can send mail immediately using the local MTA (postfix) with few restrictions. However, speed and deliverability (messages erroneously blocked or marked as spam) will not be guaranteed since your messages will be coming from an anonymous cloud server.  
 
 
-Pantheon has a partner relationship with SendGrid, a high-deliverability email service, which offers up to 200 emails a day for free, and can scale to millions if needed. Find more information, see the [SendGrid HOWTO](/docs/articles/sites/code/using-sendgrid-for-outbound-email/).
+Pantheon has a partner relationship with SendGrid, a high-deliverability email service, which offers up to 400 emails a day for free, and can scale to millions if needed. Find more information, see the [SendGrid HOWTO](/docs/articles/sites/code/using-sendgrid-for-outbound-email/).
 
 We recommend using an external SMTP server or service for all production use-cases. For low-volume transactional emails - account registration, forgot password, etc - you may be able to use whatever email service you use for inbound email (including Gmail). For high-volume email, you should integrate with a volume email gateway.
 


### PR DESCRIPTION
conflicting text in outgoing email documentation, on page
https://www.getpantheon.com/docs/articles/sites/code/email/
"... high-deliverability email service, which offers up to 200 emails a
day for free."

https://www.getpantheon.com/docs/articles/sites/code/using-sendgrid-for-
outbound-email/
The text on the linked page reads:
"You can send up to 400 emails per day for free with SendGrid."
