### PR TITLE
Replace getpantheon.com with pantheon.io where appropriate

### DIFF
--- a/source/docs/articles/local/git-faq.md
+++ b/source/docs/articles/local/git-faq.md
@@ -197,13 +197,13 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
 
 The easiest way to find out which SSH keys your Git client is using when trying to connect is running the following command:
 ```bash
-ssh -vT git@code.getpantheon.com
+ssh -vT git@code.pantheon.io
 ```
 The output should be similar to this:
 
     debug1: Reading configuration data /etc/ssh/ssh_config
     debug1: Applying options for *
-    debug1: Connecting to code.getpantheon.com [50.57.148.117] port 22.
+    debug1: Connecting to code.pantheon.io [50.57.148.117] port 22.
     debug1: Connection established.
     debug1: identity file /home/username/.ssh/id_rsa type 1
 
@@ -214,9 +214,9 @@ You should now be able to configure Git with the matching SSH key and clone your
 If you're getting errors after committing your reverted changes, make sure you have included the `-f` option, as you will be forcing a fast-forward update. Without this, you will receive an error similar to the one below:
 ```bash
 $: git push
-To git@code.getpantheon.com:3ef6264e-51d9-43b9-a60b-6cc22c3081c9
+To git@code.pantheon.io:3ef6264e-51d9-43b9-a60b-6cc22c3081c9
  ! [rejected] master -> master (non-fast-forward)
-error: failed to push some refs to 'git@code.getpantheon.com:3ef6264e-51d9-43b9-a60b-6cc22c3081c9'
+error: failed to push some refs to 'git@code.pantheon.io:3ef6264e-51d9-43b9-a60b-6cc22c3081c9'
 To prevent you from losing history, non-fast-forward updates were rejected
 Merge the remote changes (e.g. 'git pull') before pushing again. See the
 'Note about fast-forwards' section of 'git push --help' for details.

--- a/source/docs/articles/local/git-faq.md
+++ b/source/docs/articles/local/git-faq.md
@@ -197,13 +197,13 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
 
 The easiest way to find out which SSH keys your Git client is using when trying to connect is running the following command:
 ```bash
-ssh -vT git@code.pantheon.io
+ssh -vT git@code.getpantheon.com
 ```
 The output should be similar to this:
 
     debug1: Reading configuration data /etc/ssh/ssh_config
     debug1: Applying options for *
-    debug1: Connecting to code.pantheon.io [50.57.148.117] port 22.
+    debug1: Connecting to code.getpantheon.com [50.57.148.117] port 22.
     debug1: Connection established.
     debug1: identity file /home/username/.ssh/id_rsa type 1
 
@@ -214,9 +214,9 @@ You should now be able to configure Git with the matching SSH key and clone your
 If you're getting errors after committing your reverted changes, make sure you have included the `-f` option, as you will be forcing a fast-forward update. Without this, you will receive an error similar to the one below:
 ```bash
 $: git push
-To git@code.pantheon.io:3ef6264e-51d9-43b9-a60b-6cc22c3081c9
+To git@code.getpantheon.com:3ef6264e-51d9-43b9-a60b-6cc22c3081c9
  ! [rejected] master -> master (non-fast-forward)
-error: failed to push some refs to 'git@code.pantheon.io:3ef6264e-51d9-43b9-a60b-6cc22c3081c9'
+error: failed to push some refs to 'git@code.getpantheon.com:3ef6264e-51d9-43b9-a60b-6cc22c3081c9'
 To prevent you from losing history, non-fast-forward updates were rejected
 Merge the remote changes (e.g. 'git pull') before pushing again. See the
 'Note about fast-forwards' section of 'git push --help' for details.

--- a/source/docs/articles/organizations/pantheon-for-agencies/faq.md
+++ b/source/docs/articles/organizations/pantheon-for-agencies/faq.md
@@ -56,7 +56,7 @@ Yes. Roles designated on the Team page at the site level will override any roles
 Yes. Please follow [@pantheonstatus](https://twitter.com/pantheonstatus) on twitter and bookmark [status.getpantheon.com](http://status.getpantheon.com).
 
 ### How do I submit a ticket when the dashboard is down?
-If you need to submit a ticket and can’t access the Dashboard, send an email to helpdesk@getpantheon.com.
+If you need to submit a ticket and can’t access the Dashboard, send an email to helpdesk@pantheon.io.
 
 ### As a Partner, do I get enhanced support?
 

--- a/source/docs/articles/sites/settings/selecting-a-plan.md
+++ b/source/docs/articles/sites/settings/selecting-a-plan.md
@@ -5,7 +5,7 @@ category:
   - getting-started
 keywords: plan, how to select a plan, how to select a paid plan, what plans are available, how to view site plan, how to see plan, how to change plan, changing plans, change plan, select plan, selecting a plan
 ---
-Pantheon offers multiple service levels, called [Plans](https://www.getpantheon.com/pricing). You can select the plan that works best for you and your needs. In the beginning, you can start on the Basic Plan. Then once you start to grow and have more specific requirements, you can take a look at the Pro Plan, which can be part of the recipe to get your site or application to scale and perform better.
+Pantheon offers multiple service levels, called [Plans](https://www.pantheon.io/pricing). You can select the plan that works best for you and your needs. In the beginning, you can start on the Basic Plan. Then once you start to grow and have more specific requirements, you can take a look at the Pro Plan, which can be part of the recipe to get your site or application to scale and perform better.
 
 To get started, select the site you would like to associate with a plan.
 

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -1,5 +1,5 @@
 /*!
-* Pantheon Docs (http://docs.getpantheon.com)
+* Pantheon Docs (http://pantheon.io/docs)
 * Copyright 2014 Pantheon, Inc.
 * Licensed under the Creative Commons Attribution 3.0 Unported License. For
 * details, see http://creativecommons.org/licenses/by/3.0/.

--- a/source/docs/assets/js/src/application.js
+++ b/source/docs/assets/js/src/application.js
@@ -3,7 +3,7 @@
 // ++++++++++++++++++++++++++++++++++++++++++
 
 /*!
- * JavaScript for Pantheon's docs (http://getpantheon.com)
+ * JavaScript for Pantheon's docs (http://pantheon.io)
  * Copyright 2014 Pantheon Systems, Inc.
  * Licensed under the Creative Commons Attribution 3.0 Unported License. For
  * details, see http://creativecommons.org/licenses/by/3.0/.

--- a/source/docs/guides/create-a-wordpress-site-from-the-commandline-with-terminus-and-wp-cli.md
+++ b/source/docs/guides/create-a-wordpress-site-from-the-commandline-with-terminus-and-wp-cli.md
@@ -40,7 +40,7 @@ Now we need to tell terminus who you are. You can do that with the `auth` comman
 ```nohighlight
 $ terminus auth login your@email.tld
 Your dashboard password (input will not be shown):
-Logging in as brian@getpantheon.com
+Logging in as brian@pantheon.io
 Saving session data
 
 ```
@@ -170,11 +170,11 @@ $ terminus wp core install --site=cli-test \
                            --title="WP-CLI Test" \
                            --admin_user=admin \
                            --admin_password=pantheon.rocks \
-                           --admin_email="cal@getpantheon.com"
+                           --admin_email="cal@pantheon.io"
 ```
 The same command shown on a single line:
 ```nohighlight
-terminus wp core install --site=cli-test --url=http://dev-cli-test.pantheion.io --title="WP-CLI-Test" --admin_user=admin --admin_password=pantheon.rocks --admin_email=cal@getpantheon.com
+terminus wp core install --site=cli-test --url=http://dev-cli-test.pantheion.io --title="WP-CLI-Test" --admin_user=admin --admin_password=pantheon.rocks --admin_email=cal@pantheon.io
 ```
 If everything goes as planned you'll see this message:
 ```bash

--- a/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
+++ b/source/docs/guides/using-sendgrid-to-deliver-email-with-wordpress-and-drupal.md
@@ -52,7 +52,7 @@ Your WordPress application is now set up to send email through SendGrid! Complet
 
 Pantheon recommends using the actively maintained [SMTP module](https://www.drupal.org/project/smtp) to send email with Drupal, regardless of your email gateway. Luckily, SendGrid plugs right in.
 
-Download and enable the latest recommended release in the `code/sites/all/modules` directory. You can push it with Git, use the SFTP account in your Pantheon dashboard, or even use [Drush](https://www.getpantheon.com/blog/five-steps-feeling-drush). The following commands can be used to download and enable the module if you have Drush configured locally:
+Download and enable the latest recommended release in the `code/sites/all/modules` directory. You can push it with Git, use the SFTP account in your Pantheon dashboard, or even use [Drush](https://pantheon.io/blog/five-steps-feeling-drupal-drush). The following commands can be used to download and enable the module if you have Drush configured locally:
 ```nohighlight
 drush @pantheon.your-site.dev dl smtp
 drush @pantheon.your-site.dev en smtp -y

--- a/style-guide.md
+++ b/style-guide.md
@@ -165,13 +165,13 @@ When linking to an article in a sentence without using the exact title, display 
 In WordPress, [advanced custom fields can be exported to code](http://stevegrunwell.com/blog/exploring-the-wordpress-advanced-custom-fields-export-feature/ "Steve Grunwell blog, WordPress post").
 
 When referring to another article to provide detailed instructions that are important for completing the current task, use this format:
-
+```
 For detailed instructions, see [Article Title](/docs/articles/path).
-
+```
 When cross-referencing a document as suggested reading that the user may find helpful because it is related to the task/topic, but not essential for completing the current task, use this format:
-
+```
 For more information, see [Article Title](/docs/articles/path).
-
+```
 ## Dates
 
 Use this format to indicate a date: January 10, 2014. Do not abbreviate the month.

--- a/style-guide.md
+++ b/style-guide.md
@@ -2,7 +2,7 @@
 
 #About This Guide
 
-This style guide will help Pantheors who create technical content write in consistent voice, tone, and style. See the [glossary](https://docs.google.com/a/getpantheon.com/spreadsheets/d/1npBDQl1v0l-mukVC9yF9RSwvwjdSlrqUY5B1oDgy9kw/edit "Pantheon google drive, glossary") for an alphabetical listing of commonly used words, terms, UI elements, and titles.
+This style guide will help Pantheors who create technical content write in consistent voice, tone, and style. See the [glossary](https://docs.google.com/a/pantheon.io/spreadsheets/d/1npBDQl1v0l-mukVC9yF9RSwvwjdSlrqUY5B1oDgy9kw/edit "Pantheon google drive, glossary") for an alphabetical listing of commonly used words, terms, UI elements, and titles.
 
 For any questions or comments, [create an issue](https://github.com/pantheon-systems/documentation/issues).
 
@@ -135,7 +135,7 @@ Select the **Settings** tab.
 Use sentence case for body content and short phrases, even when the content is a link. Sentence case means you only capitalize the first letter of the sentence.
 
 **Example:**
-We run our status checks on your site automatically once an hour. If you'd like fresher data, [run the checks now](www.getpantheon.com).  
+If you want to permanently opt-out of a check, you can use the [$conf array in settings.php](https://www.drupal.org/node/1525472).  
 
 **Code Snippets**
 
@@ -159,18 +159,18 @@ sites/all/modules/contrib
 
 When linking to an article in a sentence, use the exact title of the article if possible. If using the exact title, display it in title case. The link should be blue with no other formatting (bold, italics, quotations).   **Example**:
 
-For help with SSH keys, see [Generating SSH Keys](https://www.getpantheon.com/docs/articles/users/generating-ssh-keys/).
+For help with SSH keys, see [Generating SSH Keys](https://www.pantheon.io/docs/articles/users/generating-ssh-keys/).
 
 When linking to an article in a sentence without using the exact title, display it as part of the sentence in sentence case. **Example**:
 In WordPress, [advanced custom fields can be exported to code](http://stevegrunwell.com/blog/exploring-the-wordpress-advanced-custom-fields-export-feature/ "Steve Grunwell blog, WordPress post").
 
 When referring to another article to provide detailed instructions that are important for completing the current task, use this format:
 
-For detailed instructions, see [Article Title](www.getpantheon.com).
+For detailed instructions, see [Article Title](/docs/articles/path).
 
 When cross-referencing a document as suggested reading that the user may find helpful because it is related to the task/topic, but not essential for completing the current task, use this format:
 
-For more information, see [Article Title](www.getpantheon.com).
+For more information, see [Article Title](/docs/articles/path).
 
 ## Dates
 
@@ -413,7 +413,7 @@ Generating SSH Keys
 
 ## User Interface Terminology
 
-See below for visual examples of the terms to use when referring to specific pages. Also see the [Glossary](https://docs.google.com/a/getpantheon.com/spreadsheets/d/1npBDQl1v0l-mukVC9yF9RSwvwjdSlrqUY5B1oDgy9kw/edit#gid=0 "Pantheon google drive, Glossary").
+See below for visual examples of the terms to use when referring to specific pages. Also see the [Glossary](https://docs.google.com/a/pantheon.io/spreadsheets/d/1npBDQl1v0l-mukVC9yF9RSwvwjdSlrqUY5B1oDgy9kw/edit#gid=0 "Pantheon google drive, Glossary").
 
 ### User Dashboard
 

--- a/style-guide.md
+++ b/style-guide.md
@@ -159,7 +159,7 @@ sites/all/modules/contrib
 
 When linking to an article in a sentence, use the exact title of the article if possible. If using the exact title, display it in title case. The link should be blue with no other formatting (bold, italics, quotations).   **Example**:
 
-For help with SSH keys, see [Generating SSH Keys](https://www.pantheon.io/docs/articles/users/generating-ssh-keys/).
+For help with SSH keys, see [Generating SSH Keys](/docs/articles/users/generating-ssh-keys/).
 
 When linking to an article in a sentence without using the exact title, display it as part of the sentence in sentence case. **Example**:
 In WordPress, [advanced custom fields can be exported to code](http://stevegrunwell.com/blog/exploring-the-wordpress-advanced-custom-fields-export-feature/ "Steve Grunwell blog, WordPress post").


### PR DESCRIPTION
Legacy links removed, excluding the following: 
- [varnishcheck.getpantheon.com](http://varnishcheck.getpantheon.com/)
- [status page](http://status.getpantheon.com)


The followoing DNS docs were NOT updated within this PR and will need to be addressed via #350 
- [Domains and SSL Tools](https://pantheon.io/docs/articles/sites/domains/)
- [DNS Records for Directing Your Domain to Your Pantheon Site](https://pantheon.io/docs/articles/sites/domains/dns-records-for-directing-your-domain-to-your-pantheon-site/)
- [Gandi & Pantheon: Pointing your DNS](https://pantheon.io/docs/articles/sites/domains/gandi-pantheon-pointing-your-dns/)


@bmackinney and/or @nataliejeremy can you review?

