### PR TITLE
Remove () from gcse js

### DIFF
--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -5,7 +5,7 @@ layout: default
 <div class="container article">
   <div class="col-md-7">
   <script>
-    (function() {
+    function() {
       var cx = '017416971424255486898:moj1j4obfwm';
       var gcse = document.createElement('script');
       gcse.type = 'text/javascript';
@@ -14,7 +14,7 @@ layout: default
           '//cse.google.com/cse.js?cx=' + cx;
       var s = document.getElementsByTagName('script')[0];
       s.parentNode.insertBefore(gcse, s);
-    })();
+    }();
   </script>
   <gcse:searchresults-only linkTarget="_self"></gcse:searchresults-only>
 </div>


### PR DESCRIPTION
FF Developer tools showed the following error:
![screen shot 2015-08-24 at 10 12 08 am](https://cloud.githubusercontent.com/assets/10119525/9443776/a2fd22dc-4a48-11e5-91c2-3d1ab4ba853e.png)
After a bit of searching, I came across the following forum: [Google Custom Search results not displaying in Firefox, but work for Safari, Chrome and IE](https://productforums.google.com/forum/#!topic/customsearch/lQAKjUmysfo;context-place=forum/customsearch)

This PR removes the mentioned "brackets" from the js code and _should_ resolve the issue. There's not a way to test since results are written to our production environment.

@bmackinney @ari-gold 