### PR TITLE
Debug Deploys to Multidev

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -3,16 +3,15 @@ machine:
   php:
     # https://circleci.com/docs/environment#php
     version: 5.5.11
-  environment:
-    PHANTOM_JS: phantomjs-1.9.8-linux-x86_64
 
 dependencies:
   cache_directories:
     - ~/.composer/cache
   pre:
-    - wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2
-    - sudo tar xvjf $PHANTOM_JS.tar.bz2
-    - sudo mv $PHANTOM_JS /usr/local/share
+    - sudo apt-get update; sudo apt-get install libicu52
+    - curl --output /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic https://s3.amazonaws.com/circle-support-bucket/phantomjs/phantomjs-2.0.1-linux-x86_64-dynamic
+    - chmod a+x /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic
+    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic /usr/local/bin/phantomjs
     - bundle config build.nokogiri --use-system-libraries
 
   post:


### PR DESCRIPTION
Closes #1277 
Fixes the following:

- **Bug:** Multidev is not created when `-` is the 11th character of the branch name 
 - **Symptom(s):** Circle fails during rsync because the destination was never created due to invalid name (ex: [build 3662](https://circleci.com/gh/pantheon-systems/documentation/3662))
 - **Solution:** Remove `-`'s from the branch name before Multidev is created 
- **Bug:** Existing comments saved as null or invalid json value 
 - **Symptom(s):** Incomplete GitHub comments when a previous comment is not found, build passes (ex: [build 3698](https://circleci.com/gh/pantheon-systems/documentation/3698) and [comment](https://github.com/pantheon-systems/documentation/commit/36a926534767192b79eed4912995dacb263d2a46#commitcomment-15686026)). Build passes but no comment is added due to invalid json value (ex: [build 3699](https://circleci.com/gh/pantheon-systems/documentation/3699))
 - **Solution:** Replace comment only if an existing comment is found, store the existing comment in a json compatible format
- **Bug:** Hitting rate limit using wget to download phantomjs via bitbucket (ex: [build 3659](https://circleci.com/gh/pantheon-systems/documentation/3659))
 - **Symptom(s)**: Build fails with error `ERROR 429: TOO MANY REQUESTS. Action failed: wget https://bitbucket.org/ariya/phantomjs/downloads/$PHANTOM_JS.tar.bz2`
 - **Solution:** [Install via CDN provided by Circle](https://discuss.circleci.com/t/how-to-use-phantomjs-2-0/405)
- **Bug:** Rate limit hit for GH api due to unauthenticated request 
 - **Symptom(s):** Build passes but comment fails due to exceeding rate limit of GitHub API
 - **Solution:** Use machine token in favor of un/pw auth on curl commands
