### PR TITLE
Remove tool from title/descriptions for landing pages

### DIFF
--- a/source/docs/articles/sites/backups.md
+++ b/source/docs/articles/sites/backups.md
@@ -1,9 +1,9 @@
 ---
-title: Backups Tool
-description: Learn about the Backups tool.
+title: Backups on Pantheon
+description: Learn to create and manage your site's backups.
 category:
   - developing
-keywords: backups, backing up,
+keywords: backups, backing up, archive, archives, create backup
 ---
 The Backups tab is where you manage all the details for your site's backup. A backup is made up of three separate archives: a database backup, a files backup, and a code backup. Backups are stored with Amazon's multi-datacenter Simple Storage Solution service.
 

--- a/source/docs/articles/sites/code.md
+++ b/source/docs/articles/sites/code.md
@@ -1,5 +1,5 @@
 ---
-title: Pantheon Dashboard Code Tool
+title: Code in the Pantheon Dashboard
 description: Learn how to work with your site's code on Pantheon.
 keywords: code, commit, sftp, development, how to connect, connection information, wp-admin, admin, administrator, codebase, repository, upstream
 ---

--- a/source/docs/articles/sites/database.md
+++ b/source/docs/articles/sites/database.md
@@ -1,5 +1,5 @@
 ---
-title: Database Workflow Tool
+title: Database Workflow on Pantheon
 description: Learn about the database that runs in your site.
 keywords: mysql, sql, database, db, databases
 ---

--- a/source/docs/articles/sites/domains.md
+++ b/source/docs/articles/sites/domains.md
@@ -1,5 +1,5 @@
 ---
-title: Domains and SSL Tool
+title: Domains and SSL on Pantheon
 description: Learn about the Domains tool
 category:
   - developing
@@ -98,4 +98,3 @@ For sites launched with Pantheon.io base domains, redirecting root domains using
 
 * [Redirect to a Common Domain](/docs/articles/sites/code/redirect-incoming-requests/#redirect-to-a-common-domain)
 * [Redirecting to HTTPS](/docs/articles/sites/code/redirect-incoming-requests/#redirecting-to-https)
-

--- a/source/docs/articles/sites/security.md
+++ b/source/docs/articles/sites/security.md
@@ -1,5 +1,5 @@
 ---
-title: The Security Tool
+title: Security on the Pantheon Dashboard
 description: Learn how to keep your work hidden from the public for development or updates.
 category:
   - developing


### PR DESCRIPTION
This PR closes issue #552 and removes the word "tool" from landing page titles and descriptions. 
@nataliejeremy can you review and merge? 