### PR TITLE
drush make file and build path

### DIFF
--- a/source/_docs/content-delivery-network.md
+++ b/source/_docs/content-delivery-network.md
@@ -83,7 +83,7 @@ Before you start, be sure that you have an AWS S3 bucket set up.
 
 ```bash
 drush @pantheon.SITENAME.dev dl media-2.x-dev amazons3 amazons3_cors devel jquery_update awssdk views file_entity
-drush @pantheon.SITENAME.dev make sites/all/modules/awssdk/awssdk.make --no-core
+drush @pantheon.SITENAME.dev make --no-core code/sites/all/modules/awssdk/awssdk.make code 
 drush @pantheon.SITENAME.dev en devel amazons3 amazons3_cors media jquery_update libraries awssdk views file_entity awssdk_ui
 drush @pantheon.SITENAME.dev cc all
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

@rachelwhitton please test
cc @nataliejeremy for copy edit

The manifest file path has to start with code/sites otherwise it can't be found. Also, build path needs to be code as by default the build path is sites/all which doesn't work in Pantheon. A bit cumbersome but that's what I needed to get drush make work. The original command downloads the library to /srv/bindings/UUID/sites/all/libraries. It really should be /srv/bindings/UUID/code/sites/all/libraries