### PR TITLE
Remove nokogiri global and phantomjs from dependencies

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -7,12 +7,6 @@ machine:
 dependencies:
   cache_directories:
     - ~/.composer/cache
-  pre:
-    - sudo apt-get update; sudo apt-get install libicu52
-    - curl --output /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic https://s3.amazonaws.com/circle-support-bucket/phantomjs/phantomjs-2.0.1-linux-x86_64-dynamic
-    - chmod a+x /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic
-    - sudo ln -s --force /home/ubuntu/bin/phantomjs-2.0.1-linux-x86_64-dynamic /usr/local/bin/phantomjs
-    - bundle config build.nokogiri --use-system-libraries
 
   post:
     # Build the static site.


### PR DESCRIPTION
- nokogiri command is superfluous: `You are replacing the current global value of build.nokogiri, which is currently "--use-system-libraries"`

- phantomjs 1.9.8 is already provided by the [CircleCI Test environment](https://circleci.com/docs/environment#browsers) 

Not a huge impact, but it'll shave ~30s off of build times. 
