### PR TITLE
Remove unnecessary white space from docs

### DIFF
--- a/source/docs/articles/architecture.md
+++ b/source/docs/articles/architecture.md
@@ -3,7 +3,6 @@ title: Pantheon Architecture
 description: Detailed information about our infrastructure.
 draft: true
 ---
-
 ## Cloud Infrastructure Provider
 Pantheon proudly runs on RackSpace and Amazon S3. We utilize the most advanced hardware our infrastructure providers can provide, and we do so very efficiently.
 

--- a/source/docs/articles/architecture/edge/ipv6-addresses.md
+++ b/source/docs/articles/architecture/edge/ipv6-addresses.md
@@ -3,10 +3,7 @@ title: IPv6 Addresses on Pantheon
 description: Detailed information about IPv6.
 category:
   - getting-started
-
-
 ---
-
 ## IPv6 Overview
 
 [Internet Protocol version 6](http://en.wikipedia.org/wiki/IPv6) (IPv6) is the latest revision of the Internet Protocol (IP), intended to replace IPv4. IPv6 traffic is expected to reach 2% by the end of 2013 ([source](http://www.circleid.com/posts/20121128_ipv6_a_2012_report_card/)). Pantheon, in an effort to future proof our platform, is in the process of providing IPv6 support. IPv4 will still be supported.

--- a/source/docs/articles/architecture/edge/pantheon_stripped-get-parameter-values.md
+++ b/source/docs/articles/architecture/edge/pantheon_stripped-get-parameter-values.md
@@ -4,7 +4,6 @@ description: Learn how Pantheon's edge cache uses the request URL as the cache k
 category:
   - developing
 ---
-
 ## Overview
 
 Pantheon's edge cache uses the request URL as the cache key. To allow requests for the same site content but distinct Google Analytics parameters to be served from cache, Pantheon replaces a specific subset of GET parameter values with `PANTHEON_STRIPPED` to normalize the cache location.

--- a/source/docs/articles/architecture/edge/varnish/caching-advancedtopics.md
+++ b/source/docs/articles/architecture/edge/varnish/caching-advancedtopics.md
@@ -3,7 +3,6 @@ title: Caching - Advanced Topics
 description: Learn advanced details about cached and authentication.
 category:
   - developing
-
 ---
 ## Allow a User to Bypass the Cache
 

--- a/source/docs/articles/architecture/edge/varnish/debugging-cache.md
+++ b/source/docs/articles/architecture/edge/varnish/debugging-cache.md
@@ -3,7 +3,6 @@ title: Debugging Cache
 description: Learn how to resolve caching errors.
 category:
   - debugging
-
 ---
 ## Clear Varnish Caches
 

--- a/source/docs/articles/drupal/caching-in-drupal-modules.md
+++ b/source/docs/articles/drupal/caching-in-drupal-modules.md
@@ -4,9 +4,7 @@ description: Configure Drupal's performance and caching settings to make signifi
 category:
   - developing
   - drupal
-
 ---
-
 ## Overview
 While configuring [Drupal's performance and caching settings](/docs/articles/drupal/drupal-s-performance-and-caching-settings) and using [redis as a Drupal caching backend](/docs/articles/sites/redis-as-a-caching-backend) will make a significant performance difference, not every module uses Drupal's caching out of the box.
 

--- a/source/docs/articles/drupal/cdn-setting-up-cloudfront.md
+++ b/source/docs/articles/drupal/cdn-setting-up-cloudfront.md
@@ -5,7 +5,6 @@ category:
     - drupal
     - developing
 ---
-
 ## Before You Begin
 
 Make sure that you have:  

--- a/source/docs/articles/drupal/configuring-jetbrains-phpstorm-ide-with-pantheon.md
+++ b/source/docs/articles/drupal/configuring-jetbrains-phpstorm-ide-with-pantheon.md
@@ -3,9 +3,7 @@ title: Configuring JetBrains PhpStorm IDE with Drupal on Pantheon
 description: Best practices and recommendations for building a site using PhpStorm.
 category:
   - developing
-
 ---
-
 ## Overview
 
 [JetBrains PhpStorm](http://www.jetbrains.com/phpstorm/) is a commercial PHP IDE that can be configured to work with Drupal sites.

--- a/source/docs/articles/drupal/configuring-settings-php.md
+++ b/source/docs/articles/drupal/configuring-settings-php.md
@@ -3,7 +3,6 @@ title: Configuring Settings.php
 description: Detailed information about configuring your Drupal database settings.
 category:
   - developing
-
 ---
 ## Overview
 

--- a/source/docs/articles/drupal/content-delivery-network-cdn-for-file-distribution.md
+++ b/source/docs/articles/drupal/content-delivery-network-cdn-for-file-distribution.md
@@ -3,9 +3,7 @@ title: Content Delivery Network (CDN) for file distribution
 description: Learn about the benefits of using a Content Delivery Network (CDN).
 category:
     - drupal
-
 ---
-
 ## Overview
 
 A CDN (Content Delivery Network) is a distributed system for rapidly serving files from multiple locations.

--- a/source/docs/articles/drupal/cron.md
+++ b/source/docs/articles/drupal/cron.md
@@ -4,7 +4,6 @@ description: Understand Pantheon cron execution and management.
 category:
   - developing
 ---
-
 ## Overview
 
  **Note**: Cron will always run unless all jobs are specifically set to 'Off' via Elysia or Ultimate cron modules. Cron will also not run via Drush if a cron key is set with Elysia.

--- a/source/docs/articles/drupal/drupal-s-performance-and-caching-settings.md
+++ b/source/docs/articles/drupal/drupal-s-performance-and-caching-settings.md
@@ -3,9 +3,7 @@ title: Drupal's Performance and Caching Settings
 description: Use Varnish caching to maximize your site's performance.  
 category:
   - drupal
-
 ---
-
 To maximize your site's performance on Pantheon and to take advantage of our Varnish caching, you'll need to configure your site's performance settings.​ For more information, see  [Varnish caching for high performance](/docs/articles/architecture/edge/varnish).
 
 ## Drupal 7 Performance Configuration

--- a/source/docs/articles/drupal/fix-broken-links-that-reference-ip-port-instead-of-domain-name.md
+++ b/source/docs/articles/drupal/fix-broken-links-that-reference-ip-port-instead-of-domain-name.md
@@ -4,11 +4,8 @@ description: Learn how to update links so that the URL references the correct fi
 category:
   - debugging
   - drupal
-
 ---
-
 ## Overview
-
 
 ### Scenario:
 When editing content, links can be inserted that don't reflect the site's domain name. For example, an image URL appears as http://192.237.142.203:5555/files/cernettes.gif instead of the proper http://www.example.com/files/cernettes.gif

--- a/source/docs/articles/drupal/getting-the-client-ip-address.md
+++ b/source/docs/articles/drupal/getting-the-client-ip-address.md
@@ -1,7 +1,6 @@
 ---
 title: Getting the Client IP Address
 description: Set up geolocation capabilities on your site.
-
 category:
   - developing
 ---

--- a/source/docs/articles/drupal/importing-an-existing-drupal-site-to-pantheon.md
+++ b/source/docs/articles/drupal/importing-an-existing-drupal-site-to-pantheon.md
@@ -5,8 +5,6 @@ category:
 - drupal
 - getting-started
 ---
-
-
 ## Overview
 
 The easiest way to import an existing Drupal site into Pantheon is to create a new site, and select **Import manually** when asked to choose a Start State.

--- a/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
+++ b/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
@@ -3,9 +3,7 @@ title: Launch Check - Drupal Performance and Configuration Analysis
 description: Get site analysis and recommendations.
 category:
   - developing
-
 ---
-
 Pantheon provides static site analysis as a service for Drupal 7 sites to make best practice recommendations on site configurations. These reports can be found in the site dashboard under the status tab and are accessible by site team members.
 
 ## Overview

--- a/source/docs/articles/drupal/major-version-drupal-upgrades.md
+++ b/source/docs/articles/drupal/major-version-drupal-upgrades.md
@@ -4,9 +4,7 @@ description: Learn how to upgrade to the next major revision of Drupal.
 category:
   - drupal
   - managing
-
 ---
-
 ## Overview
 
 The best practice for doing a major Drupal revision upgrade (e.g. version 6 to version 7) is to start a new site. Even the simplest of upgrades require their own QA and deployment process, and trying to do an upgrade on an existing site is not a recipe for success.

--- a/source/docs/articles/drupal/manually-apply-drupal-7-32-security-update.md
+++ b/source/docs/articles/drupal/manually-apply-drupal-7-32-security-update.md
@@ -4,7 +4,6 @@ description: Instructions on updating to Drupal 7.32.
 category:
   - drupal
 ---
-
 If your Drupal 7 site is based on the Pantheon Drupal 7 upstream, you will be able to apply a one-click update in your dashboard. If you are running a site that does not yet have a one-click update available, we recommend you manually make the update immediately.
 
 1. Download [Drupal 7.32 Security Update](https://github.com/drupal/drupal/commit/26a7752c34321fd9cb889308f507ca6bdb777f08.patch)

--- a/source/docs/articles/drupal/multilingual-best-practices.md
+++ b/source/docs/articles/drupal/multilingual-best-practices.md
@@ -3,9 +3,7 @@ title: Multilingual Best Practices on Pantheon
 description: Configure a multilingual site on Pantheon.
 category:
   - developing
-
 ---
-
 Pantheon is home to many polylingual and non-English sites, and hosting a multi-language site on Pantheon requires no additional platform configuration.  
 
 For detailed information on how to configure a multilingual Drupal site, see the [Multilingual Guide on Drupal.org](https://drupal.org/documentation/multilingual).  
@@ -21,6 +19,6 @@ It’s possible to specify a site language given a particular domain or path. In
 
 Each of these configurations is possible with Drupal’s built-in language switching.  
 
-You can associate multiple domains with a single site environment. See [adding a domain to a site environment](/docs/articles/sites/domains/adding-a-domain-to-a-site-environment) for details.    
+You can associate multiple domains with a single site environment. See [adding a domain to a site environment](/docs/articles/sites/domains/adding-a-domain-to-a-site-environment) for details.
 
 If you have a particular Pantheon platform related question that is not addressed in this document, please submit a support ticket through your Pantheon dashboard and we’ll be happy to help.

--- a/source/docs/articles/drupal/optimizing-the-image-cache-module-in-drupal-6.md
+++ b/source/docs/articles/drupal/optimizing-the-image-cache-module-in-drupal-6.md
@@ -3,9 +3,7 @@ title: Optimizing the ImageCache Module in Drupal 6
 description: Important details about the ImageCache Module.
 category:
   - drupal
-
 ---
-
 ImageCache is a widely used Drupal 6 contributed module for dynamically generating thumbnails and other derivative images. Unfortunately, its internal logic relies heavily on a locally attached filesystem and suffers from performance issues in cloud environments like Pantheon.
 
 To help with this, we have produced a patch that can be applied against the latest version of ImageCache (2.0-rc2). You can download the patch [here](http://pantheon-content.s3.amazonaws.com/patches/imagecache_pantheon.patch).

--- a/source/docs/articles/drupal/private-files.md
+++ b/source/docs/articles/drupal/private-files.md
@@ -4,10 +4,7 @@ description: Learn how to incorporate non-web-accessible data on Pantheon's plat
 category:
     - development
     - drupal
-
-
 ---
-
 ## Overview
 Pantheon provides two spaces for non-web-accessible data. Take some time to understand the best method for you if you are looking for more refined permissions for your files and code.
 

--- a/source/docs/articles/drupal/running-drupal-8.md
+++ b/source/docs/articles/drupal/running-drupal-8.md
@@ -3,10 +3,7 @@ title: Running Drupal 8 on Pantheon
 description: Important information about running Drupal 8.
 category:
     - drupal
-
-
 ---
-
 # Coming Soon
 
 Drupal 8 is currently in a feature freeze and will be available again on Pantheon once it is slightly more stable.

--- a/source/docs/articles/drupal/session-and-cookie-handling.md
+++ b/source/docs/articles/drupal/session-and-cookie-handling.md
@@ -4,9 +4,7 @@ description: Details about configuring settings for session expiration and cooki
 category:
   - developing
   - drupal
-
 ---
-
 ## Control Session Expiration Length
 
 Pantheon allows developers to control the length of sessions. There are two pieces; the lifetime of the cookie and the lifetime of the session itself.  

--- a/source/docs/articles/drupal/updating-modules-through-drupal.md
+++ b/source/docs/articles/drupal/updating-modules-through-drupal.md
@@ -4,9 +4,7 @@ description: Learn how to update Drupal modules.
 category:
   - developing
   - drupal
-
 ---
-
 ## Updating Modules Through Drupal
 Drupal has a very good, built-in system for updating contributed modules through the administrative interface.
 1. Log in to Pantheon, and choose the site you want to update.

--- a/source/docs/articles/drupal/using-simplesamlphp-with-shibboleth-sso.md
+++ b/source/docs/articles/drupal/using-simplesamlphp-with-shibboleth-sso.md
@@ -5,7 +5,6 @@ category:
   - drupal
   - developing
 ---
-
 ## Overview
 
 **Note**: This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal sites on Pantheon using the [simplesaml\_php auth module](http://drupal.org/project/simplesamlphp_auth) from drupal.org.

--- a/source/docs/articles/frequently-asked-questions.md
+++ b/source/docs/articles/frequently-asked-questions.md
@@ -3,7 +3,6 @@ title: Frequently Asked Questions
 description: Answers to common questions about using Pantheon.
 category:
   - getting-started
-
 ---
 ## Getting Started
 

--- a/source/docs/articles/getting-started.md
+++ b/source/docs/articles/getting-started.md
@@ -4,10 +4,7 @@ description: Learn how to spin up a site on Pantheon.
 category:
   - getting-started
 ---
-
-
 Welcome to Pantheon! In a few simple steps, your Drupal or WordPress site will be up and running faster than ever. Use this checklist to get the most out of the platform.
-
 
 ## Create Your Free Account
 

--- a/source/docs/articles/going-live.md
+++ b/source/docs/articles/going-live.md
@@ -4,7 +4,6 @@ description: Best practices for preparing your site launch.
 category:
   - going-live
 ---
-
 ## Preparing for Your Site Launch
 
 Congratulations, you're almost ready to launch your site on Pantheon! There are a couple things to do to get ready, but we'll help you with every step.

--- a/source/docs/articles/guide-example.md
+++ b/source/docs/articles/guide-example.md
@@ -4,7 +4,6 @@ description: Learn how to create a great guide.
 draft: true
 
 ---
-
 ## <span style="color: red">Introduction Section</span>
 
 ### <span style="color: red">Problem Scenario</span>

--- a/source/docs/articles/guide-publishing-workflow.md
+++ b/source/docs/articles/guide-publishing-workflow.md
@@ -2,7 +2,6 @@
 title: Guide Publishing Workflow
 description: Learn how to create a great guide.
 draft: true
-
 ---
 Roles: <span style="color: orange">**Submitter**</span>, <span style="color: blue">**Writer**</span>, <span style="color: brown">**Editor**</span>, <span style="color: green">**Management Team**</span>, <span style="color: purple">**Technical Resource**</span>, <span style="color: magenta">**Tester**</span>, <span style="color: red">**Marketing Content Manager**</span>
 
@@ -44,6 +43,4 @@ It's important that moderators know what follow up actions are required when Pul
 
 ### Merge Instructions
 
-When the doc has received a +1 from a founder and editor. Merge and publish it. Delete the branch. Any fixes noticed after the fact will enter a normal update workflow. 
-
-
+When the doc has received a +1 from a founder and editor. Merge and publish it. Delete the branch. Any fixes noticed after the fact will enter a normal update workflow.

--- a/source/docs/articles/load-and-performance-testing.md
+++ b/source/docs/articles/load-and-performance-testing.md
@@ -3,9 +3,7 @@ title: Load and Performance Testing
 description: Learn how to monitor internal execution performance.
 category:
   - going-live
-
 ---
-
 We highly recommend load testing a site both prior and post launch to ensure your site is optimally configured.
 
 ## Before You Begin

--- a/source/docs/articles/local.md
+++ b/source/docs/articles/local.md
@@ -3,9 +3,7 @@ title: Local Development Setup and Operation
 description: Suggestions and solutions for working locally.
 category:
 - getting-started
-
 ---
-
 While Pantheon provides a number of options for on-server development, local development has a number of advantages, especially if continuous Internet access is a concern. While Pantheon cannot troubleshoot or support local development solutions, we can provide some suggestions and known working solutions.  
 
 If you're looking for a self-contained local development solution on Mac, check out [Kalabox](http://www.kalamuna.com/products/kalabox), which integrates with the Pantheon platform.

--- a/source/docs/articles/local/accessing-mysql-databases.md
+++ b/source/docs/articles/local/accessing-mysql-databases.md
@@ -5,7 +5,6 @@ description: Configure and troubleshoot database connections.
 category:
   - developing
 ---
-
 ## Overview
 
 Pantheon provides direct access for your MySQL databases, both for debugging and for importing large databases. Each site environment (Dev, Test and Live) has a separate database, so credentials for one cannot be used on another. The credentials are automatically included in your site configuration.

--- a/source/docs/articles/local/continuous-integration-solutions.md
+++ b/source/docs/articles/local/continuous-integration-solutions.md
@@ -4,9 +4,7 @@ description: Run automated unit and integration tests.
 category:
   - going-live
   - developing
-
 ---
-
 ## Overview
 Continuous Integration is a method of running automated unit and integration tests to apply quality control. Pantheon doesn't provide or host tools for continuous integration, but many tools and techniques are compatible with Pantheon. If you have a particular use case or technique that you'd like to highlight, let us know by opening a support ticket.
 

--- a/source/docs/articles/local/drush-command-line-utility.md
+++ b/source/docs/articles/local/drush-command-line-utility.md
@@ -4,9 +4,7 @@ description: Administer and maintain your site from your local Drush installatio
 category:
   - getting-started
   - developing
-
 ---
-
 [Drush](http://drush.org) is a command-line interface for Drupal that provides a wide set of utilities for administering and maintaining your site.
 
 Pantheon does not need the settings.php for your site to work, and your Drupal sites do not contain one out of the box. Drush commands require a settings.php file and it's considered a best practice to have one. Simply duplicate the `sites/default/default.settings.php` to `sites/default/settings.php` for Drush to work on a new site.

--- a/source/docs/articles/local/filezilla.md
+++ b/source/docs/articles/local/filezilla.md
@@ -4,10 +4,7 @@ description: Detailed information about using the FileZilla FTP client.
 category:
     - getting-started
     - developing
-
-
 ---
-
 [FileZilla](http://winscp.net/eng/index.php) is a free open source FTP client that is available for Windows, Mac OS X, and Linux.
 
 ## Getting Started

--- a/source/docs/articles/local/git-commit-best-practices.md
+++ b/source/docs/articles/local/git-commit-best-practices.md
@@ -6,7 +6,6 @@ category:
 
 draft: true
 ---
-
 ## Commit often
 Commit your code every time you:
 - Install a module or theme and its dependencies,

--- a/source/docs/articles/local/git-faq.md
+++ b/source/docs/articles/local/git-faq.md
@@ -1,11 +1,9 @@
 ---
 title: Git FAQs
 description: Answers to commonly asked questions about Git.
-
 category:
   - developing
 ---
-
 ## Resolving Conflicts
 ### How do I resolve conflicts when updating Core?
 

--- a/source/docs/articles/local/installing-cygwin-on-windows.md
+++ b/source/docs/articles/local/installing-cygwin-on-windows.md
@@ -3,9 +3,7 @@ title: Installing Cygwin on Windows
 description: Learn how to install and configure Cygwin.
 category:
   - getting-started
-
 ---
-
 ## Overview
 
 [Cygwin](http://cygwin.com/install.html) is a collection of tools which provide a Linux tools and utilities for Windows computers. If you do not have access to a Mac or Linux environment you can use Cygwin to generate the .key and .csr file that are needed to get a SSL certificate from a provider.

--- a/source/docs/articles/local/port-2222-blocked-workaround.md
+++ b/source/docs/articles/local/port-2222-blocked-workaround.md
@@ -4,9 +4,6 @@ description: Instructions for accessing Port 2222.
 category:
   - developing
 ---
-
-​
-
 In order to push and pull code to your Pantheon site you'll need access to port 2222. If for some reason this port isn't open to you, either because of a corporate firewall or router configuration, you'll get an error resembling the following:
 
     SSH: connect to host codeserver.dev.<site UUID>.drush.in port 2222: No route to host

--- a/source/docs/articles/local/refreshing-dns-records-on-your-local-machine.md
+++ b/source/docs/articles/local/refreshing-dns-records-on-your-local-machine.md
@@ -3,9 +3,7 @@ title: Refreshing DNS Records on Your Local Machine
 description: Flush your DNS cache to clear and update the data.
 category:
   - developing
-
 ---
-
 ## Overview
 DNS is the main naming system for the internet, allowing computers to exchange data over TCP/IP. It takes any domain name, such as "pantheon.io" and "ties" it to an IP address like 50.57.202.75. The numbers identify computers to each other, and the names are easier for humanoids to remember.  
 

--- a/source/docs/articles/local/rsync-and-sftp.md
+++ b/source/docs/articles/local/rsync-and-sftp.md
@@ -3,10 +3,7 @@ title: rsync and SFTP
 description: Transfer large files using an SFTP client or rsync.
 category:
   - getting-started
-
-
 ---
-
 ## Overview
 
  **Note**: Due to the nature of our platform architecture, the connection information will change from time to time due to server upgrades, endpoint migrations, etc. You will need to check this with the dashboard periodically or when you find that you can’t connect.

--- a/source/docs/articles/local/ssh-tunnels-for-secure-connections-to-pantheon-services.md
+++ b/source/docs/articles/local/ssh-tunnels-for-secure-connections-to-pantheon-services.md
@@ -4,7 +4,6 @@ description: Securely connect to your database and caching service using SSH tun
 category:
   - developing
 ---
-
 ## Overview
 For additional security, Pantheon provides the ability to securely connect to your database and caching service over an encrypted connection using  [secure shell tunneling](http://en.wikipedia.org/wiki/Tunneling_protocol#Secure_shell_tunneling). This will increase the security of your remote connection, especially in a public or untrusted environment.  
 

--- a/source/docs/articles/local/starting-with-git.md
+++ b/source/docs/articles/local/starting-with-git.md
@@ -4,9 +4,7 @@ description: Use Git version control with your Pantheon site.
 category:
   - getting-started
   - developing
-
 ---
-
 ## Overview
 Git is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use local development, it's likely the best way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon development environment.
 

--- a/source/docs/articles/local/terminus-the-pantheon-command-line-interface.md
+++ b/source/docs/articles/local/terminus-the-pantheon-command-line-interface.md
@@ -3,7 +3,6 @@ title: The Terminus Drush Extension (Deprecated)
 description: The original Terminus project
 category:
   - developing
-
 ---
 ## NOTE: Archive Reference
 The Original Terminus project was a drush extension and is now Deprecated. It has been replaced with a stand-alone command-line utility, which you can read about at our new [Terminus article](/docs/articles/local/cli/ "Pantheon documentation article on the CLI project") and its [github repository](https://github.com/pantheon-systems/cli "Pantheon's CLI Repository on github")

--- a/source/docs/articles/local/undo-git-commits-like-overwriting-drupal-core.md
+++ b/source/docs/articles/local/undo-git-commits-like-overwriting-drupal-core.md
@@ -4,7 +4,6 @@ description: Instructions on how to undo a Git commit.
 category:
   - drupal
 ---
-
 ## Overview
 We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem for Drupal users is overwriting Drupal core. We [try](/docs/articles/required-reading-essential-pantheon-documentation) [our](/docs/articles/local/git-faq#git-faq) [best](/docs/articles/sites/code/applying-upstream-updates#core-updates) to warn you, but it is still possible to execute a Drush update on a local environment and push to Pantheon. This example is Drupal specific but the following steps can be applied to undo a commit on any framework, including WordPress.
 

--- a/source/docs/articles/local/using-mysql-workbench-to-access-a-database.md
+++ b/source/docs/articles/local/using-mysql-workbench-to-access-a-database.md
@@ -4,7 +4,6 @@ description: Use MySQL Workbench for creating, executing, and optimizing SQL que
 category:
   - developing
 ---
-
 [MySQL Workbench](http://dev.mysql.com/downloads/tools/workbench/) provides DBAs and developers an integrated tools environment for: Database Design & Modeling, SQL Development, database administration, and support for Windows, Mac OS X and Linux.
 
 ## Get Started

--- a/source/docs/articles/local/using-phpmyadmin-to-locally-administer-a-database.md
+++ b/source/docs/articles/local/using-phpmyadmin-to-locally-administer-a-database.md
@@ -4,7 +4,6 @@ description: Configure and troubleshoot MySQL connections.
 category:
   - developing
 ---
-
 ## Overview
 [PHPMyAdmin](https://github.com/phpmyadmin/phpmyadmin/) is a common tool to administer databases locally and can also provide DBAs the ability to access remote databases. PHPMyAdmin runs PHP so it is possible to install this on Windows, Mac OS X, and Linux.
 

--- a/source/docs/articles/local/using-winscp.md
+++ b/source/docs/articles/local/using-winscp.md
@@ -4,9 +4,7 @@ description: Detailed information about the WinSCP SFTP client.
 category:
   - getting-started
   - developing
-
 ---
-
 [WinSCP](http://winscp.net/eng/index.php) is an open source graphical SFTP client for Windows that also supports the Legacy SCP protocol.
 
 ## Getting Started

--- a/source/docs/articles/optimizing.md
+++ b/source/docs/articles/optimizing.md
@@ -3,9 +3,7 @@ title: Optimization for Pantheon and the Cloud
 description: Learn how to optimize your site to efficiently function on Pantheon's cloud.  
 category:
   - developing
-
 ---
-
 Pantheon as a platform attempts to balance the tradeoff between high performance and high availability. It is important to reduce single points of failure and insure scalability, but this effort can introduce complexity and latency vs. a “one box” architecture.  
 
 A traditional single server has a high risk of being impacted by any unexpected event because it is a single point of failure. If a single service becomes unavailable due to a webserver problem, database failure, network degradation, or even because of high traffic, the entire site goes down.  

--- a/source/docs/articles/organizations.md
+++ b/source/docs/articles/organizations.md
@@ -4,7 +4,6 @@ description: Pantheon organization types and the features available to them.
 category:
 - managing
 ---
-
 Organizations on Pantheon bring together users, sites, custom upstreams, unified support, and Multidev to provide administrators with the tools needed to effectively manage a large number of websites. Several service levels are as types of organizations on our platform. Please see your organization dashboard or contact your sales representative to determine which type you are. Partners who signed up for "Pantheon for Agencies" via our self-service form are "Ally Partners." Ally Partners do not qualify for custom upstreams or free sites. Take a moment to read about all of the awesome we have available for your organization.
 
 ## The Organization Dashboard

--- a/source/docs/articles/organizations/adding-a-custom-upstream.md
+++ b/source/docs/articles/organizations/adding-a-custom-upstream.md
@@ -4,9 +4,7 @@ description: Add and test a custom version of WordPress or Drupal.
 category:
   - managing
   - going-live
-
 ---
-
 By following this guide, you'll go from creating a custom version of WordPress or Drupal, to having it ready for us to add to the platform for members of your organization to spin up.
 
 ## 1. Create a Remote Repository.

--- a/source/docs/articles/organizations/change-management.md
+++ b/source/docs/articles/organizations/change-management.md
@@ -5,7 +5,6 @@ category:
   - getting-started
   - developing
 ---
-
 Change Management is a feature of Organizations that enables role-based permissions for users on the Organization. Sites which list the Organization as a supporting Organization are accessible to privileged members of the Organization. The roles exist to restrict who can deploy and manage other users in the Organization or sites it works on.
 
 ## Features
@@ -38,7 +37,7 @@ To change the owner of a paid site (e.g. Personal, Pro, Business), you'll need t
 
 Enterprise Organizations can use the same process to assume ownership of a site, however Agency Partners do not have the ability to own sites directly.
 
-For Sandbox sites, within the Team modal, the site owner can click **Make Owner** next to the team member that should receive ownership of the site. 
+For Sandbox sites, within the Team modal, the site owner can click **Make Owner** next to the team member that should receive ownership of the site.
 
 
 ## Permissions

--- a/source/docs/articles/organizations/managing-sites-and-teams-with-the-organization-dashboard.md
+++ b/source/docs/articles/organizations/managing-sites-and-teams-with-the-organization-dashboard.md
@@ -3,9 +3,7 @@ title: Managing Sites and Teams with the Pantheon for Agencies Dashboard
 description: Learn to add users and sites to your organization.
 category:
 - managing
-
 ---
-
 The organization dashboard is where you manage all your sites in a single location. You can access support tickets, add or remove team members, and manage new or existing sites.
 
 ## Add Users to Your Organization
@@ -32,7 +30,7 @@ From the site dashboard you wish to add,
 
 
 1. Click **Team**
-2. Click **Add Supporting Organization** 
+2. Click **Add Supporting Organization**
 3. Search for your organization
 4. Click **Add**
 

--- a/source/docs/articles/organizations/managing-upstreams.md
+++ b/source/docs/articles/organizations/managing-upstreams.md
@@ -3,10 +3,7 @@ title: Managing Upstreams
 description: Merge updates to core, extensions, and themes.
 category:
   - managing
-
-
 ---
-
 Once you have a distribution running on Pantheon, keep it and its downstream sites up-to-date by merging in updates to core, extensions, and themes.
 
 ## Merging Core Releases

--- a/source/docs/articles/organizations/pantheon-for-agencies/faq.md
+++ b/source/docs/articles/organizations/pantheon-for-agencies/faq.md
@@ -3,9 +3,7 @@ title: Pantheon for Agencies FAQ
 description: A collection of anticipated and commonly asked questions and answers about Partner Organizations on the Platform.
 category:
 - managing
-
 ---
-
 ## Multidev
 
 ### What is the benefit of Multidev?

--- a/source/docs/articles/organizations/running-a-custom-upstream.md
+++ b/source/docs/articles/organizations/running-a-custom-upstream.md
@@ -6,7 +6,6 @@ category:
   - managing
 
 ---
-
 An **upstream** is a specific package of your base web application. Drupal has several publicly maintained packages that can be used as an upstream for any project. WordPress does not have publicly maintained uptreams, however, privately maintained ones can be created. An example of this would be a package containing the WordPress Core, plus your company's collection of default plugins and themes.
 
 Pantheon provides support for running three types of custom distribution on the platform:

--- a/source/docs/articles/readme.md
+++ b/source/docs/articles/readme.md
@@ -3,7 +3,6 @@ title: Readme
 description: About article types for Pantheon Documentation
 draft: true
 ---
-
 Documentation articles for the Pantheon website platform will initially be written in two types: Tools, which provide general information and step-by-step procedures for using different tools, and [Guides](./readme#GuideArticles), which explain how to solve website problems by breaking goals into phases and subphases, and providing rules-of-thumb as if-then statements.
 
 ## Tool Articles

--- a/source/docs/articles/required-reading-essential-pantheon-documentation.md
+++ b/source/docs/articles/required-reading-essential-pantheon-documentation.md
@@ -4,7 +4,6 @@ description: Recommended documentation to learn about Pantheon's technologies.
 category:
   - getting-started
 ---
-
 ## Overview
 
 Pantheon is not web hosting. It is a highly-tuned, distributed, and instantly scalable web platform. Pantheon also integrates development best practices and tools into the platform, to get the developer back to writing code, not configuring servers and carrying pagers.

--- a/source/docs/articles/scope-of-support.md
+++ b/source/docs/articles/scope-of-support.md
@@ -4,7 +4,6 @@ description: Understand how Pantheon's support team can help you.
 category:
   - getting-started
 ---
-
 We love helping developers succeed! We also have limits to the support we can provide. The key to a great relationship is clear expectations of our support scope.
 
 - We don't touch client code.

--- a/source/docs/articles/sites/apache-solr.md
+++ b/source/docs/articles/sites/apache-solr.md
@@ -4,12 +4,8 @@ description: Using Apache Solr on the Pantheon platform.
 category:
     - drupal
     - developing
-
 ---
-
 Apache Solr is a system for indexing and searching site content. Pantheon provides Apache Solr v3.5 as a service for most plans including the free sandbox. No permission or action is required from Pantheon to use Solr.  
-
-
 
 One of the modules already included in every Pantheon Drupal site is [pantheon\_apachesolr](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr). This module **must** be enabled and configured in each environment (dev, test, and live, and each multi-dev) in order to use Pantheon's Apache Solr service. pantheon\_apachesolr is not required if you are using a third-party Solr service.
 

--- a/source/docs/articles/sites/backups/cloning-an-existing-site-from-a-dashboard-backup.md
+++ b/source/docs/articles/sites/backups/cloning-an-existing-site-from-a-dashboard-backup.md
@@ -4,7 +4,6 @@ description: Make a copy of your existing code, files, and database.
 category:
   - developing
 ---
-
 ## Clone an Existing Site from a Dashboard Backup
 
 All Pantheon sites consist of three parts:

--- a/source/docs/articles/sites/backups/restoring-an-environment-from-a-backup.md
+++ b/source/docs/articles/sites/backups/restoring-an-environment-from-a-backup.md
@@ -5,7 +5,6 @@ category:
   - managing
 
 ---
-
 Each site environment's backups can be found on the Backups subtab for the environment in the Pantheon Dashboard.  
 
 

--- a/source/docs/articles/sites/cloudflare-cdn-and-dns.md
+++ b/source/docs/articles/sites/cloudflare-cdn-and-dns.md
@@ -5,7 +5,6 @@ category:
   - developing
   - drupal
 ---
-
 ## Overview
 
 [CloudFlare](https://www.cloudflare.com) is awesome and we highly recommend them. Here's a list of benefits:

--- a/source/docs/articles/sites/code/applying-upstream-updates.md
+++ b/source/docs/articles/sites/code/applying-upstream-updates.md
@@ -5,8 +5,6 @@ category:
   - developing
   - drupal
 ---
-
-
 ## Overview
 
 **Note: Only use the one-click updates on the dashboard to update your site's core. Do not update core using Drush or WP-CLI; you will overwrite your core.**

--- a/source/docs/articles/sites/code/bots-and-indexing.md
+++ b/source/docs/articles/sites/code/bots-and-indexing.md
@@ -5,7 +5,6 @@ category:
   - developing
 
 ---
-
 ## Overview
 
 Bots are part of every public-facing website's lifecycle. We wouldn't be able to find a thing on the internet without them! Bots perform the hard work taken for granted when browsing the multitudes of indexed search results from any given search engine. In the wrong hands, bots can become nagging nuisances slowing down or even taking down your site. As a web developer or admin, knowing how to handle bots comes with the territory.

--- a/source/docs/articles/sites/code/debugging-slow-performance.md
+++ b/source/docs/articles/sites/code/debugging-slow-performance.md
@@ -6,8 +6,6 @@ category:
   - going-live
 
 ---
-
-
 ## Overview
 
 When your site is fast, everybody wins. When it’s slow, nobody's happy...so how can you fix it? In this article, we’ll discuss the most common causes for performance problems, demonstrate how to diagnose bottlenecks, and provide actionable solutions for developers.

--- a/source/docs/articles/sites/code/developing-directly-with-sftp-mode.md
+++ b/source/docs/articles/sites/code/developing-directly-with-sftp-mode.md
@@ -5,7 +5,6 @@ category:
   - developing
 
 ---
-
 ## Overview
 In some cases working via `git push` is not the best option. You may not like local development, or you may want to show work to a remote collaborator (or client) immediately, or need to debug a specific problem that only occurs on the Pantheon platform.
 

--- a/source/docs/articles/sites/code/email.md
+++ b/source/docs/articles/sites/code/email.md
@@ -3,9 +3,7 @@ title: Email on Pantheon
 description: Understand email hosting on Pantheon.
 category:
     - drupal
-
 ---
-
 ## Incoming Email
 
 Pantheon does not host inboxes for you. We recommend making use of an externally hosted email solution, such as [Gmail](http://www.google.com/intl/en/enterprise/apps/business/index.html) as an adjunct to our service.

--- a/source/docs/articles/sites/code/hot-fixes.md
+++ b/source/docs/articles/sites/code/hot-fixes.md
@@ -1,11 +1,9 @@
 ---
 title: Hot Fixes
 description: Learn how to deploy a hotfix on Pantheon.
-
 category:
   - developing
 ---
-
 Sometimes it's necessary to push a quick fix without pushing everything that's been going on in dev. This is called a "hotfix", and this article will help you do it on Pantheon.
 
 ## Requirements

--- a/source/docs/articles/sites/code/ldap-and-ldaps.md
+++ b/source/docs/articles/sites/code/ldap-and-ldaps.md
@@ -4,9 +4,7 @@ description: Configure LDAP on your Pantheon site.
 category:
   - going-live
   - developing
-
 ---
-
 ## LDAP as a Provider  
 
 This is not available on Pantheon. For sites at the Enterprise plan level that need a secure tunnel between your firewall, contact your sales representative regarding [Pantheon Enterprise Gateway](https://pantheon.io/features/secure-integration).

--- a/source/docs/articles/sites/code/more-ways-of-managing-code-in-sftp-mode.md
+++ b/source/docs/articles/sites/code/more-ways-of-managing-code-in-sftp-mode.md
@@ -3,9 +3,7 @@ title: More Ways of Managing Code in SFTP Mode
 description: Understand alternative code management options when using SFTP Mode.
 category:
   - managing
-
 ---
-
 ## Overview
 When using Pantheon's SFTP mode to develop directly on your Dev environment, you have several options in addition to using a SFTP client to manage your code. In this mode, the website has access to write to itself, meaning built-in admin tools are open to function, as are some novel command-line capabilities.
 

--- a/source/docs/articles/sites/code/php-slow-log.md
+++ b/source/docs/articles/sites/code/php-slow-log.md
@@ -1,11 +1,9 @@
 ---
 title: PHP Slow Log
 description: Learn how to use a site's PHP Slow Log to identify serious performance issues.
-
 category:
 - debugging
 ---
-
 One of the key ways to find issues on your website is to check your PHP logs. Pantheon makes available to you many different logs, but in this case, we will look at how to use your PHP Slow Log and PHP FPM Error Logs to find performance issues and PHP errors on sites hosted by Pantheon.
 
 ## Before You Begin

--- a/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
+++ b/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
@@ -3,9 +3,7 @@ title: Reading Pantheon Environment Configuration
 description: Understand the separation of configuration and code within the Pantheon framework.
 category:
   - going-live
-
 ---
-
 ## Overview
 Pantheon promotes the separation of configuration and code, especially where security is a concern. You should never copy/paste credentials from your dashboard into any of your sites code.
 

--- a/source/docs/articles/sites/code/redirect-incoming-requests.md
+++ b/source/docs/articles/sites/code/redirect-incoming-requests.md
@@ -4,9 +4,7 @@ description: Learn to redirect requests to an alternate domain name or path.
 category:
   - going-live
   - managing
-
 ---
-
 ## Overview
 Often, it's useful to redirect requests to a different domain or path. While it's technically possible to use Drupal or WordPress to perform the redirect, it's faster and more efficient to redirect without having to fully bootstrap your web application.  
 

--- a/source/docs/articles/sites/code/server_name-and-server_port.md
+++ b/source/docs/articles/sites/code/server_name-and-server_port.md
@@ -3,7 +3,6 @@ title: SERVER_NAME and SERVER_PORT on Pantheon
 description: Learn how to work around SERVER_NAME and SERVER_PORT variables in your environment configuration.
 category:
   - developing
-
 ---
 There's code out there that relies on `$_SERVER['SERVER_NAME']` and sometimes `$_SERVER['SERVER_PORT']` to construct URLs, either to "call itself" or to create URLs that are passed to third parties and expect to be routed back. This doesn't work well on Pantheon because the environmental data will be for ephemeral container data.
 

--- a/source/docs/articles/sites/code/sso-and-identity-federation.md
+++ b/source/docs/articles/sites/code/sso-and-identity-federation.md
@@ -3,9 +3,7 @@ title: SSO and Identity Federation on Pantheon
 description: Centrally manage user identities and provide seamless integration across multiple applications.
 category:
   - developing
-
 ---
-
 ## Overview
 Many organizations need to centrally manage their user's identities and provide seamless integration across multiple applications. Numerous Pantheon customers, including higher educational institutions, school districts, local governments, and other groups use a variety of Single Sign-On (SSO) solutions.  
 

--- a/source/docs/articles/sites/code/using-indexdepot-with-pantheon-sites.md
+++ b/source/docs/articles/sites/code/using-indexdepot-with-pantheon-sites.md
@@ -4,7 +4,6 @@ description: Create and configure IndexDepot and Solr.
 category:
   - developing
 ---
-
 ## Overview
 
 Apache Solr is a system for indexing and searching site content. Pantheon provides Apache Solr v3.5 as a service that works well for the majority of sites on the platform. No permission or action is required from Pantheon to use Solr.

--- a/source/docs/articles/sites/code/using-the-pantheon-workflow.md
+++ b/source/docs/articles/sites/code/using-the-pantheon-workflow.md
@@ -4,9 +4,7 @@ description: Learn the Pantheon environments and overall workflow.
 category:
   - going-live
   - developing
-
 ---
-
 ## Overview
 
 Every Pantheon site comes with three environments: Dev, Test, and Live. Separate Dev, Test, and Live environments allow you to develop and test your site without impacting the live site that's available to the world. Additional development environments are available with [Multidev](/docs/articles/sites/multidev/).

--- a/source/docs/articles/sites/code/what-is-the-pantheon_api-module.md
+++ b/source/docs/articles/sites/code/what-is-the-pantheon_api-module.md
@@ -4,11 +4,7 @@ description: Learn how to incorporate Pantheon's internal API modules.
 category:
   - getting-started
   - developing
-
-
-
 ---
-
 Pantheon supplies a few modules with all sites to provide better integration with the platform. There is a module dedicated to serving the ApacheSolr use-case, and there is the general `pantheon_api.module`.
 
 This module is extremely light-weight and efficient. It provides general methods your site needs to access aspects of the internal Pantheon API. This is necessary for clearing caches from our reverse-proxy/edge cache, as well as provisioning new Solr cores and other features.

--- a/source/docs/articles/sites/create/migrating-sites.md
+++ b/source/docs/articles/sites/create/migrating-sites.md
@@ -3,9 +3,7 @@ title: Migrating Sites from Other Hosts
 description: General instructions for preparing and importing sites to Pantheon.
 category:
 - getting-started
-
 ---
-
 ## Overview
 
 Migrating a website from another environment is a complex task. Whether it is running locally, on a shared host, or on a cluster of virtual machines at an infrastructure-as-a-service provider, The goal is the same. Move to Pantheon and enjoy the freedom to build awesome sites..
@@ -49,7 +47,7 @@ When preparing a site for export, there are a few best practices to follow:
 
 ### Create Single-file Archives
 If your site can be packaged with a total archived size less than 500MB, then you can import that single file to create your site.
-Drupal archives created with [drush archive dump](http://drushcommands.com/drush-6x/archive/archive-dump) are known to work when imported during site creation. 
+Drupal archives created with [drush archive dump](http://drushcommands.com/drush-6x/archive/archive-dump) are known to work when imported during site creation.
 <!--@TODO: Test archives created with [Backup and Migrate](https://www.drupal.org/project/backup_migrate).-->
 
 WordPress archives created with [Duplicator](https://wordpress.org/plugins/duplicator/) are known to work when imported during site creation.

--- a/source/docs/articles/sites/database/database-connection-errors.md
+++ b/source/docs/articles/sites/database/database-connection-errors.md
@@ -3,9 +3,7 @@ title: Database Connection Errors
 description: Understand the causes and solutions for database connection errors.
 category:
   - debugging
-
 ---
-
 ## Overview
 If your site suddenly reverts to `install.php`, or you see database connection errors like the following:
 

--- a/source/docs/articles/sites/database/myisam-to-innodb.md
+++ b/source/docs/articles/sites/database/myisam-to-innodb.md
@@ -3,9 +3,7 @@ title: Moving MySQL Tables From MyISAM to InnoDB
 description: Improve the reliability and performance of your database by moving to InnoDB.
 category:
   - debugging
-
 ---
-
 One of the best things to ever happen to MySQL was the [InnoDB](https://dev.mysql.com/doc/refman/5.5/en/innodb-storage-engine.html) engine. Before InnoDB, indexes would get corrupted, updates meant table locks—not just row locks, and there was no support for transactions. Since the advent of InnoDB we've come a long way. These days, most serious DBAs using MySQL build exclusively on the InnoDB engine.
 
 However, many sites are still using the MyISAM engine. Some are hosted on shared hosting servers and some just don't have a proper DBA to look after their databases. These sites are missing out on the performance and stability gains that the rest of us take for granted. At Pantheon, we know there are a lot of these sites out there because we see them when they migrate their sites onto our platform. As part of our Launch Check, we check the engine type on every table. If we find a table using the MyISAM engine, we notify the user so they can fix it.

--- a/source/docs/articles/sites/database/mysql-slow-log.md
+++ b/source/docs/articles/sites/database/mysql-slow-log.md
@@ -1,11 +1,9 @@
 ---
 title: MySQL Slow Log
 description: Learn how to use a site's MySQL Slow Log to identify serious performance issues.
-
 category:
 - debugging
 ---
-
 Analyzing the MySQL Slow Log is an important part of troubleshooting client issues before and after launch. Below are various methods for retrieving and examining them.
 
 ## Requirements

--- a/source/docs/articles/sites/debugging-sites-with-log-files.md
+++ b/source/docs/articles/sites/debugging-sites-with-log-files.md
@@ -3,9 +3,7 @@ title: Debugging Sites with Log Files
 description: Learn to debug sites using log files with Drupal.
 category:
   - developing
-
 ---
-
 ## Database Logging
 
 ### Drupal

--- a/source/docs/articles/sites/deleting-a-site.md
+++ b/source/docs/articles/sites/deleting-a-site.md
@@ -3,9 +3,7 @@ title: Deleting a Site on Pantheon
 description: Learn how to remove a site from Pantheon.
 category:
   - managing
-
 ---
-
 At some point, you may need or want to delete one of your sites on Pantheon. Deleting a site requires just a few simple steps.
 
 ### Delete Your Site

--- a/source/docs/articles/sites/domains/adding-a-domain-to-a-site-environment.md
+++ b/source/docs/articles/sites/domains/adding-a-domain-to-a-site-environment.md
@@ -5,7 +5,6 @@ category:
   - going-live
   - managing
 ---
-
 ## Overview
 In order for Pantheon to know where to send your site traffic, you need to associate your domain to the target site environment through the Pantheon dashboard.
 

--- a/source/docs/articles/sites/domains/developing-with-ssl.md
+++ b/source/docs/articles/sites/domains/developing-with-ssl.md
@@ -5,7 +5,6 @@ category:
   - developing
 
 ---
-
 Every free Pantheon development site comes ready to roll with SSL for development. Simply switch your connection method to HTTPS and your `dev-yoursite.pantheon.io` domain will work.
 
 **Note**: older sites with domain names like `dev.mysite.gotpantheon.com` (a dot rather than a dash in the prefix) can benefit from being reset to use the new style. This will prevent SSL warnings. Contact support if you have an older-style domain name and would like it to be reformatted.

--- a/source/docs/articles/sites/domains/dns-records-for-directing-your-domain-to-your-pantheon-site.md
+++ b/source/docs/articles/sites/domains/dns-records-for-directing-your-domain-to-your-pantheon-site.md
@@ -3,10 +3,7 @@ title: DNS Records for Directing Your Domain to Your Pantheon Site
 description: Learn how to adjust DNS settings for your domain in order to redirect traffic to your Pantheon site.
 category:
   - developing
-
-
 ---
-
 ## Overview
 
 The last step of launching your site on Pantheon is to update your DNS records to direct traffic to your domain to your Pantheon site. To learn more about launching your site, see [going live](/docs/articles/going-live/).

--- a/source/docs/articles/sites/domains/gandi-pantheon-pointing-your-dns.md
+++ b/source/docs/articles/sites/domains/gandi-pantheon-pointing-your-dns.md
@@ -4,11 +4,9 @@ description: Learn how to point your domain's DNS to Pantheon using Gandi.
 category:
   - going-live
   - managing
-
-
 ---
+**Note**: This guide assumes you have already registered your domain through Gandi.net.
 
- **Note**: This guide assumes you have already registered your domain through Gandi.net.
 ## Your Domains
 
 Gandi provides you with a nice, clean list of your domains. Click on the domain that you are interested in pointing to Pantheon.

--- a/source/docs/articles/sites/domains/setting-up-a-domain-with-gandi.md
+++ b/source/docs/articles/sites/domains/setting-up-a-domain-with-gandi.md
@@ -3,9 +3,7 @@ title: Setting Up a Domain with Gandi
 description: Learn how to edit a domain's Zone Record in Gandi so that it resolves to your Pantheon site.
 category:
   - going-live
-
 ---
-
 This article assumes that you have already purchased a domain from Gandi.
 
 ## Setting Up the Zone Record

--- a/source/docs/articles/sites/domains/setting-up-a-domain-with-godaddy.md
+++ b/source/docs/articles/sites/domains/setting-up-a-domain-with-godaddy.md
@@ -3,9 +3,7 @@ title: Setting up a domain with GoDaddy
 description: Learn how to point a new GoDaddy domain name to your Pantheon site.
 category:
   - going-live
-
 ---
-
 ## Choose your domain name
 When you have searched for your domain name you can go ahead and add it to your cart. It is important to note that if you purchase more than one domain that you will be required to configure the A records or CNAME for each one.  
 

--- a/source/docs/articles/sites/domains/using-pantheon-io-for-better-uptime.md
+++ b/source/docs/articles/sites/domains/using-pantheon-io-for-better-uptime.md
@@ -3,9 +3,7 @@ title: Using Pantheon.io For Better Uptime
 description: Understand the new pantheon.io system and how it improves uptime.
 category:
   - developing
-
 ---
-
 ## About pantheon.io
 
 **Note**: Pantheon is no longer offering shared static IP addresses for customer sites. Existing sites are not affected and can continue to use the legacy configuration. This information applies only to sites created after Oct 22nd, 2014.

--- a/source/docs/articles/sites/errors-and-server-responses.md
+++ b/source/docs/articles/sites/errors-and-server-responses.md
@@ -3,7 +3,6 @@ title: Errors and Server Responses
 description: Understand server responses and error messages.
 category:
   - debugging
-
 ---
 ## Pantheon Error Messages
 

--- a/source/docs/articles/sites/external-libraries.md
+++ b/source/docs/articles/sites/external-libraries.md
@@ -3,9 +3,7 @@ title: External Libraries on Pantheon
 description: Learn to incorporate external libraries for Drupal modules on the Pantheon platform.
 category:
     - developing
-
 ---
-
 ## Overview
 
 While Drupal's contributed modules offer a plethora of extended functionality, there are some scenarios when an external library is required. Pantheon has installed a number of common libraries that are available throughout the platform.

--- a/source/docs/articles/sites/fastly-domain-masking.md
+++ b/source/docs/articles/sites/fastly-domain-masking.md
@@ -5,9 +5,7 @@ category:
   - developing
   - drupal
   - wordpress
-
 ---
-
 ## Overview
 
 There are many cases in which a user needs to use two different, disparate systems on a single common domain. For example, using Drupal as a front end for marketing efforts or custom applications while using WordPress for blog content. This typically looks something like:

--- a/source/docs/articles/sites/files/filesystem-faqs.md
+++ b/source/docs/articles/sites/files/filesystem-faqs.md
@@ -3,9 +3,7 @@ title: Filesystem FAQs
 description: Understand writable errors and the Pantheon filesystem.
 category:
   - getting-started
-
 ---
-
 Question: _I am curious why the Pantheon dashboard lists my file system as: Error, Writable (public download method)?_
 
 ![](/source/docs/assets/images/desk_images/284378.png)  

--- a/source/docs/articles/sites/files/non-standard-files-locations.md
+++ b/source/docs/articles/sites/files/non-standard-files-locations.md
@@ -3,9 +3,7 @@ title: Non-Standard Files Locations
 description: Learn how to address non-standard file locations from within the Pantheon filesystem.
 category:
     - developing
-
 ---
-
 Pantheon provides one location for files that are part of your sites content, those that are managed through Drupal upload forms, e.g. user profile pictures: `/sites/default/files`. For Drupal sites, this is the _only_ location you can use for files that are uploaded as part of your application. For WordPress sites, `/wp-content/uploads` is the only acceptable location for files. All other locations will be in your codebase.
 
 If you are importing a site which has files in another location (e.g. "/files") you will need to move the files into the standard location, and add, commit and push a symlink from that location to the new location via Git:  

--- a/source/docs/articles/sites/installing-redis-on-wordpress.md
+++ b/source/docs/articles/sites/installing-redis-on-wordpress.md
@@ -3,9 +3,7 @@ title: Installing Redis on WordPress
 description: A walkthrough of how to enable WP-Redis on Pantheon
 category:
     - developing
-
 ---
-
 ## Enable Redis
 
 Enable Redis cache server from your Pantheon site dashboard by going to Settings > Add Ons > Add.

--- a/source/docs/articles/sites/known-limitations.md
+++ b/source/docs/articles/sites/known-limitations.md
@@ -2,7 +2,6 @@
 title: Known Limitations
 description: A list of Pantheon's known limitations.
 ---
-
 This page is used to keep track of common/known limitations. Most of Pantheon's limitations stem from its distributed nature. Check back, as we are keeping it up to date as we improve Pantheon to address these limitations.
 
 ## Multisite

--- a/source/docs/articles/sites/multidev.md
+++ b/source/docs/articles/sites/multidev.md
@@ -4,7 +4,6 @@ description: Learn how to create branches and cloud development environments, to
 category:
 - developing
 ---
-
 Multidev is cloud development environments for teams and allows a developer to fork the entire stack (code and content), work independently, then merge the code changes back into the master. Each forked branch will have its own separate development environment, including database and files.
 
 ## Benefits of Multidev

--- a/source/docs/articles/sites/new-site-owner.md
+++ b/source/docs/articles/sites/new-site-owner.md
@@ -3,10 +3,8 @@ title: New Site Owner FAQs
 description: Learn about common billing and administrative tasks performed by a site owner.
 category:
     - developing
-
 ---
 When you become a site owner, you receive administrator permissions to manage the billing information, team members, and site settings.
-
 
 ## Frequently Asked Questions
 

--- a/source/docs/articles/sites/newrelic/mysql-troubleshooting-with-new-relic-pro.md
+++ b/source/docs/articles/sites/newrelic/mysql-troubleshooting-with-new-relic-pro.md
@@ -3,9 +3,7 @@ title: MySQL Troubleshooting with New Relic Pro
 description: Understanding integrated reporting services for MySQL troubleshooting.
 category:
   - developing
-
 ---
-
 While going through mysql and PHP slow logs is a great way to find issues, modern reporting services that are integrated with your site help speed the process up tremendously. There are a few different systems to choose from, but at Pantheon we use New Relic. It comes integrated with the majority of our service plans. This presentation will show you how, in conjunction with more traditional system logs, to use New Relic Pro. For the sake of this article, I will be walking through a real life scenario on a Drupal installation to help illustrate the techniques. The methods here can be used with WordPress, as they transcend any given application.
 
 ## Open New Relic

--- a/source/docs/articles/sites/newrelic/new-relic-performance-analysis.md
+++ b/source/docs/articles/sites/newrelic/new-relic-performance-analysis.md
@@ -4,9 +4,7 @@ description: Learn how to utilize New Relic performance metrics and reports.
 category:
   - going-live
   - managing
-
 ---
-
 ## Overview
 New Relic offers a wide array of metrics that provide a nearly real-time look into the performance of a web application.
 

--- a/source/docs/articles/sites/php-errors-and-exceptions.md
+++ b/source/docs/articles/sites/php-errors-and-exceptions.md
@@ -4,9 +4,7 @@ description: Detailed information about basic PHP errors.
 category:
   - debugging
   - drupal
-
 ---
-
 ## Overview
 
 There are three basic kinds of PHP errors:

--- a/source/docs/articles/sites/redis-as-a-caching-backend.md
+++ b/source/docs/articles/sites/redis-as-a-caching-backend.md
@@ -3,10 +3,7 @@ title: Redis as a Caching Backend
 description: Understand how to use Redis as a caching mechanism.
 category:
     - developing
-
 ---
-
-
 ## About Redis
 
 Redis is an open-source, networked, in-memory, key-value data store that can be used as a drop-in caching backend for your Drupal or WordPress website.

--- a/source/docs/articles/sites/secure-phpinfo.md
+++ b/source/docs/articles/sites/secure-phpinfo.md
@@ -4,7 +4,6 @@ description: Important security considerations when working with phpinfo on Pant
 category:
   - developing
 ---
-
 We serve our customers by provisioning isolated linux containers with an optimized PHP stack. The php.ini is part of a highly tuned configuration and is not user-configurable.
 We continually deploy new builds of PHP and you also have the ability to [toggle PHP versions](
 https://pantheon.io/docs/articles/sites/settings/toggling-between-php-versions/). If you'd like to see

--- a/source/docs/articles/sites/security.md
+++ b/source/docs/articles/sites/security.md
@@ -4,8 +4,7 @@ description: Learn how to keep your work hidden from the public for development 
 category:
   - developing
 ---
-
-**Note**: When a dev environment is locked, a lock icon will be added to the screenshot of a site on the Your Sites page.
+**Note**: When a Dev environment is locked, a lock icon will be added to the screenshot of a site on the Your Sites page.
 
 There are occasions while you are work on your Drupal site that  you would like to keep your progress hidden from the world as you prepare to Go Live or possibly make updates.
 

--- a/source/docs/articles/sites/security/locking-your-site.md
+++ b/source/docs/articles/sites/security/locking-your-site.md
@@ -5,7 +5,6 @@ category:
   - getting-started
   - drupal
 ---
-
 ## Overview
  **Note**: When a Dev environment is locked, a lock icon will be added to the thumbnail of the site on the Your Sites page.
 

--- a/source/docs/articles/sites/settings/selecting-a-plan.md
+++ b/source/docs/articles/sites/settings/selecting-a-plan.md
@@ -3,9 +3,7 @@ title: Selecting a Plan
 description: Learn the various plans offered and understand which plan meets your unique needs.
 category:
   - getting-started
-
 ---
-
 ## Overview
 Pantheon offers multiple service levels, called [Plans](https://www.getpantheon.com/pricing). You can select the plan that works best for you and your needs. In the beginning, you can start on the Basic Plan. Then once you start to grow and have more specific requirements, you can take a look at the Pro Plan, which can be part of the recipe to get your site or application to scale and perform better.
 

--- a/source/docs/articles/sites/settings/toggling-between-php-versions.md
+++ b/source/docs/articles/sites/settings/toggling-between-php-versions.md
@@ -4,7 +4,6 @@ description: Learn how to change between various PHP versions.
 category:
   - developing
 ---
-
 ## Upgrade Your PHP Version
 
 1. In your Site Dashboard, click the **Settings** menu and select the **PHP version** tab.

--- a/source/docs/articles/sites/sftp-faqs.md
+++ b/source/docs/articles/sites/sftp-faqs.md
@@ -4,7 +4,6 @@ description: Understand common SFTP connection problems.
 category:
   - developing
 ---
-
 ## SFTP Connection Issues
 
     Status:	Connecting to appserver.dev.dc82c743-3088-426f-bfcf-e388e4add2b3.drush.in:2222...

--- a/source/docs/articles/sites/team-management.md
+++ b/source/docs/articles/sites/team-management.md
@@ -6,7 +6,6 @@ category:
   - managing
 
 ---
-
 Pantheon has powerful workflow tools that are packed with real-time features that are great for people working in teams, and getting started is easy and simple.
 
 ## Team Management

--- a/source/docs/articles/sites/timeouts.md
+++ b/source/docs/articles/sites/timeouts.md
@@ -4,7 +4,6 @@ description: Detailed information about timeout errors.
 category:
   - debugging
 ---
-
 Rules are for the good of the group, and timeouts are no exception. At Pantheon, we've configured our timeouts to fit normal program execution. Sometimes, these limits can be reached when working with a particularly inefficient bit of code. In order to set expectations, the following chart describes the various user-facing timeouts on Pantheon.
 
 <table class=table>

--- a/source/docs/articles/sites/what-is-apc-and-what-is-it-used-for.md
+++ b/source/docs/articles/sites/what-is-apc-and-what-is-it-used-for.md
@@ -3,9 +3,7 @@ title: What is APC and what is it used for?
 description: Understand Alternative PHP Cache and its uses within the Pantheon workflow.
 category:
   - getting-started
-
 ---
-
 ## Overview
 APC stands for the [Alternative PHP Cache](http://php.net/manual/en/book.apc.php "Alternative PHP Cache manual on php.net"). PHP is a dynamic language that is compiled on-demand into bytecode at execution time. To improve performance, APC stores this bytecode so that it can be reused instead of having to be recompiled each time.
 

--- a/source/docs/articles/updating-payment-methods.md
+++ b/source/docs/articles/updating-payment-methods.md
@@ -3,9 +3,7 @@ title: Updating Payment Methods
 description: Learn how to update a credit card as a payment method for your site.
 category:
   - managing
-
 ---
-
 If you would like to add a new credit card or edit the existing card a site uses, it's quick and easy to do.
 
 

--- a/source/docs/articles/users/choosing-start-state.md
+++ b/source/docs/articles/users/choosing-start-state.md
@@ -4,7 +4,6 @@ description: Available options for starting new sites and site import considerat
 category:
   - getting-started
 ---
-
 When you create a new site with Pantheon, you're asked to choose a start state. You can choose a base Drupal or Wordpress version, a Pantheon optimized distribution, or import an existing site.
 
 ## Start with Core

--- a/source/docs/articles/users/clone-a-drupal-site-using-drush.md
+++ b/source/docs/articles/users/clone-a-drupal-site-using-drush.md
@@ -6,7 +6,6 @@ category:
   - drupal
   - developing
 ---
-
 There may be times when you need to copy an existing Drupal site to an entirely new, separate environment. This is a fairly simple, manual process. This article will walk you through the basic method of doing so.
 
 ## Archive Your Live Code/Files/Database

--- a/source/docs/articles/users/deleting-your-pantheon-account.md
+++ b/source/docs/articles/users/deleting-your-pantheon-account.md
@@ -4,10 +4,9 @@ description: Learn how to completely remove your Pantheon account.
 category:
   - managing
 ---
-
 Follow the steps below to completely delete your site(s). 
 
-## 1. Backup and Export 
+## 1. Backup and Export
 
 The first thing to do is to backup and export your site(s). Yes, you are leaving the platform, but you should always have a backup of your work just in case you need it in the future.
 

--- a/source/docs/articles/users/generating-ssh-keys.md
+++ b/source/docs/articles/users/generating-ssh-keys.md
@@ -3,9 +3,7 @@ title: Generating SSH Keys
 description: Understand how to generate SSH keys to configure Drush or SFTP.
 category:
   - getting-started
-
 ---
-
 SSH as a protocol is not supported on Pantheon. <!--You can not connect via SSH using Putty.--> These directions are to allow you have passwordless access if you configure Drush or SFTP to use the keys setup by putty.
 
 **Note**: SSH keys include the user and hostname of the account/computer that it was generated on as a comment (in the form of "==user@usercomputer") at the end of the file. If you experience errors, see the troubleshooting section at the end of the document.

--- a/source/docs/articles/users/importing-a-large-site.md
+++ b/source/docs/articles/users/importing-a-large-site.md
@@ -5,7 +5,6 @@ category:
   - getting-started
   - developing
 ---
-
 ## Overview
 This article will cover the techniques required to import a large site into Pantheon outside of the Dashboard interface. Follow this procedure if:
 

--- a/source/docs/articles/users/importing-an-existing-site.md
+++ b/source/docs/articles/users/importing-an-existing-site.md
@@ -5,8 +5,6 @@ category:
   - drupal
   - getting-started
 ---
-
-
 ## Overview
 
 The easiest way to import an existing site into Pantheon is to create a new site and select **Import manually** when asked to choose a Start State.

--- a/source/docs/articles/users/importing-drush-site-archives-with-terminus.md
+++ b/source/docs/articles/users/importing-drush-site-archives-with-terminus.md
@@ -4,7 +4,6 @@ description: Import a Drush archive using the Terminus command-line interface.
 category:
   - getting-started
 ---
-
 ## Overview
 
 One of the easiest ways to move an existing Drupal site to Pantheon is to import a [Drush archive file](http://drush.ws/#archive-dump) using our [Terminus command-line interface](/docs/articles/local/terminus-the-pantheon-command-line-interface). This automates the packaging of the existing installation, improving the changes of success.

--- a/source/docs/articles/users/loading-ssh-keys.md
+++ b/source/docs/articles/users/loading-ssh-keys.md
@@ -5,7 +5,6 @@ category:
   - getting-started
 
 ---
-
 ## Overview
 To take full advantage of Pantheon, you should load your public SSH key into your account. SSH keys are a best-practice for authentication, allowing you more security than a simple password. You will only need to do this once, no matter how many sites you work on.
 

--- a/source/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites.md
+++ b/source/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites.md
@@ -5,7 +5,6 @@ category:
   - WordPress
   - Going Live
 ---
-
 CloudFlare offers free shared SSL services, providing the opportunity to improve your site's security and SEO rankings. The following instructions will walk you through how to setup the SSL certificate and secure your entire site with the HTTPS protocol.
 
 ##Get Started
@@ -48,7 +47,7 @@ Go to the Page Rules section of your CloudFlare account.
 
 ### Pushing the Changes Live
 
-The final step is to deploy your code and plugin settings to the Live environment. For details, see [Using the Pantheon Workflow](/docs/articles/sites/code/using-the-pantheon-workflow/). Plugin configuration is stored in the database, so you will need to configure the plugin again on the live environment. Using the [wp-cfm plugin](https://github.com/forumone/wp-cfm) can make this a simpler task. See [our article](/docs/articles/wordpress/wordpress-configuration-management-wp-cfm/) for more information. 
+The final step is to deploy your code and plugin settings to the Live environment. For details, see [Using the Pantheon Workflow](/docs/articles/sites/code/using-the-pantheon-workflow/). Plugin configuration is stored in the database, so you will need to configure the plugin again on the live environment. Using the [wp-cfm plugin](https://github.com/forumone/wp-cfm) can make this a simpler task. See [our article](/docs/articles/wordpress/wordpress-configuration-management-wp-cfm/) for more information.
 
 It can take up to 24 hours before the SSL certificate takes effect on your Live site; please be patient. Once it's complete, you will see a green lock next to your domain name:
 

--- a/source/docs/articles/wordpress/clone-a-wordpress-site-with-duplicator-plugin.md
+++ b/source/docs/articles/wordpress/clone-a-wordpress-site-with-duplicator-plugin.md
@@ -6,7 +6,6 @@ category:
   - getting-started
   - developing
 ---
-
 ## 1. Install [Duplicator](https://wordpress.org/plugins/duplicator/) on your Existing WordPress Site
 
 ## 2. Archive Your Site's Code/Files/Database

--- a/source/docs/articles/wordpress/cloudFront-setup-for-wordpress.md
+++ b/source/docs/articles/wordpress/cloudFront-setup-for-wordpress.md
@@ -5,9 +5,7 @@ category:
   - going-live
   - developing
   - WordPress
-
 ---
-
 ## Before You Begin
 
 Be sure that you:
@@ -111,7 +109,7 @@ From within your WordPress dashboard:
 
   ![AWS Plugin Settings User Added](/source/docs/assets/images/aws-plugin-add-user.png)
 1. Click on **AWS** and then **S3 and CloudFront** from within your WordPress Dashboard.
-1. Create a new bucket by entering a unique name, and then click **Create**. 
+1. Create a new bucket by entering a unique name, and then click **Create**.
 1. Ensure that "Copy Files to S3" and "Rewrite File URLs" are both set to "ON".
 
 There are several other options available within this plugin for you to experiment with. Take a tour of the settings to find the best configuration for your particular use case.
@@ -136,7 +134,7 @@ Now for the final step: turning on Amazon's CloudFront. These combined services 
 1. Click inside the **Origin Name** field and select your recently created S3 bucket.
 
   **Note**: This action will automatically populate the **Origin ID** field.
-  
+
 1. All other options are set to a default value. You can use the provided configuration or tweak them as you see fit.  
 1. Click on **Create Distribution**.
 

--- a/source/docs/articles/wordpress/configuring-phpstorm-on-pantheon-for-wordpress.md
+++ b/source/docs/articles/wordpress/configuring-phpstorm-on-pantheon-for-wordpress.md
@@ -4,7 +4,6 @@ description: Best practices and recommendations for building a WordPress site us
 category:
   - developing
   - WordPress
-
 ---
 ## Overview
 
@@ -28,7 +27,7 @@ If you do not already have one, [create a WordPress site](/docs/articles/wordpre
 There will not be any files open within your project once you complete these steps. You will find a PHP file in the project's root, which contains the standard plugin header for WordPress.
 
 ## Configure WP-CLI (Optional)
-Many WordPress plugin developers use the command line tool [WP-CLI](http://wp-cli.org/). This is useful if you have a local development environment and want to use WP-CLI to manage it. 
+Many WordPress plugin developers use the command line tool [WP-CLI](http://wp-cli.org/). This is useful if you have a local development environment and want to use WP-CLI to manage it.
 
 **Note**: You must successfully create a project before adding WP-CLI as a Command Line Tool.
 

--- a/source/docs/articles/wordpress/configuring-wp-config-php.md
+++ b/source/docs/articles/wordpress/configuring-wp-config-php.md
@@ -3,9 +3,7 @@ title: Configuring wp-config.php
 description: Understand how to adjust and customize the Wordpress configuration file for your Pantheon site.
 category:
   - developing
-
 ---
-
 ## Overview
 
 Wordpress configuration is set in wp-config.php, located within your Wordpress site root. When you spin up a Wordpress site, we automatically include this file for you with all the boilerplate you need to get started. Most users will not need to customize this file.

--- a/source/docs/articles/wordpress/cron-for-wordpress.md
+++ b/source/docs/articles/wordpress/cron-for-wordpress.md
@@ -4,7 +4,6 @@ description: Understand how the WordPress cron system works and how you can cont
 category:
     - WordPress
 ---
-
 ## WP-Cron Overview
 WP-Cron, one of the lesser known features of WordPress, executes specific tasks for WordPress powered sites. The name `cron` comes from the Unix system for scheduling jobs, ranging from once a minute to once a year. Whether it's routine maintenance or scheduled alerts, any command that can be executed on Unix without user intervention can be scheduled as a `cron` task.
 

--- a/source/docs/articles/wordpress/fix-broken-links-in-wordpress.md
+++ b/source/docs/articles/wordpress/fix-broken-links-in-wordpress.md
@@ -4,9 +4,7 @@ description: Learn how to update broken links so that the URL references the cor
 category:
   - debugging
   - drupal
-
 ---
-
 ## Update Links Referencing IP:Port
 Whether by accident or by virtue of "web rot", links in your content may eventually stop working. This happens when links are placed into your site's code that use an IP address instead of your actual domain name. These links will eventually break when your application container’s IP address changes due to the nature of Pantheon’s cloud-based infrastructure.
 

--- a/source/docs/articles/wordpress/importing-a-wordpress-site.md
+++ b/source/docs/articles/wordpress/importing-a-wordpress-site.md
@@ -5,7 +5,6 @@ category:
   - wordpress
   - getting-started
 ---
-
 ## Overview  
  **Note:** Most WordPress sites with session-using code are relying on PHP's default session manager, which uses temporary files on local disk. Pantheon does not support this because it will not work properly in our distributed environment. You can read more [here](/docs/articles/wordpress/wordpress-and-php-sessions#wordpress-and-php-sessions).
 

--- a/source/docs/articles/wordpress/launch-check-wordpress-performance-and-configuration-analysis.md
+++ b/source/docs/articles/wordpress/launch-check-wordpress-performance-and-configuration-analysis.md
@@ -3,9 +3,7 @@ title: Launch Check - WordPress Performance and Configuration Analysis
 description: Learn more about the checks we automatically run on your site.
 category:
   - WordPress
-
 ---
-
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports can be found in the Site Dashboard under the **Status tab**, and are accessible by site team members.
 
 ## Overview

--- a/source/docs/articles/wordpress/starting-wordpress-site.md
+++ b/source/docs/articles/wordpress/starting-wordpress-site.md
@@ -5,7 +5,6 @@ category:
   - going-live
   - WordPress
 ---
-
 ## Create and Name Your Site
 
 After you have created an account, log into your Dashboard and click **Create your first site**.

--- a/source/docs/articles/wordpress/wordpress-and-php-sessions.md
+++ b/source/docs/articles/wordpress/wordpress-and-php-sessions.md
@@ -4,9 +4,7 @@ description: Understand the behaviors of WordPress and PHP sessions.
 category:
   - developing
   - WordPress
-
 ---
-
 WordPress Core [does not use sessions](http://wordpress.org/support/topic/how-does-wordpress-handle-sessions-and-session-variables?replies=7). All "user state" is managed via cookies. This is a Core design decision.
 
 However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires an [additional plugin](https://wordpress.org/plugins/wp-native-php-sessions) which we maintain.

--- a/source/docs/articles/wordpress/wordpress-configuration-management-wp-cfm.md
+++ b/source/docs/articles/wordpress/wordpress-configuration-management-wp-cfm.md
@@ -3,11 +3,8 @@ title: WordPress Configuration Management (wp-cfm) on Pantheon
 description: Learn how to install and use the WordPress Configuration Management plugin.
 category:
   - managing
-
 ---
-
 Use steps 1-3 to track and deploy configuration changes from Dev to Test and Live. 
-
 ## Install wp-cfm
 
 Keeping your dev environment in SFTP Mode, install the [wp-cfm plugin](https://wordpress.org/plugins/wp-cfm/) on your development site, and create a new directory: `wp-content/config`. Return to the site dashboard (`#dev/code`), type “Install wp-cfm for configuration management and create the `wp-content/config` directory for it to function”, and click **Commit** .   

--- a/source/docs/articles/wordpress/wordpress-faq.md
+++ b/source/docs/articles/wordpress/wordpress-faq.md
@@ -4,9 +4,7 @@ description: Questions to Frequently Asked Questions concerning WordPress on the
 category:
   - getting-started
   - WordPress
-
 ---
-
 ## Getting Started
 
 ### Does Pantheon Support WordPress?

--- a/source/docs/articles/wordpress/wordpress-known-issues.md
+++ b/source/docs/articles/wordpress/wordpress-known-issues.md
@@ -3,9 +3,7 @@ title: WordPress Known Issues
 description: Learn the recommended solutions for known issues on the Pantheon platform for Wordpress.
 category:
   - WordPress
-
 ---
-
 This page tracks known issues and the recommended solution (if any) for running WordPress on the Pantheon website platform. Most sites work fine, but there are some common gotchas we are tracking and working to address.
 
 ## Table Prefixes

--- a/source/docs/guides/collaborative-development-github-pantheon.md
+++ b/source/docs/guides/collaborative-development-github-pantheon.md
@@ -10,7 +10,6 @@ authors:
   - jessifischer
 date: 4/3/2015
 ---
-
 While Pantheon provides Git repositories for all sites on the platform, many teams need to use an external repository hosted at a provider, like Github or BitBucket, as the canonical version of the site's codebase. This guide will show you how to get up and running using a Github account as the example, although the steps should be similar for any provider.
 
 ## Git Repositories on Pantheon

--- a/source/docs/guides/create-a-wordpress-site-from-the-commandline-with-terminus-and-wp-cli.md
+++ b/source/docs/guides/create-a-wordpress-site-from-the-commandline-with-terminus-and-wp-cli.md
@@ -6,7 +6,6 @@ authors:
   - calevans
 date: 2/25/2015
 ---
-
 Many developers feel more at home at the command line than they do using a GUI. Edit a text file, issue a command, and bang—you've completed your task. There's just something about doing it all from the command line that makes it a little more exciting.
 
 Until recently, WordPress didn't have a great answer for developers who are most at home on the CLI.

--- a/source/docs/guides/rerouting-outbound-email.md
+++ b/source/docs/guides/rerouting-outbound-email.md
@@ -7,9 +7,7 @@ category:
 authors:
   - ari
 date: 2/25/2015
-
 ---
-
 If your Drupal site sends outbound email, you don't want to accidentally spam your users or customers from your Dev or Test environments. Maybe your site has a complex editorial workflow that alerts people when action is required, or maybe you’re redesigning email templates for your drip marketing campaign. Whatever your use case, you’ll want to make sure that you’re not accidentally spamming customers during debugging or quality assurance testing, and you’ll want to add the [Reroute Email](https://www.drupal.org/project/reroute_email) module to your dev toolkit.
 
 Pantheon makes it easy to pull the Live database to other environments with the push of a button. However, if you mistakenly forget to manually change a setting stored in the database—you guessed it—you could accidentally spam folks during debugging or quality assurance testing.

--- a/source/docs/guides/terminus-drupal-site-management.md
+++ b/source/docs/guides/terminus-drupal-site-management.md
@@ -4,10 +4,7 @@ description: Using Terminus, learn how to create and update new Drupal sites fro
 authors:
   - erikmathy
 date: 2/25/2015
-
 ---
-
-
 ## Create Sites Faster and More Efficiently
 The latest version of Pantheon's CLI, [Terminus](https://github.com/pantheon-systems/cli), incorporates not only Drush and WP-CLI, but also the vast majority of tasks available to you within the Pantheon Dashboard. You can create new sites, clone one environment to another, create branches, check for upstream updates, and more. By using Terminus, a site administrator can massively reduce the time spent on relatively simple tasks. In this guide, we will walk through the basics of creating a completely new Drupal site on Pantheon, installing some contrib modules, committing code, and cloning from one site environment to another&mdash;all through the Terminus CLI.
 

--- a/source/docs/guides/two-factor-authentication.md
+++ b/source/docs/guides/two-factor-authentication.md
@@ -11,9 +11,7 @@ authors:
 date: 4/13/2015
 image: https.pantheon.io/docs/assets/images/pantheon-fistbump.png
 keywords: Drupal, WordPress, security, two-factor auth, 2fa, onelogin, Pantheon
-
 ---
-
 Two-factor authentication (TFA) is a security practice that requires users of your website to provide, along with their standard username and password, an additional form of authentication to log in. The two most common methods involve authentication through an SMS message, or a one-time code generated via an application on a user’s mobile phone. More advanced methods such as using a biometric information, location through GPS, or a hardware token are also possible. For more information, see [Multi Factor Authentication in Drupal Watchdog](http://drupalwatchdog.com/volume-2/issue-2/multi-factor-authentication) and [Two Step Authentication on WordPress.org](http://codex.wordpress.org/Two_Step_Authentication).
 
 ## Benefits of Two-Factor Authentication

--- a/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
+++ b/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
@@ -6,9 +6,7 @@ category:
 authors:
   - erikmathy
 date: 2/25/2015
-
 ---
-
 Email is a necessity when running a website, whether it’s used with a simple contact form or to manage subscription based services, odds are you’re going to need it. Users may want to receive notices of content updates, have sales receipts sent to them, update their password or membership information, and more. Email is the most effective way of communicating with a site's user base, but it does no good if these messages are filtered and marked as spam.
 
 One of the most common reasons that email gets blocked is because it originates from a website hosted by a third party service, like Pantheon. In order to ensure this doesn't happen to you, we at Pantheon highly encourage using your own email server or a service provider such as SendGrid.


### PR DESCRIPTION
Too many of our articles follow the frontmatter with
```
frontmatter
  ---



  #Overview
  text
```

We should get rid of that - it's inconsistent and looks bad.