### PR TITLE
Remove overflow scroll to remove scrollbars from main section

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -105,8 +105,6 @@ body.row.main {
 .article {
   background-color: white;
   padding-bottom: 40px;
-  overflow-y:scroll!important;
-  overflow-x:scroll!important;
   text-overflow: clip!important;
 }
 


### PR DESCRIPTION
Before removing overflow:
![docs](https://cloud.githubusercontent.com/assets/192576/8943998/da465694-3532-11e5-9c5a-cc775f57c591.jpg)

After removing overflow:
![after](https://cloud.githubusercontent.com/assets/192576/8943986/b510913c-3532-11e5-8b0b-0f22899d76cc.png)

Chrome Version 42.0.2311.152 (64-bit)
Linux