### PR TITLE
Update unsupported-modules-plugins.md

### DIFF
--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -74,7 +74,10 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   $conf['composer_manager_autobuild_packages'] = 0;
 }
 ```
-Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via terminus while the DEV site is in SFTP mode, `composer install` must be run locally, committed vis Git, and pushed back to Pantheon.
+<div class="alert alert-info">
+<h4>Note</h4>
+This disables auto-building in <em>all</em> Pantheon environments. This will allow Drush commands such as <code>pm-enable</code> and <code>pm-disable</code> to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when <em>explicitly</em> told to do so via <code>drush composer-manager [COMMAND] [OPTIONS]</code> or <code>drush composer-json-rebuild</code>. This is the setting recommended by Pantheon.  While <code>composer.json</code> can be rebuilt via terminus while the DEV site is in SFTP mode, <code>composer install</code> must be run locally, committed via Git, and pushed back to Pantheon.
+</div>
 
 There is an open [drupal.org issue](https://www.drupal.org/node/2567885) where file creation errors occur despite autobuild settings being disabled. This can be resolved by applying the [provided patch (#25)](https://www.drupal.org/node/2567885#comment-10874438) until the fix has been merged into a future release.
 <hr>

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -74,7 +74,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   $conf['composer_manager_autobuild_packages'] = 0;
 }
 ```
-Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.
+Note: This disables auto-building in *all* Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via terminus while the DEV site is in SFTP mode, `composer install` must be run locally, committed vis Git, and pushed back to Pantheon.
 
 There is an open [drupal.org issue](https://www.drupal.org/node/2567885) where file creation errors occur despite autobuild settings being disabled. This can be resolved by applying the [provided patch (#25)](https://www.drupal.org/node/2567885#comment-10874438) until the fix has been merged into a future release.
 <hr>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- explain that composer install should be run locally
-
-
Clarifies that composer install cannot be run on the Pantheon server.

@rachelwhitton Please review - thanks!