### PR TITLE
Optimize Builds on CircleCI

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -5,13 +5,15 @@ machine:
     version: 5.5.11
   environment:
     PHANTOM_JS: phantomjs-1.9.8-linux-x86_64
+    NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
 dependencies:
   pre:
     - wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
     - sudo tar xvjf $PHANTOM_JS.tar.bz2
     - sudo mv $PHANTOM_JS /usr/local/share
-    - gem install html-proofer
+    - bundle install
+
   post:
     # Build the static site.
     - bin/sculpin generate
@@ -33,7 +35,7 @@ test:
     # Look for merge conflicts.
     - scripts/merge_conflicts.sh
     # Run htmlproofer.
-    - rake
+    - bundle exec rake
 
 deployment:
   production:

--- a/circle.yml
+++ b/circle.yml
@@ -12,13 +12,13 @@ dependencies:
     - wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
     - sudo tar xvjf $PHANTOM_JS.tar.bz2
     - sudo mv $PHANTOM_JS /usr/local/share
-    - bundle install
 
   post:
     # Build the static site.
     - bin/sculpin generate
     - cd output_dev && ln -s ./ source
-    - scripts/deploy-multidev.sh # Deploy Multidev environment
+    # Deploy Multidev environment
+    - scripts/deploy-multidev.sh
 test:
   pre:
     # Start Ghost Driver.

--- a/circle.yml
+++ b/circle.yml
@@ -8,6 +8,8 @@ machine:
     NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
 dependencies:
+  cache_directories:
+    - ~/.composer/cache
   pre:
     - wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
     - sudo tar xvjf $PHANTOM_JS.tar.bz2

--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -58,7 +58,6 @@ getExistingEnvs "filtered_env_list.txt"
 
 
 # Identify merged remote branches, ignoring Pantheon defaults and master
-git remote prune origin # remove outdated references on remote
 git branch -r --merged master | awk -F'/' '/^ *origin/{if(!match($0, /(>|master)/) && (!match($0, /(>|dev)/)) && (!match($0, /(>|test)/)) && (!match($0, /(>|live)/))){print $2}}' | xargs -0 > merged-branches.txt
 # Delete empty line at the end of txt file produced by awk
 sed '/^$/d' merged-branches.txt > merged-branches-clean.txt


### PR DESCRIPTION
- Use system libraries for nokogiri
- Cache composer dependencies
- Remove gem install html-proofer, as the gem is installed via inferred `bundle install`


Faster builds