### PR TITLE
CircleCI Bug Fixes for Terminus Auth and npm install error

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -2,7 +2,7 @@
 machine:
   php:
     # https://circleci.com/docs/environment#php
-    version: 5.5.11
+    version: 5.5.31
 
 dependencies:
   cache_directories:

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "grunt-replace": "^0.11.0",
     "highlight.js": "^9.3.0",
     "node-font-awesome": "^1.0.2",
-    "sitespeed.io": "^3.11.5"
+    "sitespeed.io": "4.0.0-alpha.5"
   },
   "scripts": {
     "test": "grunt && rake && scripts/merge_conflicts.sh"

--- a/scripts/run-sitespeed-test.sh
+++ b/scripts/run-sitespeed-test.sh
@@ -19,5 +19,5 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
   # production urls is used as a source, the production domain is then replaced
   # with the multdev url.
   sed "s,https://pantheon.io/docs,$url,g" scripts/sitespeed-urls.txt > /tmp/sitespeed-urls-multidev.txt
-  sitespeed.io -u $url --no=1 --budget budget.json -b firefox -r $CIRCLE_ARTIFACTS/sitespeed --suppressDomainFolder --outputFolderName multidev --file=/tmp/sitespeed-urls-multidev.txt --skipTest=redirects,textcontent,ycdn,privateheaders,longexpirehead,expiresmod,avoidscalingimages,ycompress,frontEndTime,yminify,domContentLoadedTime
+  sitespeed.io $url --no=1 --budget budget.json -b firefox -r $CIRCLE_ARTIFACTS/sitespeed --suppressDomainFolder --outputFolderName multidev --file=/tmp/sitespeed-urls-multidev.txt --skipTest=redirects,textcontent,ycdn,privateheaders,longexpirehead,expiresmod,avoidscalingimages,ycompress,frontEndTime,yminify,domContentLoadedTime
 fi


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Resolve [slimerjs npm install error](https://circleci.com/gh/pantheon-systems/documentation/5373) by upgrading sitespeed.io to 4.0.0-alpha.5
- Update sitespeed command (remove deprecated `-u` flag)
- Up PHP version to 5.5.31 to play nice on ubuntu 14.04 build environments since CircleCi's ubuntu 12.04 env is compiled with TLS1.2 disabled: 
 
 ```
 $ openssl version -a
OpenSSL 1.0.1 14 Mar 2012
built on: Mon Feb 29 18:18:20 UTC 2016
platform: debian-amd64
options:  bn(64,64) rc4(16x,int) des(idx,cisc,16,int) blowfish(idx)
compiler: cc -fPIC -DOPENSSL_PIC -DZLIB -DOPENSSL_THREADS -D_REENTRANT -DDSO_DLFCN -DHAVE_DLFCN_H -m64 -DL_ENDIAN -DTERMIO -g -O2 -fstack-protector --param=ssp-buffer-size=4 -Wformat -Wformat-security -Werror=format-security -D_FORTIFY_SOURCE=2 -Wl,-Bsymbolic-functions -Wl,-z,relro -Wa,--noexecstack -Wall -DOPENSSL_NO_TLS1_2_CLIENT -DMD32_REG_T=int -DOPENSSL_IA32_SSE2 -DOPENSSL_BN_ASM_MONT -DOPENSSL_BN_ASM_MONT5 -DOPENSSL_BN_ASM_GF2m -DSHA1_ASM -DSHA256_ASM -DSHA512_ASM -DMD5_ASM -DAES_ASM -DVPAES_ASM -DBSAES_ASM -DWHIRLPOOL_ASM -DGHASH_ASM
OPENSSLDIR: "/usr/lib/ssl"
```

cc @stevector causes reduced reliability for sitespeed tests until logic is updated to iterate tests accross urls in the provided txt file. First pass to debug auth issues and slimerjs failures. 

