### PR TITLE
Update script for disabling APM for Google AMP

### DIFF
--- a/source/_docs/new-relic.md
+++ b/source/_docs/new-relic.md
@@ -93,6 +93,7 @@ if (extension_loaded('newrelic')) {
   // set variable $amp to TRUE or FALSE. If $amp is true, disable new relic
   if ($amp) {
     newrelic_disable_autorum (FALSE);
+    newrelic_ignore_transaction();
   }
 }
 ```


### PR DESCRIPTION
PR includes the following change:

- Added `newrelic_ignore_transaction();` right after ` newrelic_disable_autorum (FALSE);` in the script without it is still being monitored by NR see https://pantheon.io/docs/new-relic/#amp-validation-errors
