### PR TITLE
Remove extra div tags to fix footer on index

### DIFF
--- a/source/docs/index.html
+++ b/source/docs/index.html
@@ -63,7 +63,4 @@ use: [documents_category]
         <h2 align="middle">Guides</h2></a>
         <p align ="middle">Best practices for dynamic sites</p>
   </div>
-
-</div>
-</div>
 </div>


### PR DESCRIPTION
This PR fixes the footer on the docs index page by removing extra `</div>` tags. 
@nataliejeremy can you review and merge? 
## Before:

![screen shot 2015-04-20 at 8 53 31 am](https://cloud.githubusercontent.com/assets/10119525/7231419/ce05b640-e73a-11e4-96ba-64cb04b213ed.png)
## After:

![screen shot 2015-04-20 at 8 53 13 am](https://cloud.githubusercontent.com/assets/10119525/7231417/c8f3de16-e73a-11e4-978a-51e76bdcc5ce.png)
