### PR TITLE
Remove {} from ln 65 68 importing large site doc

### DIFF
--- a/source/docs/articles/sites/create/importing-a-large-site.md
+++ b/source/docs/articles/sites/create/importing-a-large-site.md
@@ -62,11 +62,11 @@ As long as you've chosen the same codebase (Drupal 7, Commerce Kickstarter, etc.
 
   ![](/source/docs/assets/images/pantheon-dashboard-git-connection-info.png)
 
-8. From your terminal within the site directory, use the Git remote add command with an alias to make sure you know when you are moving code to or from Pantheon. Replace the {pantheon-site-git-repo-information} with the Git information from the previous step.  
+8. From your terminal within the site directory, use the Git remote add command with an alias to make sure you know when you are moving code to or from Pantheon. Replace the pantheon-site-git-repo-information with the Git information from the previous step.  
   **From:**
-  ```
-  git remote add pantheon {pantheon-site-git-repo-information}
-  ```
+ ```
+ git remote add pantheon pantheon-site-git-repo-information
+ ```
 
   **To:**
   ```


### PR DESCRIPTION
PR fixes blank doc. `/docs/articles/sites/create/importing-a-large-site/`