### PR TITLE
New Article: /docs/articles/sites/code/dynamic-outgoing-ip-addresses

### DIFF
--- a/source/docs/articles/sites/code/dynamic-outgoing-ip-addresses.md
+++ b/source/docs/articles/sites/code/dynamic-outgoing-ip-addresses.md
@@ -1,0 +1,43 @@
+---
+title: Dynamic Outgoing IP Addresses
+description: Understand how outgoing requests are made for WordPress and Drupal sites on Pantheon.
+category:
+  - developing
+keywords: outgoing, outgoing requests, outgoing request, static ip, static ip outgoing, dynamic ip, dynamic outgoing ip, dynamic ip outgoing, outbound requests, dynamic outgoing ip addresses, payment gateway, gateway
+---
+Outgoing request sent by Drupal and WordPress applications facilitate tasks between your site and external services, such as authentication and payment gateways. Due to Pantheon's cloud-based infrastructure, these outbound requests are sent via dynamic IP addresses. There is no way to predict what IP address your code will be executed "from".
+
+## Pantheon Enterprise Gateway
+If your site relies on a static IP address for outgoing requests, the recommended solution is the [Pantheon Enterprise Gateway](/docs/articles/sites/code/pantheon-enterprise-gateway/). This is the only way to guarantee compatibility with extensions or services that require a known outgoing IP. Otherwise, you will need to find an alternative service to accomplish the request.
+
+## IP-Address Based Security Schemes
+Each Application Container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.
+
+IP-based security is not recommended on Pantheon - or any cloud platform. Instead, we recommend that you encrypt your communication using SSL certificates and other forms of authentication.
+
+For more information, see [SSO and Identity Federation on Pantheon](/docs/articles/sites/code/sso-and-identity-federation/#ip-based-security-considerations).
+
+## Compatible Payment Gateways
+The following payment gateways are known to work in cloud-based infrastructures such as ours:
+
+- Recurly
+- Braintree
+- Square
+- 2Checkout
+- GoCardless
+- Pingit
+- PayM
+- MasterPass
+- Charity Clear
+
+
+## Known Problematic Services
+The following services are known to be problematic without using the [Pantheon Enterprise Gateway](/docs/articles/sites/code/pantheon-enterprise-gateway/):
+
+- LDAP
+- FirstData
+- SagePay
+
+## See Also
+
+- [Known Limitations](/docs/articles/sites/known-limitations/#ip-address-based-security-schemes)

--- a/source/docs/articles/sites/code/dynamic-outgoing-ip-addresses.md
+++ b/source/docs/articles/sites/code/dynamic-outgoing-ip-addresses.md
@@ -5,15 +5,15 @@ category:
   - developing
 keywords: outgoing, outgoing requests, outgoing request, static ip, static ip outgoing, dynamic ip, dynamic outgoing ip, dynamic ip outgoing, outbound requests, dynamic outgoing ip addresses, payment gateway, gateway
 ---
-Outgoing request sent by Drupal and WordPress applications facilitate tasks between your site and external services, such as authentication and payment gateways. Due to Pantheon's cloud-based infrastructure, these outbound requests are sent via dynamic IP addresses. There is no way to predict what IP address your code will be executed "from".
+Outgoing requests sent by Drupal and WordPress applications facilitate tasks between your site and external services, such as authentication and payment gateways. Due to Pantheon's cloud-based infrastructure, these outbound requests are sent via dynamic IP addresses. There is no way to predict what IP address your code will be executed from.
 
 ## Pantheon Enterprise Gateway
 If your site relies on a static IP address for outgoing requests, the recommended solution is the [Pantheon Enterprise Gateway](/docs/articles/sites/code/pantheon-enterprise-gateway/). This is the only way to guarantee compatibility with extensions or services that require a known outgoing IP. Otherwise, you will need to find an alternative service to accomplish the request.
 
 ## IP-Address Based Security Schemes
-Each Application Container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.
+Each application container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.
 
-IP-based security is not recommended on Pantheon - or any cloud platform. Instead, we recommend that you encrypt your communication using SSL certificates and other forms of authentication.
+IP-based security is not recommended on Pantheon—or any cloud platform. Instead, we recommend that you encrypt your communication using SSL certificates and other forms of authentication.
 
 For more information, see [SSO and Identity Federation on Pantheon](/docs/articles/sites/code/sso-and-identity-federation/#ip-based-security-considerations).
 
@@ -25,9 +25,6 @@ The following payment gateways are known to work in cloud-based infrastructures 
 - Square
 - 2Checkout
 - GoCardless
-- Pingit
-- PayM
-- MasterPass
 - Charity Clear
 
 
@@ -37,7 +34,3 @@ The following services are known to be problematic without using the [Pantheon E
 - LDAP
 - FirstData
 - SagePay
-
-## See Also
-
-- [Known Limitations](/docs/articles/sites/known-limitations/#ip-address-based-security-schemes)

--- a/source/docs/articles/sites/code/sso-and-identity-federation.md
+++ b/source/docs/articles/sites/code/sso-and-identity-federation.md
@@ -8,7 +8,8 @@ keywords: sso, identity federation, single sign-on, single sign on, security, ld
 Many organizations need to centrally manage their user's identities and provide seamless integration across multiple applications. Numerous Pantheon customers, including higher educational institutions, school districts, local governments, and other groups use a variety of single sign-on (SSO) solutions.  
 
 Pantheon’s flexible infrastructure does not restrict protocols or ports used for communication. There are no outbound restrictions (protocol, port, etc.) for traffic from Pantheon to external services.
-SSL certificates can and should be used for encrypted secure communication with externally hosted servers for authentication.
+
+SSL certificates can and should be used for encrypted secure communication with externally hosted servers for authentication.
 
 ## LDAP and LDAPS (LDAP over SSL)
 
@@ -27,9 +28,15 @@ Also, Pantheon includes the [PECL OAuth](http://us.php.net/oauth) PHP extension.
 ## IP-Based Security Considerations
 
 Pantheon is a cloud platform, so there are some considerations that you should be aware of.  
-Pantheon provides a single dedicated incoming IP address for sites with custom SSL certificates. Each dedicated IP is assigned by the datacenter.  
-Pantheon does not have a mechanism for providing a dedicated outbound IP address. This is important to know if you are using a firewall with IP-based rules.  
 
-Each Application Container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.  
-Live sites on Pantheon on professional plans and above use multiple Application Container workers. This means (among other things) multiple distinct application servers and distinct outbound IPs.  
-In short, IP-based security is not recommended on Pantheon - or any cloud platform. Instead, we recommend that you encrypt your communication using SSL certificates and other forms of authentication.
+Pantheon provides a single dedicated incoming IP address for sites with custom SSL certificates. Each dedicated IP is assigned by the datacenter.  
+
+Pantheon does not have a mechanism for providing a dedicated outbound IP address. This is important to know if you are using a firewall with IP-based rules.  
+
+Each application container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.  
+
+Live sites on Pantheon on professional plans and above use multiple Application Container workers. This means (among other things) multiple distinct application servers and distinct outbound IPs.  
+
+In short, IP-based security is not recommended on Pantheon - or any cloud platform. Instead, we recommend that you encrypt your communication using SSL certificates and other forms of authentication.
+
+For more infromation, see [Dynamic Outgoing IP Addresses](/docs/articles/sites/code/dynamic-outgoing-ip-addresses).

--- a/source/docs/articles/sites/code/unsupported-modules-plugins.md
+++ b/source/docs/articles/sites/code/unsupported-modules-plugins.md
@@ -12,7 +12,7 @@ We do not prevent you from installing and using these plugins/modules; however, 
 
 - Adaptive Image Styles
 
-- Apache Solr Search   
+- Apache Solr Search
 **Issue** If Acquia Solr modules are present in the site codebase (even if disabled) and Pantheon Apache Solr is enabled, the site will be unable to connect to Solr server.  
 **Solution** Delete the Acquia Solr modules from the codebase and then disable and re-enable the Pantheon Apache Solr module.
 
@@ -87,3 +87,9 @@ Using sites/default/files/tmp as a work around for these issues will produce unp
 - batcache
 
 - Timthumb
+
+
+## Dynamic Outbound IPs
+Due to the cloud-based infrastructure of the Pantheon platform, outbound requests will be served by dynamic IP addresses. If your site relies on a static IP address for outgoing requests, the recommended solution is the [Pantheon Enterprise Gateway](/docs/articles/sites/code/pantheon-enterprise-gateway). This is the only way to guarantee compatibility with extensions or services that require a known outgoing IP. Otherwise, you will need to find an alternative to accomplish the request.
+
+For more information, see [Dynamic Outgoing IP Addresses](/docs/articles/sites/code/dynamic-outgoing-ip-addresses).

--- a/source/docs/articles/sites/known-limitations.md
+++ b/source/docs/articles/sites/known-limitations.md
@@ -46,14 +46,9 @@ If you are distributing large binaries or hosting big media files, we recommend 
 File directories on Pantheon's file serving infrastructure cannot be moved or renamed. To move or rename a directory, create a new directory, move all the files from inside the old directory into the new one, and delete the old directory.
 
 ## IP-Address Based Security Schemes
+IP-based security is not recommended on Pantheon - or any cloud platform because the actual IP address where code executes from can change as application containers are migrated throughout the infrastructure.
 
-All enterprise customers and customers with SSL will have a dedicated incoming IP to route public traffic. The actual IP address location where code executes can change on Pantheon, as application containers are migrated throughout the infrastructure.
-
-Typically, it is not possible to support access to external web services via an IP address based restriction, for example, LDAP or FirstData. There's no way to predict what IP address your code will be executing "from". 
-
-This is also a consideration for some payment gateways, including SagePay, which require a known IP address.
-
-We offer the [Pantheon Enterprise Gateway](https://pantheon.io/features/secure-integration) for Enterprise customers, as a solution to this problem.
+For more information, see [Dynamic Outgoing IP Addresses](/docs/articles/sites/code/dynamic-outgoing-ip-addresses).
 
 ## Maintenance Mode
 


### PR DESCRIPTION
**Dynamic Outgoing IP Addresses**

Closes #786 

This PR creates a centralized location concerning outbound requests made by a site on Pantheon. It recommends that if a dedicated outgoing IP is required, PEG must be used. Otherwise an alternative service must be used instead. This doc also provides recommended payment gateways and lists know services that are problematic on cloud-based infrastructures. 

This is a WIP and not yet ready for final review. See issue for up to date todo list. 