### PR TITLE
Use rsync to automate downloading logs

### DIFF
--- a/source/docs/articles/sites/logs.md
+++ b/source/docs/articles/sites/logs.md
@@ -56,7 +56,8 @@ To automate this process, see [Automate Downloading Logs from the Live Environme
 ```nohighlight
 get logs/mysqld-slow-query.log
 ```
-You now have a local copy of the `mysqld-slow-query.log` file.
+You now have a local copy of the `mysqld-slow-query.log` file. To automate this process, see [Automate Downloading Logs from the Live Environment](/docs/articles/sites/logs/downloading-live-error-logs/).
+
 ## See Also
 - [Debugging Sites with Log Files](/docs/articles/sites/logs/debugging-sites-with-log-files)
 - [MySQL Slow Log](/docs/articles/sites/logs/mysql-slow-log/)

--- a/source/docs/articles/sites/logs/downloading-live-error-logs.md
+++ b/source/docs/articles/sites/logs/downloading-live-error-logs.md
@@ -22,8 +22,12 @@ SITE=xxxxxxxxxxx
 ENV=live
 for app_server in `dig +short appserver.$ENV.$SITE.drush.in`;
 do
-  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:logs $app_server
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:logs app_server_$app_server
 done
+
+# Include MySQL logs
+db_server=`dig dbserver.$ENV.$SITE.drush.in +short`
+rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@dbserver.$ENV.$SITE.drush.in:logs db_server_$db_server
 ```
 ## Collect Logs
 Download logs by executing the script from within the `site-logs` directory:

--- a/source/docs/articles/sites/logs/downloading-live-error-logs.md
+++ b/source/docs/articles/sites/logs/downloading-live-error-logs.md
@@ -7,7 +7,7 @@ keywords: debug, debugging sites, debug sites, debugging site, debugging mysql, 
 Logs help you find, debug, and isolate current or potential problems on your live site. You can automate the process of accessing and maintaining these logs with a simple script.
 
 ## Enable Passwordless Access
-Logs are stored within application container(s) which house your site's codebase and files. [Add an SSH key](/docs/articles/users/generating-ssh-keys/) within your User Dashboard to enable passwordless access and avoid authentication prompts. Otherwise, provide your Pantheon Dashboard credentials when prompted.
+Logs are stored within application containers that house your site's codebase and files. [Add an SSH key](/docs/articles/users/generating-ssh-keys/) within your User Dashboard to enable passwordless access and avoid authentication prompts. Otherwise, provide your Pantheon Dashboard credentials when prompted.
 
 ## Create Script
 Open terminal and run the following commands to create and access a new local directory:

--- a/source/docs/articles/sites/logs/downloading-live-error-logs.md
+++ b/source/docs/articles/sites/logs/downloading-live-error-logs.md
@@ -6,8 +6,8 @@ keywords: debug, debugging sites, debug sites, debugging site, debugging mysql, 
 
 Logs help you find, debug, and isolate current or potential problems on your live site. You can automate the process of accessing and maintaining these logs with a simple script.
 
-## Password/SSH Key
-The script requires access to your codebase, which means you will be interactively prompted for your password. To avoid this, add an SSH key to your Pantheon user account. See [Generating SSH Keys](/docs/articles/users/generating-ssh-keys/) for more information.
+## Enable Passwordless Access
+Logs are stored within application container(s) which house your site's codebase and files. [Add an SSH key](/docs/articles/users/generating-ssh-keys/) within your User Dashboard to enable passwordless access and avoid authentication prompts. Otherwise, provide your Pantheon Dashboard credentials when prompted.
 
 ## Create Script
 Open terminal and run the following commands to create and access a new local directory:
@@ -17,16 +17,12 @@ cd $HOME/site-logs
 ```
 Using your favorite text editor, create a file within the `site-logs` directory called `collect-logs.sh` and save the following:
 ```
-# Replace SITE_UUID with value from Dashboard URL
-SITE_UUID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
-for app_server in `dig +short appserver.live.$SITE_UUID.drush.in`;
+# Replace SITE with value from Dashboard URL
+SITE=xxxxxxxxxxx
+ENV=live
+for app_server in `dig +short appserver.$ENV.$SITE.drush.in`;
 do
-mkdir $app_server
-sftp -o Port=2222 live.$SITE_UUID@$app_server << !
-  cd logs
-  lcd $app_server
-  mget *.log
-!
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:logs $app_server
 done
 ```
 ## Collect Logs

--- a/source/docs/articles/sites/logs/mysql-slow-log.md
+++ b/source/docs/articles/sites/logs/mysql-slow-log.md
@@ -21,7 +21,7 @@ To download the environment's MySQL slow log, use the [method outlined here](/do
 $ sftp -o Port=2222 live.91fd3bea-d11b-401a09iamd9-85e0-07ca0f4ce7bf@dbserver.live.91fd3bea-d11b-401a09iamd9-85e0-07ca0f4ce7bf.drush.in  
 live.91fd3bea-d11b-401a-85e0-0@dbserver.live.91fd3bea-d11b-401a09iamd9-85e0-07ca0f4ce7bf.drush.in's password:
 Connected to dbserver.live.91fd3bea-d11b-401a09iamd9-85e0-07ca0f4ce7bf.drush.in.  
-sftp> cd data  
+sftp> cd logs  
 sftp> ls -l  
 get-rw-rw---- 1 16373 16373 16384 Dec 15 16:55 aria_log.00000001  
 -rw-rw---- 1 16373 16373 52 Dec 15 16:55 aria_log_control  


### PR DESCRIPTION
Closes #527 

- Uses rsync in place of sftp (thanks @ari-gold!)
- Refactor Password/SSH Key section 

Todo: 
- [ ] Test behavior after log rotation on sites with multiple app servers. I'm using the script on the panther site and will merge after this todo is done

@nataliejeremy mind doing a copy edit? We'll hold off on merging for now though. 