### PR TITLE
Undo Git Commits CMS Update

### DIFF
--- a/source/docs/articles/local/undo-git-commits-like-overwriting-drupal-core.md
+++ b/source/docs/articles/local/undo-git-commits-like-overwriting-drupal-core.md
@@ -6,7 +6,7 @@ category:
 ---
 
 ## Overview
-We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem for Drupal users is overwriting Drupal core. We [try](/docs/articles/required-reading-essential-pantheon-documentation) [our](/docs/articles/local/git-faq#git-faq) [best](/docs/articles/sites/code/applying-upstream-updates#core-updates) to warn you, but it is still possible to execute a Drush update on a local environment and push to Pantheon.
+We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem for Drupal users is overwriting Drupal core. We [try](/docs/articles/required-reading-essential-pantheon-documentation) [our](/docs/articles/local/git-faq#git-faq) [best](/docs/articles/sites/code/applying-upstream-updates#core-updates) to warn you, but it is still possible to execute a Drush update on a local environment and push to Pantheon. This example is Drupal specific but the following steps can be applied to undo a commit on any framework, including WordPress.
 
 **Note**: DO NOT UPDATE CORE VIA `drush up`.  But presumably you are here because that has already happened.
 


### PR DESCRIPTION
This PR completes work on [Sprint.ly task 189](https://sprint.ly/product/24553/item/189)

Cal suggested we move this doc to the Drupal directory, but I think it's valuable to both Drupal and WP users. @nataliejeremy can you review and merge if you agree this should stay in the current directory? 

This PR includes a minor tweak to the first paragraph so WP is represented.
