### PR TITLE
Fix frontmatter of 2 docs

### DIFF
--- a/source/docs/articles/sites/security.md
+++ b/source/docs/articles/sites/security.md
@@ -1,5 +1,4 @@
 ---
-<<<<<<< HEAD
 title: Security on the Pantheon Dashboard
 description: Learn how to keep your work hidden from the public for development or updates.
 category:

--- a/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
+++ b/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
@@ -1,6 +1,6 @@
 ---
 title: Considerations for Google Analytics and PANTHEON_STRIPPED
-description:Detailed information on how Pantheon optimizes your site's cache performance.
+description: Detailed information on how Pantheon optimizes your site's cache performance.
 category:
   - developing
 keywords: google analytics, analytics, pantheon_stripped, utm, query parameters, cache


### PR DESCRIPTION
This PR fixes frontmatter on the following docs: [Considerations for Google Analytics and PANTHEON_STRIPPED](https://pantheon.io/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values/) and [Security on the Pantheon Dashboard](https://pantheon.io/docs/articles/sites/security/)

## Before
![screen shot 2015-06-08 at 12 33 03 pm](https://cloud.githubusercontent.com/assets/10119525/8041128/bc681938-0ddb-11e5-8641-0c433805677a.png)
![screen shot 2015-06-08 at 12 33 41 pm](https://cloud.githubusercontent.com/assets/10119525/8041127/bc678662-0ddb-11e5-87bb-c572454bc950.png)

## After
![screen shot 2015-06-08 at 12 33 51 pm](https://cloud.githubusercontent.com/assets/10119525/8041138/caaff038-0ddb-11e5-8ac4-8af0fbe45d9a.png)
![screen shot 2015-06-08 at 12 40 57 pm](https://cloud.githubusercontent.com/assets/10119525/8041139/cac13f3c-0ddb-11e5-97f1-4966cb9e1ec3.png)