### PR TITLE
Added links to unsupported plugins on the WP known issues doc

### DIFF
--- a/source/docs/articles/wordpress/wordpress-known-issues.md
+++ b/source/docs/articles/wordpress/wordpress-known-issues.md
@@ -39,8 +39,8 @@ It's especially ill-advised to use Multisite to set up many distinct/separate si
 
 ## Unsupported Plugins
 
-- WP Super Cache
-- W3 Total Cache
-- batcache
+- [WP Super Cache](https://wordpress.org/plugins/wp-super-cache/)
+- [W3 Total Cache](https://wordpress.org/plugins/w3-total-cache/)
+- [batcache](https://wordpress.org/plugins/batcache/)
 
 More to come on this list. Let us know what other plugin issues you see.


### PR DESCRIPTION
This PR adds links to the unsupported plugins on the WordPress Known Issues doc. 

@nataliejeremy can you review and merge if everything looks good? thx!
