### PR TITLE
Add warning about deleting default.settings.php

### DIFF
--- a/source/docs/articles/drupal/configuring-settings-php.md
+++ b/source/docs/articles/drupal/configuring-settings-php.md
@@ -13,7 +13,7 @@ Drupal 8 sites on Pantheon run an unmodified version of core, bundled with a cus
 For Drupal 6/7, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing settings.php. Permissions are handled automatically by Pantheon, so you can customize settings.php like any other site code.
 
 <div class="alert alert-danger" role="alert"><h4>Warning</h4>
-You should not delete the default.settings.php file as this will render the symlink to your sites/default/files directory invalid.</div>
+You should not delete the <code>default.settings.php</code> file as this will render the symlink to your <code>sites/default/files</code> directory invalid.</div>
 
 <div class="alert alert-danger" role="alert"><h4>Warning</h4>
 You should NEVER put the database connection information for a Pantheon database within your settings.php. These credentials will change. If you are having connection errors, please ensure you are running Pressflow core. This is a requirement and is not optional.</div>

--- a/source/docs/articles/drupal/configuring-settings-php.md
+++ b/source/docs/articles/drupal/configuring-settings-php.md
@@ -13,6 +13,9 @@ Drupal 8 sites on Pantheon run an unmodified version of core, bundled with a cus
 For Drupal 6/7, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing settings.php. Permissions are handled automatically by Pantheon, so you can customize settings.php like any other site code.
 
 <div class="alert alert-danger" role="alert"><h4>Warning</h4>
+You should not delete the default.settings.php file as this will render the symlink to your sites/default/files directory invalid.</div>
+
+<div class="alert alert-danger" role="alert"><h4>Warning</h4>
 You should NEVER put the database connection information for a Pantheon database within your settings.php. These credentials will change. If you are having connection errors, please ensure you are running Pressflow core. This is a requirement and is not optional.</div>
 
 ## Pantheon Articles on Settings.php

--- a/source/docs/articles/drupal/configuring-settings-php.md
+++ b/source/docs/articles/drupal/configuring-settings-php.md
@@ -13,9 +13,6 @@ Drupal 8 sites on Pantheon run an unmodified version of core, bundled with a cus
 For Drupal 6/7, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing settings.php. Permissions are handled automatically by Pantheon, so you can customize settings.php like any other site code.
 
 <div class="alert alert-danger" role="alert"><h4>Warning</h4>
-You should not delete the <code>default.settings.php</code> file as this will render the symlink to your <code>sites/default/files</code> directory invalid.</div>
-
-<div class="alert alert-danger" role="alert"><h4>Warning</h4>
 You should NEVER put the database connection information for a Pantheon database within your settings.php. These credentials will change. If you are having connection errors, please ensure you are running Pressflow core. This is a requirement and is not optional.</div>
 
 ## Pantheon Articles on Settings.php
@@ -31,7 +28,7 @@ The following articles include techniques and configurations for settings.php on
 
 Use these configuration snippets to specify a local configuration that will be ignored by Pantheon, such as database credentials.
 
-## Drupal 8
+### Drupal 8
 Configure environment-specific settings within the `settings.local.php` file, which is `.gitignored`. Modifying the bundled `settings.php` file is not necessary, as it already includes `settings.local.php` if one exists.
 
     ​// Local development configuration.
@@ -55,7 +52,7 @@ To use the Pantheon `HASH_SALT` in your local site (not necessary), you can get 
 ```
 terminus drush --site=<site> --env=<env> "ev return getenv("DRUPAL_HASH_SALT")"
 ```
-## Drupal 7
+### Drupal 7
 
     ​// Local development configuration.
     if (!defined('PANTHEON_ENVIRONMENT')) {
@@ -71,7 +68,7 @@ terminus drush --site=<site> --env=<env> "ev return getenv("DRUPAL_HASH_SALT")"
       );
     }
 
-## Drupal 6
+### Drupal 6
 
     // Local development configuration.
     if (!defined('PANTHEON_ENVIRONMENT')) {
@@ -81,6 +78,9 @@ terminus drush --site=<site> --env=<env> "ev return getenv("DRUPAL_HASH_SALT")"
     }
 
 ## Frequently Asked Questions
+
+#### Can I delete the `default.settings.php` file?
+Yes, but only if at least one other file (e.g. `settings.php`) is present within the `sites/default` directory. Otherwise, the existing symlink to `sites/default/files` will be invalid.
 
 #### How can I write logic based on the Pantheon server environment?
 


### PR DESCRIPTION
Git will consider the directory to be empty and the symlink is lost leading to a broken site