### PR TITLE
WordPress Pantheon Cache Plugin Configuration - update

### DIFF
--- a/source/docs/articles/wordpress/wordpress-pantheon-cache-plugin-configuration.md
+++ b/source/docs/articles/wordpress/wordpress-pantheon-cache-plugin-configuration.md
@@ -26,42 +26,42 @@ You'll want to strike a balance between freshness of content and speed. We recom
 
 Within the `pantheon-cache.php` file that houses the Pantheon Cache plugin code, there are three functions that are useful to developers. You can call them from within your own custom code using various WordPress hooks, such as [save_post()](https://codex.wordpress.org/Plugin_API/Action_Reference/save_post). Currently, the [limit on the number of paths](https://github.com/pantheon-systems/WordPress/issues/24) that can be cleared in a single call is 10.
 
-**flush_site**  
+### flush_site 
 Flushes the site cache for the entire site. This achieves the same result as the Clear Site Cache button on the Pantheon Cache administration page.
 
 ```
 /**
-	 * Clear the cache for the entire site.
-	 *
-	 * @return void
-	 */
-	public function flush_site()
+ * Clear the cache for the entire site.
+ *
+ * @return void
+ */
+public function flush_site()
 ```
 
-**clean_post_cache**  
+### clean_post_cache
 Flushes the cache for an individual post, which is identified by the `$post_id`. The optional `$include_homepage` argument can also be passed, but if not the default value is "true".
 
 ```
-  /**
-	 * Clear the cache for a post.
-	 *
-	 * @param  int $post_id A post ID to clean.
-	 * @return void
-	 */
-	public function clean_post_cache( $post_id, $include_homepage = true )
+/**
+ * Clear the cache for a post.
+ *
+ * @param  int $post_id A post ID to clean.
+ * @return void
+ */
+public function clean_post_cache( $post_id, $include_homepage = true )
 ```
 
-**clean_term_cache**  
+### clean_term_cache
 Flushes the cache for an individual term or terms which are passed in an array, or for a complete taxonomy passed via a single taxonomy ID.
-```
-  /**
-	 * Clear the cache for a given term or terms and taxonomy.
-	 *
-	 * @param int|array $ids Single or list of Term IDs.
-	 * @param string $taxonomy Can be empty and will assume tt_ids, else will use for context.
-	 * @return void
-	 */
-	public function clean_term_cache( $term_ids, $taxonomy )
+```php
+/**
+ * Clear the cache for a given term or terms and taxonomy.
+ *
+ * @param int|array $ids Single or list of Term IDs.
+ * @param string $taxonomy Can be empty and will assume tt_ids, else will use for context.
+ * @return void
+ */
+public function clean_term_cache( $term_ids, $taxonomy )
 ```
 
 ## See Also

--- a/source/docs/articles/wordpress/wordpress-pantheon-cache-plugin-configuration.md
+++ b/source/docs/articles/wordpress/wordpress-pantheon-cache-plugin-configuration.md
@@ -21,6 +21,49 @@ You can increase the default value to increase the chances that a visitor will r
 
 You'll want to strike a balance between freshness of content and speed. We recommend a minimum of 600 seconds.  If you can increase the setting to 30 minutes (1800 seconds) or 1 hour (3600 seconds), many more requests will hit the Edge Cache. Every page served from the Edge Cache won't hit your application container's PHP workers or MySQL database, which means faster page load times and a better user experience for site visitors.
 
+
+## Programmatically Using Pantheon Cache Functions
+
+Within the `pantheon-cache.php` file that houses the Pantheon Cache plugin code, there are three functions that are useful to developers. You can call them from within your own custom code using various WordPress hooks, such as [save_post()](https://codex.wordpress.org/Plugin_API/Action_Reference/save_post). Currently, the [limit on the number of paths](https://github.com/pantheon-systems/WordPress/issues/24) that can be cleared in a single call is 10.
+
+**flush_site**  
+Flushes the site cache for the entire site. This achieves the same result as the Clear Site Cache button on the Pantheon Cache administration page.
+
+```
+/**
+	 * Clear the cache for the entire site.
+	 *
+	 * @return void
+	 */
+	public function flush_site()
+```
+
+**clean_post_cache**  
+Flushes the cache for an individual post, which is identified by the `$post_id`. The optional `$include_homepage` argument can also be passed, but if not the default value is "true".
+
+```
+  /**
+	 * Clear the cache for a post.
+	 *
+	 * @param  int $post_id A post ID to clean.
+	 * @return void
+	 */
+	public function clean_post_cache( $post_id, $include_homepage = true )
+```
+
+**clean_term_cache**  
+Flushes the cache for an individual term or terms which are passed in an array, or for a complete taxonomy passed via a single taxonomy ID.
+```
+  /**
+	 * Clear the cache for a given term or terms and taxonomy.
+	 *
+	 * @param int|array $ids Single or list of Term IDs.
+	 * @param string $taxonomy Can be empty and will assume tt_ids, else will use for context.
+	 * @return void
+	 */
+	public function clean_term_cache( $term_ids, $taxonomy )
+```
+
 ## See Also
 * [Testing Varnish](/docs/articles/sites/varnish/testing-varnish/)
 * [Varnish Caching for High Performance](/docs/articles/sites/varnish)


### PR DESCRIPTION
Closes #1061 
This PR will replace and close PR #1123 as the content from both docs as been combined into the existing WP Cache doc.
I tested per Ari's comment and you cannot set Pantheon Cache to 0. If you try, it changes it to 600. I removed that content from the previous PR.

@erik-pantheon @rachelwhitton @ari-gold Please review.