### PR TITLE
Enable Secure HTTPS Communication - Remove line break in openssl command

### DIFF
--- a/source/_docs/enable-https.md
+++ b/source/_docs/enable-https.md
@@ -27,8 +27,7 @@ Enable HTTPS before updating DNS. HTTPS for custom domains is available for Prof
 Run `openssl` from the command line to generate an [RSA private key](https://en.wikipedia.org/wiki/RSA_(cryptosystem)) (.key file) and [certificate signing request](https://en.wikipedia.org/wiki/Certificate_signing_request) (.csr) file:
 
 ```bash
-openssl req -new -newkey rsa:2048 -nodes -out www_example_com.csr
--keyout www_example_com.key
+openssl req -new -newkey rsa:2048 -nodes -out www_example_com.csr -keyout www_example_com.key
 ```
 
 You'll be prompted interactively to enter the information needed to request your certificate. The most important part of this information is the *Common Name*, which is the domain.


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Removes line break in docs
-
-

## Remaining Work
N/A

@rachelwhitton please test
cc @nataliejeremy for copy edit

The key generation code sample is confusing/broken—can't be directly copy/pasted. Since the line wraps to two lines I didn't end up setting the -keyout flag twice while trying to enable SSL, which caused a 'Your key is encrypted with a passcode' issue later on.