### PR TITLE
Document cookie-stripping on URLs ending in .html and .htm

### DIFF
--- a/source/docs/articles/sites/varnish/debugging-cache.md
+++ b/source/docs/articles/sites/varnish/debugging-cache.md
@@ -53,6 +53,8 @@ If you have cleared the caches from your Pantheon Dashboard and are still seeing
 
 By default, Pantheon's edge will ignore most cookies, preventing them from breaking the cache and being passed to the backend. These cookies are still available to JavaScript, so analytics tools (e.g. Google, Chartbeat, etc.) will function out of the box on Pantheon. 
 
+Pantheon's edge will also ignore session cookies by default too when the requested URL seems to be an static asset (such as images, css files, and static HTML documents), this could lead to the behaviour where authenticated users won't be recognized as such when visiting pages ending in the .html or .htm extension (which could be a normal Drupal node with that URL set manually for reverse compatability with and old site, the recommended behaviour in this case is to send a 301 redirect from the URL with the .html or .htm extension to a URL with no such extension).
+
 To test whether or not a cookie is preventing Varnish from caching, you can examine the headers output (Age, Max-Age, Cookie) via the following curl command:
 
 ```nohighlight


### PR DESCRIPTION
Editing the documentation on debugging the cache, to include in the Cookies & Varnish section the information regarding how cookies are stripped on URLs that end in .html and .htm (as per this conversation[0]) so that anyone experiencing this behaviour know it's expected and not a malfunction. Also adding the recommended way to deal with the scenario where a .html or .htm extension must be used to satisfy backwards compatibility with an old site that used to have those extensions (as stated here[1]).

[0] https://twitter.com/DavidStrauss/status/659063304636116992
[1] https://twitter.com/DavidStrauss/status/659064986778537984