### PR TITLE
Remove alert styling for definition lists - multiple docs

### DIFF
--- a/source/docs/articles/drupal/caching-in-drupal-modules.md
+++ b/source/docs/articles/drupal/caching-in-drupal-modules.md
@@ -11,7 +11,6 @@ While configuring [Drupal's performance and caching settings](/docs/articles/dru
 ## Views
 
 Views has a very granular caching system, down to the individual View display. There's no single control that will just turn on views caching, and the caching is off by default. There are three different kinds of user-configurable caching within Views:
-<div class="alert alert-info" role="alert">
 
 <dl>
 	<dt>Query Results Caching</dt>
@@ -21,7 +20,6 @@ Views has a very granular caching system, down to the individual View display. T
 	<dt>Block Caching</dt>
 	<dd>If you're generating a block, this will expose the block to Drupal's built-in block caching.</dd>
 </dl>
-</div>
 ### Configure Views Caching
 
 1. Go to /admin/structure/views/

--- a/source/docs/articles/sites/apache-solr.md
+++ b/source/docs/articles/sites/apache-solr.md
@@ -123,7 +123,6 @@ Some customers have reported success using external Solr service providers such 
 
 ## Apache Solr Vocabulary
 
-<div class="alert alert-info" role="alert">
 <dl>
 	<dt>bias</dt>
 	<dd>Allows certain parts of indexed items to influence the importance of search results. The higher the bias, the greater the influence; the range is 0.1 to 21.0.</dd>
@@ -141,7 +140,7 @@ Some customers have reported success using external Solr service providers such 
 	<dt>schema.xml</dt>
 	<dd>Contains details about the fields that documents can contain, and how those fields are handled when adding documents to the index or querying those fields. Must be posted using the pantheon_apachesolr module before indexing and searching will work. For more information, see <a href="http://wiki.apache.org/solr/SchemaXml">http://wiki.apache.org/solr/SchemaXml</a>.
 </dd>
-</dl></div>
+</dl>
 
 ## Additional Help
 

--- a/source/docs/articles/sites/code.md
+++ b/source/docs/articles/sites/code.md
@@ -8,14 +8,12 @@ The Code tool within the Pantheon Dashboard on any environment allows you to int
 You can set the site's [connection mode](/docs/articles/getting-started/#interact-with-your-code) and access [connection information](/docs/articles/sites/code/developing-directly-with-sftp-mode/#sftp-connection-information) from within the Dev environment's Code tool. This is also where all changes to the site's codebase (located in the `/code` directory) are committed.
 ![Code Workflow Dev SFTP Commit](/source/docs/assets/images/interface-dev-code-sftp-commit.png)
 The Dev environment also provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for your site's codebase upstream. Updates will appear in the Code tool when they are committed to the upstream repository.
-<div class="alert alert-info">
   <dl>
     <dt>Upstream</dt>
       <dd>A code repository that serves as a common package for your web application.</dd>
     <dt>Repository</dt>
       <dd>Centralized location of code intended for distribution.</dd>
   </dl>
-</div>
 
 <div class="alert alert-warning" role="alert">
 <strong>Note</strong>: The Test and Live environments do not have write access to code outside of the deployment process.</div>

--- a/source/docs/articles/sites/database/myisam-to-innodb.md
+++ b/source/docs/articles/sites/database/myisam-to-innodb.md
@@ -43,7 +43,6 @@ Here is the command line script:
 <script src="https://gist.github.com/calevans/9943627.js"></script>
 
 Here are the parameters you will need to configure before running the script:
-<div class="alert alert-info" role="alert">
 <dl>
 	<dt>host</dt>
 	<dd>This is the name of the machine your db is running on. If you are a Pantheon customer localhost is wrong. Get the correct host and paste it in there to replace localhost.</dd>
@@ -55,7 +54,7 @@ Here are the parameters you will need to configure before running the script:
   <dd>This is your MySQL password for the user you specified in the line above.</dd>
   <dt>database</dt>
   <dd>This is the name of the database that contains the tables. If you are a pantheon customer, this is "pantheon". If you are not a Pantheon customer, you will need to get this from your host.</dd>
-</dl></div>
+</dl>
 
 Now, save the file. Then from a command window execute the program.
 

--- a/source/docs/articles/sites/domains/dns-records-for-directing-your-domain-to-your-pantheon-site.md
+++ b/source/docs/articles/sites/domains/dns-records-for-directing-your-domain-to-your-pantheon-site.md
@@ -47,7 +47,6 @@ Your Site Dashboard recommends the specific DNS settings you should use. These c
 If you are using HTTPS for security and using an identity certificate, you **must** use your custom load-balanced IP address as an A record. See [adding a SSL certificate for secure HTTPS communication](/docs/articles/sites/domains/adding-a-ssl-certificate-for-secure-https-communication/) for details.
 
 ## DNS Vocabulary Terms
-<div class="alert alert-info" role="alert">
 <dl>
 	<dt><a href="http://en.wikipedia.org/wiki/Domain_Name_System">DNS</a></dt>
 	<dd>The Domain Name System (DNS) translates human readable domain names to numerical IP addresses</dd>
@@ -67,7 +66,7 @@ If you are using HTTPS for security and using an identity certificate, you **mus
 	<dd>Core routing Internet protocol intended to replace IPv4, supports more addresses</dd>
 	<dt><a href="http://en.wikipedia.org/wiki/Time_to_live#DNS_records">TTL</a></dt>
 	<dd>Length of time for requests to a DNS server to be cached; measured in seconds</dd>
-</dl></div>
+</dl>
 
 ## Frequently Asked Questions
 

--- a/source/docs/articles/sites/multidev.md
+++ b/source/docs/articles/sites/multidev.md
@@ -22,7 +22,6 @@ Branching is a standard mechanism for duplicating source code under revision con
 
 There are a number of terms used throughout the Multidev workflow:
 
-<div class="alert alert-info" role="alert">
 <dl>
 <dt>commit</dt>
 <dd>Record snapshot to history.</dd>
@@ -37,7 +36,7 @@ There are a number of terms used throughout the Multidev workflow:
 <dt>merge</dt>
 <dd>Combine contents of a&nbsp;branch into another, like a bug fix branch into master.</dd>
 <dt>master</dt>
-<dd>Name of default branch; deployed to Pantheon Dev, Test and Live environments.</dd></dl></div>
+<dd>Name of default branch; deployed to Pantheon Dev, Test and Live environments.</dd></dl>
 
 ## Getting Started
 


### PR DESCRIPTION
- This PR closes issue #549 and removes alert styling for all definition lists throughout the docs. 

@nataliejeremy can you review and merge if everything looks good? 