### PR TITLE
Correct "Creating a services.yml File for Drupal 8"

### DIFF
--- a/source/docs/articles/drupal/8/create-services-yml-file.md
+++ b/source/docs/articles/drupal/8/create-services-yml-file.md
@@ -6,20 +6,25 @@ category:
   - drupal
 keywords: drupal, services.yml, yml file
 ---
-Drupal 8 enables developers to define services used by core within the `sites/default/services.yml` configuration file, eliminating the need for hacks to swap functionality. Creating or modifying this file is not required when installing a new Drupal 8 site.
+Drupal 8 allows users to easily define core services and environment-specific settings within the `sites/default/services.yml` configuration file, eliminating the need for hacks to swap functionality. Creating or modifying this file is not required when installing a new Drupal 8 site.
 
-Define core services in `sites/default/services.yml` and module specific services in a separate `.yml` file, located in the root directory of the respective module (e.g. `sites/all/modules/module_name/module_name.services.yml`).
-
-## Create and Modify services.yml via Git
-From within an up-to-date Git clone on your local environment, create the `services.yml` file inside the `sites/default` directory. Once edits are complete, commit and push the new file to the remote repository following standard Git workflows. For more instructions, see [Starting with Git](/docs/articles/local/starting-with-git/).
-
-## Create and Modify services.yml via SFTP
 <div class="alert alert-danger">
 <h4>Warning</h4>
-For security reasons, we recommend creating and modifying <code>sites/default/services.yml</code> via Git as SFTP requires tweaking file permissions.
+Due to environment-specific settings (e.g. Twig debug mode), <code>sites/default/services.yml</code> should only be created or modified via SFTP. This file should <strong>not</strong> be managed via Git, so that settings are not migrated between environments when pushing code.
 </div>
-Depending on your SFTP client, use 'get info' or 'file attribute' to change permissions of the `sites/default` directory to 777 (read + write + execute). Writable files, such as `services.yml`, should be changed to 666 (read + write).
 
+## Change Permissions
+Access your site's codebase via SFTP and temporarily make the `sites/default` directory writeable (read + write + execute). Change writable files, such as `default.services.yml`, to 666 (read + write). Depending on your SFTP client, change permissions using the 'get info' or 'file attribute' options.
+
+For general SFTP instructions, see [Developing on Pantheon Directly with SFTP Mode](/docs/articles/sites/code/developing-directly-with-sftp-mode/).
+## Create and Modify services.yml
+From within the `sites/default` directory, create a new file named `services.yml` by duplicating the existing `default.services.yml` file. Use your typical SFTP workflow to modify `services.yml` accordingly.
+<div class="alert alert-info">
+<h4>Note</h4>
+Module specific services should be defined in a separate <code>.yml</code> file, located in the root directory of the respective module (e.g. <code>sites/all/modules/module_name/module_name.services.yml</code>).
+</div>
+
+## Restore Default Permissions
 You will need to set the permissions back to default (555 for directories, 444 for files) once edits are complete. This file should remain non-writable for security concerns.
 
 ## See Also
@@ -27,6 +32,7 @@ You will need to set the permissions back to default (555 for directories, 444 f
 View the following [Drupal.org](https://drupal.org) resources for more information:
 
 - [Create settings.php, services.yml and the files directory](https://www.drupal.org/documentation/install/settings-file)
+- [Issue: Use container parameters instead of settings](https://www.drupal.org/node/2251113)
 - [Services and dependency injection in Drupal 8](https://www.drupal.org/node/2133171)
 - [Service Tags](https://www.drupal.org/node/2239393)
 - [Structure of a service file](https://www.drupal.org/node/2194463)


### PR DESCRIPTION
source/docs/articles/drupal/8/create-services-yml-file.md
Closes #1039

- Remove recommendations to create/modify services.yml via Git, as the file is ignored and should not be migrated between environments when pushing code.
- Redraft includes warning note stating why Git cannot be used.
- Link to resource on environment-configurable settings issue on drupal.org
- Link to SFTP doc for general instructions on modifying files via SFTP
- Move module note to more appropriate section (file creation step)

@greg-1-anderson and @bmackinney can you review?