### PR TITLE
Remove title case from title meta

### DIFF
--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -33,7 +33,7 @@
 
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    <title>{% block title %}{{ page.title|title }} | {{ site.title }}{% endblock %}</title>
+    <title>{% block title %}{{ page.title }} | {{ site.title }}{% endblock %}</title>
     <meta name="description" content="{{ page.description }}">
     <meta name="keywords" content="{{ page.keywords }}">
     <meta name="viewport" content="width=device-width, initial-scale=1">


### PR DESCRIPTION
@rachelwhitton please test/review. Fixes the `Ssl` from showing up on google...