### PR TITLE
Update file import limit

### DIFF
--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -9,7 +9,7 @@ keywords: rsync and sftp, files, transfer, file transfer, drupal, wordpress
 <h4>Warning</h4>
 Due to the nature of our platform architecture, the connection information will change from time to time due to server upgrades, endpoint migrations, etc. You will need to check this with the Dashboard periodically or when you are unable to connect.</div>
 
-If you have more than 500 MB of content to be transferred to your `/files` directory (`sites/default/files` for Drupal and `wp-content/uploads` for WordPress), you won't be able to use your Pantheon Dashboard to import. Instead, you'll need to use a SFTP client or rsync to transfer.
+If you have more than 1 GB of content to be transferred to your `/files` directory (`sites/default/files` for Drupal and `wp-content/uploads` for WordPress), you won't be able to use your Pantheon Dashboard to import. Instead, you'll need to use a SFTP client or rsync to transfer.
 
 This allows you to transfer unlimited data "server-to-server", which is much faster than transferring from your workstation. Files can be transferred to and from any Pantheon site environment (Dev, Test, and Live).
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Update the limit of file imports

Recently, a customer tried to import files from a backup archive which was over 7 GB and of course ran over the limit.  The associated Jenkins job (https://104.239.201.18:8090/jenkins/job/import_site/37407/console) had the line:
```
[CRITICAL] titan.ellis.response_postback: File import exceeds the maximum allowed size of 1GB
```
which clearly states the current file import limit.