### PR TITLE
Error in Configuring Settings.php documentation

### DIFF
--- a/source/docs/articles/drupal/configuring-settings-php.md
+++ b/source/docs/articles/drupal/configuring-settings-php.md
@@ -57,12 +57,12 @@ Use these configuration snippets to specify a local configuration that will be i
 
 Depending on your use case, there are two possibilities:
 
-For web only actions, like redirects, check for the existence of $\_SERVER['PANTHEON\_ENVIRONMENT']. If it exists, it will contain a string with the current environment (Dev, Test, or Live).
+For web only actions, like redirects, check for the existence of $\_ENV['PANTHEON\_ENVIRONMENT']. If it exists, it will contain a string with the current environment (Dev, Test, or Live).
 
     // Pantheon - web only.
-    if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
+    if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
       // Only on dev web environment.
-      if ($_SERVER['PANTHEON_ENVIRONMENT'] == 'dev') {
+      if ($_ENV['PANTHEON_ENVIRONMENT'] == 'dev') {
         // Custom code.
       }
     }


### PR DESCRIPTION
In a support ticket, `$_SERVER['PANTHEON_ENVIRONMENT']` was apparently not working.  I thought perhaps it should be `$_ENV['PANTHEON_ENVIRONMENT']`, because I did not notice PANTHEON_ENVIRONMENT in $_SERVER when I dumped it at first, but it looks like it is there after all.

Leaving open for now, but I think perhaps this can be closed without merging. Perhaps wait for the ticket resolution first.

**ENV**
```
DB_HOST=10.223.176.68
DB_NAME=pantheon
DB_PORT=18440
PANTHEON_ENVIRONMENT=dev
USER=...
PANTHEON_SITE=...
PATH=/usr/local/bin:/bin:/usr/bin:/srv/bin
DOCROOT=/
PWD=...
DB_PASSWORD=...
DRUPAL_HASH_SALT=...
PANTHEON_SITE_NAME=...
SHLVL=1
FILEMOUNT=sites/default/files
HOME=...
DB_USER=pantheon
FRAMEWORK=drupal
PANTHEON_INFRASTRUCTURE_ENVIRONMENT=live
_=/bin/printenv
```
**SERVER**
```
array (
  'USER' => '...',
  'HOME' => '...',
  'FCGI_ROLE' => 'RESPONDER',
  'QUERY_STRING' => '',
  'REQUEST_METHOD' => 'GET',
  'CONTENT_TYPE' => '',
  'CONTENT_LENGTH' => '',
  'SCRIPT_NAME' => '/index.php',
  'REQUEST_URI' => '/',
  'DOCUMENT_URI' => '/index.php',
  'DOCUMENT_ROOT' => '...',
  'SERVER_PROTOCOL' => 'HTTP/1.1',
  'GATEWAY_INTERFACE' => 'CGI/1.1',
  'SERVER_SOFTWARE' => 'nginx/1.4.7',
  'REMOTE_ADDR' => '71.139.3.138',
  'REMOTE_PORT' => '52123',
  'SERVER_ADDR' => '10.223.145.209',
  'SERVER_PORT' => '15450',
  'SERVER_NAME' => '...',
  'REDIRECT_STATUS' => '200',
  'PATH_INFO' => '',
  'PATH_TRANSLATED' => '...',
  'HTTPS' => 'OFF',
  'SCRIPT_FILENAME' => '...',
  'HTTP_HOST' => '...',
  'HTTP_USER_AGENT' => 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_0) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.101 Safari/537.36',
  'HTTP_ACCEPT' => 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
  'HTTP_ACCEPT_ENCODING' => 'gzip',
  'HTTP_ACCEPT_LANGUAGE' => 'en-US,en;q=0.8',
  'HTTP_COOKIE' => 'Drupal.toolbar.collapsed=0; has_js=1',
  'HTTP_SURROGATE_CAPABILITY' => 'styx="ESI/1.0"',
  'HTTP_UPGRADE_INSECURE_REQUESTS' => '1',
  'HTTP_USER_AGENT_HTTPS' => 'OFF',
  'HTTP_X_FORWARDED_FOR' => '71.139.3.138',
  'HTTP_X_PANTHEON_CLIENT_IP' => '71.139.3.138',
  'HTTP_X_PANTHEON_STYX' => '1',
  'HTTP_X_PROTO' => 'http://',
  'HTTP_X_VARNISH' => '3946591436',
  'PHP_SELF' => '/index.php',
  'REQUEST_TIME_FLOAT' => 1443672454.5929971,
  'REQUEST_TIME' => 1443672454,
  'PRESSFLOW_SETTINGS' => '{...}',
  'FRAMEWORK' => 'drupal',
  'DOCROOT' => '/',
  'FILEMOUNT' => 'sites/default/files',
  'DRUPAL_HASH_SALT' => '...',
  'DB_HOST' => '10.223.176.68',
  'DB_PORT' => '18440',
  'DB_USER' => 'pantheon',
  'DB_PASSWORD' => '...',
  'DB_NAME' => 'pantheon',
  'PANTHEON_SITE' => '...',
  'PANTHEON_SITE_NAME' => '...',
  'PANTHEON_ENVIRONMENT' => 'dev',
  'PANTHEON_INFRASTRUCTURE_ENVIRONMENT' => 'live',
  'HTTP_REFERER' => '',
)
```