### PR TITLE
Clarify instructions for configuring private files in Drupal

### DIFF
--- a/source/docs/articles/drupal/private-files.md
+++ b/source/docs/articles/drupal/private-files.md
@@ -15,7 +15,7 @@ If you have not already created these directories, you will need to do that firs
 
 These files will be web-accessible based on the access control rules that you set for your site and will use the following directory: `sites/default/files/private`
 
-To configure, navigate to **Administration** >> **Configuration** >> **Media** >> **File System** and select **Private local files served by Drupal** as the default download method then click **Save Configuration**. 
+To configure, go to **Administration** > **Configuration** > **Media** > **File System**, select **Private local files served by Drupal** as the default download method, and click **Save Configuration**. 
 
 ## Storing Private Keys and Certs
 

--- a/source/docs/articles/drupal/private-files.md
+++ b/source/docs/articles/drupal/private-files.md
@@ -13,7 +13,9 @@ If you have not already created these directories, you will need to do that firs
 
 ## Private Files and Uploads In Drupal
 
-This can be done by setting your file-system settings to private. These files will be web-accessible based on the access control rules that you set for your site and will use the following directory: `sites/default/files/private`
+These files will be web-accessible based on the access control rules that you set for your site and will use the following directory: `sites/default/files/private`
+
+To configure, navigate to **Administration** >> **Configuration** >> **Media** >> **File System** and select **Private local files served by Drupal** as the default download method then click **Save Configuration**. 
 
 ## Storing Private Keys and Certs
 


### PR DESCRIPTION
Closes https://github.com/pantheon-systems/documentation/issues/937

- Instruct to configure from within admin/config/media/file-system
- No d8 specific instructions need, see above issue for d8 planning

I don't believe we need to hold this for release. No D8 specific content. 