### PR TITLE
Add question to P4A FAQ

### DIFF
--- a/source/docs/articles/organizations/pantheon-for-agencies/faq.md
+++ b/source/docs/articles/organizations/pantheon-for-agencies/faq.md
@@ -43,7 +43,7 @@ When you or the administrators, team members, or developers in your agency [crea
 All Organizations that are Partners or Allies will have Change Management and Multidev. If your Organization is an Enterprise, then by default these features are not enabled. To request the activation of Multidev and Change Management for Enterprise organizations, please [contact sales](https://pantheon.io/contact-us).
 
 ### Why can't I access Multidev on my site when the Supporting Organization has the feature enabled?
-Only team members and administrators of an Organization with Multidev will be able to use this feature. If you would like to add Multidev at the site level, you can do so by [contacting sales](https://pantheon.io/contact-us).
+Only team members and administrators of an Supporting Organization with Multidev will be able to use this feature. If you would like to add Multidev at the site level, you can do so by upgrading to a Business or [Enterprise](https://pantheon.io/contact-us) plan. Team members who are associated with site but not the agency can access multidev environments via the unique URL, but will not be able to commit code to them.
 
 ### Why can't my Agency Organization own a site?
 Depending on your service level, your Organization may or may not be able to own a site directly. Pantheon for Enterprise level Organizations will be able to own sites, however Pantheon for Agencies (Partners) Organizations will not. This is because an agency's role is to develop, service, and maintain a site on behalf of it's owner. See our [Change Management](/docs/articles/organizations/change-management/#managing-people) doc for more details.


### PR DESCRIPTION
- This PR adds a question to the P4A faq concerning multidev at the site level for team members who are not members of their supporting organization. 
- This PR changes the slug title to **Pantheon for Agencies FAQ**

@bmackinney can you review and merge if this question makes sense? 
