### PR TITLE
Redis doc update: rename subheader for d7-d6, add d8

### DIFF
--- a/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
+++ b/source/docs/articles/sites/code/reading-pantheon-environment-configuration.md
@@ -73,7 +73,7 @@ Place [Domain Access setup routine](http://drupal.org/node/1096962) at the **en
       extract(json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE));
       // All $conf variables and Redis configuration go after extract()
 
-      // If using Redis add appropriate settings per https://pantheon.io/docs/articles/sites/redis-as-a-caching-backend/#using-redis-with-drupal
+      // If using Redis add appropriate settings per https://pantheon.io/docs/articles/sites/redis-as-a-caching-backend#using-redis-with-drupal-7.x-and-6.x
 
       // Add other $conf variables, for example for Fast 404 pages
 

--- a/source/docs/articles/sites/redis-as-a-caching-backend.md
+++ b/source/docs/articles/sites/redis-as-a-caching-backend.md
@@ -32,12 +32,11 @@ Currently, all plans except for Personal can use Redis. Redis is available to Sa
 ---
 
 
-
 ### Using Redis with WordPress
 
 For detailed information, see [Installing Redis on WordPress](/docs/articles/wordpress/installing-redis-on-wordpress).
 
-### Using Redis with Drupal
+### Using Redis with Drupal 7.x and 6.x
 
 The common community module for Drupal to use Redis is simply called [redis](http://drupal.org/project/redis). Enabling it on Pantheon takes only a few steps:
 
@@ -106,6 +105,9 @@ The common community module for Drupal to use Redis is simply called [redis](htt
 
  ![](/source/docs/assets/images/desk_images/71423.png)
  - For Drupal 6 visit  `admin/settings/performance/cache-backend` and you should be able to see the available backends and their statuses.
+
+ ### Using Redis with Drupal 8 
+ At this time, sites running Drupal 8 cannot use Redis. Check the status on the [Redis project page](https://www.drupal.org/project/redis), or view to the [issue queue](https://www.drupal.org/project/issues/redis?categories=All).
 
 ## Using the Redis Command-Line Client
 

--- a/source/docs/articles/sites/redis-as-a-caching-backend.md
+++ b/source/docs/articles/sites/redis-as-a-caching-backend.md
@@ -107,7 +107,7 @@ The common community module for Drupal to use Redis is simply called [redis](htt
  - For Drupal 6 visit  `admin/settings/performance/cache-backend` and you should be able to see the available backends and their statuses.
 
  ### Using Redis with Drupal 8 
- At this time, sites running Drupal 8 cannot use Redis. Check the status on the [Redis project page](https://www.drupal.org/project/redis), or view to the [issue queue](https://www.drupal.org/project/issues/redis?categories=All).
+ At this time, sites running Drupal 8 cannot use Redis. Check the status on the [Redis project page](https://www.drupal.org/project/redis), or view to the [Port Redis issue queue](https://www.drupal.org/node/2233413)for updates.
 
 ## Using the Redis Command-Line Client
 


### PR DESCRIPTION
Closes #911 This PR:
* renames the Drupal subheader to specify 7.x and 6.x
* adds a new Drupal 8 subheader/section
* updates cross-reference link to the Drupal section in the "Reading Pantheon Environment  Configuration" doc

@ttrowell @davidstrauss @alexdicianu Please review. Do we have an alternative we can recommend for D8?