### PR TITLE
Drupal 8 Configuration Override System Example

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -140,3 +140,10 @@ contributors:
     twitter: petersuhm
     github: //github.com/petersuhm
     bio: Web Developer and Travel Addict | Taking the pain out of WordPress development with @WP_Pusher
+  mmenavas:
+    name: Maximo Mena
+    avatar: //avatars0.githubusercontent.com/u/770699
+    url: //mmenavas.github.io/
+    twitter: mmenavas
+    github: //github.com/mmenavas
+    bio: Maximo Mena was born in Lima, Peru. He moved to Phoenix, Arizona, in 2003 to attend Arizona State University (ASU), where he got a bachelor’s degree in Computer Systems Technology.

--- a/source/_docs/settings-php.md
+++ b/source/_docs/settings-php.md
@@ -4,6 +4,7 @@ description: Detailed information about configuring your Drupal database setting
 categories: [drupal]
 tags: [code, drupal-8]
 keywords: drupal, settings.php, database configuration, configuration
+contributors: mmenavas
 ---
 The Drupal system configuration in code is set in:
 `sites/default/settings.php`
@@ -176,6 +177,32 @@ As an example, here's how you can hard-code your Drupal 7 caching configuration 
       else if (PANTHEON_ENVIRONMENT == 'live') {
         // Google Analytics.
         $conf['googleanalytics_account'] = 'UA-XXXXXXXX-Z';
+      }
+    }
+
+Drupal 8's [configuration override system](https://www.drupal.org/node/1928898) uses the global `$config` variable:
+
+    // All Pantheon Environments.
+    if (defined('PANTHEON_ENVIRONMENT')) {
+      // Drupal caching in development environments.
+      if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+        // Expiration of cached pages - none.
+        $config['system.performance']['cache']['page']['max_age'] = 0;
+        // Aggregate and compress CSS files in Drupal - off.
+        $config['system.performance']['css']['preprocess'] = false;
+        // Aggregate JavaScript files in Drupal - off.
+        $config['system.performance']['js']['preprocess'] = false;
+      }
+      // Drupal caching in test and live environments.
+      else {
+        // Expiration of cached pages - 15 minutes.
+        $config['system.performance']['cache']['page']['max_age'] = 900;
+        // Aggregate and compress CSS files in Drupal - on.
+        $config['system.performance']['css']['preprocess'] = true;
+        // Aggregate JavaScript files in Drupal - on.
+        $config['system.performance']['js']['preprocess'] = true;
+        // Google Analytics.
+        $config['google_analytics.settings']['account'] = 'UA-xxxxxxx-xx';
       }
     }
 


### PR DESCRIPTION
Closes #1602 

- Add code snippet to settings-php.md that demonstrates Drupal 8's global $config var
- Attribute new contributor

@alexdicianu or @slashzero  can you review? 

@mmenavas Thanks for opening the issue and contributing - much appreciated! 