### PR TITLE
Debug URLs within Automated GitHub Comments

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -113,11 +113,11 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
       if [[ $doc =~ $doc_path ]]
       then
         export guide=${doc:13: -3}
-        if ls -a output_dev/docs/guides | grep "$guide"
+        if ls -a output_dev/docs/guides | grep '^\<'"$guide"'\>'
         then
-          grep -- ''"$guide"'' comment.txt || echo -n "-\u0020[docs/guides/"$guide"]("$url"/docs/guides/"$guide")\n" >> comment.txt
+          grep -- '\<'guides/"$guide"'\>' comment.txt || echo -n "-\u0020[docs/guides/"$guide"]("$url"/docs/guides/"$guide")\n" >> comment.txt
         else
-          grep -- ''"${doc:8: -3}"'' comment.txt || echo -n "-\u0020["${doc:8: -3}"]("$url"/"${doc:8: -3}")\n" >> comment.txt
+          grep -- '\<'docs/"${doc:8: -3}"'\>' comment.txt || echo -n "-\u0020["${doc:8: -3}"]("$url"/"${doc:8: -3}")\n" >> comment.txt
         fi
       elif [[ $doc =~ $changelog_path ]]
       then


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Optimize regex within multidev deployment script to [correct broken links](https://github.com/pantheon-systems/documentation/pull/1719#commitcomment-18175466) within GitHub comments. Matches now construct valid URLs for docs/guides sharing similar filenames and paths:
![screen shot 2016-07-19 at 3 32 19 pm](https://cloud.githubusercontent.com/assets/10119525/16965537/33b9d492-4dc6-11e6-8686-5eeff23d2a13.png)


