### PR TITLE
Footer update to include link to pantheon.io

### DIFF
--- a/source/_partials/footer_content.html
+++ b/source/_partials/footer_content.html
@@ -1,4 +1,4 @@
 <div class="pio-docs-footer">
 <div id="copyright">&copy; {{ "now"|date("Y") }}
-  Pantheon Pantheon &middot; 717 California Street, San Francisco, CA</div>
+  <a href="https://pantheon.io/" target="blank"> Pantheon</a>  &middot; 717 California Street, San Francisco, CA</div>
 </div>


### PR DESCRIPTION
- This PR removes duplicate 'Pantheon' in the footer and adds a link to pantheon.io. The link uses target="blank" so that it opens in a new tab.
- @bmackinney can you test and merge? 
