### PR TITLE
Using SimpleSAMLphp with Shibboleth SSO doc update

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -8,66 +8,65 @@ keywords: drupal, simplesamlphp, shibboleth sso, sso, saml, single-sign on,
 Start by following the SimpleSAMLphp's [service provider quickstart instructions](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon.
 <div class="alert alert-info" role="alert">
 <h4>Note</h4>
-This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal sites on Pantheon using the <a href="http://drupal.org/project/simplesamlphp_auth">simpleSAMLphp Authentication</a> module from drupal.org.</div>
+This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal sites on Pantheon using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from drupal.org.</div>
 
-When you're done following the quickstart instructions above and have completed all the directions below, you'll have something like http://dev-simplesaml.pantheonsite.io. Note the "Federated Log In" link. See the [pantheon-simplesaml-example](https://github.com/ari-gold/pantheon-simplesaml-example) repo to see how it was implemented. If you click each commit message of the most recent commits, you'll see what was added in each commit.
+1. Download [SimpleSAMLphp version 1.11.x](http://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`.
+2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.11.x/www`:
 
-- Download [SimpleSAMLphp version 1.11.x](http://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`
-- Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.11.x/www`:
-```
-ln -s ./private/simplesamlphp-1.11.x/www ./simplesaml
-git add simplesaml
-git commit -am "Adding SimpleSAML symlink"
-```
-- [Generate or install certs](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to Git in `/private/simplesamlphp-1.11.x/cert`
-- Set up your config.php as follows.
+    ```
+    ln -s ./private/simplesamlphp-1.11.x/www ./simplesaml
+    git add simplesaml
+    git commit -am "Adding SimpleSAML symlink"
+    ```
+3. [Generate or install certs](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to Git in `/private/simplesamlphp-1.11.x/cert`.
+4. Set up your `config.php` as follows:
 
-Enable local sessions to ensure that SimpleSaml can keep a session when used in standalone mode:
+    Enable local sessions to ensure that SimpleSaml can keep a session when used in standalone mode:
 
-```
-if (!ini_get('session.save_handler')) {
+    ```
+    if (!ini_get('session.save_handler')) {
   ini_set('session.save_handler', 'file');
-}
-```
+   }
+    ```
 
-Load necessary environmental data:
+    Load necessary environmental data:
 
-```
-$ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
-$host = $_SERVER['HTTP_HOST'];
-$drop_id = $ps['conf']['pantheon_binding'];
-$db = $ps['databases']['default']['default'];
-```
+    ```
+    $ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
+    $host = $_SERVER['HTTP_HOST'];
+    $drop_id = $ps['conf']['pantheon_binding'];
+    $db = $ps['databases']['default']['default'];
+    ```
 
-Set up base config:
+    Set up base config:
 
-```
-$config = array (
-  'baseurlpath' => 'http://'. $host .'/simplesaml/',
-  'certdir' => 'cert/',
-  'loggingdir' => 'log/',
-  'datadir' => 'data/',
-  'tempdir' => '/srv/bindings/'. $drop_id .'/tmp/simplesaml',
-  Your $config array continues for a while...
-  until we get to the "store.type" value, where we put in DB config...
-  'store.type' => 'sql',
-  'store.sql.dsn' => 'mysql:host='. $db['host'] .';port='. $db['port'] .';dbname='. $db['database'],
-  'store.sql.username' => $db['username'],
-  'store.sql.password' => $db['password'],
-```
+    ```
+    $config = array (
+      'baseurlpath' => 'http://'. $host .'/simplesaml/',
+      'certdir' => 'cert/',
+      'loggingdir' => 'log/',
+      'datadir' => 'data/',
+      'tempdir' => '/srv/bindings/'. $drop_id .'/tmp/simplesaml',
+      Your $config array continues for a while...
+      until we get to the "store.type" value, where we put in DB config...
+      'store.type' => 'sql',
+      'store.sql.dsn' => 'mysql:host='. $db['host'] .';port='. $db['port'] .';dbname='. $db['database'],
+      'store.sql.username' => $db['username'],
+      'store.sql.password' => $db['password'],
+    ```
 
-With configuration completed, add SimpleSaml files to your repository:
+5. With configuration completed, add SimpleSaml files to your repository:
 
-```
-git add private/simplesamlphp-1.11.x
-git commit -am "Adding SimpleSaml config files."
-```
+    ```
+    git add private/simplesamlphp-1.11.x
+    git commit -am "Adding SimpleSaml config files."
+    ```
 
-You can now visit your site/simplesaml and complete your metadata configuration.
+You can now visit your `site/simplesaml` and complete your metadata configuration.
 
 ## Drupal Configuration
 
-Add the following lines to your settings.php so that the Drupal module can locate SimpleSAMLphp:
+Add the following lines to your `settings.php` so that the Drupal module can locate SimpleSAMLphp:
 
 ```php
 # Decode Pantheon Settings
@@ -78,6 +77,7 @@ $conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.
 
-## Varnish Not Working/Cookie Being Set for Anonymous Users
+## Troubleshooting
+### Varnish Not Working/Cookie Being Set for Anonymous Users
 
-The current version of the simpleSAMLphp Authentication module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. There are two patches; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.
+The current version of the SimpleSAMLphp Authentication module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. There are two patches; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.


### PR DESCRIPTION
Closes #1542 

## Effect
PR includes the following changes:
- removes the following text as the example site is no longer active:    
When you're done following the quickstart instructions above and have completed all the directions  below, you'll have something like http://dev-simplesaml.pantheonsite.io. Note the "Federated Log In" link. See the pantheon-simplesaml-example repo to see how it was implemented. If you click each commit message of the most recent commits, you'll see what was added in each commit.

- copy edits

Thanks for submitting the issue @eeeschwartz 
@ari-gold please review