### PR TITLE
Disable the posts content type

### DIFF
--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -3,6 +3,9 @@ sculpin_theme:
     theme: sculpin/bootstrap-3-blog-theme
 sculpin_content_types:
 
+    posts:
+        enabled: false
+
     articles:
         type: path
         path: docs/articles


### PR DESCRIPTION
When running the `sculpin generate` command to generate the site, the following message is displayed.

> Didnt find at least one of this type : posts

This is because the core "Post" content type is being used. This PR disables the content type so that Sculpin doesn't look for it whilst generating, so doesn't show the error.