### PR TITLE
deleted the dash in between "sites" and "create" because sites-create…

### DIFF
--- a/source/docs/articles/sites/create/importing-drush-site-archives-with-terminus.md
+++ b/source/docs/articles/sites/create/importing-drush-site-archives-with-terminus.md
@@ -55,7 +55,7 @@ At that point the script will poll as the site containers are spun up and the ar
 
 Every aspect of the Terminus process is designed to support automation. You can kick off an import non-interactively using the following options:
 ```bash
-terminus sites-create-from-import --name=<sitename> --import=<archive/url.tar.gz>
+terminus sites create-from-import --name=<sitename> --import=<archive/url.tar.gz>
 ```
 You can script out imports like this to run several concurrently (or in serial).
 


### PR DESCRIPTION
…-from-import is not a registered command (modification in source/docs/articles/sites/create/importing-drush-archives-with-terminus.md)