### PR TITLE
Managing Upstreams: add d8 upstream

### DIFF
--- a/source/docs/articles/organizations/managing-upstreams.md
+++ b/source/docs/articles/organizations/managing-upstreams.md
@@ -10,11 +10,11 @@ Upstream maintainers bear the responsibility of updating Drupal and WordPress co
 ## Merging Core Releases
 1. Create an update branch:
 
- ```bash
- git checkout -b update
- ```
+```bash
+git checkout -b update
+```
 2. Pull down changes from the applicable core:
- 
+
  <!-- Nav tabs -->
  <ul class="nav nav-tabs" role="tablist">
  <li role="presentation" class="active"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
@@ -49,10 +49,10 @@ Upstream maintainers bear the responsibility of updating Drupal and WordPress co
  
 3. Commit and push:
 
- ```nohighlight
- git commit -m “Update to Drupal 7.33. http://link-to-release-notes”
- git push origin update
- ```
+```nohighlight
+git commit -m “Update to Drupal 7.33. http://link-to-release-notes”
+git push origin update
+```
 
 ## Adding or Updating Custom Code
 

--- a/source/docs/articles/organizations/managing-upstreams.md
+++ b/source/docs/articles/organizations/managing-upstreams.md
@@ -15,22 +15,37 @@ Upstream maintainers bear the responsibility of updating Drupal and WordPress co
  ```
 2. Pull down changes from the applicable core:
 
- **WordPress**
- ```bash
- git pull git://github.com/pantheon-systems/wordpress.git master
- ```
+ <!-- Nav tabs -->
+ <ul class="nav nav-tabs" role="tablist">
+   <li role="presentation" class="active"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
+   <li role="presentation"><a href="#d7" aria-controls="d7" role="tab" data-toggle="tab">Drupal 7</a></li>
+   <li role="presentation"><a href="#d6" aria-controls="d6" role="tab" data-toggle="tab">Drupal 6</a></li>
+   <li role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+ </ul>
 
- **Drupal 6**
-
- ```bash
- git pull git://github.com/pantheon-systems/drops-6.git master
- ```
-
- **Drupal 7**
-
- ```bash
- git pull git://github.com/pantheon-systems/drops-7.git master
- ```
+ <!-- Tab panes -->
+ <div class="tab-content">
+   <div role="tabpanel" class="tab-pane active" id="d8">
+   <pre><code class="bash hljs">
+   git pull git://github.com/pantheon-systems/drops-8.git master
+   </code></pre>
+   </div>
+   <div role="tabpanel" class="tab-pane" id="d7">
+   <pre><code class="bash hljs">
+   git pull git://github.com/pantheon-systems/drops-7.git master
+   </code></pre>
+   </div>
+   <div role="tabpanel" class="tab-pane" id="d6">
+   <pre><code class="bash hljs">
+   git pull git://github.com/pantheon-systems/drops-6.git master
+   </code></pre>
+   </div>
+   <div role="tabpanel" class="tab-pane" id="wp">
+   <pre><code class="bash hljs">
+   git pull git://github.com/pantheon-systems/WordPress.git master
+   </code></pre>
+   </div>
+ </div>
 
 3. Commit and push:
 
@@ -49,7 +64,7 @@ Using the testing site created when you submitted your distribution, test your u
 
 ## Update Release Branching Strategy
 
-We encourage you to use a continuous integration server, like Jenkins, Travis-CI, or Circle-CI, to automate this process. 
+We encourage you to use a continuous integration server, like Jenkins, Travis-CI, or Circle-CI, to automate this process.
 
 For example:
 
@@ -59,7 +74,7 @@ For example:
 4. Push the `update` branch to Pantheon.
 5. Create a Multidev environment for the `update` branch.
 6. Wipe the `update` Multidev environment.
-7. Run acceptance tests for a new-site installation use case.
+7. Run acceptance tests for a new site installation use case.
 8. Clone database and files from Live to your Multidev environment.
 9. Test update process (run update.php) for an existing site update use case.
 10. Merge to Dev and deploy code to Test and Live.
@@ -70,4 +85,4 @@ For example:
 1. Prepare release notes.
 2. Merge your pull request into the branch, providing a descriptive commit message. The message can follow the pattern: “Upstream release version, release notes http://link-to-release-notes”.
 
-After you have merged an update, all sites that use the distribution are given the option to apply updates on their Site Dashboard at Dev > Code. It typically takes up to an hour before the update is detected. Use your browser’s hard refresh if the updates do not appear after the first hour (`cmd+shift+R` on OSX, `shift+f5` on Windows).
+After you have merged an update, all sites that use the distribution can apply updates on the Site Dashboard at Dev > Code. It typically takes up to an hour before the update is detected. Use your browser’s hard refresh if the updates do not appear after the first hour (`cmd+shift+R` on OS X, `shift+f5` on Windows).

--- a/source/docs/articles/organizations/managing-upstreams.md
+++ b/source/docs/articles/organizations/managing-upstreams.md
@@ -14,39 +14,39 @@ Upstream maintainers bear the responsibility of updating Drupal and WordPress co
  git checkout -b update
  ```
 2. Pull down changes from the applicable core:
-
+ 
  <!-- Nav tabs -->
  <ul class="nav nav-tabs" role="tablist">
-   <li role="presentation" class="active"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
-   <li role="presentation"><a href="#d7" aria-controls="d7" role="tab" data-toggle="tab">Drupal 7</a></li>
-   <li role="presentation"><a href="#d6" aria-controls="d6" role="tab" data-toggle="tab">Drupal 6</a></li>
-   <li role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+ <li role="presentation" class="active"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
+ <li role="presentation"><a href="#d7" aria-controls="d7" role="tab" data-toggle="tab">Drupal 7</a></li>
+ <li role="presentation"><a href="#d6" aria-controls="d6" role="tab" data-toggle="tab">Drupal 6</a></li>
+ <li role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
  </ul>
-
+ 
  <!-- Tab panes -->
  <div class="tab-content">
-   <div role="tabpanel" class="tab-pane active" id="d8">
-   <pre><code class="bash hljs">
-   git pull git://github.com/pantheon-systems/drops-8.git master
-   </code></pre>
-   </div>
-   <div role="tabpanel" class="tab-pane" id="d7">
-   <pre><code class="bash hljs">
-   git pull git://github.com/pantheon-systems/drops-7.git master
-   </code></pre>
-   </div>
-   <div role="tabpanel" class="tab-pane" id="d6">
-   <pre><code class="bash hljs">
-   git pull git://github.com/pantheon-systems/drops-6.git master
-   </code></pre>
-   </div>
-   <div role="tabpanel" class="tab-pane" id="wp">
-   <pre><code class="bash hljs">
-   git pull git://github.com/pantheon-systems/WordPress.git master
-   </code></pre>
-   </div>
+ <div role="tabpanel" class="tab-pane active" id="d8">
+ <pre><code class="bash hljs">
+ git pull git://github.com/pantheon-systems/drops-8.git master
+ </code></pre>
  </div>
-
+ <div role="tabpanel" class="tab-pane" id="d7">
+ <pre><code class="bash hljs">
+ git pull git://github.com/pantheon-systems/drops-7.git master
+ </code></pre>
+ </div>
+ <div role="tabpanel" class="tab-pane" id="d6">
+ <pre><code class="bash hljs">
+ git pull git://github.com/pantheon-systems/drops-6.git master
+ </code></pre>
+ </div>
+ <div role="tabpanel" class="tab-pane" id="wp">
+ <pre><code class="bash hljs">
+ git pull git://github.com/pantheon-systems/WordPress.git master
+ </code></pre>
+ </div>
+ </div>
+ 
 3. Commit and push:
 
  ```nohighlight


### PR DESCRIPTION
Closes #1122 
I added the drops-8 example and changed the format to tabs, similar to Applying Upstream Updates: https://pantheon.io/docs/articles/sites/code/applying-upstream-updates/

@rachelwhitton Please review and merge.