### PR TITLE
Revert "Set cron job doing_wp_cron param to true."

### DIFF
--- a/source/docs/articles/wordpress/cron-for-wordpress.md
+++ b/source/docs/articles/wordpress/cron-for-wordpress.md
@@ -101,7 +101,7 @@ Once you have disabled WP-Cron, you will need a service that calls a URL at regu
 Any of the above services will get the job done. By disabling WP-Cron, you have turned off the automatic checking and calling of the `wp-cron.php` script. You will now have to call that URL yourself using one of the services above. With most of them, it is as easy as this:
 
 1. Set up an account
-2. Set up a job that calls `http://yourdomain.tld/wp-cron.php?doing_wp_cron`
+2. Set up a job that calls `http://yourdomain.tld/wp-cron.php?doing_wp_cron=1`
 
 <div class="alert alert-info" role="alert">
 <h4>Note</h4>


### PR DESCRIPTION
Reverts pantheon-systems/documentation#1017

Solution reported by client is to set GET param to false, not represented in the update. 

Also, solution reported by client has yet to be confirmed for general use cases. Reverting