### PR TITLE
Update redirects.md to remove redirect to lowercase snippet

### DIFF
--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -227,3 +227,8 @@ When transitioning from a system that used a tilde to indicate a home directory,
       // Your custom logic.
     }
 
+## Redirect to Force Lowercase Letters
+WordPress automatically forces lowercase letters within URLs using the [`sanitize_title_with_dashes()`](https://core.trac.wordpress.org/browser/tags/4.6/src/wp-includes/formatting.php#L1744) function in core. Drupal sites can force lowercase letters using the following:
+
+1. Set general automatic alias settings  to **Change to lower case** within the [PathAuto](https://www.drupal.org/project/pathauto) module configuration (`/admin/build/path/pathauto`).
+2. Enable **Case Sensitive URL Checking** within the [Global Redirect](https://www.drupal.org/project/globalredirect) module configuration (`/admin/settings/globalredirect`).

--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -227,13 +227,3 @@ When transitioning from a system that used a tilde to indicate a home directory,
       // Your custom logic.
     }
 
-## Redirect to Force Lowercase Letters
-
-
-    if (preg_match('/[A-Z]+/', $_SERVER['REQUEST_URI'])) {
-      $request_uri = strtolower($_SERVER['REQUEST_URI']);
-      header('Location: http://www.yoursite.com' . $request_uri, TRUE, 301);
-      exit;
-    }
-
-Alternatively, Drupal users can enforce lowercase URLs with the [Global Redirect](https://www.drupal.org/project/globalredirect) module.


### PR DESCRIPTION
This snippets breaks Drupal 7's default image upload function.

Error message:

"An unrecoverable error occurred. The uploaded file likely exceeded the maximum file size (100 MB) that this server supports."

Reproduced with a clean vanilla D7 site with no extra modules or themes installed, only added the snippet to settings.php.