### PR TITLE
Update pantheon-workflow.md with link to Terminus for command line deployment

### DIFF
--- a/source/_docs/pantheon-workflow.md
+++ b/source/_docs/pantheon-workflow.md
@@ -27,6 +27,8 @@ When you're ready to test a new set of changes, take your code from Dev, your co
 
 ![Site dashboard, test environment, code section](/source/docs/assets/images/test-env.png)
 
+While you are able to update Dev via Git, if you would like to deploy your changes to Test or Live from the command line, you'll need to use [Terminus](/docs/terminus/).
+
 After running this operation, be sure that:
 
 * Your database updates succeed  


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
-  Adds a note for users working from command line, that they need to use Terminus, rather than Git to push to Test and Live.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

@rachelwhitton please test
cc @nataliejeremy for copy edit

adding a note about deploying via command line, re: https://pantheon-systems.desk.com/agent/case/60097