### PR TITLE
Comment out date from _views/changelog.html

### DIFF
--- a/source/_views/changelog.html
+++ b/source/_views/changelog.html
@@ -35,7 +35,7 @@
 <span class="pull-right">
 <script type="text/javascript" src="http://platform.linkedin.com/in.js"></script><script type="in/share"></script></span>
             <br>
-            {{ page.date|date('F d, Y') }}
+            <!--{{ page.date|date('F d, Y') }}-->
         </div>
             </header>
           </div>


### PR DESCRIPTION
@bmackinney - the date in changelog.html resets build date for changelog md files:
```
$ git diff docs/changelogs/2015-02-February/index.html
diff --git a/docs/changelogs/2015-02-February/index.html b/docs/changelogs/2015-02-February/index.html
index 62cf73e..ce4bd0b 100644
--- a/docs/changelogs/2015-02-February/index.html
+++ b/docs/changelogs/2015-02-February/index.html
-            July 07, 2015
+            July 08, 2015
         </div>
```

We should remove it until a better solution can be incorporated. This affects files modified when deploying.