### PR TITLE
Correct crumb logic - remove empty href

### DIFF
--- a/source/_partials/breadcrumbs.html
+++ b/source/_partials/breadcrumbs.html
@@ -2,7 +2,6 @@
     {% set crumbs = page.url|split('/') %}
     {% for crumb in crumbs %}
     {% if loop.first %}
-    <a href="{{ crumb }}">{{ crumb|capitalize }}</a>
     {% elseif loop.last %}
     <span class="active-trail disabled">{{ page.title }}</span>
     {% else %}


### PR DESCRIPTION
Fixes bug

The existing code writes an empty href tag (`<a href=""></a>`) on all generated pages using the article layout, causing a large number of accessibility failures:
```
  *  anchor has no href attribute (line 135)
```

This PR removes `<a href="{{ crumb }}">{{ crumb|capitalize }}</a>` from the loop statement's first pass, resolving the issue without affecting desired crumb functionality.

@bmackinney please review and merge 
cc @ari-gold 