### PR TITLE
SendGrid guide revision to include SMTP

### DIFF
--- a/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
+++ b/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
@@ -37,7 +37,7 @@ The official [SendGrid Plugin](https://wordpress.org/plugins/sendgrid-email-deli
 Install and activate the latest release through the WordPress dashboard or place it in the `code/wp-content/plugins` directory and activate via the dashboard.
 
 ### Add Your SendGrid Account Details
-Once you have installed and activated the plugin, click on the SendGrid menu item in the Settings tab on the site’s dashboard. You will be able to select between sending mail via the SendGrid Web API or via SMTP. Either will work on Pantheon, but using SMTP requires the installation of [Swift Mailer](https://wordpress.org/plugins/swift-mailer/).
+Once you have installed and activated the plugin, click on the SendGrid menu item in the Settings tab on the site’s Dashboard. You will be able to select between sending mail via the SendGrid Web API or SMTP. Either will work on Pantheon, but using SMTP requires the installation of [Swift Mailer](https://wordpress.org/plugins/swift-mailer/).
 
 Simply enter your site's SendGrid account credentials and select the desired the protocol for sending mail. Next, enter the sending email address and provide a reply email address if you prefer replies to go to another address (optional).  SendGrid supports categories so you can track email analytics and organize message types. Include any categories you would like to use, separated by commas.
 

--- a/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
+++ b/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
@@ -37,9 +37,10 @@ The official [SendGrid Plugin](https://wordpress.org/plugins/sendgrid-email-deli
 Install and activate the latest release through the WordPress dashboard or place it in the `code/wp-content/plugins` directory and activate via the dashboard.
 
 ### Add Your SendGrid Account Details
-Once you have installed and activated the plugin, click on the SendGrid menu item in the Settings tab on the site’s dashboard. Simply enter your site's SendGrid account credentials and select API as the protocol for sending mail. Next, enter the sending email address and provide a reply email address if you prefer replies to go to another address (optional).  SendGrid supports categories so you can track email analytics and organize message types. Include any categories you would like to use, separated by commas.
+Once you have installed and activated the plugin, click on the SendGrid menu item in the Settings tab on the site’s dashboard. You will be able to select between sending mail via the SendGrid Web API or via SMTP. Either will work on Pantheon, but using SMTP requires the installation of [Swift Mailer](https://wordpress.org/plugins/swift-mailer/).
 
-**Note**: At this time, choosing SMTP for the "Send mail with" option will not work on Pantheon, because the code uses PHP short tags. See [Known Limitations](/docs/articles/sites/known-limitations/#php-short-tags) for more information. Currently, the API protocol is the only one that will work with SendGrid on Pantheon.
+Simply enter your site's SendGrid account credentials and select the desired the protocol for sending mail. Next, enter the sending email address and provide a reply email address if you prefer replies to go to another address (optional).  SendGrid supports categories so you can track email analytics and organize message types. Include any categories you would like to use, separated by commas.
+
 
 ![WP Settings example](/source/docs/assets/images/sendgrid_wpconfig.png)​
 


### PR DESCRIPTION
This PR closes issue #547 

Previously, [SMTP with SendGrid was not supported because the required plugin Swift Mailer utilized php short tags](https://wordpress.org/support/topic/php-short-tags-to-full-tags?replies=4#post-6993742). The plugin was recently updated and no longer uses php short tags.

- [x] Test SMTP
- [x] Update guide w/ SMTP instructions

This does not affect the Drupal instructions.

@nataliejeremy can you review and merge? 