### PR TITLE
SSO and Identity Federation - link update

### DIFF
--- a/source/docs/articles/sites/code/sso-and-identity-federation.md
+++ b/source/docs/articles/sites/code/sso-and-identity-federation.md
@@ -18,7 +18,7 @@ Both LDAP and LDAPS are supported on Pantheon. For more information, see our art
 
 ## Shibboleth and SimpleSAMLphp
 
-[Shibboleth](http://shibboleth.net/) is an open-source single sign-on solution. [SimpleSAMLphp](http://simplesamlphp.org/) can be used as a Service Provider to connect to either Shibboleth or a SAML 2.0 Identity Provider. For more information on SimpleSAMLphp on Pantheon, see our article  [Using SimpleSAMLphp](http://helpdesk.getpantheon.com/customer/portal/docs/articles/555188-using-simplesamlphp).
+[Shibboleth](http://shibboleth.net/) is an open-source single sign-on solution. [SimpleSAMLphp](http://simplesamlphp.org/) can be used as a Service Provider to connect to either Shibboleth or a SAML 2.0 Identity Provider. For more information on SimpleSAMLphp on Pantheon, see our article  [Using SimpleSAMLphp](/docs/articles/drupal/using-simplesamlphp-with-shibboleth-sso).
 
 ## OAuth
 


### PR DESCRIPTION
- This PR fixes the broken link to the simplesamlphp link within the **SSO and Identity Federation on Pantheon** doc. 
- @nataliejeremy can you :mag: and merge if everything looks okay?
