### PR TITLE
Replace #site/#env with <site> <env> in user modification alerts

### DIFF
--- a/source/docs/articles/drupal/cron.md
+++ b/source/docs/articles/drupal/cron.md
@@ -31,10 +31,11 @@ Clicking **Run cron** will run all scheduled tasks.
 ![Click Run Cron](/source/docs/assets/images/desk_images/73176.png)
 Alternatively, all scheduled cron tasks can be run with the following [Terminus](https://github.com/pantheon-systems/cli) command:
 
-    terminus drush --site=#site --env=#env cron
+    terminus drush --site=<site> --env=<env> cron
 
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+
 To ensure that Cron tasks are being run, you can check the reports via the Drupal Admin interface at Reports > Recent Log Messages. 
 ![Reports--->Recent Log Messages](/source/docs/assets/images/desk_images/74068.png)
 If Cron has been recently run, entries will appear in the log. The two entries featured in the screenshot below are evidence that Cron has run and a Cron task called "cron\_example" has run.
@@ -79,7 +80,7 @@ You can check the log messages through the Drupal Admin interface, as mentioned 
 
 You can also use [Terminus](https://github.com/pantheon-systems/cli) to see when cron was last run with the following command:
 
-    terminus drush --site=#site --env=#env wd-show --type='cron'
+    terminus drush --site=<site> --env=<env> wd-show --type='cron'
 
 ### Can I Prevent Drupal Cron From Running?
 

--- a/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
+++ b/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
@@ -45,13 +45,13 @@ The Dashboard integration is intended to provide developers with the most action
 
 You can get a list of all available site audit reports using [Terminus](https://github.com/pantheon-systems/cli):
 
-    terminus drush help --site=#site --env=#env --filter=site_audit
+    terminus drush help --site=<site> --env=<env> --filter=site_audit
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 
 You can also execute a full report in HTML format.
 
-    terminus drush aa --site=#site --env=#env --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
+    terminus drush aa --site=<site> --env=<env> --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
 
 #### Are there plans for supporting Drupal 6 sites?
 
@@ -73,7 +73,7 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](https://github.com/pantheon-systems/cli) command to execute Site Audit directly on your Pantheon site:
 
-    terminus drush --site=#site --env=#env -vd @pantheon.SITENAME.ENV aa --skip=insights --detail --vendor=pantheon --strict=0
+    terminus drush --site=<site> --env=<env> -vd @pantheon.SITENAME.ENV aa --skip=insights --detail --vendor=pantheon --strict=0
 
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 

--- a/source/docs/articles/local.md
+++ b/source/docs/articles/local.md
@@ -22,11 +22,11 @@ To begin, you'll need:
 To save time, clear the target site environment's cache. This can be done from the Pantheon dashboard, from the application itself, or by running the following Terminus command:
 
 ```
-terminus site clear-caches --site=#site --env=#env
+terminus site clear-caches --site=<site> --env=<env>
 ```
 
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 
 There are three parts to any dynamic website:
 
@@ -62,8 +62,8 @@ $ gunzip < database.sql.gz | mysql -uUSER -pPASSWORD DATABASENAME
 You can also export the database running the following Terminus commands:
 
 ```
-terminus site backup create --element=database --site=#site --env=#env
-terminus site backup get --element=database --site=#site --env=#env --to-directory=$HOME/Desktop/ --latest
+terminus site backup create --element=database --site=<site> --env=<env>
+terminus site backup get --element=database --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
 ```
 
 This will create and download the database to your Desktop. Once you have exported it to a local file, you can import it into your local MySQL database using the following command:
@@ -79,8 +79,8 @@ For an overview of ways to transfer files, see [SFTP and rsync on Pantheon](/doc
 
 Run the following Terminus commands:
 ```
-terminus site backup create --element=files --site=#site --env=#env
-terminus site backup get --element=files --site=#site --env=#env --to-directory=$HOME/Desktop/ --latest
+terminus site backup create --element=files --site=<site> --env=<env>
+terminus site backup get --element=files --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
 ```
 This will create and download a backup of the site's files to your Desktop.
 

--- a/source/docs/articles/organizations/adding-a-custom-upstream.md
+++ b/source/docs/articles/organizations/adding-a-custom-upstream.md
@@ -86,10 +86,10 @@ git push origin master
 
 Use the standard install process to make sure your distribution spins up cleanly on Pantheon. Testers might find it helpful to use the wipe functionality as part of the workflow tools to easily run through the install process multiple times.
 ```
-terminus site wipe --site=#site --env=#env
+terminus site wipe --site=<site> --env=<env>
 ```
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 #### Acceptance Tests
 
 Run your automated acceptance tests, using behat, casper.js, or by manually executing user stories.

--- a/source/docs/articles/sites/apache-solr.md
+++ b/source/docs/articles/sites/apache-solr.md
@@ -177,16 +177,16 @@ Keep in mind that newly indexed items have a 2-minute delay until cron has been 
 ####apachesolr.module
 If you're using the Apache Solr module, you can check for the existence of this variable using [Terminus](https://github.com/pantheon-systems/cl):
 
-    terminus drush --site=#site --env=#env vget apachesolr_service_class
+    terminus drush --site=<site> --env=<env> vget apachesolr_service_class
 
 ####search_api_solr.module
 If you are using search_api_solr.module you can check it with the command:
 
-    terminus drush --site=#site --env=#env vget search_api_solr_connection_class
+    terminus drush --site=<site> --env=<env> vget search_api_solr_connection_class
 
 
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 
 ### Error During Search API Solr Installation
 

--- a/source/docs/articles/sites/code/ldap-and-ldaps.md
+++ b/source/docs/articles/sites/code/ldap-and-ldaps.md
@@ -76,11 +76,10 @@ The majority of problems with LDAP on Pantheon come from misconfigurations. Pant
 
 The following script has been used to troubleshoot a variety of configuration problems. Customize it with your settings, then place it in your site root with a name like ldap-test.php. You can execute it remotely using [Terminus](https://github.com/pantheon-systems/cli) to fully bootstrap Drupal and include the environmental configurations from your settings.php:
 
-    terminus drush --site=#site --env=#env scr ldap-test.php
+    terminus drush --site=<site> --env=<env> scr ldap-test.php
 
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
-
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 The entire script:
 
 ````

--- a/source/docs/articles/sites/debugging-sites-with-log-files.md
+++ b/source/docs/articles/sites/debugging-sites-with-log-files.md
@@ -15,15 +15,15 @@ Drupal, by default, logs events using the Database Logging module (dblog). Somet
 2. Using [Terminus](https://github.com/pantheon-systems/cli):  
 
 ```
-terminus drush --site=#site --env=#env watchdog-show
+terminus drush --site=<site> --env=<env> watchdog-show
 ```
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 
 Terminus can invoke Drush commands to "watch" events in real-time; tail can be used to continuously show new watchdog messages until interrupted (Control+C).  
 
 ```
-terminus drush --site=#site --env=#env watchdog-show --tail
+terminus drush --site=<site> --env=<env> watchdog-show --tail
 ```
 
 ### WordPress

--- a/source/docs/articles/sites/resetting-passwords.md
+++ b/source/docs/articles/sites/resetting-passwords.md
@@ -21,11 +21,11 @@ Please keep in mind that your site password is stored in a database, so whatever
 If you still can’t get access to your site using password reset, for example if you don't have access to the corresponding email address for the account, you can still generate a one-time password reset link by using the following [Terminus](https://github.com/pantheon-systems/cli) command for generating one-time login links:
 
 ```
-$ terminus drush --site=#site --env=#env user-login
+$ terminus drush --site=<site> --env=<env> user-login
 ```
 
 <div class="alert alert-info" role="alert">
-<strong>Note</strong>: Replace <code>#site</code> with your site name, and <code>#env</code> with the environment (dev, test, or live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+<strong>Note</strong>: Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
 
 ## WordPress User Login
 If your site is powered by WordPress you have two options. The first is to request a password reset from the log in form and the second is to update via the [Terminus CLI](https://github.com/pantheon-systems/cli).


### PR DESCRIPTION
This PR closes issue #534 and creates a standard for user modifications in alerts. 
![screen shot 2015-05-28 at 3 03 53 pm](https://cloud.githubusercontent.com/assets/10119525/7869888/28bccd5c-054b-11e5-96de-6c705fe5c471.png)
@nataliejeremy can you review and merge? 
