### PR TITLE
Highlight CloudFlare HTTPS limitations

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -84,3 +84,13 @@ authors:
       twitter: KateKligman
       linkedin: http://www.linkedin.com/in/katekligman
       bio: Open source contributor, indie game developer, retro gamer.
+  iameap:
+      name: Eric Peterson
+      url: https://www.eric.pe/terson
+      avatar: https://s.gravatar.com/avatar/0cd9fdc3a5e346d8fd7b74c527a93346?s=300
+      twitter: iamEAP
+      gplus: https://plus.google.com/+iamEAP
+      github: https://github.com/iamEAP
+      linkedin: https://www.linkedin.com/in/iamEAP
+      drupal: https://www.drupal.org/u/iamEAP
+      bio: Marketing engineering

--- a/source/docs/guides/ssl-with-cloudflare.md
+++ b/source/docs/guides/ssl-with-cloudflare.md
@@ -160,14 +160,14 @@ There are a few things worth noting in the above example:
 
 Depending on whether you like to control these things directly with code or prefer to use a tool like CloudFlare, as well as how concerned you are with `pantheon.io` domains potentially "leaking", you can choose your implementation. It's probably wisest to pick one route to avoid future confusion.
 
-## Compatibility and limitiations
+## Compatibility and Limitiations
 
 CloudFlare's free HTTPS service is compatible with browsers and clients that support server name indication (SNI), an extension of the TLS protocol. Whereas traditionally, a single IP address is bound to a single certificate, SNI allows a server to present multiple certificates across multiple domains from the same IP address.
 
 Although SNI allows services like CloudFlare to economically offer HTTPS for free at scale, its support is not universal. Below are some notable incompatibilities:
 
 * Any version of Internet Explorer or Safari on Windows XP
-* Versions Chrome prior to 6
+* Versions of Chrome prior to 6
 * Versions of Firefox prior to 2.0
 * Versions of iOS 3 and older
 * Versions of Android 2.x and older

--- a/source/docs/guides/ssl-with-cloudflare.md
+++ b/source/docs/guides/ssl-with-cloudflare.md
@@ -6,6 +6,7 @@ category:
   - security
 authors:
   - joshkoenig
+  - iameap
 date: 6/1/2015
 ---
 

--- a/source/docs/guides/ssl-with-cloudflare.md
+++ b/source/docs/guides/ssl-with-cloudflare.md
@@ -160,6 +160,21 @@ There are a few things worth noting in the above example:
 
 Depending on whether you like to control these things directly with code or prefer to use a tool like CloudFlare, as well as how concerned you are with `pantheon.io` domains potentially "leaking", you can choose your implementation. It's probably wisest to pick one route to avoid future confusion.
 
+## Compatibility and limitiations
+
+CloudFlare's free HTTPS service is compatible with browsers and clients that support server name indication (SNI), an extension of the TLS protocol. Whereas traditionally, a single IP address is bound to a single certificate, SNI allows a server to present multiple certificates across multiple domains from the same IP address.
+
+Although SNI allows services like CloudFlare to economically offer HTTPS for free at scale, its support is not universal. Below are some notable incompatibilities:
+
+* Any version of Internet Explorer or Safari on Windows XP
+* Versions Chrome prior to 6
+* Versions of Firefox prior to 2.0
+* Versions of iOS 3 and older
+* Versions of Android 2.x and older
+* New Relic's [availability monitoring service](https://docs.newrelic.com/docs/alerts/alert-policies/downtime-alerts/availability-monitoring#limits)
+
+Or check this [more complete compatibility list](http://en.wikipedia.org/wiki/Server_Name_Indication#Implementation).
+
 ## Alternative Methods For HTTPS
 
 Because of the structure of our network, we won't be able to offer reduced-cost HTTPS service any time soon, so for Personal sites this is the best way to get HTTPS service. However, for developers who want to run their site securely but don't want to (or can't) make use of CloudFlare, there are options.


### PR DESCRIPTION
Biggest bummer for me when I set this up a similar way was that New Relic's availability monitor no longer worked.  Would be good to highlight that.

Also, the legacy IE thing.