### PR TITLE
Meta fixes

### DIFF
--- a/source/_partials/footer_scripts.html
+++ b/source/_partials/footer_scripts.html
@@ -1,7 +1,7 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
   <script>window.jQuery || document.write('<script src="{{ site.url }}/assets/js/vendor/jquery-1.11.0.min.js"><\/script>')</script>  <script src="{{ site.url }}/assets/js/vendor/jquery-1.11.0.min.js"></script>
-  <script src="{{ site.url }}/assets/js/vendor/bootstrap.min.js"></script>
-  <script src="{{ site.url }}/assets/js/main.js"></script>
+  <!-- Latest compiled and minified JavaScript -->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>  <script src="{{ site.url }}/assets/js/main.js"></script>
   <script src="{{ site.url }}/assets/js/vendor/jquery-ui-1.9.1.custom.min.js"></script>
   <script src="{{ site.url }}/assets/js/src/application.js"></script>
   <script src="{{ site.url }}/assets/js/jquery.tocify.js"></script>

--- a/source/_partials/footer_scripts.html
+++ b/source/_partials/footer_scripts.html
@@ -1,5 +1,5 @@
   <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>
-  <script>window.jQuery || document.write('<script src="{{ site.url }}/assets/js/vendor/jquery-1.11.0.min.js"><\/script>')</script>  <script src="{{ site.url }}/assets/js/vendor/jquery-1.11.0.min.js"></script>
+  
   <!-- Latest compiled and minified JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/js/bootstrap.min.js"></script>  <script src="{{ site.url }}/assets/js/main.js"></script>
   <script src="{{ site.url }}/assets/js/vendor/jquery-ui-1.9.1.custom.min.js"></script>

--- a/source/_views/article.html
+++ b/source/_views/article.html
@@ -22,7 +22,7 @@
                 <a class="pull-right" href="https://github.com/pantheon-systems/documentation/edit/master/source{{ page.url }}.md" target="_blank">
                   <span class="icon-github">
                   </span>
-                  Edit on Github
+                  Edit on GitHub
                 </a>
 
                 <div>

--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -32,13 +32,18 @@ if (window.location.hostname == 'www.getpantheon.com' ||
   window.location = redirect
 }
   </script>
+<!-- Name the site for mobile search -->
+  <script type="application/ld+json">
+   {  "@context" : "http://schema.org",
+      "@type" : "WebSite",
+      "name" : "Pantheon",
+      "alternateName" : "Pantheon Website Management Platform",
+      "url" : "https://pantheon.io"
+   }
+   </script>
 
   <!--Meta Tags -->
-  {% if page.authors %}
-      {% set author_list = page.authors %}{% if author_list %}
-          {% for authorhandle in author_list %}
-              {% if site.authors[authorhandle] %}
-                  {% set author = site.authors[authorhandle] %}
+
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
   <title>{% block title %}{{ page.title|title }} | {{ site.title }}{% endblock %}</title>
@@ -46,8 +51,8 @@ if (window.location.hostname == 'www.getpantheon.com' ||
   <meta name="keywords" content="{{ page.keywords }}">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <!-- Schema.org markup for Google+ -->
-  <meta itemprop="name" content="The Name or Title Here">
-  <meta itemprop="description" content="This is the page description">
+  <meta itemprop="name" content="{{ page.title}}">
+  <meta itemprop="description" content="{{ page.description }}">
   <meta itemprop="image" content="{{ page.image }}">
 
   <!-- Twitter Card data -->
@@ -55,14 +60,21 @@ if (window.location.hostname == 'www.getpantheon.com' ||
   <meta name="twitter:site" content="@getpantheon">
   <meta name="twitter:title" content="{{ page.title}}">
   <meta name="twitter:description" content="{{ page.description }}">
+  {% if page.authors %}
+      {% set author_list = page.authors %}
+      {% if author_list %}
+          {% for authorhandle in author_list %}
+              {% if site.authors[authorhandle] %}
+                  {% set author = site.authors[authorhandle] %}
   <meta name="twitter:creator" content="@{{ author.twitter }}">
+              {% endif %}
+            {% if not loop.last %},
+            {% endif %}
+          {% endfor %}
+      {% endif %}
+  {% endif %}
   <!-- Twitter summary card with large image must be at least 280x150px -->
   <meta name="twitter:image:src" content="{{ page.image }}">
-  {% endif %}
-                  {% if not loop.last %}, {% endif %}
-              {% endfor %}
-          {% endif %}
-        {% endif %}
   <!-- Open Graph data -->
   <meta property="og:title" content="{{ page.title}}" />
   <meta property="og:type" content="article" />
@@ -76,13 +88,11 @@ if (window.location.hostname == 'www.getpantheon.com' ||
   <meta property="article:tag" content="{{ page.category }}" />
   <!--<meta property="fb:admins" content="Facebook numberic ID" />-->
 
-  <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap.min.css">
   <!-- Latest compiled and minified CSS -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap.min.css">
   <!-- Optional theme -->
-  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.1/css/bootstrap-theme.min.css">
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.4/css/bootstrap-theme.min.css">
   <!-- Latest compiled and minified JavaScript -->
-  <link rel="stylesheet" href="{{ site.url }}/assets/css/bootstrap-theme.min.css">
   <link rel="stylesheet" href="{{ site.url }}/assets/css/main.css">
   <link href="{{ site.url }}/assets/fonts/pan-docs-icons/css/pan-docs.css" rel="stylesheet">
   <link href="{{ site.url }}/assets/css/prettyPhoto.css" rel="stylesheet">

--- a/source/docs/about.md
+++ b/source/docs/about.md
@@ -5,7 +5,7 @@ title: Welcome to our Docs
 ---
 ## We Have a New Docs Site!
 
-Welcome to our new documentation site! You may have arrived here from a link to our old helpdesk.getpantheon.com site, which we didn't know about! Please proceed to our new docs page at [https://pantheon.io/docs](https://pantheon.io/docs) to search for the page you were looking for. Have an issue with the site? Let us know with a support ticket for now. We'll open the repository for issues and pull requests. 
+Welcome to our new documentation site! You may have arrived here from a link to our old helpdesk.getpantheon.com site, which we didn't know about! Please proceed to our new docs page at [https://pantheon.io/docs](https://pantheon.io/docs) to search for the page you were looking for. Have an issue with the site? Let us know with a support ticket for now. We'll open the repository for issues and pull requests.
 
 ## Built with Sculpin
 
@@ -13,4 +13,4 @@ This site is a static site, built with [Sculpin](https://sculpin.io/).
 
 ## Roadmap
 
-We have big plans for our docs. Let us know what you think we can do to make them better  by contributing to the issue queue.
+Let us know what you think we can do to make them better by contributing to the [issue queue](https://github.com/pantheon-systems/documentation/issues).

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -90,8 +90,6 @@ h4 {
 }
 
 body {
-  margin-top: 10px;
-  margin-left: 10px;
   font-family: 'Open Sans', Helvetica, sans-serif;
   font-size: 16px;
   line-height: 1.65em;
@@ -319,7 +317,7 @@ img.noborder {border:none;}
   background-color: #444;
 }
 .pio-docs-nav .navbar-toggle .icon-bar {
-  background-color: #563d7c;
+  background-color: #FFFFFF;
 }
 .pio-docs-nav .navbar-header .navbar-toggle {
   border-color: #fff;


### PR DESCRIPTION
I broke the `<head` with the twitter card meta logic. This PR closes #472, #428, #429, #471, #473, a minor performance issue, and Adds a link to this issue queue at `docs/about`. 