### PR TITLE
Calevans move timeout doc

### DIFF
--- a/source/docs/articles/sites/timeouts.md
+++ b/source/docs/articles/sites/timeouts.md
@@ -90,7 +90,7 @@ Rules are for the good of the group, and timeouts are no exception. At Pantheon,
 
 #### Can I manually run Drupal cron for longer than the Pantheon executed Drupal cron?
 
-Yes; just use <tt>drush @pantheon.SITENAME.env cron</tt> to execute cron. With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an efficient process, determine why it's slow and fix the root cause.
+Yes; just use `drush @pantheon.SITENAME.env cron` to execute cron using Drush or `terminus drush cron --site=sitename --env=live` using [Terminus](https://github.com/pantheon-systems/cli). With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an efficient process, determine why it's slow and fix the root cause.
 
 #### Can Pantheon change the non-configurable timeouts for my site?
 


### PR DESCRIPTION
- This PR originates from [PR 238](https://github.com/pantheon-systems/documentation/pull/238)
- Redirect task created [Sprint.ly 275](https://sprint.ly/product/24553/item/275)
- This moves the timeouts.md doc to the /sites dir. @bmackinney can you merge and complete the redirect task in sprintly? 
