### PR TITLE
Launch Check - Drupal: add d8 support info

### DIFF
--- a/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
+++ b/source/docs/articles/drupal/launch-check-drupal-performance-and-configuration-analysis.md
@@ -55,8 +55,10 @@ You can also execute a full report in HTML format.
 ```bash
 terminus drush aa --site=<site> --env=<env> --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
 ```
-#### Are there plans for supporting Drupal 6 sites?
+#### Is Launch Check available for Drupal 8 sites?
+Launch Check for Drupal 8 is currently in development and will be available at a later date.
 
+#### Are there plans to support Drupal 6 sites?
 At this time, there are no plans to support Drupal 6 with this tool.
 
 #### Can I opt-out of a specific recommendation?


### PR DESCRIPTION
Closes #994 
Replaces #996 
Note that Launch Check for Drupal 8 is in development at this time and not currently supported. 