### PR TITLE
fix logic for multidev

### DIFF
--- a/source/_docs/settings-php.md
+++ b/source/_docs/settings-php.md
@@ -183,17 +183,8 @@ The Drupal 8 [configuration override system](https://www.drupal.org/node/1928898
 
     // All Pantheon Environments.
     if (defined('PANTHEON_ENVIRONMENT')) {
-      // Drupal caching in development environments.
-      if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
-        // Expiration of cached pages - none.
-        $config['system.performance']['cache']['page']['max_age'] = 0;
-        // Aggregate and compress CSS files in Drupal - off.
-        $config['system.performance']['css']['preprocess'] = false;
-        // Aggregate JavaScript files in Drupal - off.
-        $config['system.performance']['js']['preprocess'] = false;
-      }
       // Drupal caching in test and live environments.
-      else {
+      if (in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
         // Expiration of cached pages - 15 minutes.
         $config['system.performance']['cache']['page']['max_age'] = 900;
         // Aggregate and compress CSS files in Drupal - on.
@@ -202,6 +193,15 @@ The Drupal 8 [configuration override system](https://www.drupal.org/node/1928898
         $config['system.performance']['js']['preprocess'] = true;
         // Google Analytics.
         $config['google_analytics.settings']['account'] = 'UA-xxxxxxx-xx';
+      }
+      // Drupal caching on dev environment, and all multidevs
+      else {
+        // Expiration of cached pages - none.
+        $config['system.performance']['cache']['page']['max_age'] = 0;
+        // Aggregate and compress CSS files in Drupal - off.
+        $config['system.performance']['css']['preprocess'] = false;
+        // Aggregate JavaScript files in Drupal - off.
+        $config['system.performance']['js']['preprocess'] = false;
       }
     }
 


### PR DESCRIPTION
## Effect
PR includes the following changes:

Logic is backwards. Let's be positive. We should define TEST and LIVE, then catch the rest: DEV, and multidev. Not only is this clearer to read, but as it stood we would be implementing production cache settings on multidev environments. Perhaps it is desirable to set multidevs to mirror production, like we do TEST, but that really depends on workflow.

## Remaining Work
- [ ] determine if we want to enforce dev standards in multidev, or add a comment ot this effect.