### PR TITLE
Update domains.md

### DIFF
--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -71,6 +71,7 @@ One alternative to CNAME flattening is to use **[ALIAS/ANAME records](http://hel
 
 Learn more about ANAME records:
 
+*   [Dyn](http://dyn.com/managed-dns/alias/)
 *   [DNSimple](http://support.dnsimple.com/articles/differences-between-a-cname-alias-url/)
 *   [DNS Made Easy](http://www.dnsmadeeasy.com/services/aname-records/)
 *   [EasyDNS](http://docs.easydns.com/aname-records/)

--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -56,7 +56,7 @@ Using the provided destinations in the Site Dashboard, create the recommended DN
 ### Serving Sites from Bare Domains with HTTP
 To serve your site from the bare domain, you must:
 
-1. Select a DNS provider that supports CNAME flattening, such as [CloudFlare (recommended)](https://support.cloudflare.com/hc/en-us/articles/200169056-CNAME-Flattening-RFC-compliant-support-for-CNAME-at-the-root), [ClouDNS](https://www.cloudns.net/features/), or [NameCheap](https://www.namecheap.com/domains/freedns.aspx).
+1. Select a DNS provider that supports CNAME flattening, such as [Dyn](http://dyn.com/managed-dns/alias/) [CloudFlare (recommended)](https://support.cloudflare.com/hc/en-us/articles/200169056-CNAME-Flattening-RFC-compliant-support-for-CNAME-at-the-root), [ClouDNS](https://www.cloudns.net/features/), or [NameCheap](https://www.namecheap.com/domains/freedns.aspx).
 2. Do not add the recommended DNS entries from the Dashboard. Instead, create 2 CNAME records:
 
  ```bash

--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -56,7 +56,7 @@ Using the provided destinations in the Site Dashboard, create the recommended DN
 ### Serving Sites from Bare Domains with HTTP
 To serve your site from the bare domain, you must:
 
-1. Select a DNS provider that supports CNAME flattening, such as [Dyn](http://dyn.com/managed-dns/alias/) [CloudFlare (recommended)](https://support.cloudflare.com/hc/en-us/articles/200169056-CNAME-Flattening-RFC-compliant-support-for-CNAME-at-the-root), [ClouDNS](https://www.cloudns.net/features/), or [NameCheap](https://www.namecheap.com/domains/freedns.aspx).
+1. Select a DNS provider that supports CNAME flattening, such as [Dyn](http://dyn.com/managed-dns/alias/), [CloudFlare (recommended)](https://support.cloudflare.com/hc/en-us/articles/200169056-CNAME-Flattening-RFC-compliant-support-for-CNAME-at-the-root), [ClouDNS](https://www.cloudns.net/features/), or [NameCheap](https://www.namecheap.com/domains/freedns.aspx).
 2. Do not add the recommended DNS entries from the Dashboard. Instead, create 2 CNAME records:
 
  ```bash


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [x] List any outstanding todos
- [x] If needed

@rachelwhitton please test
cc @nataliejeremy for copy edit

Dyn’s Alias Uses CNAME flattening without forcing anyone to use a third party CDN. Dyn reduces the time required to resolve named resources by collapsing the chain of CNAME records that often occur, identifying the actual IP address being utilized by these services and caching that data prior to sending this information to the end user’s DNS resolver.

See [Dyn’s Alias / CNAME flattening](http://dyn.com/managed-dns/alias/)
**Cost starts at $7 a month.**
[Dyn DNS](http://dyn.com/managed-dns/)

**Dyn has never been down since Dyn Anycast was created, in 2007** 
