### PR TITLE
Remove Route 53 from **Domains and DNS**

### DIFF
--- a/source/docs/articles/sites/domains.md
+++ b/source/docs/articles/sites/domains.md
@@ -65,10 +65,10 @@ Users may also have success with **[ALIAS or ANAME](http://help.dnsmadeeasy.com/
 
 Learn more about ANAME records:
 
-*   [Route 53](http://aws.amazon.com/route53/faqs/#Supported_DNS_record_types)
 *   [DNSimple](http://support.dnsimple.com/articles/differences-between-a-cname-alias-url/)
 *   [DNS Made Easy](http://www.dnsmadeeasy.com/services/aname-records/)
 *   [EasyDNS](http://docs.easydns.com/aname-records/)
+
 
 
 ## Frequently Asked Questions


### PR DESCRIPTION
Remove Route 53 from **Domains and DNS**

Closes #350 

The Route 53 alias type is for AWS resources only, and should not be recommended in this capacity - because it does not "allow the alias at the root domain" as the doc currently suggests.  

From [Route 53 docs](http://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-choosing-alias-non-alias.html): 
> Instead of an IP address or a domain name, an alias resource record set contains a pointer to a CloudFront distribution, an ELB load balancer, an Amazon S3 bucket that is configured as a static website, or another Amazon Route 53 resource record set in the same hosted zone.

