### PR TITLE
Consistent terminology for Multidev environments

### DIFF
--- a/source/docs/articles/organizations.md
+++ b/source/docs/articles/organizations.md
@@ -12,7 +12,7 @@ Access the Organization Dashboard from the User Dashboard in the Organizations t
 
 ## Multidev
 
-All Partner organizations have Multidev available on every site. Click on **Multidev** in your Site Dashboard to get going. Sites have a maximum of ten Cloud Development Environments (CDE's) and unlimited git branches, from which CDE's can be created on-demand. Learn how to [use Multidev](/source/docs/articles/sites/multidev).
+All Partner organizations have Multidev available on every site. Click on **Multidev** in your Site Dashboard to get going. Sites have a maximum of ten Multidev environments and unlimited git branches, from which Multidev environments can be created on-demand. Learn how to [use Multidev](/source/docs/articles/sites/multidev).
 
 ## Change Management
 

--- a/source/docs/articles/organizations/change-management.md
+++ b/source/docs/articles/organizations/change-management.md
@@ -77,7 +77,7 @@ Change Management is enabled for all Pantheon for Agencies Partners, and for som
 <tr>
 <td class="tg-031e">Developer</td>
 <td class="tg-031e">- Tag Sites<br>- Access Sites<br>- Create Sites</td>
-<td class="tg-031e">- Commit code to CDEs and Dev<br>- Cannot deploy code or clone content to Test/Live, unless invited to the site or were the creator of the site, in which case they are on the site team as member or owner.</td>
+<td class="tg-031e">- Commit code to Multidev and Dev environments<br>- Cannot deploy code or clone content to Test/Live, unless invited to the site or were the creator of the site, in which case they are on the site team as member or owner.</td>
 </tr>
 <tr>
 <td class="tg-031e">Unprivileged*</td>

--- a/source/docs/articles/organizations/managing-upstreams.md
+++ b/source/docs/articles/organizations/managing-upstreams.md
@@ -52,7 +52,7 @@ We encourage you to use a continuous integration server, like Jenkins, Travis-CI
 2. Pull the remote repository into the local clone of your testing site.
 3. Checkout the updates branch.
 4. Push the updates branch to Pantheon.
-5. Create a cloud development environment for the branch.
+5. Create a Multidev environment for the branch.
 6. Wipe the database and files from the update branch.
 7. Run acceptance tests for a new-site installation use case.
 8. Merge the code into dev.

--- a/source/docs/articles/organizations/pantheon-for-agencies/faq.md
+++ b/source/docs/articles/organizations/pantheon-for-agencies/faq.md
@@ -13,7 +13,7 @@ Multidev allows you to more seamlessly collaborate on your website development p
 
 ### How does Multidev work?
 
-Forking a CDE creates an application server, a database server, and connects them to backing services. It creates a Git branch of your codebase off of master, and checks it out in the CDE's application server. It clones the database from the Development environment into the new database server, and clones the filesystem similarly. The new CDE has a unique URL, and behaves the same as the Development environment, with the ability to receive code changes via Git pushes or SFTP file uploads.
+Forking a Multidev environment creates an application server, a database server, and connects them to backing services. It creates a Git branch of your codebase off of master, and checks it out in the Multidev environment's application server. It clones the database from the Development environment into the new database server, and clones the filesystem similarly. The new Multidev environment has a unique URL, and behaves the same as the Development environment, with the ability to receive code changes via Git pushes or SFTP file uploads.
 
 
 ## Change Management

--- a/source/docs/articles/sites.md
+++ b/source/docs/articles/sites.md
@@ -50,12 +50,12 @@ The core of the Pantheon Workflow is to move code up from Dev to Test to Live an
 - **Code** includes plugins, modules, themes, CSS, JS—anything that's under Git version control.
 - **Content** includes files not under Git version control, like images and pdfs, and the database.  
 
-The [Code tool](/docs/articles/sites/code) on Dev/CDEs includes a Connection Mode toggle to switch between SFTP and Git. The Code tool on the Test and Live environments displays a Commit Log that displays all the commits that are on the environment.
+The [Code tool](/docs/articles/sites/code) on Dev/Multidev environments includes a Connection Mode toggle to switch between SFTP and Git. The Code tool on the Test and Live environments displays a Commit Log that displays all the commits that are on the environment.
 
 Learn how to use the [Pantheon workflow](/docs/articles/sites/code/using-the-pantheon-workflow/) to manage your site's code.
 
 ## Merge
-Visit this tab in the Dev environment when you have commits from CDEs that you need to merge into Test or Live.
+Visit this tab in the Dev environment when you have commits from Multidev environments that you need to merge into Test or Live.
 
 ## Status
 Pantheon provides static site analysis as a service for your site to make best practice recommendations on site configurations and to help detect common problems. This mechanism does not perform requests on your site, and in doing so avoids the observer effect. It's non-intrusive, so no installation or configuration is required. Finally, it's completely automated for consistent reports and results. Learn more about our Launch Check for

--- a/source/docs/articles/sites/multidev.md
+++ b/source/docs/articles/sites/multidev.md
@@ -1,17 +1,17 @@
 ---
 title: Multidev
-description: Detailed information on Pantheon's cloud development environment, Multidev.
+description: Detailed information on Pantheon's Multidev.
 category:
 - developing
-keywords: multidev, organization, cloud development environment, cloud development environments, cde, team management, developing with teams, what is multidev, multidev workflow, what is a branch, what is branching, branch, what is a commit, what is a fork, clone content, clone to a cde, clone to development environment, delete cde, remove cde, delete multidev branch
+keywords: multidev, organization, multidev environment, team management, developing with teams, what is multidev, multidev workflow, what is a branch, what is branching, branch, what is a commit, what is a fork, clone content, clone to a environment, clone to development environment, delete multidev environment, remove multidev environment, delete multidev branch
 ---
-Multidev is cloud development environments for teams and allows a developer to fork the entire stack (code and content), work independently, then merge the code changes back into the master. Each forked branch will have its own separate development environment, including database and files.
+Multidev is development environments for teams and allows a developer to fork the entire stack (code and content), work independently, then merge the code changes back into the master. Each forked branch will have its own separate development environment, including database and files.
 
 ## Benefits of Multidev
 
 **Easy workflow.** Developers on your team can use a standardized best-practice development workflow in the cloud through their Dashboard.
 
-**No more surprises.** Each developer on your team gets their own cloud development environment with the same configuration and stack as the Live environment. Multidev makes it easy to keep in sync with code from every team member and content updates from any environment. As a result, deployments become surprisingly predictable.
+**No more surprises.** Each developer on your team gets their own Multidev environment with the same configuration and stack as the Live environment. Multidev makes it easy to keep in sync with code from every team member and content updates from any environment. As a result, deployments become surprisingly predictable.
 
 **A fork for every developer on your team.** Multidev gets new developers started quickly; you can’t have too many cooks in a Multidev kitchen.
 ![](/source/docs/assets/images/desk_images/170383.png)​
@@ -41,13 +41,13 @@ There are a number of terms used throughout the Multidev workflow:
 ## Getting Started
 
 1. From your Site Dashboard, click the **Multidev** tab.
-2. Click **Create Cloud Development Environment**. This will create a new fork of the environment that you choose in the select box on the pop-up modal, including code, database and files.
+2. Click **Create Multidev Environment**. This will create a new fork of the environment that you choose in the select box on the pop-up modal, including code, database and files.
 3. Specify the name for the environment; the URL will incorporate the environment name.
-4. Click **Create Environment**.  
+4. Click **Create Environment**.
 
 It will take a few minutes to create the environment and clone the content from the source environment. You can continue working on the Dashboard while it's being created.
 
-You can create cloned cloud environments from Dev, Test or Live; existing branch environments can also be forked. Any branch not associated with an environment will be listed on Multidev > Git Branches.
+You can create cloned Multidev environments from Dev, Test or Live; existing branch environments can also be forked. Any branch not associated with an environment will be listed on Multidev > Git Branches.
 
 You can also create an environment for an existing Git branch. Content can be cloned from any existing environment during the environment creation.
 
@@ -87,7 +87,7 @@ Instructions for using the command-line to merge the changes into the target are
 
 ## Delete a Branch Environment
 
-Go to Multidev > Cloud Development Environments, and click **Delete Environment**.
+Go to Multidev > Multidev Environments, and click **Delete Environment**.
 
 When an environment is deleted, the branch will remain and needs to be removed manually.
 
@@ -98,7 +98,7 @@ A branch with no environment associated with it can be deleted by going to Multi
 Branches can be deleted locally and the commit can be pushed to Pantheon, but this may have unintended consequences if an environment is associated with it; use the interface instead.​
 
 ## Rename a Branch
-There is an 11-character limit for branch names. If you push a branch to Pantheon that exceeds the character limit, it cannot become a cloud development environment (CDE). The solution is to rename the branch. This is only recommended if you don't have any other users working on this branch, or if you have already coordinated with them.
+There is an 11-character limit for branch names. If you push a branch to Pantheon that exceeds the character limit, it cannot become a Multidev environment. The solution is to rename the branch. This is only recommended if you don't have any other users working on this branch, or if you have already coordinated with them.
 
 From the command line, rename the branch:
 

--- a/source/docs/guides/collaborative-development-github-pantheon.md
+++ b/source/docs/guides/collaborative-development-github-pantheon.md
@@ -250,7 +250,7 @@ pantheon	ssh://codeserver.dev.59b2dd69-2305-4ca2-a745-4f00e4100c88@codeserver.de
 ## Feature Branching
 
 Working with teams on Github requires a branching strategy. We are fans of Github flow and continuous integration here at Pantheon. In order to collaborate, I need to add my colleagues to the site we’re developing, both [on Github](https://help.github.com/enterprise/2.0/admin/guides/user-management/organizations-and-teams/) and [on Pantheon](/docs/articles/sites/team-management).
-Locally, our codebase is in sync with both repositories. In order to start working on a new feature, we’ll checkout a branch. Since my site is associated with a supporting organization that has Multidev, I can test out any feature in a cloud development environment. These environments have an 11-character limit for branch names, so I'm choosing to use short branch names for my feature branches.  
+Locally, our codebase is in sync with both repositories. In order to start working on a new feature, we’ll checkout a branch. Since my site is associated with a supporting organization that has Multidev, I can test out any feature in a Multidev environment. These environments have an 11-character limit for branch names, so I'm choosing to use short branch names for my feature branches.  
 
 ```nohighlight
 $ git checkout -b configs
@@ -289,24 +289,24 @@ Total 365 (delta 70), reused 0 (delta 0)
 remote:
 remote: PANTHEON NOTICE:
 remote:
-remote: Skipping code sync, no cloud development environments were found for branch "configs".
+remote: Skipping code sync, no multidev environments were found for branch "configs".
 remote:
 To ssh://codeserver.dev.59b2dd69-2305-4ca2-a745-4f00e4100c88@codeserver.dev.59b2dd69-2305-4ca2-a745-4f00e4100c88.drush.in:2222/~/repository.git
  * [new branch]      configs -> configs
 ```
-The platform is telling me that no cloud development environments (CDEs) were found associated with the Git branch. I can stay on the command-line and quickly create one with Terminus.
+The platform is telling me that no Multidev environments were found associated with the Git branch. I can stay on the command-line and quickly create one with Terminus.
 
 ```nohighlight
 $ terminus site create-env --site=d7-ci --env=configs --from-env=dev
 ```
-![New environment named configs](/source/docs/assets/images/new-env-configs.png "New Pantheon Cloud Development Environment named configs, created with Terminus")
-The module will now be available to activate and test on Pantheon for my colleagues to experience. I'll add a link to the module's configuration page on the CDE on my Github pull request.
+![New environment named configs](/source/docs/assets/images/new-env-configs.png "New Pantheon Multidev Environment named configs, created with Terminus")
+The module will now be available to activate and test on Pantheon for my colleagues to experience. I'll add a link to the module's configuration page on the Multidev environment on my Github pull request.
 
 ![New environment configuration admin url](/source/docs/assets/images/configs-admin-url-configs-env.png "The configuration management module's admin url on the configs environment")
 
 ### Create Pull Request
 
-We’re now ready to create a pull request on GitHub. The pull request can include things like links to the CDE where the team can view the effects of the commits, @-mentions of team members, and a list of tasks for team members to perform before merging.
+We’re now ready to create a pull request on GitHub. The pull request can include things like links to the Multidev environment where the team can view the effects of the commits, @-mentions of team members, and a list of tasks for team members to perform before merging.
 
 ![Pull request for configs branch](/source/docs/assets/images/configuration-pull-request-1.png "A pull request on github for the configs branch to be merged to master")
 

--- a/source/docs/guides/rerouting-outbound-email.md
+++ b/source/docs/guides/rerouting-outbound-email.md
@@ -144,7 +144,7 @@ If you don’t see what you’re expecting, review your settings.php and ensure 
 That’s it! Now when Drupal sends out an email from any environment (except Live), it will get rerouted to the email address specified in settings.php. Our settings.php will make sure email is not rerouted on Live, so it’s business as usual. Make sure you’re using a [SMTP gateway](https://pantheon.io/docs/articles/sites/code/email/#outgoing-email) on Live to ensure email deliverability.
 
 ###See Reroute Email In Action
-To see exactly what we did, I forked a new [MultiDev](https://pantheon.io/docs/articles/sites/multidev/) CDE called ```demo``` and requested a new account:
+To see exactly what we did, I forked a new [MultiDev](https://pantheon.io/docs/articles/sites/multidev/) Multidev environment called ```demo``` and requested a new account:
 
 ![Drupal site showing account requested and emails sent](/source/docs/assets/images/reroute-email-account-requested.png)
 


### PR DESCRIPTION
We are very inconsistent with what we call "Multidev environments".

We are inconsistent in four places:
1. Docs
2. Dashboard
3. Workflow Names / Descriptions
4. Marketing site.

I propose we standardize on calling an environment created as part of the Multidev feature a "Multidev environment"

If this seems reasonable, I can help make sure we update our terminology on the Docs, Dashboard and the API (workflows)

ping @bmackinney @nstielau @slivermon @joshkoenig 