### PR TITLE
Move Pantheon Plugin doc into the wp dir

### DIFF
--- a/source/docs/articles/wordpress/pantheon-plugins.md
+++ b/source/docs/articles/wordpress/pantheon-plugins.md
@@ -4,6 +4,7 @@ description: Learn the specific Plugins developed and maintained for the Pantheo
 category:
   - getting-started
   - developing
+  - WordPress
 ---
 Pantheon maintains multiple plugins to facilitate its workflow within WordPress. The [Pantheon plugin](https://github.com/pantheon-systems/WordPress/tree/master/wp-content/mu-plugins/pantheon) encourages updating plugins and themes in the Development environment and using Pantheon's git-based upstream core updates.
 


### PR DESCRIPTION
- This PR moves the **Pantheon Plugin** doc into the WordPress directory and adds the WordPress category. 
- @nataliejeremy can you review and merge? We can make a redirect for this move when I deploy this afternoon. 
