### PR TITLE
Footer Content Addition

### DIFF
--- a/source/_partials/footer_content.html
+++ b/source/_partials/footer_content.html
@@ -5,5 +5,6 @@
 <div class="pio-docs-footer">
 <div id="copyright">&copy; {{ "now"|date("Y") }}
   <a href="https://pantheon.io/" target="blank"> Pantheon</a>  &middot; 717 California Street, San Francisco, CA <br />
+  <a href="https://pantheon.io/features/wordpress-hosting" target="blank"> WordPress Hosting</a> | <a href="https://pantheon.io/features/drupal-hosting" target="blank"> Drupal Hosting</a> | <a href="https://pantheon.io/platform/website-management-platform" target="blank"> Website Management Platform</a><br />
   <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>   All work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />
   Code snippets are additionally licensed under <a href="http://opensource.org/licenses/MIT" target="blank">The MIT License</a> </div>

--- a/source/_partials/footer_content.html
+++ b/source/_partials/footer_content.html
@@ -3,8 +3,7 @@
 </div>
 
 <div class="pio-docs-footer">
-<div id="copyright">&copy; {{ "now"|date("Y") }}
-  <a href="https://pantheon.io/" target="blank"> Pantheon</a>  &middot; 717 California Street, San Francisco, CA <br />
   <a href="https://pantheon.io/features/wordpress-hosting" target="blank"> WordPress Hosting</a> | <a href="https://pantheon.io/features/drupal-hosting" target="blank"> Drupal Hosting</a> | <a href="https://pantheon.io/platform/website-management-platform" target="blank"> Website Management Platform</a><br />
+  <div id="copyright">&copy; {{ "now"|date("Y") }}<a href="https://pantheon.io/" target="blank"> Pantheon</a>  &middot; 717 California Street, San Francisco, CA <br />
   <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>   All work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />
   Code snippets are additionally licensed under <a href="http://opensource.org/licenses/MIT" target="blank">The MIT License</a> </div>


### PR DESCRIPTION
Internal linking addition to Docs footer content. Added internal links for 3 primary keyword targets WordPress Hosting, Drupal Hosting, Website Management Platform

Here's what it looks like on my local:

![newfooter](https://cloud.githubusercontent.com/assets/2190542/8444564/f93c5b72-1f46-11e5-8e9f-0be83e02388c.png)

@bmackinney please review as this will affect all Docs pages
@informanddelight this is a slight UX change to footer
@rachelwhitton thanks again for your help!

Signed-off-by: barthballard <bballard@gmail.com>