### PR TITLE
Rsync optimize

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -4,13 +4,13 @@ module.exports = function(grunt) {
       dev: {
         options: {
           urls: [
-            'output_*/docs/about/*.html',
-            'output_*/docs/articles/**/*.html',
-            'output_*/docs/authors/**/*.html',
-            'output_*/docs/changelog/**/*.html',
-            'output_*/docs/guides/**/*.html',
-            'output_*/docs/objects/*.html',
-            'output_*/docs/search/*.html'
+            'output_dev/docs/about/*.html',
+            'output_dev/docs/articles/**/*.html',
+            'output_dev/docs/authors/**/*.html',
+            'output_dev/docs/changelog/**/*.html',
+            'output_dev/docs/guides/**/*.html',
+            'output_dev/docs/objects/*.html',
+            'output_dev/docs/search/*.html'
           ]
         }
       }

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,6 @@ machine:
     version: 5.5.11
   environment:
     PHANTOM_JS: phantomjs-1.9.8-linux-x86_64
-    NOKOGIRI_USE_SYSTEM_LIBRARIES: 1
 
 dependencies:
   cache_directories:
@@ -14,13 +13,14 @@ dependencies:
     - wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
     - sudo tar xvjf $PHANTOM_JS.tar.bz2
     - sudo mv $PHANTOM_JS /usr/local/share
+    - bundle config build.nokogiri --use-system-libraries
 
   post:
     # Build the static site.
     - bin/sculpin generate
     - cd output_dev && ln -s ./ source
     # Deploy Multidev environment
-    - scripts/deploy-multidev.sh
+    - bash scripts/deploy-multidev.sh
 test:
   pre:
     # Start Ghost Driver.
@@ -43,4 +43,4 @@ deployment:
   production:
     branch: master
     commands:
-      - scripts/deploy-live.sh
+      - bash scripts/deploy-live.sh

--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -14,7 +14,7 @@ echo "rsync log - deploy to Live environment on `date +%F-%I%p`" > ../docs-rsync
 #===============================================================#
 # Deploy modified files to production, create log   #
 #===============================================================#
-rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/docs/
+rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/docs/
 if [ "$?" -eq "0" ]
 then
     echo "Success: Deployed to https://pantheon.io/docs"

--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -14,7 +14,7 @@ echo "rsync log - deploy to Live environment on `date +%F-%I%p`" > ../docs-rsync
 #===============================================================#
 # Deploy modified files to production, create log   #
 #===============================================================#
-rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/
+rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/docs/
 if [ "$?" -eq "0" ]
 then
     echo "Success: Deployed to https://pantheon.io/docs"

--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -14,7 +14,7 @@ echo "rsync log - deploy to Live environment on `date +%F-%I%p`" > ../docs-rsync
 #===============================================================#
 # Deploy modified files to production, create log   #
 #===============================================================#
-rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/* --temp-dir=../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/
+rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ live.$PROD_UUID@appserver.live.$PROD_UUID.drush.in:files/
 if [ "$?" -eq "0" ]
 then
     echo "Success: Deployed to https://pantheon.io/docs"

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -54,7 +54,7 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
     echo "rsync log - deploy to $normalize_branch environment on `date +%F-%I%p`" > ../docs-rsync-logs/rsync-`date +%F-%I%p`.log
 
     # rsync output_prod/* to Valhalla
-    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
+    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
     if [ "$?" -eq "0" ]
     then
         echo "Success: Deployed to http://"$normalize_branch"-static-docs.pantheon.io/docs"

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -54,7 +54,7 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
     echo "rsync log - deploy to $normalize_branch environment on `date +%F-%I%p`" > ../docs-rsync-logs/rsync-`date +%F-%I%p`.log
 
     # rsync output_prod/* to Valhalla
-    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/
+    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
     if [ "$?" -eq "0" ]
     then
         echo "Success: Deployed to http://"$normalize_branch"-static-docs.pantheon.io/docs"

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -54,7 +54,7 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
     echo "rsync log - deploy to $normalize_branch environment on `date +%F-%I%p`" > ../docs-rsync-logs/rsync-`date +%F-%I%p`.log
 
     # rsync output_prod/* to Valhalla
-    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/* --temp-dir=../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/
+    rsync --log-file=../docs-rsync-logs/rsync-`date +%F-%I%p`.log --human-readable --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/
     if [ "$?" -eq "0" ]
     then
         echo "Success: Deployed to http://"$normalize_branch"-static-docs.pantheon.io/docs"


### PR DESCRIPTION
- Adjust paths in rsync commands so that only output_prod/docs/* are deployed
- Revise Grunt task so that only output_dev is tested for a11y instead of output_*
- Correct nokogiri command to use system libraries