### PR TITLE
Built-in maintenance mode works for WordPress too

### DIFF
--- a/source/docs/articles/sites/known-limitations.md
+++ b/source/docs/articles/sites/known-limitations.md
@@ -52,9 +52,9 @@ For more information, see [Dynamic Outgoing IP Addresses](/docs/articles/sites/c
 
 ## Maintenance Mode
 
-Drupal's built-in Maintenance Mode works and can be customized; clear caches when toggling.
+Pantheon may send a [generic Maintenance Mode message](/docs/articles/sites/errors-and-server-responses#pantheon-503-target-in-maintenance) during platform problems; this message cannot be customized.
 
-​Pantheon may send a generic Maintenance Mode message during platform problems; this message cannot be customized.
+Built-in Maintenance Mode for both Drupal and WordPress sites can be customized; clear caches when toggling.
 
 ## Server Side Includes (SSI)
 


### PR DESCRIPTION
http://codex.wordpress.org/Function_Reference/wp_maintenance

Tested and confirmed working on http://dev-ari-wp.pantheon.io/  

Screenshot:
<img width="638" alt="screenshot 2015-10-05 13 03 02" src="https://cloud.githubusercontent.com/assets/7874556/10292013/a2ab10b6-6b61-11e5-9074-d80a2b21df15.png">

followed http://www.stevendobbelaere.be/how-to-enable-the-wordpress-maintenance-mode/
