### PR TITLE
deploy-multidev.sh revision - single file deployments

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -4,23 +4,24 @@
 # Define env and site UUID
 export ENV=docs-files
 export SITE=72e163bd-0054-4332-8bf8-219c50b78581
-
-
-# Generate docs production files
-rm -rf output_prod/docs
-sculpin generate --env=prod
-
-# Create local directory and file to log rsync output (local path: "$HOME/sites/docs-backups"), then open for review in real-time
+# Create local directory and file to log rsync output (local path: "$HOME/sites/docs-backups")
 mkdir ../docs-backups
 mkdir ../docs-backups/`date +%F-%I%p`
 echo "rsync log - deploy to docsfiles Multidev environment on `date +%F-%I%p`" > ../docs-backups/`date +%F-%I%p`/rsync-`date +%F-%I%p`.log
-open ../docs-backups/`date +%F-%I%p`/rsync-`date +%F-%I%p`.log
+# Build prod
+rm -rf output_prod/docs
+sculpin generate --env=prod
+cd output_prod
 
-
-# rsync local output_prod/docs to files dir on appserver
-rsync -bv --backup-dir=docs-backups/`date +%F-%I%p` --log-file=../docs-backups/`date +%F-%I%p`/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
-
-
-# Send the rysnc log file to remote directory "/docs-backups/`date +%F-%I%p`/"
-rsync -rlvz --temp-dir=../../../tmp/ --size-only --progress -e 'ssh -p 2222' ../docs-backups/`date +%F-%I%p`/rsync-`date +%F-%I%p`.log $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/docs-backups/`date +%F-%I%p`
-open http://docs-files-panther.pantheon.io/docs
+### Get path for deploy from user and deploy only specified doc
+read -p "What doc or directory? (e.g. docs/articles/users/index.html or docs/articles/users/): " path
+[ -z "${path}" ] && path='docs'
+if [ ! -e $path ]
+    then
+    echo "The doc '$path' does not exist. Check file path and try again."
+    exit 1
+else
+    # rsync file path provided by user.
+    rsync --temp-dir=~/tmp --log-file=../../docs-backups/`date +%F-%I%p`/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' $path $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/$path
+fi
+open http://$ENV-panther.pantheon.io/$path


### PR DESCRIPTION
Revise deploy-multidev.sh so that work is not overwritten on the multidev test environment
 when QA'ing deployments.

Closes #1049

- Ask user for file path
- Check file path, if it does not exist - kill script.
- No backups, log file created locally but no
t sent to remote filesystem