### PR TITLE
Update reading-pantheon-environment-configuration.md

### DIFF
--- a/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
+++ b/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
@@ -80,7 +80,7 @@ Place [Domain Access setup routine](http://drupal.org/node/1096962) at the **en
       /**
        * Add the domain module setup routine to the end of settings.php
        */
-      include DRUPAL_ROOT . 'sites/all/modules/domain/settings.inc';
+      include DRUPAL_ROOT . '/sites/all/modules/domain/settings.inc';
     }
 
 


### PR DESCRIPTION
The code snippet for Domain Access was missing a leading forward slash before sites/all/modules/domain/settings.inc (which is in conflict with Domain access documentation). 

Drupal was interpreting this as /srv/bindings/foo/codesites/all/modules/domain/settings.inc. After this change it correctly comes out to /srv/bindings/foo/code/sites/all/modules/domain/settings.inc.