### PR TITLE
Update unsupported-modules-plugins.md

### DIFF
--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -61,10 +61,7 @@ $baseUrl = '/ckfinder/userfiles/';
 
 <hr>
 ### Composer Manager
-<div class="alert alert-danger">
-<h4>Warning</h4>
 This module has been deprecated by its authors. The suggestions made below are not guaranteed to be successful in all use cases.
-</div>
 
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
@@ -81,10 +78,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 ```
-<div class="alert alert-info">
-<h4>Note</h4>
 This disables auto-building in <em>all</em> Pantheon environments. This will allow Drush commands such as <code>pm-enable</code> and <code>pm-disable</code> to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when <em>explicitly</em> told to do so via <code>drush composer-manager [COMMAND] [OPTIONS]</code> or <code>drush composer-json-rebuild</code>. This is the setting recommended by Pantheon.  While <code>composer.json</code> can be rebuilt via terminus while the DEV site is in SFTP mode, <code>composer install</code> must be run locally, committed via Git, and pushed back to Pantheon.
-</div>
 
 <hr>
 ### Global Redirect  

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -78,8 +78,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 ```
-This disables auto-building in <em>all</em> Pantheon environments. This will allow Drush commands such as <code>pm-enable</code> and <code>pm-disable</code> to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when <em>explicitly</em> told to do so via <code>drush composer-manager [COMMAND] [OPTIONS]</code> or <code>drush composer-json-rebuild</code>. This is the setting recommended by Pantheon.  While <code>composer.json</code> can be rebuilt via terminus while the DEV site is in SFTP mode, <code>composer install</code> must be run locally, committed via Git, and pushed back to Pantheon.
-
+This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via terminus while the DEV site is in SFTP mode, `composer install` must be run locally, committed via Git, and pushed back to Pantheon.
 <hr>
 ### Global Redirect  
  **Issue**: Too many redirects error when site is in maintenance mode.  

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -65,16 +65,18 @@ $baseUrl = '/ckfinder/userfiles/';
 
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
-**Solution**: As suggested within the [module documentation](https://www.drupal.org/node/2405805), manage dependencies in Dev exclusively. Place the following configuration within `settings.php` to disable autobuild on Pantheon. This will also set appropriate file paths for Composer and packages so that they are stored within the root directory of the site's codebase and version controlled:
+**Solution**: As suggested within the [module documentation](https://www.drupal.org/node/2405805), manage dependencies in Dev exclusively. Place the following configuration within `settings.php` to disable autobuild on Pantheon. This will also set appropriate file paths for Composer so that checks to see if the path is writable will not fail. Packages, however, are stored within the root directory of the site's codebase and version controlled:
 ```
+
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   # Set appropriate paths for Composer Manager
-  $conf['composer_manager_file_dir'] = $_SERVER["HOME"] . '/code';
-  $conf['composer_manager_vendor_dir'] = $_SERVER["HOME"] . '/code/vendor';
+  $conf['composer_manager_file_dir'] = 'private://composer/'.$_ENV['PANTHEON_ENVIRONMENT'];
+  $conf['composer_manager_vendor_dir'] = $_SERVER['HOME'] . '/code/vendor';
   # Disable autobuild on Pantheon
   $conf['composer_manager_autobuild_file'] = 0;
   $conf['composer_manager_autobuild_packages'] = 0;
 }
+
 ```
 Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  
 

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -78,7 +78,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 ```
-This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via terminus while the DEV site is in SFTP mode, `composer install` must be run locally, committed via Git, and pushed back to Pantheon.
+This disables auto-building in all Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via terminus while the DEV site is in SFTP mode, `composer install` must be run locally, committed via Git, and pushed back to Pantheon.
 <hr>
 ### Global Redirect  
  **Issue**: Too many redirects error when site is in maintenance mode.  

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -61,6 +61,9 @@ $baseUrl = '/ckfinder/userfiles/';
 
 <hr>
 ### Composer Manager
+<div class="alert alert-danger" role="alert"><h4>Warning</h4>
+This module has been deprecated by it's authors. [Composer Manager](https://www.drupal.org/project/composer_manager/releases) Suggestions made below are not guaranteed to be successful in all use cases.</div>
+
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
 **Solution**: As suggested within the [module documentation](https://www.drupal.org/node/2405805), manage dependencies in Dev exclusively. Place the following configuration within `settings.php` to disable autobuild on Pantheon. This will also set appropriate file paths for Composer and packages so that they are stored within the root directory of the site's codebase and version controlled:
@@ -74,9 +77,8 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   $conf['composer_manager_autobuild_packages'] = 0;
 }
 ```
-Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.
+Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  
 
-There is an open [drupal.org issue](https://www.drupal.org/node/2567885) where file creation errors occur despite autobuild settings being disabled. This can be resolved by applying the [provided patch (#25)](https://www.drupal.org/node/2567885#comment-10874438) until the fix has been merged into a future release.
 <hr>
 ### Global Redirect  
  **Issue**: Too many redirects error when site is in maintenance mode.  

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -61,8 +61,7 @@ $baseUrl = '/ckfinder/userfiles/';
 
 <hr>
 ### Composer Manager
-<div class="alert alert-danger" role="alert"><h4>Warning</h4>
-This module has been deprecated by it's authors. [Composer Manager](https://www.drupal.org/project/composer_manager/releases) Suggestions made below are not guaranteed to be successful in all use cases.</div>
+**This module has been deprecated by its authors. The suggestions made below are not guaranteed to be successful in all use cases.**
 
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -61,7 +61,10 @@ $baseUrl = '/ckfinder/userfiles/';
 
 <hr>
 ### Composer Manager
-**This module has been deprecated by its authors. The suggestions made below are not guaranteed to be successful in all use cases.**
+<div class="alert alert-danger">
+<h4>Warning</h4>
+This module has been deprecated by its authors. The suggestions made below are not guaranteed to be successful in all use cases.
+</div>
 
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
@@ -78,7 +81,10 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 
 ```
-Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  
+<div class="alert alert-info">
+<h4>Note</h4>
+This disables auto-building in <em>all</em> Pantheon environments. This will allow Drush commands such as <code>pm-enable</code> and <code>pm-disable</code> to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when <em>explicitly</em> told to do so via <code>drush composer-manager [COMMAND] [OPTIONS]</code> or <code>drush composer-json-rebuild</code>. This is the setting recommended by Pantheon.  While <code>composer.json</code> can be rebuilt via terminus while the DEV site is in SFTP mode, <code>composer install</code> must be run locally, committed via Git, and pushed back to Pantheon.
+</div>
 
 <hr>
 ### Global Redirect  


### PR DESCRIPTION
## Effect
PR includes the following changes:
- add warning of deprecation
- remove ineffectual workaround
-

Composer manager has been specifically deprecated.  This PR warns of that and removes a suggested workaround that does not actually work.

@rachelwhitton pls check my spelling and syntax!  💃 