### PR TITLE
Override Google CSS for search results; full width

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 3.2
+assets_version: 3.3
 
 managing: Learn how to manage sites, users, teams, and organizations on Pantheon.
 developing: Learn how to build and launch your site on Pantheon.

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -2440,3 +2440,12 @@ display: block;
 .jumbotron small{
   padding-left: 10px;
 }
+
+.gsc-control-cse, .gsc-control-cse .gsc-table-result {
+  font-family: 'pan-docs' !important;
+  font-size: 16px !important;
+}
+
+.gs-result .gs-title, .gs-result .gs-title {
+  font-size: 20px !important;
+}

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -1,5 +1,6 @@
 ---
 use: [articles]
+title: Search
 layout: default
 ---
   <div class="col-md-12 search-results">

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -3,7 +3,7 @@ use: [articles]
 title: Search
 layout: default
 ---
-  <div class="col-md-8 search-results">
+  <div class="col-md-8 search-results" style="margin-left: 50px;">
   <script>
     function() {
       var cx = '016844496173863628783:moj1j4obfwm';

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -3,7 +3,7 @@ use: [articles]
 layout: default
 ---
 <div class="container article search-results">
-  <div class="col-md-7">
+  <div class="col-md-12">
   <script>
     function() {
       var cx = '016844496173863628783:moj1j4obfwm';

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -2,8 +2,7 @@
 use: [articles]
 layout: default
 ---
-<div class="container article search-results">
-  <div class="col-md-12">
+  <div class="col-md-12 search-results">
   <script>
     function() {
       var cx = '016844496173863628783:moj1j4obfwm';
@@ -16,5 +15,4 @@ layout: default
     }();
   </script>
   <gcse:searchresults-only linkTarget="_self"></gcse:searchresults-only>
-</div>
 </div>

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -3,7 +3,7 @@ use: [articles]
 title: Search
 layout: default
 ---
-  <div class="col-md-12 search-results">
+  <div class="col-md-8 search-results">
   <script>
     function() {
       var cx = '016844496173863628783:moj1j4obfwm';


### PR DESCRIPTION
Closes #1674 

## Effect
PR includes the following changes:
- Override Google's CSS for font size and family
- Titles are 20px and body text is 16px for consistency 
- Full width search results

## Existing
<img width="1424" alt="screen shot 2016-06-23 at 11 01 50 am" src="https://cloud.githubusercontent.com/assets/10119525/16310391/f7500fa6-3931-11e6-91b5-2201090a71ba.png">

## Updated
<img width="1416" alt="screen shot 2016-06-23 at 11 07 32 am" src="https://cloud.githubusercontent.com/assets/10119525/16310594/c3653364-3932-11e6-8926-b723c8aee06b.png">


ping @kimby77 @informanddelight @nataliejeremy @ccorpus for review
[Preview](https://1674result-static-docs.pantheonsite.io/docs//search/?term=rsync)