### PR TITLE
500 firefox css

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -1836,25 +1836,26 @@ input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:
   input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:focus{
     padding-top: 20px !important;
     padding-bottom: 15px !important;
+
 }}
 }
 
-@-moz-document url-prefix(http://localhost:8000/docs/guides) {
+@-moz-document url-prefix(https://pantheon.io/docs/guides) {
 .gsc-search-box-tools .gsc-search-box .gsc-input {
     width: 275px !important;
   }
 }
-@-moz-document url-prefix(http://localhost:8000/docs/changelog) {
+@-moz-document url-prefix(https://pantheon.io/docs/changelog) {
 .gsc-search-box-tools .gsc-search-box .gsc-input {
     width: 275px !important;
   }
 }
-@-moz-document url(http://localhost:8000/docs) {
+@-moz-document url(https://pantheon.io/docs/) {
 .gsc-search-box-tools .gsc-search-box .gsc-input {
     width: 100% !important;
   }
 }
-@-moz-document url-prefix(http://localhost:8000/docs/articles) {
+@-moz-document url-prefix(https://pantheon.io/docs//articles) {
 .gsc-search-box-tools .gsc-search-box .gsc-input {
     width: 275px !important;
   }

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -1830,7 +1830,34 @@ input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:
   margin-top: 8px !important;
   border-color:  none !important;
   border: 0px !important;
-  padding-top: 5px !important;
+  margin-bottom: 0px!important;
+}
+@-moz-document url-prefix() {
+  input.gsc-search-button, input.gsc-search-button:hover, input.gsc-search-button:focus{
+    padding-top: 20px !important;
+    padding-bottom: 15px !important;
+}}
+}
+
+@-moz-document url-prefix(http://localhost:8000/docs/guides) {
+.gsc-search-box-tools .gsc-search-box .gsc-input {
+    width: 275px !important;
+  }
+}
+@-moz-document url-prefix(http://localhost:8000/docs/changelog) {
+.gsc-search-box-tools .gsc-search-box .gsc-input {
+    width: 275px !important;
+  }
+}
+@-moz-document url(http://localhost:8000/docs) {
+.gsc-search-box-tools .gsc-search-box .gsc-input {
+    width: 100% !important;
+  }
+}
+@-moz-document url-prefix(http://localhost:8000/docs/articles) {
+.gsc-search-box-tools .gsc-search-box .gsc-input {
+    width: 275px !important;
+  }
 }
 .gs-result .gs-title, .gs-result .gs-title * {
   font-size: 18px !important;


### PR DESCRIPTION
Closes #500 
Correct CSS for Firefox
## Home Page
<img width="1189" alt="screen shot 2015-07-16 at 11 18 06 am" src="https://cloud.githubusercontent.com/assets/10119525/8728807/ef2a95a0-2bac-11e5-8f6b-e8882797c313.png">
## All other pages
<img width="1200" alt="screen shot 2015-07-16 at 11 18 28 am" src="https://cloud.githubusercontent.com/assets/10119525/8728808/ef322f2c-2bac-11e5-9bfc-3599aece5bb8.png">

When testing locally, replace **https://pantheon.io/docs/** with **http://localhost:8000/docs/** in `main.css`

@nataliejeremy can you review and merge? 