### PR TITLE
Move filesystem-faqs doc to drupal dir, update slug title and restyle

### DIFF
--- a/source/docs/articles/drupal/filesystem-faqs.md
+++ b/source/docs/articles/drupal/filesystem-faqs.md
@@ -1,0 +1,14 @@
+---
+title: Drupal File System Error
+description: Understand writable errors and the Pantheon filesystem.
+category:
+  - getting-started
+
+---
+
+## File System Error on Status Page
+
+The root cause is that Drupal's warning you that your settings.php file is writable, and as a security precaution, you should change the permissions. However, in our cloud filesystem, there are multiple layers of protection against exterior entities making changes to your files; so in reality this warning is not critical. If you'd like to address the error status, you can switch your site into SFTP mode, and change the permissions on the settings.php to 644.
+
+
+ ![](https://www.getpantheon.com/sites/default/files/docs/desk_images/284378)  

--- a/source/docs/articles/sites/files/filesystem-faqs.md
+++ b/source/docs/articles/sites/files/filesystem-faqs.md
@@ -1,15 +1,0 @@
----
-title: Filesystem FAQs
-description: Understand writable errors and the Pantheon filesystem. 
-category:
-  - getting-started
-
----
-
-Question: _I am curious why the Pantheon dashboard lists my file system as: Error, Writable (public download method)?_  
-
-
- ![](https://www.getpantheon.com/sites/default/files/docs/desk_images/284378)  
-
-
-Answer: The root cause is that Drupal's warning you that your settings.php file is writable, and as a security precaution, you should change the permissions. However in our cloud filesystem, there's multiple layers of protection against exterior entities making changes to your files; so in reality this warning is not critical. If you'd like to address the error status, you can switch your site into SFTP mode, and change the permissions on the settings.php to 644.


### PR DESCRIPTION
- This PR moves the filesystem-faq doc to the drupal dir within the docs repo. The slug title has been changed to Drupal File System Error and the flow of the article has been updated.
- @bmackinney can you :mag: and +1 if you agree this should be merged or comment back with any feedback/suggestions. 
- This closes item:151 - https://sprint.ly/product/24553/item/151

Thanks!
