### PR TITLE
Use Global variable to explicitly disable cache

### DIFF
--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -31,6 +31,7 @@ $build['#cache']['max-age'] = 0;
   <pre><code class="php hljs">
   // Set or replace $regex_path_match accordingly.
   if ((preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+    $GLOBALS['conf']['cache'] = FALSE; // <- Added this
     $conf['page_cache_maximum_age'] = 0;
   }
   </code></pre>

--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -31,7 +31,7 @@ $build['#cache']['max-age'] = 0;
   <pre><code class="php hljs">
   // Set or replace $regex_path_match accordingly.
   if ((preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
-    $GLOBALS['conf']['cache'] = FALSE; // <- Added this
+    drupal_page_is_cacheable(FALSE);
     $conf['page_cache_maximum_age'] = 0;
   }
   </code></pre>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- adds additional means to exclude Drupal 7 page from cache.
-
-

## Remaining Work
- [ ] Test and confirm with wise folks that this is a good idea.

Based on https://www.drupal.org/node/23797#comment-3600288

@rachelwhitton please test :)