### PR TITLE
Add issues CTA and encoded URL

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 1.5
+assets_version: 1.6
 
 #######################################################################################################
 # The authors. Include your info here, under the "authors" key, using the following template:

--- a/source/_views/article.html
+++ b/source/_views/article.html
@@ -6,10 +6,17 @@
           <div class="col-md-9">
             <header>
               <h1 class="pio-docs-title">{{ page.title }}</h1>
-              <span style="font-size:20px; font-weight:bold;"><a href="https://github.com/pantheon-systems/documentation/edit/master/source{{ page.url }}.md" target="_blank"><strong>
-                <span class="icon-github">Edit on GitHub</span></strong></a></span><br /><br />
-
-
+              <div class="dropdown" id="edit">
+                  <button class="btn-secondary dropdown-toggle" type="button" id="dropdownMenu1" data-toggle="dropdown"  aria-expanded="true">
+                      <span class="icon-github"></span> Contribute to Docs
+                      <span class="caret"></span>
+                  </button>
+    <div class="dropdown-menu edit" aria-labelledby="dropdownMenu1">
+        <a href="https://github.com/pantheon-systems/documentation/edit/master/source{{ page.url }}.md" target="blank"><span class="glyphicon glyphicon-pencil"></span> Edit This Doc</a><br>
+        <a href="https://github.com/pantheon-systems/documentation/issues/new?title={{page.title}}%20Doc%20Update%20&body=Re%3A%20%5B{{page.title}}%5D(https%3A%2F%2Fpantheon.io{{page.url}})%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=type%3A%20doc%20update" target="blank"><span class="glyphicon glyphicon-tag"></span> Report Doc Issue</a><br>
+        <a href="https://github.com/pantheon-systems/documentation/issues/new?title=New%20Doc%20Proposal%20&body=%23%23%20Title%0A%0A%0A%23%23%20Description%0A%0A%0A%23%23%20Outline%0A%0A%0A%23%23%20Expected%20Audience%0A%0A%0A%23%23%20Path%0A(e.g.%20%60source%2Fdocs%2Farticles%2Fsites%2Fcode%60%20or%20%60source%2Fdocs%2Farticles%2Fwordpress%60)&labels=type%3A%20new%20article" target="blank"><span class="glyphicon glyphicon-file"></span> Suggest New Doc</a>
+    </div>
+</div>
 
             </header>
               <!--{% if page.category %}
@@ -23,14 +30,15 @@
               <!--div class="outline-alert"><strong>Want to improve this doc? Check the <a href="https://github.com/pantheon-systems/documentation/issues?utf8=✓&q=is%3Aissue+{{ page.title }}" target="blank">issues queue</a>, review <a href="https://github.com/pantheon-systems/documentation/blob/master/CONTRIBUTING.md" target="blank">contributor guidelines</a>, and -->
 
 
-                <div>
+                <div style="margin-top:15px;">
                     {{ page.blocks.content|raw }}
                 </div>
           </div>
 
             <div class="col-md-3">
               <div class="pio-docs-sidebar hidden-print hidden-xs hidden-sm" role="complementary">
-                <div id="toc"><h3>Contents</h3>
+                <div id="toc">
+                    <h3>Contents</h3>
                 </div>
               </div>
             </div>

--- a/source/docs/assets/css/jquery.tocify.css
+++ b/source/docs/assets/css/jquery.tocify.css
@@ -5,12 +5,12 @@
 
 /* The Table of Contents container element */
 .tocify {
-    margin-top: 20px;
+    margin-top: 45px;
     max-height: 90%;
     overflow: auto;
-    webkit-border-radius: 6px;
-    moz-border-radius: 6px;
-    border-radius: 6px;
+    webkit-border-radius: 0px;
+    moz-border-radius: 0px;
+    border-radius: 0px;
     text-align: left;
 }
 
@@ -21,7 +21,9 @@
     border: none;
     line-height: 18px;
 }
-
+.tocify h3 {
+    margin-top: 0px;
+}
 /* Top level header elements */
 .tocify-header {
 }

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -357,6 +357,35 @@ img.noborder {
 * Separated section of content at the bottom of all pages, save the homepage.
 */
 
+
+#edit .btn-secondary, .btn-secondar:visited {
+        text-shadow: none !important;
+        background: #ededed;
+        color: #000 !important;
+        margin: 0px 0px 5px 0px !important;
+        padding: 12px 22px 12px 16px;
+        text-decoration: none !important;
+        font-weight: bold;
+        display: inline-block;
+        white-space: nowrap !important;
+        line-height: 1;
+        border-color: transparent;
+        border: none;
+        text-transform: uppercase;
+        margin-left: 0px;
+
+    }
+
+#edit a {
+    margin-left: 20px;
+    margin-right: 40px;
+    text-decoration: none;
+    font-size: medium;
+}
+#edit a:hover {
+    text-decoration: none;
+}
+
 .cta-docs-footer{
   padding: 20px;
   background: #DDE5E7;


### PR DESCRIPTION
Closes #833 

WIP - Feedback requested

@bmackinney this PR adds a second link under the existing CTA. The URL populates the doc title and adds the doc update label, along with body content for a description/suggestion. Just a starting point - let me know if you think this should be an actual button instead of a link. 

![screen shot 2015-08-24 at 10 01 11 am](https://cloud.githubusercontent.com/assets/10119525/9443521/1d611bd4-4a47-11e5-8aa1-b7991ec62d9f.png)
### Link opens: 
![screen shot 2015-08-24 at 10 01 20 am](https://cloud.githubusercontent.com/assets/10119525/9443522/1d6bdcc2-4a47-11e5-9b7a-a57d6b3368f8.png)
