### PR TITLE
Don't redirect platform domains

### DIFF
--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -46,7 +46,7 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT']) &&
   ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live') &&
   (php_sapi_name() != "cli")) {
   if ($_SERVER['HTTP_HOST'] == 'yoursite.com' ||
-      $_SERVER['HTTP_HOST'] == 'live-yoursite.pantheonsite.io') {
+      $_SERVER['HTTP_HOST'] == 'thatothersiteyouhad.com') {
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: http://www.yoursite.com'. $_SERVER['REQUEST_URI']);
     exit();
@@ -73,8 +73,7 @@ To direct all traffic to the bare domain using CloudFlare:
     if (isset($_SERVER['PANTHEON_ENVIRONMENT']) &&
       ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live') &&
       (php_sapi_name() != "cli")) {
-      if ($_SERVER['HTTP_HOST'] == 'www.yoursite.com' ||
-          $_SERVER['HTTP_HOST'] == 'live-yoursite.pantheonsite.io') {
+      if ($_SERVER['HTTP_HOST'] == 'www.yoursite.com') {
         header('HTTP/1.0 301 Moved Permanently');
         header('Location: http://yoursite.com'. $_SERVER['REQUEST_URI']);
         exit();


### PR DESCRIPTION
Closes #1582 

## Effect
PR includes the following changes:
- Remove pantheonsite.io from examples to discourage redirection from our platform domains

## Remaining Work
none.

cc @nataliejeremy for copy edit

Our example shouldn't encourage redirecting platform domains as it can make certain issues more difficult to debug.