### PR TITLE
Update unsupported-modules-plugins.md

### DIFF
--- a/source/_docs/content-delivery-network.md
+++ b/source/_docs/content-delivery-network.md
@@ -72,7 +72,7 @@ Here's logic that you can use in settings.php to hard-code the URL of the CDN pe
 
 <div class="alert alert-info">
 <h4>Note</h4>
-The latest version of the Amazon S3 CORS module has Composer Manager as a dependency.  Composer Manager is not recommended or supported on the platform at this time. Native Composer installations are supported.  For details, see related drupal.org issue <a href="https://www.drupal.org/node/2688553">Composer Manager dependency</a>.
+The latest version of the Amazon S3 CORS module has Composer Manager as a dependency, which can be problematic on Pantheon if the <a href="/docs/unsupported-modules-plugins/#composer-manager">recommended configuration</a> is not implemented for sites running Drupal 7. This module is still being developed for Drupal 8 and is not yet officially supported.
 </div>
 
 You can configure the [Amazon S3 CORS](https://drupal.org/project/amazons3_cors) module to directly upload to Amazon S3 from within your browser, without needing to upload to Pantheon. This avoids file size limitations on Pantheon and reduces the number of steps necessary to process files.

--- a/source/_docs/content-delivery-network.md
+++ b/source/_docs/content-delivery-network.md
@@ -72,7 +72,7 @@ Here's logic that you can use in settings.php to hard-code the URL of the CDN pe
 
 <div class="alert alert-info">
 <h4>Note</h4>
-The latest version of the Amazon S3 CORS module has Composer Manager as a dependency, which can be problematic on Pantheon if the <a href="/docs/unsupported-modules-plugins/#composer-manager">recommended configuration</a> is not implemented for sites running Drupal 7. This module is still being developed for Drupal 8 and is not yet officially supported.
+The latest version of the Amazon S3 CORS module has Composer Manager as a dependency, which can be problematic on Pantheon if the <a href="/docs/unsupported-modules-plugins/#composer-manager">recommended configuration</a> is not implemented.
 </div>
 
 You can configure the [Amazon S3 CORS](https://drupal.org/project/amazons3_cors) module to directly upload to Amazon S3 from within your browser, without needing to upload to Pantheon. This avoids file size limitations on Pantheon and reduces the number of steps necessary to process files.

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -52,6 +52,18 @@ $baseUrl = '/ckfinder/userfiles/';
 ```
 
 <hr>
+### Composer Manager
+**Issue**: Composer Manager expects to be able to write files to directories that are not writable on Pantheon.
+
+**Solution**: As per the recommendations found [here](https://www.drupal.org/node/2405805), ensure that the automatic generation of files is disabled in your settings.php for the live and test environments (dev as well if you have your dev site in git mode):
+```
+if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live' || $_SERVER['PANTHEON_ENVIRONMENT'] === 'test')) {
+  $conf['composer_manager_autobuild_file'] = 0;
+  $conf['composer_manager_autobuild_packages'] = 0;
+}
+```
+  
+<hr>
 ### Global Redirect  
  **Issue**: Too many redirects error when site is in maintenance mode.  
 

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -53,16 +53,23 @@ $baseUrl = '/ckfinder/userfiles/';
 
 <hr>
 ### Composer Manager
-**Issue**: Composer Manager expects to be able to write files to directories that are not writable on Pantheon.
+**Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
-**Solution**: As per the recommendations found in the [module documentation](https://www.drupal.org/node/2405805), ensure that the automatic generation of files is disabled in your settings.php for the live and test environments (dev as well if you have your dev site in git mode):
+**Solution**: As suggested within the [module documentation](https://www.drupal.org/node/2405805), dependencies should be managed in Dev exclusively. Place the following configuration within `settings.php` to disable autobuild on Test/Live. This will also set appropriate file paths for composer and packages so that they are stored within the root directory of the site's codebase and version controlled:
 ```
-if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live' || $_SERVER['PANTHEON_ENVIRONMENT'] === 'test')) {
-  $conf['composer_manager_autobuild_file'] = 0;
-  $conf['composer_manager_autobuild_packages'] = 0;
+if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    if ($_ENV['PANTHEON_ENVIRONMENT'] === 'dev') {
+    # Set appropriate paths for Composer Manager
+    $conf['composer_manager_file_dir'] = $_SERVER["HOME"] . '/code';
+    $conf['composer_manager_vendor_dir'] = $_SERVER["HOME"] . '/code/vendor';
+  }
+    if (($_ENV['PANTHEON_ENVIRONMENT'] === 'live') || ($_ENV['PANTHEON_ENVIRONMENT'] === 'test' )) {
+    # Disable autobuild on test and live
+    $conf['composer_manager_autobuild_file'] = 0;
+    $conf['composer_manager_autobuild_packages'] = 0;
+  }
 }
 ```
-  
 <hr>
 ### Global Redirect  
  **Issue**: Too many redirects error when site is in maintenance mode.  

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -55,7 +55,7 @@ $baseUrl = '/ckfinder/userfiles/';
 ### Composer Manager
 **Issue**: Composer Manager expects to be able to write files to directories that are not writable on Pantheon.
 
-**Solution**: As per the recommendations found [here](https://www.drupal.org/node/2405805), ensure that the automatic generation of files is disabled in your settings.php for the live and test environments (dev as well if you have your dev site in git mode):
+**Solution**: As per the recommendations found in the [module documentation](https://www.drupal.org/node/2405805), ensure that the automatic generation of files is disabled in your settings.php for the live and test environments (dev as well if you have your dev site in git mode):
 ```
 if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live' || $_SERVER['PANTHEON_ENVIRONMENT'] === 'test')) {
   $conf['composer_manager_autobuild_file'] = 0;


### PR DESCRIPTION
related to #1449 

## Effect
PR includes the following changes:
- Give instructions to use composer manager on the platform

## Remaining Work
- [x] Confirm that using this method allows cron and all other regularly scheduled tasks to run
- [x] Confirm that enabling and disabling modules does not cause Composer Manager to fire any composer tasks (composer update, etc)

@rachelwhitton please test
cc @nataliejeremy for copy edit