### PR TITLE
Related to #1163: Set site URI via policy file.

### DIFF
--- a/source/docs/articles/local/drupal-drush-command-line-utility.md
+++ b/source/docs/articles/local/drupal-drush-command-line-utility.md
@@ -193,7 +193,18 @@ If you have successfully set up [Terminus](/docs/articles/local/cli/), the Panth
 ## Drush Alias Strict Control
 Create a file called `policy.drush.inc`, and place in in the `.drush` folder of your home directory.  You can create a new file or use the example policy file in Drush’s `examples` folder to get started.
 
-For this example, we will write a policy file that changes all remote aliases to use `drush7` instead of the default version of Drush, but only if the target is the Pantheon platform.  Our `hook_drush_sitealias_alter` function looks like this:
+If your live site is associated with multiple domains, Pantheon will select an arbitrary one to include in the alias file that you download from the Dashboard. In some instances, it can cause problems in Drupal if the wrong uri is used, and Drush will not allow you to override the uri value in the alias with a commandline --uri option. To avoid the need to edit the generated Pantheon aliases file every time it is downloaded, you may use a `hook_drush_sitealias_alter` function to change the URI for your specific Pantheon site.
+```
+function policy_drush_sitealias_alter(&$alias_record) {
+  // Provide the correct 'uri' for a specific site
+  if ($alias_record['#name'] == 'pantheon.SITENAME.live') {
+    $alias_record['uri'] = 'example.com';
+  }
+}
+```
+Replace `SITENAME` with your Pantheon site name, and `example.com` with the correct uri to use for that site.
+
+For the next example, we will write a policy file that changes all remote aliases to use `drush7` instead of the default version of Drush, but only if the target is the Pantheon platform.  Our `hook_drush_sitealias_alter` function looks like this:
 
 ```
 function policy_drush_sitealias_alter(&$alias_record) {


### PR DESCRIPTION
If the user has a site with multiple domains, this article modification will help the user select which domain should be used with their Drush alias for the specific site and environment.