### PR TITLE
reorg doc, remove note styling

### DIFF
--- a/source/docs/articles/sites/code/applying-upstream-updates.md
+++ b/source/docs/articles/sites/code/applying-upstream-updates.md
@@ -7,16 +7,9 @@ category:
 keywords: upstream, update upstream, apply updates, apply update, update core, update plugin, update module, update theme, update distribution, distribution, deploy update, deploy updates, update, updates, security update, apply security update, patch
 ---
 
-## Preparation
-
-- ​If you have updates on Dev or Test that are not ready to be deployed to Live with your upstream updates, see  [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
-- If the Development environment is in SFTP mode with pending changes that you are ready to deploy to Live, commit code changes.
-- If you are not ready to deploy to Live, use an SFTP connection to copy the files locally.
-- Change the Development environment connection to Git. Note: Changing the connection mode to Git without committing code will delete those changes.
-
-## Apply a Core Update
-
 Only use the one-click updates on the Dashboard to update your site's core. Do not update core using Drush or WP-CLI; you will overwrite your core.
+
+## Apply Upstream Updates via the Dashboard
 
 1. Check the options you want to run after pulling the update.
 2. Click **Apply Updates**.
@@ -29,19 +22,13 @@ Only use the one-click updates on the Dashboard to update your site's core. Do n
 8. Click **Visit Live Environment** to verify the update is live.
 ![The Code tab in the Pantheon site's dashboard's Live Environment, showing the upstream commits in the log as deployed.](/source/docs/assets/images/desk_images/357435.png)
 
-## About Core Updates
-Core updates appear on your Dashboard after review and testing by our team, usually within a week of release. These updates appear in your code workspace beneath the Connection Mode bar when they are available. Due to platform-wide codeserver caching settings, update notifications may appear on different Site Dashboards running the same upstream up to two hours apart.
-
-Sometimes we will add new features to the Pantheon API module and deploy bug fixes ahead of a core release. If you are observing good development practices and not modifying core, merging an available update is your best course of action.
-
-Core updates for alternate distributions (Open Atrium, Commerce Kickstart, etc.) are initiated by the maintainer, not Pantheon. Please contact them directly regarding expected updates.
-
-<div class="alert alert-danger" role="alert"><h4>Warning</h4>
-Only use the one-click updates on the Dashboard to update your site's core. Do not update core using Drush or WP-CLI; you will overwrite your core.<br /><br />
-
-You cannot unpack a tarball from Drupal.org or WordPress.org; this will overwrite the core's auto-configuration feature and your site will lose its database connection.</div>
-
-If you have overwritten core, see [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
+### Further Considerations
+- ​If you have updates on Dev or Test that are not ready to be deployed to Live with your upstream updates, see  [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
+- If the Development environment is in SFTP mode with pending changes that you are ready to deploy to Live, commit code changes.
+- If you are not ready to deploy to Live, use an SFTP connection to copy the files locally.
+- Core updates appear in your code workspace beneath the Connection Mode bar when they are available. Due to platform-wide codeserver caching settings, update notifications may appear on different Site Dashboards running the same upstream up to two hours apart.
+- Core updates for alternate distributions (Open Atrium, Commerce Kickstart, etc.) are initiated by the maintainer, not Pantheon. Please contact them directly regarding expected updates.
+- Sometimes we will add new features to the Pantheon API module and deploy bug fixes ahead of a core release. If you are observing good development practices and not modifying core, merging an available update is your best course of action.
 
 ## Debug Failed Merges
 
@@ -90,6 +77,8 @@ Conflicts can occur when the upstream you are trying to merge your code with has
 _"When a merge isn’t resolved automatically, git leaves the index and the working tree in a special state that gives you all the information you need to help resolve the merge."_ - <u>Git Manual</u>
 
 ### Delete Merge Conflicts
+
+If you have overwritten core, see [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
 
 To manually delete merge conflicts from the terminal, use the following commands in sequence:
 

--- a/source/docs/articles/sites/code/applying-upstream-updates.md
+++ b/source/docs/articles/sites/code/applying-upstream-updates.md
@@ -6,11 +6,31 @@ category:
   - drupal
 keywords: upstream, update upstream, apply updates, apply update, update core, update plugin, update module, update theme, update distribution, distribution, deploy update, deploy updates, update, updates, security update, apply security update, patch
 ---
-Core updates appear on your Dashboard after review and testing by our team, usually within a week of release. These updates appear in your code workspace beneath the Connection Mode bar when they are available.
 
-<div class="alert alert-info" role="alert">
-<h4>Note</h4>
-Due to platform-wide codeserver caching settings, update notifications may appear on different Site Dashboards running the same upstream up to two hours apart.</div>
+## Preparation
+
+- ​If you have updates on Dev or Test that are not ready to be deployed to Live with your upstream updates, see  [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
+- If the Development environment is in SFTP mode with pending changes that you are ready to deploy to Live, commit code changes.
+- If you are not ready to deploy to Live, use an SFTP connection to copy the files locally.
+- Change the Development environment connection to Git. Note: Changing the connection mode to Git without committing code will delete those changes.
+
+## Apply a Core Update
+
+Only use the one-click updates on the Dashboard to update your site's core. Do not update core using Drush or WP-CLI; you will overwrite your core.
+
+1. Check the options you want to run after pulling the update.
+2. Click **Apply Updates**.
+![A Pantheon site dashboard with upstream updates available.](/source/docs/assets/images/desk_images/357403.png)
+3. Click **Visit Development Site** in the Development Environment to test it, or run your automatic user acceptance tests.
+4. If you find errors, you can [<u>revert to the last stable commit</u>](/docs/articles/local/git-faq#how-do-i-revert-or-undo-changes?) using Git.
+5. Deploy the upstream updates to your Test Environment by clicking **Pull (Content from Live and) Code from Development** in the Code workspace in the Test Environment.
+6. Click **Visit Testing Environment** to test the update against your Live site’s content base.
+7. Deploy the upstream updates to your Live Environment by clicking **Pull Code from Testing** in the Code workspace in the Live environment.
+8. Click **Visit Live Environment** to verify the update is live.
+![The Code tab in the Pantheon site's dashboard's Live Environment, showing the upstream commits in the log as deployed.](/source/docs/assets/images/desk_images/357435.png)
+
+## About Core Updates
+Core updates appear on your Dashboard after review and testing by our team, usually within a week of release. These updates appear in your code workspace beneath the Connection Mode bar when they are available. Due to platform-wide codeserver caching settings, update notifications may appear on different Site Dashboards running the same upstream up to two hours apart.
 
 Sometimes we will add new features to the Pantheon API module and deploy bug fixes ahead of a core release. If you are observing good development practices and not modifying core, merging an available update is your best course of action.
 
@@ -23,46 +43,19 @@ You cannot unpack a tarball from Drupal.org or WordPress.org; this will overwrit
 
 If you have overwritten core, see [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
 
-## Preparation
-
-- ​If you have updates on Dev or Test that are not ready to be deployed to Live with your upstream updates, see  [Undo Git Commits](/docs/articles/local/undo-git-commits-like-overwriting-drupal-core).
-- If the Development environment is in SFTP mode with pending changes that you are ready to deploy to Live, commit code changes.
-- If you are not ready to deploy to Live, use an SFTP connection to copy the files locally.
-- Change the Development environment connection to Git. Note: Changing the connection mode to Git without committing code will delete those changes.
-
-## Apply a Core Update
-
-1. Check the options you want to run after pulling the update.
-2. Click **Apply Updates**.
-![A Pantheon site dashboard with upstream updates available.](/source/docs/assets/images/desk_images/357403.png)
-3. Click **Visit Development Site** in the Development Environment to test it, or run your automatic user acceptance tests.
-4. If you find errors, you can [<u>revert to the last stable commit</u>](/docs/articles/local/git-faq#how-do-i-revert-or-undo-changes?) using Git.
-5. Deploy the upstream updates to your Test Environment by clicking **Pull (Content from Live and) Code from Development** in the Code workspace in the Test Environment.
-6. Click **Visit Testing Environment** to test the update against your Live site’s content base.
-7. Deploy the upstream updates to your Live Environment by clicking **Pull Code from Testing** in the Code workspace in the Live environment.
-![The Code tab in a Pantheon site's dashboard's Live environment](/source/docs/assets/images/desk_images/357432.png)
-8. Click **Visit Live Environment** to verify the update is live.
-![The Code tab in the Pantheon site's dashboard's Live Environment, showing the upstream commits in the log as deployed.](/source/docs/assets/images/desk_images/357435.png)
-
 ## Debug Failed Merges
 
 If the automated core update doesn't appear to be working, it's possible there are conflicts with your codebase in the update. Usually these are easy to resolve.
 
 ### Auto-Resolve Conflicts
 
-In the event that the update fails, you may see an error indicating a conflict with some files in core.
+In the event that the update fails, you may see an error indicating a conflict with some files in core. Try the "Auto-Resolve" option when applying updates. Pantheon will try to automatically resolve conflicts in favor of the upstream Git repository. This does not solve all problems that may arise, but it should take care of most situations.
 
-Try the "Auto-Resolve" option when applying updates. Pantheon will try to automatically resolve conflicts in favor of the upstream Git repository.
-
-<div class="alert alert-warning" role="alert">
-<h4>Note</h4>
-This does not solve all problems that may arise, but it should take care of most situations.</div>
-
-In the event the "Auto-Resolve Conflicts" option fails, the next step is to manually pull your changes in using Git, resolve the conflicts, and then push the update up to your Pantheon site.
+If the "Auto-Resolve Conflicts" option fails, the next step is to manually pull your changes in using Git, resolve the conflicts, and then push the update up to your Pantheon site.
 
 ### Resolve Conflicts Locally With Drupal 7
 
-From within an up-to date Git clone on your local machine:
+From within an up-to-date Git clone on your local machine:
 ```bash
 git pull git://github.com/pantheon-systems/drops-7.git master
 # resolve conflicts

--- a/source/docs/articles/sites/code/applying-upstream-updates.md
+++ b/source/docs/articles/sites/code/applying-upstream-updates.md
@@ -120,6 +120,7 @@ For example:
  ```bash
  git push origin master
  ```
+
 ### 503 Errors When Running Update.php and Installing Modules
 
 There are multiple reasons that 503s might occur when updating:


### PR DESCRIPTION
Closes #955 

This PR:
- moves essential information above the fold
- removes note treatment from general information that doesn't need to be called out
- removes unnecessary screenshot 

@bmackinney @ari-gold Please review.