### PR TITLE
search pantheon.io/docs instead of getpantheon.com/docs

### DIFF
--- a/source/_partials/search_box.html
+++ b/source/_partials/search_box.html
@@ -3,7 +3,7 @@
 <form role="form" method="get" action="https://www.google.com/search">
   <div class="form-group has-feedback">
     <input type="text" name="q" class="form-control" placeholder="Search Pantheon Docs" />
-    <input type="hidden" name="as_sitesearch" value="getpantheon.com/docs">
+    <input type="hidden" name="as_sitesearch" value="pantheon.io/docs">
     <i class="form-control-feedback glyphicon glyphicon-search"></i>
   </div>
 </form>


### PR DESCRIPTION
This pull request should be merged because it directs search to the current domain.
![image](https://cloud.githubusercontent.com/assets/646061/6381036/1cd0a176-bcf3-11e4-8629-52ab7b41d346.png)
