### PR TITLE
More Info on Site Freezing

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -112,6 +112,6 @@ See [Unsupported Modules and Plugins](/docs/unsupported-modules-plugins) for an 
 
 ## Inactive Site Freezing
 
-Sandbox sites that are over a year old that have not had code commits or other git activity for 6 months are placed in cold storage or "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's dashboard will be unavailable.
+Sandbox sites that are over a year old that have not had code commits or other Git activity for 6 months are "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's Dashboard will be unavailable.
 
-A site can be unfrozen with a single click. Simply visit the site's dashboard and click **Unfreeze site**. Within a few minutes, the site will be ready for development again. Should there be any issues with the un-freezing process, a backup of the site is available to be restored via the site dashboard.
+You can reactivate a site with a single click. Simply visit the site's Dashboard and click **Unfreeze site**. Within a few minutes, the site will be ready for development again. If you experience any issues, a backup of the site is available and can be restored via the Site Dashboard.

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -112,6 +112,6 @@ See [Unsupported Modules and Plugins](/docs/unsupported-modules-plugins) for an 
 
 ## Inactive Site Freezing
 
-Sandbox sites with no recent development activity are automatically placed in cold storage or "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's dashboard will be unavailable.
+Sandbox sites that are over a year old that have not had code commits or other git activity for 6 months are placed in cold storage or "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's dashboard will be unavailable.
 
-A site can be unfrozen with a single click. Simply visit the site's dashboard and click **Unfreeze site**. Within a few minutes, the site will be ready for development again.
+A site can be unfrozen with a single click. Simply visit the site's dashboard and click **Unfreeze site**. Within a few minutes, the site will be ready for development again. Should there be any issues with the un-freezing process, a backup of the site is available to be restored via the site dashboard.


### PR DESCRIPTION

## Effect
PR includes the following changes:
- specifies which sites are frozen
- provides info on what to do for b0rked defrosts

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

@rachelwhitton please test
cc @nataliejeremy for copy edit

I'm iffy on this part: "Should there be any issues with the un-freezing process, a backup of the site is available to be restored via the site dashboard." 
But we (cse) are typically seeing a few cases of it per day. We can handle it on our end, but it would be good if there were something here too.