### PR TITLE
Update Moving D8 sites out of Testing Org

### DIFF
--- a/source/docs/articles/drupal/8/moving-out-of-testing.md
+++ b/source/docs/articles/drupal/8/moving-out-of-testing.md
@@ -7,8 +7,8 @@ The Drupal 8 testing organization "owns" all Drupal 8 sites created on the platf
 1. [Update Drupal to the latest release](/docs/articles/sites/code/applying-upstream-updates). This is only possible for sites running Drupal 8 Beta 14 or later, and may not work in all cases.
 2. [Create and download backups](/docs/articles/sites/backups).
 3. To use the same development URLs for the site, [delete the site](/docs/articles/sites/deleting-a-site/).
-4. [Create a new Drupal 8 site](https://dashboard.pantheon.io/products/drupal8/spinup).
-5. [Import the code, database, and files archives](/docs/articles/sites/migrate/manual-site-import).
+4. [Create a new Drupal 8 site](https://dashboard.pantheon.io/sites/create) and select **Start from scratch**.
+5. [Manually import code, database, and files](/docs/articles/sites/migrate/manual-site-import).
 
 <div class="alert alert-info" role="alert">
 <h4>Note</h4>


### PR DESCRIPTION
Closes #1042 

May require backing up beta site, creating a new site starting from scratch, and manually importing.

Updated link per Brian's recommendation.