### PR TITLE
Break words in code snippets

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -1376,6 +1376,7 @@ pre {
   border: 1px solid #ccc;
   border-radius: 4px;
   margin-bottom: 14px;
+  word-break: break-word;
 }
 /**.hljs {
   padding: 9px 14px;


### PR DESCRIPTION
Closes issue #354 

Add the following to main.css pre class:
```
  word-break: break-word;
```

Screenshot:
![screen shot 2015-06-25 at 9 44 29 am](https://cloud.githubusercontent.com/assets/10119525/8357160/00813492-1b1f-11e5-915b-b21ba7e9aaac.png)


@nataliejeremy or @bmackinney can you merge?