### PR TITLE
add environment-specific config article

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -108,6 +108,8 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
     # Update redirect script for the Multidev environment
     export avoid_redirect="window.location.hostname == '$normalize_branch-static-docs.pantheon.io' ||"
     sed -i '9i\'"      ${avoid_redirect}"'\' source/_views/default.html
+    # Update CTA edit link so that the current branch is used
+    sed '12s/master/'"$CIRCLE_BRANCH"'/' w source/_views/article.html | tee source/_views/article.html
 
     # Regenerate sculpin to reflect new redirect logic
     bin/sculpin generate --env=prod

--- a/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
+++ b/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
@@ -2,14 +2,15 @@
 title: Environment-Specific Configuration for WordPress Sites
 description: Learn how to turn plugins on and off conditionally, based on the environment they are running on.
 ---
-Developers often use plugins that speed the development or debugging process. Any plugins that should be active in dev and/or test, but inactive in Live, present with extra work reactivating them after a database clone from the live environment. To achieve this goal, we can use an mu-plugin that
+Developers often use plugins that speed up the development or debugging process. Any plugins that should be active in Dev and/or Test, but inactive in Live, present extra work to reactivate them after a database clone from the Live environment. To achieve this goal, we can use an mu-plugin that checks:
 
-1. Checks which environment we're on,
-2. Checks whether desired plugins are active and if not, activates them,
-3. Checks whether undesired plugins are active, and if so, deactivates them.
+* Which environment we're on
+* Whether desired plugins are active and if not, activates them
+* If undesired plugins are active, and if so, deactivates them
 
-## Create the Plugin `mu-plugins/site-config.php`
-Copy this plugin file to the `mu-plugins` directory. Edit accordingly.
+## Create the Plugin mu-plugins/site-config.php
+
+Copy this plugin file to the `mu-plugins` directory and edit accordingly.
 ```php
 <?php
 /*
@@ -31,7 +32,8 @@ endif;
 ```
 
 ## Add Configuration
-Create a new directory, `wp-content/mu-plugins/site-config/`, and add a `site-plugins.php` file. This example activates the `wp-reroute-email` and `debug-bar` plugins on all environments except for live.
+
+Create a `wp-content/mu-plugins/site-config/` directory, and add a `site-plugins.php` file. This example activates the `wp-reroute-email` and `debug-bar` plugins on all environments except for Live.
 ```php
 <?php
 // Only in Live Environments...
@@ -64,11 +66,11 @@ else {
         if(is_plugin_active($plugin))false;
             activate_plugin($plugin);
 
-  // We can add filters in all environments but live, too
+  // We can add filters in all environments but Live
   add_filter( 'jetpack_development_mode', '__return_true' );
 
 }
 ```
-The next time I deploy code from Dev to Test, and clone my database from Live into Test, the plugins will remain active on test, even though the database clone would normally deactivate them. This is especially important with the `wp-reroute-email` plugin, as it prevents emails from being sent to users from the Test environment accidentally.
+The next time you deploy code from Dev to Test, and clone the database from Live into Test, the plugins will remain active on Test, even though the database clone would normally deactivate them. This is especially important with the `wp-reroute-email` plugin, as it prevents emails from accidentally being sent to users from the Test environment.
 
-The Jetpack plugin has a [development mode](http://jetpack.me/support/development-mode/) filter that allows developers to build and test without connecting dev and test environments to WordPress.com. Since I want this mode on everywhere and off in Live, I added the filter do exactly that.
+The Jetpack plugin has a [development mode](http://jetpack.me/support/development-mode/) filter that allows developers to build and test without connecting Dev and Test environments to WordPress.com. If you want this mode on everywhere except in Live, you can add a filter for that.

--- a/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
+++ b/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
@@ -1,0 +1,74 @@
+---
+title: Environment-Specific Configuration for WordPress Sites
+description: Learn how to turn plugins on and off conditionally, based on the environment they are running on.
+---
+Developers often use plugins that speed the development or debugging process. Any plugins that should be active in dev and/or test, but inactive in Live, present with extra work reactivating them after a database clone from the live environment. To achieve this goal, we can use an mu-plugin that
+
+1. Checks which environment we're on,
+2. Checks whether desired plugins are active and if not, activates them,
+3. Checks whether undesired plugins are active, and if so, deactivates them.
+
+## Create the Plugin `mu-plugins/site-config.php`
+Copy this plugin file to the `mu-plugins` directory. Edit accordingly.
+```php
+<?php
+/*
+  Plugin Name: Site Config
+  Plugin URI: http://www.example.com/
+  Description: Activating and deactivates plugins based on environment.
+  Version: 0.1
+  Author: Pantheon
+  Author URI: http://pantheon.io/docs/articles/wordpress
+*/
+# Ensuring that this is on Pantheon
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) :
+
+# Enqueue the site-plugins file
+require_once( 'site-config/site-plugins.php' );
+
+endif;
+
+```
+
+## Add Configuration
+Create a new directory, `wp-content/mu-plugins/site-config/`, and add a `site-plugins.php` file. This example activates the `wp-reroute-email` and `debug-bar` plugins on all environments except for live.
+```php
+<?php
+// Only in Live Environments...
+if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'live' ) ) ) {
+  //
+  // Disable Development Plugins in Live
+  //
+   $plugins = array(
+          'wp-reroute-email/wp-reroute-email.php','debug-bar/debug-bar.php',
+      );
+      require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+      foreach ($plugins as $plugin);
+          if(is_plugin_active($plugin));
+              deactivate_plugins($plugin);
+
+  // We can also add_filters
+  add_filter( 'jetpack_development_mode', '__return_false' );
+
+}
+// In every environment except for Live
+else {
+  //
+  // Activate Development Plugins
+  //
+ $plugins = array(
+        'wp-reroute-email/wp-reroute-email.php','debug-bar/debug-bar.php',
+    );
+    require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+        foreach ($plugins as $plugin);
+        if(is_plugin_active($plugin))false;
+            activate_plugin($plugin);
+
+  // We can add filters in all environments but live, too
+  add_filter( 'jetpack_development_mode', '__return_true' );
+
+}
+```
+The next time I deploy code from Dev to Test, and clone my database from Live into Test, the plugins will remain active on test, even though the database clone would normally deactivate them. This is especially important with the `wp-reroute-email` plugin, as it prevents emails from being sent to users from the Test environment accidentally.
+
+The Jetpack plugin has a [development mode](http://jetpack.me/support/development-mode/) filter that allows developers to build and test without connecting dev and test environments to WordPress.com. Since I want this mode on everywhere and off in Live, I added the filter do exactly that.

--- a/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
+++ b/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
@@ -2,13 +2,26 @@
 title: Environment-Specific Configuration for WordPress Sites
 description: Learn how to turn plugins on and off conditionally, based on the environment they are running on.
 ---
-Developers often use plugins that speed up the development or debugging process. Any plugins that should be active in Dev and/or Test, but inactive in Live, present extra work to reactivate them after a database clone from the Live environment. To achieve this goal, we can use an mu-plugin that checks:
+Developers often use settings and plugins in their development environment that they do not use on live, in order to improve the development and debugging processes. This tutorial will show you how to use the same codebase with different settings for each environment, using values for the [PANTHEON_ENVIRONMENT variable](/docs/articles/sites/code/reading-pantheon-environment-configuration/).
+
+## Customizations to `wp-config.php`
+
+The Pantheon version of `wp-config.php` contains a nice example.
+<script src="https://gist-it.appspot.com/https://github.com/pantheon-systems/wordpress/blob/master/wp-config.php?footer=minimal&slice=79:83"></script>
+
+This is a useful model to follow for another recommended modification, defining `'WP_DEBUG', true`.
+<script src="https://gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/wordpress/wp_debug_dev.wp-config.php?footer=minimal"></script>
+
+For more options when editing `wp-config.php` for debugging, see [Configure Error Logging](https://codex.wordpress.org/Editing_wp-config.php#Configure_Error_Logging) on the WordPress Codex.
+
+## Control Plugin Activation
+Any plugins that should be active in Dev and/or Test, but inactive in Live, present extra work to reactivate them after a database clone from the Live environment. To achieve this goal, we can use an mu-plugin that checks:
 
 * Which environment we're on
 * Whether desired plugins are active and if not, activates them
 * If undesired plugins are active, and if so, deactivates them
 
-## Create the Plugin mu-plugins/site-config.php
+### Create the Plugin mu-plugins/site-config.php
 
 Copy this plugin file to the `mu-plugins` directory and edit accordingly.
 ```php
@@ -31,46 +44,48 @@ endif;
 
 ```
 
-## Add Configuration
+### Add Configuration
+Create a new directory, `wp-content/mu-plugins/site-config/`, and add a `site-plugins.php` file. This example activates the `wp-reroute-email` and `debug-bar` plugins on all environments except for live.
 
-Create a `wp-content/mu-plugins/site-config/` directory, and add a `site-plugins.php` file. This example activates the `wp-reroute-email` and `debug-bar` plugins on all environments except for Live.
 ```php
 <?php
 // Only in Live Environments...
+$plugins = array(
+        'wp-reroute-email/wp-reroute-email.php','debug-bar/debug-bar.php','developer/developer.php'
+    );
 if ( in_array( $_ENV['PANTHEON_ENVIRONMENT'], array( 'live' ) ) ) {
   //
   // Disable Development Plugins in Live
   //
-   $plugins = array(
-          'wp-reroute-email/wp-reroute-email.php','debug-bar/debug-bar.php',
-      );
-      require_once(ABSPATH . 'wp-admin/includes/plugin.php');
-      foreach ($plugins as $plugin);
-          if(is_plugin_active($plugin));
-              deactivate_plugins($plugin);
+add_filter( 'jetpack_development_mode', '__return_false' );
 
-  // We can also add_filters
-  add_filter( 'jetpack_development_mode', '__return_false' );
-
+    require_once(ABSPATH . 'wp-admin/includes/plugin.php');
+    foreach ($plugins as $plugin);
+        if(is_plugin_active($plugin));
+            deactivate_plugins($plugin);
 }
-// In every environment except for Live
 else {
+  add_filter( 'jetpack_development_mode', '__return_true' );
   //
-  // Activate Development Plugins
+  // Activate Development Plugins in other environments
+  // activate_plugin cannot accept an array as an argument.
   //
- $plugins = array(
-        'wp-reroute-email/wp-reroute-email.php','debug-bar/debug-bar.php',
-    );
     require_once(ABSPATH . 'wp-admin/includes/plugin.php');
         foreach ($plugins as $plugin);
         if(is_plugin_active($plugin))false;
             activate_plugin($plugin);
 
-  // We can add filters in all environments but Live
-  add_filter( 'jetpack_development_mode', '__return_true' );
-
 }
-```
-The next time you deploy code from Dev to Test, and clone the database from Live into Test, the plugins will remain active on Test, even though the database clone would normally deactivate them. This is especially important with the `wp-reroute-email` plugin, as it prevents emails from accidentally being sent to users from the Test environment.
 
-The Jetpack plugin has a [development mode](http://jetpack.me/support/development-mode/) filter that allows developers to build and test without connecting Dev and Test environments to WordPress.com. If you want this mode on everywhere except in Live, you can add a filter for that.
+```
+
+The next time you deploy code from Dev to Test, and clone the database from Live into Test, the plugins will remain active on Test, even though the database clone would normally deactivate them. This is especially important with for plugins like `wp-reroute-email`, that prevents test and dev environments from behaving like live, in this case, spamming emails to users.
+
+Plugins with development-specific filters can also be added. In the example above, we've activated Jetpack's [development mode](http://jetpack.me/support/development-mode/) filter. This allows developers to build and test with Jetpack, without connecting Dev and Test environments to WordPress.com.
+
+The [Developer plugin](https://wordpress.org/plugins/developer/) by Automattic also checks whether you have recommended development plugins enabled on your site. Adding those plugins to your codebase and then adding them to the $plugins array in the example plugin will ensure this happens automatically.
+
+## Recommended Development Plugins
+@TODO - List plugins  - start with the plugins checked for by Developer
+## Recommended Development Filters
+@TODO - is this helpful? 

--- a/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
+++ b/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md
@@ -24,6 +24,7 @@ Any plugins that should be active in Dev and/or Test, but inactive in Live, pres
 ### Create the Plugin mu-plugins/site-config.php
 
 Copy this plugin file to the `mu-plugins` directory and edit accordingly.
+
 ```php
 <?php
 /*
@@ -86,6 +87,15 @@ Plugins with development-specific filters can also be added. In the example abov
 The [Developer plugin](https://wordpress.org/plugins/developer/) by Automattic also checks whether you have recommended development plugins enabled on your site. Adding those plugins to your codebase and then adding them to the $plugins array in the example plugin will ensure this happens automatically.
 
 ## Recommended Development Plugins
-@TODO - List plugins  - start with the plugins checked for by Developer
+
+- [wp-reroute-email](https://wordpress.org/plugins/wp-reroute-email/)
+- [developer](https://wordpress.org/plugins/developer/)
+
+Have another to suggest? [Edit this doc!](https://github.com/pantheon-systems/documentation/edit/master/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md)
+
 ## Recommended Development Filters
-@TODO - is this helpful? 
+
+- [update_option](https://codex.wordpress.org/Function_Reference/update_option)
+- [jetpack_development_mode](http://jetpack.me/support/development-mode/)
+
+Have another to suggest? [Edit this doc!](https://github.com/pantheon-systems/documentation/edit/master/source/docs/articles/wordpress/environment-specific-config-mu-plugin.md)


### PR DESCRIPTION
This new doc covers the basics for adding an mu-plugin that controls what's active on each environment. 
@joshkoenig can you take a look?
@nataliejeremy please edit.
- [ ] Add list of useful development plugins to add to the array @aeligature
- [x] Identify other uses for env-specific config
- [x] Fix the wp-config.php snippet.

closes #1124 and #1215 
