### PR TITLE
change deleted doc links to go to ssl guide

### DIFF
--- a/source/docs/articles/wordpress.md
+++ b/source/docs/articles/wordpress.md
@@ -21,7 +21,7 @@ Pantheon analyzes code to provide performance and configuration recommendations 
 ## Additional Resources
 - [WordPress FAQ](/docs/articles/wordpress/wordpress-faq)
 - [Wordpress Known Issues](/docs/articles/wordpress/wordpress-known-issues)
-- [Add Cloudflare Free SSL to WordPress Sites](http://localhost:8000/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites)
+- [Adding HTTPS For Free with CloudFlare](/docs/guides/ssl-with-cloudflare/)
 - [CloudFront CDN Setup for WordPress](/docs/articles/wordpress/cloudFront-setup-for-wordpress)
 - [Configuring JetBrains PhpStorm IDE with WordPress on Pantheon](/docs/articles/wordpress/configuring-phpstorm-on-pantheon-for-wordpress)
 - [Fix Broken Links in WordPress](/docs/articles/wordpress/fix-broken-links-in-wordpress)

--- a/source/docs/articles/wordpress/wordpress-best-practices.md
+++ b/source/docs/articles/wordpress/wordpress-best-practices.md
@@ -14,7 +14,7 @@ This article provides suggestions, tips, and best practices for developing and m
 
 * Automate testing with [Behat](/docs/guides/automated-testing-wordpress-behat/). Adding automated testing into your development workflow will help you deliver higher quality WordPress sites.
 
-* We recommend using SSL/HTTPS. Pro plans and above can [load a certificate](/docs/articles/sites/domains/adding-a-ssl-certificate-for-secure-https-communication/) into Pantheon. On Personal plans (or others), you can use [CloudFlare Free SSL](/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites).
+* We recommend using SSL/HTTPS. Pro plans and above can [load a certificate](/docs/articles/sites/domains/adding-a-ssl-certificate-for-secure-https-communication/) into Pantheon. On Personal plans (or others), you can use [CloudFlare Free SSL](/docs/guides/ssl-with-cloudflare/).
 
 * Run [Launch Check](/docs/articles/wordpress/launch-check-wordpress-performance-and-configuration-analysis) to review errors and get recommendations on your site's configurations.
 

--- a/source/docs/guides/ssl-with-cloudflare.md
+++ b/source/docs/guides/ssl-with-cloudflare.md
@@ -185,6 +185,3 @@ Because of the structure of our network, we won't be able to offer reduced-cost 
 This basic technique — terminating your HTTPS elsewhere and then "backending" to Pantheon's provided certificate — can be used with other services, including your own infrastructure. Here's an example of [an nginx config that does essentially the same thing](https://gist.github.com/caktux/00a2161b5d849335e644).
 
 As the movement for **encryption everywhere** (e.g. [Let's Encrypt](https://letsencrypt.org/)) picks up steam, we look forward to being able to support many fine avenues for running sites under HTTPS at a low cost.
-
-## See Also  
-[Add Cloudflare Free SSL to WordPress Sites](/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites/)


### PR DESCRIPTION
Since https://pantheon.io/docs/articles/wordpress/add-cloudflare-free-ssl-to-wordpress-sites/ has been deleted, I changed the links in existing docs to go to the SSL guide. 