### PR TITLE
Move private files doc to drupal dir

### DIFF
--- a/source/docs/articles/drupal/private-files.md
+++ b/source/docs/articles/drupal/private-files.md
@@ -1,5 +1,5 @@
 ---
-title: Private Files
+title: Private Files with Drupal
 description: Learn how to incorporate non-web-accessible data on Pantheon's platform.
 category:
     - development


### PR DESCRIPTION
This PR moves the **Private Files** doc to the Drupal directory and updates the slug title to: "Private Files with Drupal" 

This completes work on [Sprint.ly task 147](https://sprint.ly/product/24553/item/147)

@nataliejeremy can you review and merge? 

I will create a redirect for this move when we deploy. 
