### PR TITLE
Test WordPress Core Development Versions

### DIFF
--- a/source/docs/articles/wordpress/wordpress-development-versions.md
+++ b/source/docs/articles/wordpress/wordpress-development-versions.md
@@ -10,7 +10,7 @@ Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstrea
 
 <div class="alert alert-danger">
 <h4>Warning</h4>
-Development versions and beta releases are not supported and should not be run on live sites. Testing should be done on a Multidev environment or within an isolated local environment on a branch other than master.
+Development versions and beta releases are not supported and should not be run on live sites. Testing should be done on a <a href="/docs/articles/sites/multidev/">Multidev</a> environment or within an isolated local environment on a branch other than master.
 </div>
 
 ## Update Core within WordPress Dashboard

--- a/source/docs/articles/wordpress/wordpress-development-versions.md
+++ b/source/docs/articles/wordpress/wordpress-development-versions.md
@@ -6,7 +6,7 @@ categories:
 tags:
   - code
 ---
-Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for WordPress core within the Site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress dashboard or via Git.
+Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for WordPress core within the Site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress Dashboard or via Git.
 
 <div class="alert alert-danger">
 <h4>Warning</h4>
@@ -20,7 +20,7 @@ Development versions and beta releases are not supported and should not be run o
  terminus site set-connection-mode --mode=sftp
  ```
 
-2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress dashboard or with Terminus:
+2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress Dashboard or with Terminus:
 
  ```
  terminus wp 'plugin install wordpress-beta-tester --activate' --yes
@@ -28,11 +28,11 @@ Development versions and beta releases are not supported and should not be run o
 
 3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you want to use, then click **Save**:
   - [Point release nightlies](https://wordpress.org/download/nightly/): This contains the work that is occurring on a branch in preparation for a x.x.x point release. This should also be fairly stable but will be available before the branch is ready for beta.
-  - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 beta releases): This is the bleeding edge development code which may be unstable at times. Only use this if you are an experienced developer.
+  - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 beta releases): This is the bleeding edge development code which may be unstable at times.
 
 
 4. Go to **Dashboard** > **Updates** and click **Update Now**.
-5. Verify the WordPress version using `terminus wp 'core version'` or check the WordPress Admin page:
+5. Verify the WordPress version using `terminus wp 'core version'` or check the bottom of any WordPress Dashboard page:
 
   > You are using a development version (4.5-beta1-36808). Cool! Please stay updated.
 

--- a/source/docs/articles/wordpress/wordpress-development-versions.md
+++ b/source/docs/articles/wordpress/wordpress-development-versions.md
@@ -1,0 +1,83 @@
+---
+title: Test WordPress Core Development Versions
+description: Learn how to test core updates using nightly builds of the current release or bleeding edge.
+categories:
+  - WordPress
+tags:
+  - code
+---
+Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for WordPress core within the site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress Dashboard or via Git.
+
+<div class="alert alert-danger">
+<h4>Warning</h4>
+Development versions and Beta releases are not supported and should not be run on live sites. Testing should be done on a Multidev environment or within an isolated local environment on a branch other than master.
+</div>
+
+## Update Core within WordPress Dashboard
+1. If working on a Multidev environment, set the connection mode to SFTP within the [Pantheon site Dashboard](/docs/articles/sites/code/developing-directly-with-sftp-mode/) or with [Terminus](/docs/articles/local/cli):
+
+ ```
+ terminus site set-connection-mode --mode=sftp
+ ```
+
+2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress Dashboard or with Terminus:
+
+ ```
+ terminus wp 'plugin install wordpress-beta-tester --activate' --yes
+ ```
+
+3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you would like to use, then click **Save**:
+  - [Point release nightlies](https://wordpress.org/download/nightly/): This contains the work that is occurring on a branch in preparation for a x.x.x point release. This should also be fairly stable but will be available before the branch is ready for beta.
+  - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 Beta releases): This is the bleeding edge development code which may be unstable at times. _Only use this if you really know what you are doing._
+
+
+4. Go to **Dashboard** > **Updates** and click **Update Now**
+5. Verify WordPress version using `terminus wp 'core version'` or check WordPress Dashboard (bottom of admin pages):
+
+  > You are using a development version (4.5-beta1-36808). Cool! Please stay updated.
+
+6. Review configuration changes within the provided `wp-config-sample.php` file and add desired changes to `wp-config.php` for testing.
+
+
+## Update Core Manually with Git
+1. If working on a Multidev environment, set the connection mode to Git within the Pantheon site Dashboard or with [Terminus](/docs/articles/local/cli):
+
+ ```
+ terminus site set-connection-mode --mode=git
+ ```
+
+2. From within the [local clone of your site's code repository](/docs/articles/local/starting-with-git/#clone-your-site-codebase):
+
+ ```
+ git checkout -b "wpcore"
+ git remote add WordPress git://github.com/WordPress/WordPress.git
+ git fetch WordPress
+ ```
+3. Determine which update stream you would like to use:
+    - [Point release nightlies](https://wordpress.org/download/nightly/):
+     Run `git tag` to identify the latest development tag (currently 4.4.2), then merge:
+
+     ```
+     git merge --squash -s recursive -X theirs tags/4.4.2
+     ```
+    - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 Beta releases):
+
+     ```
+     git merge --squash -s recursive -X theirs WordPress/master
+     ```
+
+4. Review `wp-config-sample.php` and edit `wp-config.php` with any additions you wish to test.
+
+5. For sites with Multidev, you can push the local branch to Pantheon once you've staged and committed the changes:
+
+ ```
+ git commit -am "Update WordPress core to 4.4.2 development version"
+ git push origin wpcore
+ ```
+
+ Create the Multidev from within the site Dashboard by selecting **Multidev** > **Git Branches** > **Create Environment** next to the `wpcore` branch name.
+
+## Troubleshooting
+
+### Database Update Required
+WordPress sometimes includes database schema changes in major releases. When you update WordPress to the latest version, you might see a notification in the WordPress dashboard to update the database. Update as instructed or via [terminus 'wp core update-db'](/docs/articles/local/cli).

--- a/source/docs/articles/wordpress/wordpress-development-versions.md
+++ b/source/docs/articles/wordpress/wordpress-development-versions.md
@@ -1,38 +1,38 @@
 ---
-title: Test WordPress Core Development Versions
+title: Testing WordPress Core Development Versions
 description: Learn how to test core updates using nightly builds of the current release or bleeding edge.
 categories:
   - WordPress
 tags:
   - code
 ---
-Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for WordPress core within the site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress Dashboard or via Git.
+Pantheon provides [one-click updates](/docs/articles/sites/code/applying-upstream-updates/) for WordPress core within the Site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress dashboard or via Git.
 
 <div class="alert alert-danger">
 <h4>Warning</h4>
-Development versions and Beta releases are not supported and should not be run on live sites. Testing should be done on a Multidev environment or within an isolated local environment on a branch other than master.
+Development versions and beta releases are not supported and should not be run on live sites. Testing should be done on a Multidev environment or within an isolated local environment on a branch other than master.
 </div>
 
 ## Update Core within WordPress Dashboard
-1. If working on a Multidev environment, set the connection mode to SFTP within the [Pantheon site Dashboard](/docs/articles/sites/code/developing-directly-with-sftp-mode/) or with [Terminus](/docs/articles/local/cli):
+1. If working on a Multidev environment, set the connection mode to SFTP within the [Pantheon Site Dashboard](/docs/articles/sites/code/developing-directly-with-sftp-mode/) or with [Terminus](/docs/articles/local/cli):
 
  ```
  terminus site set-connection-mode --mode=sftp
  ```
 
-2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress Dashboard or with Terminus:
+2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress dashboard or with Terminus:
 
  ```
  terminus wp 'plugin install wordpress-beta-tester --activate' --yes
  ```
 
-3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you would like to use, then click **Save**:
+3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you want to use, then click **Save**:
   - [Point release nightlies](https://wordpress.org/download/nightly/): This contains the work that is occurring on a branch in preparation for a x.x.x point release. This should also be fairly stable but will be available before the branch is ready for beta.
-  - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 Beta releases): This is the bleeding edge development code which may be unstable at times. _Only use this if you really know what you are doing._
+  - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 beta releases): This is the bleeding edge development code which may be unstable at times. Only use this if you are an experienced developer.
 
 
-4. Go to **Dashboard** > **Updates** and click **Update Now**
-5. Verify WordPress version using `terminus wp 'core version'` or check WordPress Dashboard (bottom of admin pages):
+4. Go to **Dashboard** > **Updates** and click **Update Now**.
+5. Verify the WordPress version using `terminus wp 'core version'` or check the WordPress Admin page:
 
   > You are using a development version (4.5-beta1-36808). Cool! Please stay updated.
 
@@ -40,7 +40,7 @@ Development versions and Beta releases are not supported and should not be run o
 
 
 ## Update Core Manually with Git
-1. If working on a Multidev environment, set the connection mode to Git within the Pantheon site Dashboard or with [Terminus](/docs/articles/local/cli):
+1. If working on a Multidev environment, set the connection mode to Git within the Pantheon Site Dashboard or with [Terminus](/docs/articles/local/cli):
 
  ```
  terminus site set-connection-mode --mode=git
@@ -53,20 +53,20 @@ Development versions and Beta releases are not supported and should not be run o
  git remote add WordPress git://github.com/WordPress/WordPress.git
  git fetch WordPress
  ```
-3. Determine which update stream you would like to use:
+3. Determine which update stream you want to use:
     - [Point release nightlies](https://wordpress.org/download/nightly/):
      Run `git tag` to identify the latest development tag (currently 4.4.2), then merge:
 
      ```
      git merge --squash -s recursive -X theirs tags/4.4.2
      ```
-    - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 Beta releases):
+    - [Bleeding edge nightlies](https://wordpress.org/download/beta) (Choose this option to test 4.5 beta releases):
 
      ```
      git merge --squash -s recursive -X theirs WordPress/master
      ```
 
-4. Review `wp-config-sample.php` and edit `wp-config.php` with any additions you wish to test.
+4. Review `wp-config-sample.php` and edit `wp-config.php` with any additions you want to test.
 
 5. For sites with Multidev, you can push the local branch to Pantheon once you've staged and committed the changes:
 
@@ -75,7 +75,7 @@ Development versions and Beta releases are not supported and should not be run o
  git push origin wpcore
  ```
 
- Create the Multidev from within the site Dashboard by selecting **Multidev** > **Git Branches** > **Create Environment** next to the `wpcore` branch name.
+Create the Multidev from within the Site Dashboard by selecting **Multidev** > **Git Branches** > **Create Environment** next to the `wpcore` branch name.
 
 ## Troubleshooting
 


### PR DESCRIPTION
Closes #1060 

## Effect
PR includes the following changes:
- New doc on testing development versions of WordPress core (nightly builds for point releases and beta)

cc @nataliejeremy for copy edit
@ttrowell and @greg-1-anderson - can you review and provide feedback? Thanks!