### PR TITLE
Update launch path for sculpin

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Fork and clone this repository. Issue pull-requests one document at a time.
 3. Start your local server:  
  If you do not want to install sculpin globally, you can use the following commands to start your local server:  
  ```
- ./vendor/bin/sculpin generate --server
+ ./bin/sculpin generate --server
  ```  
  Visit your docs site at: <http://localhost:8000/docs>  
 


### PR DESCRIPTION
Closes #1497

## Effect
PR includes the following changes:
- Update the sculpin path in the manual launch instructions.

## Remaining Work
@rachelwhitton please test
cc @nataliejeremy for copy edit

The composer.json bin-dir specifies that sculpin would be installed in the ./bin directory, not ./vendor/bin.