### PR TITLE
Update url parameter naming details for "Considerations for Google Analytics and PANTHEON_STRIPPED"

### DIFF
--- a/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
+++ b/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
@@ -20,6 +20,6 @@ Any URL query parameters (GET requests) matching the following criteria will hav
 
 - `utm_*` -- Matches standard Google Analytics parameters
 - `__*` (two underscores) -- Matches conventional content insignificant query parameters
-  - __Note:__ query parameters cannot contain any hyphens or camelCase keys. They should be all lowercase and without hyphens. Using either of the aforementioned naming schemes will result in an unique cache entry and lose the normalization benefit of `PANTHEON_STRIPPED`.
+  - __Note:__ query parameters cannot contain any hyphens or camelCase keys. They should be all lowercase and without hyphens. Using either of the aforementioned naming schemes will result in an unique cache entry and lose the normalization benefit of `PANTHEON_STRIPPED`. Underscores may be used as word delimiters.
   - __NO:__ `__myQueryParameter=value` or `__my-query-parameter=value`
-  - __YES:__ `__myqueryparameter=value`
+  - __YES:__ `__myqueryparameter=value` or `__my_query_parameter=value`

--- a/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
+++ b/source/docs/articles/sites/varnish/pantheon_stripped-get-parameter-values.md
@@ -20,3 +20,6 @@ Any URL query parameters (GET requests) matching the following criteria will hav
 
 - `utm_*` -- Matches standard Google Analytics parameters
 - `__*` (two underscores) -- Matches conventional content insignificant query parameters
+  - __Note:__ query parameters cannot contain any hyphens or camelCase keys. They should be all lowercase and without hyphens. Using either of the aforementioned naming schemes will result in an unique cache entry and lose the normalization benefit of `PANTHEON_STRIPPED`.
+  - __NO:__ `__myQueryParameter=value` or `__my-query-parameter=value`
+  - __YES:__ `__myqueryparameter=value`


### PR DESCRIPTION
## What? Why?
Proposed documentation details around valid url query parameter naming to trigger `PANTHEON_STRIPPED` normalization on edge caching.

This is after testing on our current Pantheon site and confirming how param naming affects normalization.

