### PR TITLE
Conditional TOC - Asset Version: 3.1

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -21,7 +21,6 @@ module.exports = function(grunt) {
             'source/docs/assets/node_modules/highlight.js/styles/tomorrow-night-eighties.css',
             'source/docs/assets/node_modules/node-font-awesome/node_modules/font-awesome/css/font-awesome.min.css',
             'source/docs/assets/node_modules/bootstrap/dist/css/bootstrap.min.css',
-            'source/docs/assets/node_modules/bootstrap/dist/css/bootstrap-theme.min.css',
             'source/docs/assets/css/main.css',
             'source/docs/assets/fonts/pan-docs-icons/css/pan-docs.css',
           ],

--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 3.0
+assets_version: 3.1
 
 managing: Learn how to manage sites, users, teams, and organizations on Pantheon.
 developing: Learn how to build and launch your site on Pantheon.

--- a/source/_views/doc.html
+++ b/source/_views/doc.html
@@ -1,7 +1,7 @@
 {% extends "default" %}
 {% block content_wrapper %}
 <div class="col-md-12">
-        <div class="article col-md-9">
+        <div id="doc" class="article col-md-9">
           <h1 class="pio-docs-title">{{ page.title }}</h1>
                 {% if page.categories %}
                 <small><i class="fa fa-folder"></i> Categories:</small>

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -844,6 +844,10 @@ img.noborder {
   max-height: 90%;
 }
 
+.tocify-hide {
+  display: none !important;
+}
+
 
 /* First level of nav */
 .pio-docs-sidenav {

--- a/source/docs/assets/js/jquery.tocify.js
+++ b/source/docs/assets/js/jquery.tocify.js
@@ -232,7 +232,8 @@
             if(!firstElem.length) {
 
                 self.element.addClass(hideTocClassName);
-
+                $('#doc').addClass('col-md-12');
+                $('#doc').removeClass('col-md-9');
                 return;
 
             }


### PR DESCRIPTION
Closes #1596

## Effects
- Add defined `hideTocClassName` (`.tocify-hide`) to `main.css`
- Add Element ID `#docs` within`doc.html` 
- Remove class `.col-md-9` from `#doc` and add `.col-md-12` for desired conditional within `jquery.tocify.js`
- Update `asset_version` to 3.1
- Remove `bootstrap-theme.min.css` from CSS concatenation task

## QA
Articles where conditional is met:
- [docs/drupal-8-testing](https://1596empty-static-docs.pantheonsite.io/docs/drupal-8-testing/)
- [docs/drupal-6-image-cache](https://1596empty-static-docs.pantheonsite.io/docs/drupal-6-image-cache)
- [docs/filesystem-faq](https://1596empty-static-docs.pantheonsite.io/docs/filesystem-faq)
- [docs/local-dns](https://1596empty-static-docs.pantheonsite.io/docs/local-dns)
- [docs/non-standard-file-paths](https://1596empty-static-docs.pantheonsite.io/docs/non-standard-file-paths)
- [docs/pantheon-enterprise-gateway](https://1596empty-static-docs.pantheonsite.io/docs/pantheon-enterprise-gateway)
- [docs/pantheon_api-module](https://1596empty-static-docs.pantheonsite.io/docs/pantheon_api-module)
- [docs/running-custom-upstream](https://1596empty-static-docs.pantheonsite.io/docs/running-custom-upstream)
- [docs/scope-of-support](https://1596empty-static-docs.pantheonsite.io/docs/scope-of-support)
- [docs/sessions-and-cookies](https://1596empty-static-docs.pantheonsite.io/docs/sessions-and-cookies)
- [docs/site-access](https://1596empty-static-docs.pantheonsite.io/docs/site-access)
- [docs/ssl-tls](https://1596empty-static-docs.pantheonsite.io/docs/ssl-tls)
- [docs/wordpress-best-practices](https://1596empty-static-docs.pantheonsite.io/docs/wordpress-best-practices)

