### PR TITLE
Update Known Limitations with SASS/Compass

### DIFF
--- a/source/docs/articles/sites/known-limitations.md
+++ b/source/docs/articles/sites/known-limitations.md
@@ -77,7 +77,7 @@ Large backups take longer, use more resources, and have a higher likelihood of f
 
 ## LESS (css)
 
-Pantheon does not currently support Less. Less will need to be compiled to make traditional CSS stylesheets before being pushed to the platform.
+Pantheon does not currently support LESS or Sass/Compass CSS preprocessor languages. LESS and Sass will need to be pre-compiled to make traditional CSS stylesheets before being pushed to the platform.
 
 ## Background Process
 

--- a/source/docs/articles/sites/known-limitations.md
+++ b/source/docs/articles/sites/known-limitations.md
@@ -75,7 +75,7 @@ Sites that consume services using CORS, such as Amazon S3 CORS, do work on Panth
 
 Large backups take longer, use more resources, and have a higher likelihood of failing.  Additionally, a 100GB tarball is in itself not particularly convenient for anyone.  For this reason, scheduled backups do not backup files for sites with footprints over 200GB (although code and database are backed-up as normal).  Despite the lack of backups, file content is highly durable and stored on multiple servers.
 
-## LESS (css)
+## CSS Preprocessors
 
 Pantheon does not currently support LESS or Sass/Compass CSS preprocessor languages. LESS and Sass will need to be pre-compiled to make traditional CSS stylesheets before being pushed to the platform.
 


### PR DESCRIPTION
Along with LESS, Sass/Compass is not currently compatible with the platform and these resources will need to be pre-compiled on a local development server before being pushed to the site code repository. #453