### PR TITLE
Adding troubleshooting section if_dir() if_link()

### DIFF
--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -43,5 +43,8 @@ The instructions for creating a symlink are supported on Mac and Linux machines 
 6. Deploy to Test and confirm results.
 7. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
+## Troubleshooting
+Some modules/plugins check and verify if the target directory exist using if_dir() which returns bool(false) if the directory is a symlink. Patching the module/plugin to use if_link() instead of if_dir() might help.
+
 ## See Also		
 For more details on creating symbolic links on Mac/Linux, see [this thread](http://apple.stackexchange.com/questions/115646/how-can-i-create-a-symbolic-link-in-terminal).		

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -44,7 +44,7 @@ The instructions for creating a symlink are supported on Mac and Linux machines 
 7. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
 ## Troubleshooting
-Some modules and plugins verify that the target directory exists using `if_dir()` which returns bool(false) if the directory is a symlink. It may help to patch the module/plugin to use `if_link()` instead of `if_dir()`.
+Some modules and plugins verify that the target directory exists using `is_dir()` which returns bool(false) if the directory is a symlink. It may help to patch the module/plugin to use `is_link()` instead of `is_dir()`.
 
 ## See Also		
 For more details on creating symbolic links on Mac/Linux, see [this thread](http://apple.stackexchange.com/questions/115646/how-can-i-create-a-symbolic-link-in-terminal).		

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -44,7 +44,7 @@ The instructions for creating a symlink are supported on Mac and Linux machines 
 7. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
 ## Troubleshooting
-Some modules/plugins check and verify if the target directory exist using if_dir() which returns bool(false) if the directory is a symlink. Patching the module/plugin to use if_link() instead of if_dir() might help.
+Some modules and plugins verify that the target directory exists using `if_dir()` which returns bool(false) if the directory is a symlink. It may help to patch the module/plugin to use `if_link()` instead of `if_dir()`.
 
 ## See Also		
 For more details on creating symbolic links on Mac/Linux, see [this thread](http://apple.stackexchange.com/questions/115646/how-can-i-create-a-symbolic-link-in-terminal).		


### PR DESCRIPTION
@rachelwhitton please test
cc @nataliejeremy for copy edit

This is when the created symlink was created properly as per our documentation but the module/plugin still say no directory found and when it try to create one the module say unable to create directory already exist.