### PR TITLE
Add meta tags to all docs, and sharing links to guides template

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -4,7 +4,7 @@
 title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
-
+site_url: https://pantheon.io
 
 #######################################################################################################
 # The authors. Include your info here, under the "authors" key, using the following template:
@@ -13,7 +13,7 @@ url: /docs
 #      name: Your Name
 #      url: http://yourURL.com
 #      avatar: http://url.to.a.valid/avatar.jpeg
-#      twitter: http://twitter.com/
+#      twitter: handle
 #      gplus: https://plus.google.com/
 #      github: https://github.com/
 #      linkedin: https://www.linkedin.com/in/
@@ -30,7 +30,7 @@ authors:
       name: Brian MacKinney
       url: http://brianmackinney.com
       avatar: http://www.gravatar.com/avatar/d942a7d4b38d10e4f4ebab9cb148d9f9.png
-      twitter: http://twitter.com/BrianMacKinney
+      twitter: BrianMacKinney
       github: https://github.com/bmackinney
       drupal: https://www.drupal.org/u/brian-mackinney
       wordpress: https://profiles.wordpress.org/brian-mackinney
@@ -41,7 +41,7 @@ authors:
       name: Cal Evans
       url: http://calevans.com
       avatar: http://2.gravatar.com/avatar/d6d504bf40dea91cd33027e5bb85f7df
-      twitter: http://twitter.com/calevans
+      twitter: calevans
       github: https://github.com/calevans
       bio: For the past 13 years Cal has worked with PHP and MySQL on Linux, OSX, and Windows. He has built a variety of projects ranging in size from simple web pages to multi-million dollar web applications. When not banging his head on his monitor, attempting a blood sacrifice to get a particular piece of code working, he enjoys building and managing development teams using his widely imitated but never patented management style of “management by wandering around”.These days, when not working with PHP, Cal can be found working on a variety of projects like CoderFaire. He speaks at conferences around the world on topics ranging from technical talks to motivational talks for developers. If you happen to meet him at a conference, don’t be afraid to buy him a shot of Bourbon.Cal is based in Nashville TN where he is happily married to wife 1.31, the lovely and talented Kathy. Together they have 2 wonderful kids. From blog.calevans.com/epk
 
@@ -64,11 +64,11 @@ authors:
   erikmathy:
       name: Erik Mathy
       avatar: http://www.gravatar.com/avatar/0e9285db4e5bdbb3356306ddb55483d8.png
-      twitter: http://twitter.com/1gearnobrains
+      twitter: 1gearnobrains
       linkedin: http://www.linkedin.com/pub/erik-mathy/28/b51/627/en
       bio: Enterprise Onboarding Manager.
   populist:
       name: Matt Cheney
       avatar: https://avatars1.githubusercontent.com/u/520521
-      twitter: http://twitter.com/populist
+      twitter: populist
       bio: Website developer extraordinaire

--- a/source/_partials/author_box.twig
+++ b/source/_partials/author_box.twig
@@ -12,7 +12,7 @@
             <div class="media-heading">
                 <h4><a href="{{ site.url }}/authors/{{ authorhandle }}">{{ author.name }}</a>
                     {% if author.url %}<a href="{{ author.url }}" target="_blank"><i class="icon icon-globe"></i></a>{% endif %}
-                    {% if author.twitter %}<a href="{{ author.twitter }}" target="_blank"> <i class="icon icon-twitter"></i></a>{% endif %}
+                    {% if author.twitter %}<a href="https://twitter.com/{{ author.twitter }}" target="_blank"> <i class="icon icon-twitter"></i></a>{% endif %}
                     {% if author.github %}<a href="{{ author.github }}" target="_blank"><i class="icon icon-github"></i></a>{% endif %}
                     {% if author.drupal %}<a href="{{ author.drupal }}" target="_blank"> <i class="icon icon-drupal"></i></a>{% endif %}
                     {% if author.wordpress %}<a href="{{ author.wordpress }}" target="_blank"> <i class="icon icon-wordpress"></i></a>{% endif %}

--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -10,7 +10,8 @@
 <![endif]-->
 <!--[if gt IE 8]>
 <!-->
-<html class="no-js">
+<!-- Update your html tag to include the itemscope and itemtype attributes. -->
+<html itemscope itemtype="http://schema.org/Article" class="no-js">
   <!--<![endif]-->
 <head>
   <!-- Quickie redirection to https and pantheon.io -->
@@ -31,11 +32,50 @@ if (window.location.hostname == 'www.getpantheon.com' ||
   window.location = redirect
 }
   </script>
+
+  <!--Meta Tags -->
+  {% if page.authors %}
+      {% set author_list = page.authors %}{% if author_list %}
+          {% for authorhandle in author_list %}
+              {% if site.authors[authorhandle] %}
+                  {% set author = site.authors[authorhandle] %}
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{% block title %}{{ page.title|title }} | {{ site.title }}{% endblock %}</title>
-  <meta name="description" content="">
+  <meta name="description" content="{{ page.description }}">
+  <meta name="keywords" content="{{ page.keywords }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
+  <!-- Schema.org markup for Google+ -->
+  <meta itemprop="name" content="The Name or Title Here">
+  <meta itemprop="description" content="This is the page description">
+  <meta itemprop="image" content="{{ page.image }}">
+
+  <!-- Twitter Card data -->
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:site" content="@getpantheon">
+  <meta name="twitter:title" content="{{ page.title}}">
+  <meta name="twitter:description" content="{{ page.description }}">
+  <meta name="twitter:creator" content="@{{ author.twitter }}">
+  <!-- Twitter summary card with large image must be at least 280x150px -->
+  <meta name="twitter:image:src" content="{{ page.image }}">
+  {% endif %}
+                  {% if not loop.last %}, {% endif %}
+              {% endfor %}
+          {% endif %}
+        {% endif %}
+  <!-- Open Graph data -->
+  <meta property="og:title" content="{{ page.title}}" />
+  <meta property="og:type" content="article" />
+  <meta property="og:url" content="{{ site.site_url}}{{ site.url}}{{ page.url }}" />
+  <meta property="og:image" content="{{ page.image }}" />
+  <meta property="og:description" content="{{ page.description }}" />
+  <meta property="og:site_name" content="Pantheon Documentation" />
+  <meta property="article:published_time" content="{{ page.date|date('F d, Y') }}" />
+  <meta property="article:modified_time" content="" />
+  <meta property="article:section" content="{{ page.category }}" />
+  <meta property="article:tag" content="{{ page.category }}" />
+  <!--<meta property="fb:admins" content="Facebook numberic ID" />-->
+
   <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap.min.css">
   <!-- Latest compiled and minified CSS -->
   <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">

--- a/source/_views/guide.html
+++ b/source/_views/guide.html
@@ -14,13 +14,17 @@
             {% for category in page.categories %}
             <br>in <a href="{{ site.url }}/entries/categories/{{ category|url_encode(true) }}">{{ category }}</a>{% if not loop.last %}, {% endif %}
             {% endfor %}
+            <a href="https://twitter.com/share" class="twitter-share-button pull-right" data-via="getpantheon" data-count="none">Tweet</a>
+<script>!function(d,s,id){var js,fjs=d.getElementsByTagName(s)[0],p=/^http:/.test(d.location)?'http':'https';if(!d.getElementById(id)){js=d.createElement(s);js.id=id;js.src=p+'://platform.twitter.com/widgets.js';fjs.parentNode.insertBefore(js,fjs);}}(document, 'script', 'twitter-wjs');</script>
+<span class="pull-right">
+<script type="text/javascript" src="http://platform.linkedin.com/in.js"></script><script type="in/share"></script></span>
             <br>
             {{ page.date|date('F d, Y') }}
         </div>
-<!-- <script type="text/javascript">
+<script type="text/javascript">
             #  breadcrumbs()
 
-            </script> -->
+            </script>
             </header>
           </div>
               <!--{% if page.category %}

--- a/source/docs/guides/two-factor-authentication.md
+++ b/source/docs/guides/two-factor-authentication.md
@@ -9,6 +9,8 @@ category:
 authors:
   - populist
 date: 4/13/2015
+image: https.pantheon.io/docs/assets/images/pantheon-fistbump.png
+keywords: Drupal, WordPress, security, two-factor auth, 2fa, onelogin, Pantheon
 
 ---
 


### PR DESCRIPTION
Completes #452 
Adds meta data to all pages in the site, following this example: http://moz.com/blog/meta-data-templates-123