### PR TITLE
Add new CTA - Live Training; Update footer

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 1.3
+assets_version: 1.4
 
 #######################################################################################################
 # The authors. Include your info here, under the "authors" key, using the following template:

--- a/source/_partials/footer_content.html
+++ b/source/_partials/footer_content.html
@@ -1,9 +1,19 @@
 <div class="cta-docs-footer">
-  <p>Want to develop with professional tools for free?<a href="https://dashboard.pantheon.io/register" target="_blank" class="btn-primary">Create Account</a></p>
+    Join our weekly training. Every Wednesday at 10am PDT <a href="https://pantheon.io/essential-technical-training" target="_blank" class="btn-primary">REGISTER NOW</a>
 </div>
-
 <div class="pio-docs-footer">
-  <a href="https://pantheon.io/features/wordpress-hosting" target="blank"> WordPress Hosting</a> | <a href="https://pantheon.io/features/drupal-hosting" target="blank"> Drupal Hosting</a> | <a href="https://pantheon.io/platform/website-management-platform" target="blank"> Website Management Platform</a><br />
-  <div id="copyright">&copy; {{ "now"|date("Y") }}<a href="https://pantheon.io/" target="blank"> Pantheon</a>  &middot; 717 California Street, San Francisco, CA <br />
-  <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank"><img alt="Creative Commons License" style="border-width:0" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" /></a>   All work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />
-  Code snippets are additionally licensed under <a href="http://opensource.org/licenses/MIT" target="blank">The MIT License</a> </div>
+    <div class="col-md-8">
+    <h4><a href="https://pantheon.io/features/wordpress-hosting" target="blank"> WordPress Hosting</a> &middot; <a href="https://pantheon.io/features/drupal-hosting" target="blank"> Drupal Hosting</a> &middot; <a href="https://pantheon.io/platform/website-management-platform" target="blank"> Website Management Platform</a></h4>
+        <ul style="margin-left:100px;">
+            <img href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank" alt="Creative Commons License" style="float:left; margin-right:10px;margin-top:5px" src="https://i.creativecommons.org/l/by-sa/4.0/88x31.png" height="15px">
+                All work is licensed under a <a rel="license" href="http://creativecommons.org/licenses/by-sa/4.0/" target="blank">Creative Commons Attribution-ShareAlike 4.0 International License</a>.<br />
+                Code snippets are additionally licensed under <a href="http://opensource.org/licenses/MIT" target="blank">The MIT License</a>
+        </ul>
+    </div>
+    <div style="float:right;margin-bottom:35px;margin-top:15px;" class="col-md-4">
+    <a style="margin-right:120px;" href="https://dashboard.pantheon.io/register" target="_blank" class="btn-primary">CREATE FREE ACCOUNT</a>
+    <ul>&copy; {{ "now"|date("Y") }} Pantheon<br>
+    717 California Street, San Francisco, CA</ul>
+    </div>
+
+</div>

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -364,19 +364,42 @@ img.noborder {
   text-align: center;
   display: block;
 }
-  .cta-docs-footer p{
+ .cta-docs-footer p{
     margin: 0px;
     display: block;
-  }
-
+ }
 .pio-docs-footer {
   padding-top: 20px;
-  padding-bottom: 20px;
   margin-top: 0px;
-  color: #777;
   text-align: center;
+  position:absolute;
+  left:0;
+  right:0;
+  background-color: #181D21;
+  color: #B5C0C3;
+}
+
+.pio-docs-footer ul {
+    list-style-type: none!important;
+    color: #B5C0C3;
+    font-size: 12px;
+    line-height: 1.2;
+    margin-right: 120px;
+    margin-top: 5px;
+    text-align: left;
+    margin-left: 10px;
+    margin-top: 15px;
 
 }
+.pio-docs-footer a:link, .pio-docs-footer a:visited {
+    color: #B5C0C3;
+    text-decoration: none;
+}
+.pio-docs-footer a:hover{
+    color: #EFD01B;
+    text-decoration: none;
+}
+
 .pio-docs-footer-links {
   padding-left: 0;
   margin-top: 20px;
@@ -1215,22 +1238,47 @@ h1[id] {
   border-color: #FE4A45;
 }
 
-.btn-primary{
+.btn-primary, .btn-primary:visited {
+  text-shadow: none !important;
   background: #EFD01B;
-  padding: 10px 20px;
-  border-radius: 6px;
-  color: #222;
+  color: #000 !important;
   transition: all 0.5s ease;
-  margin: 5px 10px;
+  margin: 0px 0px 0px 30px;
+  padding: 12px 22px 12px 16px;
+  text-decoration: none !important;
+  font-weight: bold;
   display: inline-block;
+  white-space: nowrap;
+  line-height: 1;
+}
+.btn-primary:hover {
+  color: #000;
+  text-decoration: none;
+  background: #d6b608;
 }
 
-  .btn-primary:hover{
-    color: #222;
-    text-decoration: none;
-    background: #F5E36B;
-  }
+.cta-docs-footer .btn-primary {
+    background: #000;
+    color: #fff !important;
+}
+.cta-docs-footer .btn-primary:hover {
+  color: #000 !important;
+  text-decoration: none;
+  background: #fff;
+}
+.cta-docs-footer a.btn-primary:after {
+    content: '\203a';
+    color: #EFD01B;
+    margin: 0 0 0 10px;
+    height: 100%;
+}
 
+a.btn-primary:after {
+    content: '\203a';
+    color: #000;
+    margin: 0 0 0 10px;
+    height: 100%;
+}
 
 /* Forms */
 .pio-example-control-sizing select,

--- a/source/docs/index.html
+++ b/source/docs/index.html
@@ -64,20 +64,28 @@ use: [documents_category]
   </div>
 
 <!--Articles Thumbnail-->
-<div class="col-md-6 thumbnail" style="padding-top: 22px; margin: 15px auto 15px auto">
+<div class="col-md-4 thumbnail" style="padding-top: 22px; margin: 15px auto 15px auto">
     <a href="/docs/articles">
       <!--img class="noborder" style="padding-top: 10px; padding-left: 25px" src="/source/docs/assets/images/build-better-websites.png" alt="Launch"-->
         <h2 align="middle"><span style="margin-right: 10px;" class="glyphicon glyphicon-list" aria-hidden="true"></span>All Articles</h2></a>
         <p align ="middle">Browse through the entire list of articles</p>
 </div>
 <!--Changelog Thumbnail-->
-<div class="col-md-6 thumbnail" style="padding-top: 22px; margin: 15px auto 15px auto">
+<div class="col-md-4 thumbnail" style="padding-top: 22px; margin: 15px auto 15px auto">
     <a href="/docs/changelog">
       <!--img class="noborder" style="padding-top: 10px" src="/source/docs/assets/images/multidev.png" alt="Required"-->
         <h2 align="middle"><span style="margin-right: 10px;" class="glyphicon glyphicon-wrench" aria-hidden="true"></span>Changelog</h2></a>
         <p align ="middle">Recent platform and documentation changes</p>
 
 </div>
+<!--Changelog Thumbnail-->
+<div class="col-md-4 thumbnail" style="padding-top: 22px; margin: 15px auto 15px auto">
+    <a href="/docs/articles/power-users">
+      <!--img class="noborder" style="padding-top: 10px" src="/source/docs/assets/images/multidev.png" alt="Required"-->
+        <h2 align="middle"><span style="margin-right: 10px;" class="glyphicon glyphicon-user" aria-hidden="true"></span>Power Users Group</h2></a>
+        <p align ="middle">Share best practices with other active users</p>
+</div>
+
 
 
 </div>


### PR DESCRIPTION
Closes #748 
Closes #734 
Moves existing CTA to the footer, aligns with production site and adds a new CTA to register for live training webinar. This PR also adds Power Users to the home page:
<img width="1324" alt="screen shot 2015-07-29 at 3 06 46 pm" src="https://cloud.githubusercontent.com/assets/10119525/8968535/7da20dd0-3603-11e5-9e5e-3607929b256e.png">


Styling for the live training CTA matches the production site, with hover changing background color and text:
<img width="601" alt="screen shot 2015-07-29 at 2 50 12 pm" src="https://cloud.githubusercontent.com/assets/10119525/8968173/3a7d4152-3601-11e5-8c68-2e9c12355912.png">

Tested on chrome, firefox, safari. 
assets_version updated to 1.4

article example:
<img width="1317" alt="screen shot 2015-07-29 at 3 07 22 pm" src="https://cloud.githubusercontent.com/assets/10119525/8968550/92e7a8f8-3603-11e5-9bfd-2ae0dca69ee3.png">


@bmackinney can you review?
