### PR TITLE
Solr Search for WordPress - First Pass

### DIFF
--- a/source/docs/articles/drupal/solr.md
+++ b/source/docs/articles/drupal/solr.md
@@ -1,0 +1,135 @@
+---
+title: Enabling Solr with Drupal
+description: Detailed information on using Apache Solr with Drupal.
+category:
+    - drupal
+    - developing
+keywords: apche, apache solr, index, indexing, searching, index and search, indexing and searching, solr, how to enable solr, enable solr, solr api, indexserver solr, solr indexserver, solr api, enable solr search, apachesolr, apache solor search module, solr modules, configure solr,
+---
+[Apache Solr](/docs/articles/sites/apache-solr) is a system for indexing and searching site content. First, you will need to add the Index Server to your site. From your Dashboard, go to **Settings** > **Add Ons** > **Apache Solr Index Server: Add**.
+
+This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with Drupal.
+
+## Installing Solr for Drupal
+### 1. Apply Upstream Updates
+Use [one-click updates](/docs/articles/sites/code/applying-upstream-updates) to make sure you are running the latest version of Drupal core.
+
+### 2. Add Apache Solr Search or Search API Solr Search Module
+
+Two contributed modules are supported by Pantheon:
+
+- [​https://drupal.org/project/apachesolr](https://drupal.org/project/apachesolr) - 7.x-1.x and 6.x-1.x
+- [https://drupal.org/project/search\_api\_solr](https://drupal.org/project/search_api_solr) - 7.x-1.x
+
+Solr for Drupal 8 is not supported at this time.
+
+For most users, the apachesolr module is the easiest to configure and maintain, and includes functionality like facets and other great features.  
+
+If you rely on highly customized data structures and the apachesolr module is not enough for your needs, search\_api\_solr provides an alternative with a more powerful interface, but is much more complex.  
+
+Choose one or the the other and add it to your code base. Do not enable or configure it yet.
+
+### 3. Enable the Pantheon Apache Solr Module
+
+<div class="alert alert-info" role="alert">
+<h4>Note</h4> If you previously installed the Acquia Solr module and you still have the files present in your codebase, you will need to delete them from your repo before enabling the Pantheon Apache Solr module. If you do not, you may receive an error when attempting to connect to the Solr server.</div>
+
+One of the modules already included in every Pantheon Drupal 7 site is [pantheon\_apachesolr](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr). This module **must** be enabled and configured in each environment (Dev, Test, Live, and each Multidev) in order to use Pantheon's Apache Solr service. pantheon\_apachesolr is not required if you are using a third-party Solr service.
+
+Once enabled, click **Configure**, or navigate to **Administration** > **Configuration** > **Search and metadata** > **Pantheon Apache Solr**.
+
+ ![Drupal Admin Search and Metadata Solr](/source/docs/assets/images/desk_images/192434.png)
+### 4. Post the schema.xml Using the Pantheon Apache Solr Module
+
+The next step is to post the schema.xml, which describes Drupal fields to the Solr search indexer. Posting the schema will activate the Solr server for the site environment. Click **Post schema.xml**.  
+
+ ![Solr configuration schema](/source/docs/assets/images/desk_images/192435.png)  
+Choose the appropriate schema for the module that you are using (apachesolr or search\_api\_solr) and Solr version (3.5.0). In the vast majority of cases, you will want to use 3.x/schema.xml. Do not attempt to use schemas intended for different versions of Solr, because it won't work. When you've made your selection, click **Post schema**.  
+
+<div class="alert alert-info" role="alert">
+<h4>Note</h4>
+You must post the schema.xml in each environment (Dev, Test, and Live) that you want to use Pantheon's Solr Service in.</div>
+
+### 5. Enable and Configure Your Solr Module
+
+#### Apache Solr Search (apachesolr)
+
+Enable both the **Apache Solr framework** and **Apache Solr Search** modules.
+ ![Enable Solr module](/source/docs/assets/images/desk_images/192444.png)
+Browse to the main Apache Solr settings screen and you should now see an index is ready for you. You do not need to configure any server settings, but you can still handle your facet and bias settings as per normal:
+ ![Configure Solr Settings](/source/docs/assets/images/desk_images/27787.png)
+
+Note that the default connection parameters are correct and do not need changing. After this point, your configuration and settings will be the same as any generic Apache Solr use case.
+
+#### Search API Solr Search (search\_api\_solr)
+
+Three modules are required; [entity](https://drupal.org/project/entity),  [search\_api](https://drupal.org/project/search_api) and  [search\_api\_solr](https://drupal.org/project/search_api_solr) need to be installed and enabled.  
+ ![Enable Solr Search required modules](/source/docs/assets/images/desk_images/192457.png)
+
+## Additional Help
+
+The Pantheon Solr module provides a comprehensive help section that describes a number of key Solr concepts and terms. View it by going to **Administration** > **Help** > **Pantheon Apache Solr**.
+
+## Pantheon Solr Service Status
+
+The Pantheon Solr module provides several interfaces for troubleshooting the health of the service, along with the ability to manually perform queries. These checks are independent of contrib module configurations in order to determine whether the service itself is performing properly, or if there is there is a problem with your site configuration.
+
+### Status
+
+This interface reports what the last schema that was posted to the service and whether the service itself responds to a ping.  
+
+**Administration** > **Configuration** > **Search and metadata** > **Pantheon Apache Solr**
+ ![Pantheon Apache Solr status](/source/docs/assets/images/desk_images/192483.png)
+
+### Execute Query
+
+The Pantheon Apache Solr module provides an interface for administrators to send queries directly to the Solr server, independently of any contrib module. This is advanced functionality and is intended for debugging purposes only. Try queries like `/admin/ping` to see the raw server response.
+
+ ![Send query to Solr](/source/docs/assets/images/desk_images/192486.png)
+
+### Drupal Status Report
+
+The Pantheon Apache Solr ​module also adds an item to the Administration > Reports > Status report that performs a similar check to the Status check, independently of contrib module configurations.  
+ ![Solr reports](/source/docs/assets/images/desk_images/192484.png)
+
+## Troubleshooting
+
+The following are Pantheon-specific variables that you can check for, depending on the module you are using.  
+
+Keep in mind that newly indexed items have a 2-minute delay until cron has been run or manually indexed before they become available in Solr search.
+
+####apachesolr.module
+If you're using the Apache Solr module, you can check for the existence of this variable using [Terminus](https://github.com/pantheon-systems/cl):
+```bash
+terminus drush --site=<site> --env=<env> "vget apachesolr_service_class"
+```
+####search_api_solr.module
+If you are using search_api_solr.module you can check it with the command:
+```bash
+terminus drush --site=<site> --env=<env> "vget search_api_solr_connection_class"
+```
+
+<div class="alert alert-info" role="alert">
+<h4>Note</h4>
+Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+
+### Error During Search API Solr Installation
+
+If you receive the following error, be sure that you have followed all of the instructions as described in the INSTALL.txt. We can not resolve this for you as it is part of the module setup:
+```php
+Exception: SolrPhpClient library not found! Please follow the instructions in search_api_solr/INSTALL.txt for installing the Solr search module. in _search_api_solr_solrphpclient_path()
+```
+### Common Techniques
+
+
+#### Did you post the schema into all your environments?
+
+It needs to be done for Dev, Test and Live individually. You can do this at `admin/config/search/pantheon`
+
+#### Re-index Content
+
+You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
+
+
+## See Also
+- [Apache Solr on Pantheon](/docs/articles/sites/apache-solr)

--- a/source/docs/articles/drupal/solr.md
+++ b/source/docs/articles/drupal/solr.md
@@ -27,12 +27,12 @@ For most users, the apachesolr module is the easiest to configure and maintain, 
 
 If you rely on highly customized data structures and the apachesolr module is not enough for your needs, search\_api\_solr provides an alternative with a more powerful interface, but is much more complex.  
 
-Choose one or the the other and add it to your code base. Do not enable or configure it yet.
+Choose one or the the other and add it to your codebase. Do not enable or configure it yet.
 
 ### 3. Enable the Pantheon Apache Solr Module
 
 <div class="alert alert-info" role="alert">
-<h4>Note</h4> If you previously installed the Acquia Solr module and you still have the files present in your codebase, you will need to delete them from your repo before enabling the Pantheon Apache Solr module. If you do not, you may receive an error when attempting to connect to the Solr server.</div>
+<h4>Note</h4> If you previously installed the Acquia Solr module and you still have the files present in your codebase, you will need to delete them from your repo before enabling the Pantheon Apache Solr module. If you don't, you may receive an error when attempting to connect to the Solr server.</div>
 
 One of the modules already included in every Pantheon Drupal 7 site is [pantheon\_apachesolr](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr). This module **must** be enabled and configured in each environment (Dev, Test, Live, and each Multidev) in order to use Pantheon's Apache Solr service. pantheon\_apachesolr is not required if you are using a third-party Solr service.
 
@@ -44,7 +44,7 @@ Once enabled, click **Configure**, or navigate to **Administration** > **Config
 The next step is to post the schema.xml, which describes Drupal fields to the Solr search indexer. Posting the schema will activate the Solr server for the site environment. Click **Post schema.xml**.  
 
  ![Solr configuration schema](/source/docs/assets/images/desk_images/192435.png)  
-Choose the appropriate schema for the module that you are using (apachesolr or search\_api\_solr) and Solr version (3.5.0). In the vast majority of cases, you will want to use 3.x/schema.xml. Do not attempt to use schemas intended for different versions of Solr, because it won't work. When you've made your selection, click **Post schema**.  
+Choose the appropriate schema for the module that you are using (apachesolr or search\_api\_solr) and Solr version (3.5.0). In the majority of cases, you will want to use 3.x/schema.xml. Do not attempt to use schemas intended for different versions of Solr, because it won't work. When you've made your selection, click **Post schema**.  
 
 <div class="alert alert-info" role="alert">
 <h4>Note</h4>
@@ -59,11 +59,11 @@ Enable both the **Apache Solr framework** and **Apache Solr Search** modules.
 Browse to the main Apache Solr settings screen and you should now see an index is ready for you. You do not need to configure any server settings, but you can still handle your facet and bias settings as per normal:
  ![Configure Solr Settings](/source/docs/assets/images/desk_images/27787.png)
 
-Note that the default connection parameters are correct and do not need changing. After this point, your configuration and settings will be the same as any generic Apache Solr use case.
+Note that the default connection parameters are correct and do not need changing. After this point, your configuration and settings will be the same as any generic Apache Solr use case.
 
 #### Search API Solr Search (search\_api\_solr)
 
-Three modules are required; [entity](https://drupal.org/project/entity),  [search\_api](https://drupal.org/project/search_api) and  [search\_api\_solr](https://drupal.org/project/search_api_solr) need to be installed and enabled.  
+Three modules are required; [entity](https://drupal.org/project/entity), [search\_api](https://drupal.org/project/search_api) and [search\_api\_solr](https://drupal.org/project/search_api_solr) need to be installed and enabled.  
  ![Enable Solr Search required modules](/source/docs/assets/images/desk_images/192457.png)
 
 ## Additional Help
@@ -104,14 +104,14 @@ If you're using the Apache Solr module, you can check for the existence of this 
 terminus drush --site=<site> --env=<env> "vget apachesolr_service_class"
 ```
 ####search_api_solr.module
-If you are using search_api_solr.module you can check it with the command:
+If you are using search_api_solr.module, you can check it with the command:
 ```bash
 terminus drush --site=<site> --env=<env> "vget search_api_solr_connection_class"
 ```
 
 <div class="alert alert-info" role="alert">
 <h4>Note</h4>
-Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
+Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code>.</div>
 
 ### Error During Search API Solr Installation
 
@@ -124,12 +124,12 @@ Exception: SolrPhpClient library not found! Please follow the instructions in se
 
 #### Did you post the schema into all your environments?
 
-It needs to be done for Dev, Test and Live individually. You can do this at `admin/config/search/pantheon`
+It needs to be done for Dev, Test and Live individually. You can do this at `admin/config/search/pantheon`.
 
-#### Re-index Content
+#### Re-Index Content
 
 You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
 
 
 ## See Also
-- [Apache Solr on Pantheon](/docs/articles/sites/apache-solr)
+[Apache Solr on Pantheon](/docs/articles/sites/apache-solr)

--- a/source/docs/articles/sites/apache-solr.md
+++ b/source/docs/articles/sites/apache-solr.md
@@ -63,10 +63,9 @@ Some customers have reported success using external Solr service providers for t
 </dl>
 #### Check Index and Batch Sizes
 
-Are you only indexing only 50 items at a time and wondering why 100s of new content nodes generated in the last hour aren't being indexed? Numbers are important here. If you need to increase the number of items being indexed with each Solr indexing run, feel free to do so. However, don't get ridiculous here: setting 1000 items to be indexed per run could cause a page timeout. If a specific request times out, that could be because it's trying to POST too much data at once; try reducing the quantity of items being indexed per batch and see if that allows the items to be indexed.
+Are you only indexing only 50 items at a time and wondering why hundreds of new content nodes generated in the last hour aren't being indexed? Numbers are important here. If you need to increase the number of items being indexed with each Solr indexing run, feel free to do so. However, don't get ridiculous here: setting 1000 items to be indexed per run could cause a page timeout. If a specific request times out, that could be because it's trying to POST too much data at once; try reducing the quantity of items being indexed per batch and see if that allows the items to be indexed.
 
 ### Apache Spatial Search on Pantheon
 
 Pantheon's Solr configuration does not support geospatial indexing and searching and there are currently no plans to add it.  
-
-As an alternative, there are several external Solr service providers that do support Spatial searching. Pantheon doesn’t do any blocking/filtering, so you’re welcome to use an externally hosted solr index – and in a case where you’re looking for a more complex configuration, that might be optimal.
+As an alternative, there are several external Solr service providers that do support spatial searching. Pantheon doesn’t do any blocking/filtering, so you’re welcome to use an externally hosted solr index – and in a case where you’re looking for a more complex configuration, that might be optimal.

--- a/source/docs/articles/sites/apache-solr.md
+++ b/source/docs/articles/sites/apache-solr.md
@@ -2,7 +2,6 @@
 title: Apache Solr on Pantheon
 description: Detailed information on using Apache Solr on the Pantheon Website Management Platform.
 category:
-    - drupal
     - developing
 keywords: apche, apache solr, index, indexing, searching, index and search, indexing and searching, solr, how to enable solr, enable solr, solr api, indexserver solr, solr indexserver, solr api, enable solr search, apachesolr, apache solor search module, solr modules, configure solr,
 ---
@@ -12,101 +11,18 @@ Apache Solr is a system for indexing and searching site content. Pantheon provid
 
 Currently, all plans except for a Personal plan can use Solr. Solr is available to Sandbox plans for developmental purposes, but Solr will not be available going live on a Personal plan.
 
-<table>
-	<tbody>
-			<tr>
-        <th align="left" style="width: 130px">Plan</th>
-        <th align="left" style="width: 130px">Is Solr Available?</th>
-			</tr>
-			<tr>
-			</tr>
-			<tr>
-        <td align="left">Sandbox</td>
-        <td align="left">Yes</td>
-			</tr>
-			<tr>
-        <td align="left">Personal</td>
-        <td align="left">No</td>
-			</tr>
-			<tr>
-        <td align="left">Professional</td>
-        <td align="left">Yes</td>
-			</tr>
-			<tr>
-        <td align="left">Business</td>
-        <td align="left">Yes</td>
-			</tr>
-			<tr>
-        <td align="left">Elite</td>
-        <td align="left">Yes</td>
-			</tr>
-	</tbody>
-</table>
+| Plans        | Supported
+| ------------- |:-------------:|
+| Sandbox      | **Yes** |
+| Personal      | No      |
+| Professional | **Yes**      |
+| Business | **Yes**      |
+| Elite | **Yes**      |
 
-## Adding the Apache Solr Index Server from the Dashboard
-First, you will need to add the Index Server to your site. From your Dashboard, go to **Settings** > **Add Ons** > **Apache Solr Index Server: Add**.
 
-This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with your CMS.
+## Using Solr with WordPress or Drupal
 
-## Solr Support for WordPress
-
-We are developing a modern plugin interface for WordPress to our Apache Solr infrastructure. The plugin is currently developer-ready and available [on GitHub](https://github.com/pantheon-systems/solr-power). It currently requires additional theme work to craft the user-facing search interface and results, but is being actively improved. See [the README](https://github.com/pantheon-systems/solr-power/blob/master/README.md) for details. Issues and pull requests are welcome!
-
-## Enabling Solr for a Drupal Site
-### 1. Make sure you have the latest version of Drupal
-Use [one-click updates](/docs/articles/sites/code/applying-upstream-updates) to make sure you are running the latest version of Drupal core.
-
-### 2. Add Apache Solr Search or Search API Solr Search Module
-
-Two contributed modules are supported by Pantheon:
-
-- [​https://drupal.org/project/apachesolr](https://drupal.org/project/apachesolr) - 7.x-1.x and 6.x-1.x
-- [https://drupal.org/project/search\_api\_solr](https://drupal.org/project/search_api_solr) - 7.x-1.x
-
-Solr for Drupal 8 is not supported at this time.
-
-For most users, the apachesolr module is the easiest to configure and maintain, and includes functionality like facets and other great features.  
-
-If you rely on highly customized data structures and the apachesolr module is not enough for your needs, search\_api\_solr provides an alternative with a more powerful interface, but is much more complex.  
-
-Choose one or the the other and add it to your code base. Do not enable or configure it yet.
-
-### 3. Enable the Pantheon Apache Solr Module
-
-<div class="alert alert-info" role="alert">
-<h4>Note</h4> If you previously installed the Acquia Solr module and you still have the files present in your codebase, you will need to delete them from your repo before enabling the Pantheon Apache Solr module. If you do not, you may receive an error when attempting to connect to the Solr server.</div>
-
-One of the modules already included in every Pantheon Drupal 7 site is [pantheon\_apachesolr](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr). This module **must** be enabled and configured in each environment (Dev, Test, Live, and each Multidev) in order to use Pantheon's Apache Solr service. pantheon\_apachesolr is not required if you are using a third-party Solr service.
-
-Once enabled, click **Configure**, or navigate to **Administration** > **Configuration** > **Search and metadata** > **Pantheon Apache Solr**.
-
- ![Drupal Admin Search and Metadata Solr](/source/docs/assets/images/desk_images/192434.png)
-### 4. Post the schema.xml Using the Pantheon Apache Solr Module
-
-The next step is to post the schema.xml, which describes Drupal fields to the Solr search indexer. Posting the schema will activate the Solr server for the site environment. Click **Post schema.xml**.  
-
- ![Solr configuration schema](/source/docs/assets/images/desk_images/192435.png)  
-Choose the appropriate schema for the module that you are using (apachesolr or search\_api\_solr) and Solr version (3.5.0). In the vast majority of cases, you will want to use 3.x/schema.xml. Do not attempt to use schemas intended for different versions of Solr, because it won't work. When you've made your selection, click **Post schema**.  
-
-<div class="alert alert-info" role="alert">
-<h4>Note</h4>
-You must post the schema.xml in each environment (Dev, Test, and Live) that you want to use Pantheon's Solr Service in.</div>
-
-### 5. Enable and Configure Your Solr Module
-
-#### Apache Solr Search (apachesolr)
-
-Enable both the **Apache Solr framework** and **Apache Solr Search** modules.
- ![Enable Solr module](/source/docs/assets/images/desk_images/192444.png)
-Browse to the main Apache Solr settings screen and you should now see an index is ready for you. You do not need to configure any server settings, but you can still handle your facet and bias settings as per normal:
- ![Configure Solr Settings](/source/docs/assets/images/desk_images/27787.png)
-
-Note that the default connection parameters are correct and do not need changing. After this point, your configuration and settings will be the same as any generic Apache Solr use case.
-
-#### Search API Solr Search (search\_api\_solr)
-
-Three modules are required; [entity](https://drupal.org/project/entity),  [search\_api](https://drupal.org/project/search_api) and  [search\_api\_solr](https://drupal.org/project/search_api_solr) need to be installed and enabled.  
- ![Enable Solr Search required modules](/source/docs/assets/images/desk_images/192457.png)
+For installation instructions and additional details, see [Enabling Solr for WordPress](/docs/articles/wordpress/solr) or [Enabling Solr with Drupal](/docs/articles/drupal/solr).
 
 ## Known Limitations of Pantheon's Solr Service
 
@@ -145,71 +61,6 @@ Some customers have reported success using external Solr service providers for t
 	<dd>Contains details about the fields that documents can contain, and how those fields are handled when adding documents to the index or querying those fields. Must be posted using the pantheon_apachesolr module before indexing and searching will work. For more information, see <a href="http://wiki.apache.org/solr/SchemaXml">http://wiki.apache.org/solr/SchemaXml</a>.
 </dd>
 </dl>
-
-## Additional Help
-
-The Pantheon Solr module provides a comprehensive help section that describes a number of key Solr concepts and terms. View it by going to **Administration** > **Help** > **Pantheon Apache Solr**.
-
-## Pantheon Solr Service Status
-
-The Pantheon Solr module provides several interfaces for troubleshooting the health of the service, along with the ability to manually perform queries. These checks are independent of contrib module configurations in order to determine whether the service itself is performing properly, or if there is there is a problem with your site configuration.
-
-### Status
-
-This interface reports what the last schema that was posted to the service and whether the service itself responds to a ping.  
-
-**Administration** > **Configuration** > **Search and metadata** > **Pantheon Apache Solr**
- ![Pantheon Apache Solr status](/source/docs/assets/images/desk_images/192483.png)
-
-### Execute Query
-
-The Pantheon Apache Solr module provides an interface for administrators to send queries directly to the Solr server, independently of any contrib module. This is advanced functionality and is intended for debugging purposes only. Try queries like `/admin/ping` to see the raw server response.
-
- ![Send query to Solr](/source/docs/assets/images/desk_images/192486.png)
-
-### Drupal Status Report
-
-The Pantheon Apache Solr ​module also adds an item to the Administration > Reports > Status report that performs a similar check to the Status check, independently of contrib module configurations.  
- ![Solr reports](/source/docs/assets/images/desk_images/192484.png)
-
-## Troubleshooting
-
-The following are Pantheon-specific variables that you can check for, depending on the module you are using.  
-
-Keep in mind that newly indexed items have a 2-minute delay until cron has been run or manually indexed before they become available in Solr search.
-
-####apachesolr.module
-If you're using the Apache Solr module, you can check for the existence of this variable using [Terminus](https://github.com/pantheon-systems/cl):
-```bash
-terminus drush --site=<site> --env=<env> "vget apachesolr_service_class"
-```
-####search_api_solr.module
-If you are using search_api_solr.module you can check it with the command:
-```bash
-terminus drush --site=<site> --env=<env> "vget search_api_solr_connection_class"
-```
-
-<div class="alert alert-info" role="alert">
-<h4>Note</h4>
-Replace <code>&lt;site&gt;</code> with your site name, and <code>&lt;env&gt;</code> with the environment (Dev, Test, or Live). You can see a list of all your sites by running <code>terminus sites list</code></div>
-
-### Error During Search API Solr Installation
-
-If you receive the following error, be sure that you have followed all of the instructions as described in the INSTALL.txt. We can not resolve this for you as it is part of the module setup:
-```php
-Exception: SolrPhpClient library not found! Please follow the instructions in search_api_solr/INSTALL.txt for installing the Solr search module. in _search_api_solr_solrphpclient_path()
-```
-### Common Techniques
-
-
-#### Did you post the schema into all your environments?
-
-It needs to be done for Dev, Test and Live individually. You can do this at `admin/config/search/pantheon`
-
-#### Re-index Content
-
-You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
-
 #### Check Index and Batch Sizes
 
 Are you only indexing only 50 items at a time and wondering why 100s of new content nodes generated in the last hour aren't being indexed? Numbers are important here. If you need to increase the number of items being indexed with each Solr indexing run, feel free to do so. However, don't get ridiculous here: setting 1000 items to be indexed per run could cause a page timeout. If a specific request times out, that could be because it's trying to POST too much data at once; try reducing the quantity of items being indexed per batch and see if that allows the items to be indexed.

--- a/source/docs/articles/wordpress/solr.md
+++ b/source/docs/articles/wordpress/solr.md
@@ -37,8 +37,9 @@ Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https:/
 6. Use the **Query** tab to search for words and/or phrases to validate Solr's indexing configuration.
 
 Deploy the plugin to the site's Live environment after validation and testing. The `schema.xml` file must be sent to Solr when the plugin is deployed to another environment for the first time. Select **Repost schema.xml** from the **Actions** tab, then validate expected results.
+
 ### Optimize Index
-For details, see [Optimize command](http://solarium.readthedocs.org/en/stable/queries/update-query/building-an-update-query/optimize-command/).
+For details, see the [Optimize command](http://solarium.readthedocs.org/en/stable/queries/update-query/building-an-update-query/optimize-command/) document.
 
 ## Known Issues/Limitations
 This plugin is under active development on [GitHub](https://github.com/pantheon-systems/solr-power). Use the issue queue for status updates and support. Pull requests are also welcome!
@@ -50,5 +51,6 @@ The `schema.xml` file is not automatically sent to Solr when deploying the plugi
 This is required upon initial deployment of the plugin to any environment or when a custom `schema.xml` document is changed.
 ### Custom Fields
 The plugin does not currently index custom fields as expected, check [this issue](https://github.com/pantheon-systems/solr-power/issues/51) for progress updates.
+
 ### Custom Post Types
-Future development work may allow for indexing custom post types, however they are not yet supported. Pull requests are welcome!
+Future development work may allow for indexing custom post types; however, they are not yet supported. Pull requests are welcome!

--- a/source/docs/articles/wordpress/solr.md
+++ b/source/docs/articles/wordpress/solr.md
@@ -11,7 +11,7 @@ keywords: apche, apache solr, index, indexing, searching, index and search, inde
 This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with WordPress.
 
 ## Solr Search for WordPress
-Pantheon supports and maintains [Solr Search for WordPress](https://wordpress.org/plugins/solr-power/).  This plugin replaces the default search mechanism within WordPress while preserving the familiar integration methods within themes and widgets.
+Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/).  This plugin replaces the [default search mechanism](https://codex.wordpress.org/Class_Reference/WP_Query#Search_Parameter) within WordPress while preserving the familiar integration methods within themes and widgets.
 
 
 ## Install and Configure Plugin
@@ -20,26 +20,37 @@ Pantheon supports and maintains [Solr Search for WordPress](https://wordpress.or
  terminus site set-connection-mode --site=<site> --env=dev --mode=sftp
  ```
 
-2. Install and activate the [Solr Search for WordPress](https://wordpress.org/plugins/solr-power/) on the Dev Environment using the WordPress Dashboard or with Terminus:
+2. Install and activate the [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/) plugin on the Dev or Multidev environment using the WordPress Dashboard or with Terminus:
  ```bash
  terminus wp 'plugin install --activate solr-power' --site=<site> --env=dev
  ```
- Upon activation, the plugin will index your site automatically using the default Indexing Options.
-
-3. From the WordPress Dashboard, navigate to **Settings** > **Solr Options**. You should see the **Info** tab which shows your site's Solr Server details.
-
-4. Select the **Indexing** tab to customize your Indexing Options with Solr. For example, Network Administrators on a given WordPress Site Network can select the **Index All Sites** option to extend Solr to all subsites. You can enter
-
-5. The **Actions** tab can be used to perform the following Solr tasks:
- - **Check Server Settings**
- - **Optimze Index**
- - **Delete All**
- - **Repost schema.xml**
+ Upon activation, the plugin will generate and send a `schema.xml` document to the Solr server.
+3. From the WordPress Dashboard, navigate to **Settings** > **Solr Options**. You should see your site's Solr Server details within the **Info** tab.
+4. Select the **Indexing** tab to customize content indexed on Solr. Click **Save Changes** after making modifications.
+ <div class="alert alert-info">
+ <h4>Note</h4> You can exclude pages or posts from being indexed by providing the numeric ID of the item (comma separated).
+ </div>
+5. Select the **Actions** tab and index your site's posts, pages, and/or attachments on Solr by clicking all that apply:
  - **Load All post(s)**
  - **Load All page(s)**
  - **Load All attachment(s)**
- <div class="alert alert-info">
- <h4>Note</h4>
- To use a custom <code>schema.xml</code>, upload it to the <code>/wp-content/uploads/solr-for-wordpress-on-pantheon/</code> directory.
- </div>
 6. Use the **Query** tab to search for words and/or phrases to validate Solr's indexing configuration.
+
+Deploy the plugin to the site's Live environment after validation and testing. The `schema.xml` file must be resent to Solr when deploying the plugin to another environment. Select **Repost schema.xml** from the **Actions** tab, then validate expected results.
+### Optimize Index
+For details, see [Optimize command](http://solarium.readthedocs.org/en/stable/queries/update-query/building-an-update-query/optimize-command/).
+
+## Known Issues/Limitations
+This plugin is under active development on [GitHub](https://github.com/pantheon-systems/solr-power). Use the issue queue for status updates and support. Pull requests are also welcome!
+### Automatic Re-Indexing
+Solr is updated automatically when a post is modified, published, or deleted. If modifications to the indexing options have been saved within the **Indexing** tab, the site must be indexed again within the **Actions** tab.
+### Deploy to Test and Live
+The `schema.xml` file is not automatically sent to Solr when deploying from one environment to another. Once you have deployed to the Test and/or Live environment, log into the environment's URL and navigate to **Settings** > **Solr Options** > **Actions**. Select **Repost schema.xml** and re-index your site by selecting all that apply:
+
+- **Load All post(s)**
+- **Load All page(s)**
+- **Load All attachment(s)**
+### Custom Fields
+The plugin does not currently index custom fields as expected, check [this issue](https://github.com/pantheon-systems/solr-power/issues/51) for progress updates.
+### Custom Post Types
+Future development work may allow for indexing custom post types, however they are not yet supported. Pull requests are welcome!

--- a/source/docs/articles/wordpress/solr.md
+++ b/source/docs/articles/wordpress/solr.md
@@ -1,0 +1,45 @@
+---
+title: Enabling Solr for WordPress
+description: Detailed information on using Apache Solr with WordPress.
+category:
+    - wordpress
+    - developing
+keywords: apche, apache solr, index, indexing, searching, index and search, indexing and searching, solr, how to enable solr, enable solr, solr api, indexserver solr, solr indexserver, solr api, enable solr search, apachesolr, apache solor search module, solr modules, configure solr,
+---
+[Apache Solr](/docs/articles/sites/apache-solr) is a system for indexing and searching site content. First, you will need to add the Index Server to your site. From your Dashboard, go to **Settings** > **Add Ons** > **Apache Solr Index Server: Add**.
+
+This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with WordPress.
+
+## Solr Search for WordPress
+Pantheon supports and maintains [Solr Search for WordPress](https://wordpress.org/plugins/solr-power/).  This plugin replaces the default search mechanism within WordPress while preserving the familiar integration methods within themes and widgets.
+
+
+## Install and Configure Plugin
+1. [Set the connection mode to SFTP](/docs/articles/sites/code/developing-directly-with-sftp-mode) for the Dev or Multidev environment via the Pantheon Dashboard or with [Terminus](/docs/articles/local/cli/):
+ ```bash
+ terminus site set-connection-mode --site=<site> --env=dev --mode=sftp
+ ```
+
+2. Install and activate the [Solr Search for WordPress](https://wordpress.org/plugins/solr-power/) on the Dev Environment using the WordPress Dashboard or with Terminus:
+ ```bash
+ terminus wp 'plugin install --activate solr-power' --site=<site> --env=dev
+ ```
+ Upon activation, the plugin will index your site automatically using the default Indexing Options.
+
+3. From the WordPress Dashboard, navigate to **Settings** > **Solr Options**. You should see the **Info** tab which shows your site's Solr Server details.
+
+4. Select the **Indexing** tab to customize your Indexing Options with Solr. For example, Network Administrators on a given WordPress Site Network can select the **Index All Sites** option to extend Solr to all subsites. You can enter
+
+5. The **Actions** tab can be used to perform the following Solr tasks:
+ - **Check Server Settings**
+ - **Optimze Index**
+ - **Delete All**
+ - **Repost schema.xml**
+ - **Load All post(s)**
+ - **Load All page(s)**
+ - **Load All attachment(s)**
+ <div class="alert alert-info">
+ <h4>Note</h4>
+ To use a custom <code>schema.xml</code>, upload it to the <code>/wp-content/uploads/solr-for-wordpress-on-pantheon/</code> directory.
+ </div>
+6. Use the **Query** tab to search for words and/or phrases to validate Solr's indexing configuration.

--- a/source/docs/articles/wordpress/solr.md
+++ b/source/docs/articles/wordpress/solr.md
@@ -6,9 +6,9 @@ category:
     - developing
 keywords: apche, apache solr, index, indexing, searching, index and search, indexing and searching, solr, how to enable solr, enable solr, solr api, indexserver solr, solr indexserver, solr api, enable solr search, apachesolr, apache solor search module, solr modules, configure solr,
 ---
-[Apache Solr](/docs/articles/sites/apache-solr) is a system for indexing and searching site content. First, you will need to add the Index Server to your site. From your Dashboard, go to **Settings** > **Add Ons** > **Apache Solr Index Server: Add**.
+[Apache Solr](/docs/articles/sites/apache-solr) is a system for indexing and searching site content. Currently, all plans except for a Personal plan can use Solr.
 
-This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with WordPress.
+First, you will need to add the Index Server to your site. From your Dashboard, go to **Settings** > **Add Ons** > **Apache Solr Index Server: Add**. This will provision Apache Solr containers for every environment for your site. You are now ready to begin integrating with WordPress.
 
 ## Solr Search for WordPress
 Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/).  This plugin replaces the [default search mechanism](https://codex.wordpress.org/Class_Reference/WP_Query#Search_Parameter) within WordPress while preserving the familiar integration methods within themes and widgets.
@@ -24,7 +24,7 @@ Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https:/
  ```bash
  terminus wp 'plugin install --activate solr-power' --site=<site> --env=dev
  ```
- Upon activation, the plugin will generate and send a `schema.xml` document to the Solr server.
+ Upon activation, the plugin will generate and send a [`schema.xml`](https://github.com/pantheon-systems/solr-power/blob/master/schema.xml) document to the Solr server.
 3. From the WordPress Dashboard, navigate to **Settings** > **Solr Options**. You should see your site's Solr Server details within the **Info** tab.
 4. Select the **Indexing** tab to customize content indexed on Solr. Click **Save Changes** after making modifications.
  <div class="alert alert-info">
@@ -36,20 +36,18 @@ Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https:/
  - **Load All attachment(s)**
 6. Use the **Query** tab to search for words and/or phrases to validate Solr's indexing configuration.
 
-Deploy the plugin to the site's Live environment after validation and testing. The `schema.xml` file must be resent to Solr when deploying the plugin to another environment. Select **Repost schema.xml** from the **Actions** tab, then validate expected results.
+Deploy the plugin to the site's Live environment after validation and testing. The `schema.xml` file must be sent to Solr when the plugin is deployed to another environment for the first time. Select **Repost schema.xml** from the **Actions** tab, then validate expected results.
 ### Optimize Index
 For details, see [Optimize command](http://solarium.readthedocs.org/en/stable/queries/update-query/building-an-update-query/optimize-command/).
 
 ## Known Issues/Limitations
 This plugin is under active development on [GitHub](https://github.com/pantheon-systems/solr-power). Use the issue queue for status updates and support. Pull requests are also welcome!
-### Automatic Re-Indexing
-Solr is updated automatically when a post is modified, published, or deleted. If modifications to the indexing options have been saved within the **Indexing** tab, the site must be indexed again within the **Actions** tab.
-### Deploy to Test and Live
-The `schema.xml` file is not automatically sent to Solr when deploying from one environment to another. Once you have deployed to the Test and/or Live environment, log into the environment's URL and navigate to **Settings** > **Solr Options** > **Actions**. Select **Repost schema.xml** and re-index your site by selecting all that apply:
+### Re-Indexing
+New, deleted, and modified posts and pages are automatically added to the Solr index. However, if you modify the indexing options within **Settings** > **Solr Options** > **Indexing**, you must manually re-index the site on the **Actions** tab.
+### Initial Deploy to Test and Live
+The `schema.xml` file is not automatically sent to Solr when deploying the plugin to another environment for the first time. Login to the WordPress Dashboard on the environment's URL and click **Repost schema.xml** within  **Settings** > **Solr Options** > **Actions**. Then re-index the site.
 
-- **Load All post(s)**
-- **Load All page(s)**
-- **Load All attachment(s)**
+This is required upon initial deployment of the plugin to any environment or when a custom `schema.xml` document is changed.
 ### Custom Fields
 The plugin does not currently index custom fields as expected, check [this issue](https://github.com/pantheon-systems/solr-power/issues/51) for progress updates.
 ### Custom Post Types


### PR DESCRIPTION
Closes #1291 

- Separate Drupal and WP docs for installation
- Keep general/platform/service info on main page

@bmackinney can you review and provide feedback/guidance? Not sure if splitting the doc based on CMS is ideal or not. ping @nataliejeremy 

This is a WIP - I wasn't able to search custom post types (tested with anspress q&a). I was able to search successfully on a new installation