### PR TITLE
Update CLI arguments

### DIFF
--- a/source/docs/articles/local.md
+++ b/source/docs/articles/local.md
@@ -60,8 +60,8 @@ Replace <code>database.sql.gz</code> with the name of the database archive downl
 Create and export the database by running the following Terminus commands:
 
 ```nohighlight
-terminus site backup create --element=database --site=<site> --env=<env>
-terminus site backup get --element=database --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
+terminus site backups create --element=database --site=<site> --env=<env>
+terminus site backups get --element=database --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
 ```
 
 You can now import the archive into your local MySQL database using the following command:
@@ -77,8 +77,8 @@ For an overview of ways to transfer files, see [SFTP and rsync on Pantheon](/doc
 
 Run the following Terminus commands:
 ```nohighlight
-terminus site backup create --element=files --site=<site> --env=<env>
-terminus site backup get --element=files --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
+terminus site backups create --element=files --site=<site> --env=<env>
+terminus site backups get --element=files --site=<site> --env=<env> --to-directory=$HOME/Desktop/ --latest
 ```
 This will create and download a backup of the site's files to your desktop.
 


### PR DESCRIPTION
'terminus site backup' is 'terminus site backups' in Terminus 0.8.0. Running terminus site backup produces: [error] 'site backup' is not a registered command. See 'terminus help'.