### PR TITLE
Stop redirecting from CDE, dev, and test on Docs

### DIFF
--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -15,7 +15,10 @@
 <head>
   <!-- Quickie redirection to https and pantheon.io -->
   <script type="text/javascript">
-if (window.location.hostname == 'localhost')
+if (window.location.hostname == 'localhost' ||
+    window.location.hostname == 'docs-panther.pantheon.io' ||
+    window.location.hostname == 'dev-panther.chapterthree.com' ||
+    window.location.hostname == 'test-panther.chapterthree.com')
   redirect = null
 else
 if (window.location.hostname == 'www.getpantheon.com' ||


### PR DESCRIPTION
When merged, this PR will enable documentation to be previewed at the docs- CDE, and in the dev and test environments.
@joshkoenig can you please take a look? Is it an ideal fix to https://sprint.ly/product/24553/item/272 ?
