### PR TITLE
Add a workaround for fixing Drupal Gardens site exports prior to import

### DIFF
--- a/source/_docs/migrate-drupal-gardens.md
+++ b/source/_docs/migrate-drupal-gardens.md
@@ -17,6 +17,12 @@ Drupal Gardens is ending support on August 1, 2016. This article walks you throu
 6. Once it's finished exporting, save the file (.tar.gz archive) to your computer.
 7. Verify that all files are included in the site archive. If any files are missing, download them from Drupal Gardens as instructed in their [export documentation](https://www.drupalgardens.com/documentation/site-export).
 
+Drupal Gardens may include one or more copies of the file `settings.php` in the archive. Pantheon does not need the settings.php file to import the site; to prevent import problems, it is best to simply remove settings.php using the following steps:
+
+- tar xzvf gardenssite.tar.gz 
+- rm docroot/sites/default/settings.php 
+- tar cvzf gardenssite-for-pantheon.tar.gz docroot/
+
 ## Import Your Site to Pantheon
 There are two ways to import your site: using our Importer tool in the Dashboard or manually importing the site. 
 

--- a/source/_docs/migrate-drupal-gardens.md
+++ b/source/_docs/migrate-drupal-gardens.md
@@ -17,11 +17,13 @@ Drupal Gardens is ending support on August 1, 2016. This article walks you throu
 6. Once it's finished exporting, save the file (.tar.gz archive) to your computer.
 7. Verify that all files are included in the site archive. If any files are missing, download them from Drupal Gardens as instructed in their [export documentation](https://www.drupalgardens.com/documentation/site-export).
 
-Drupal Gardens may include one or more copies of the file `settings.php` in the archive. Pantheon does not need the settings.php file to import the site; to prevent import problems, it is best to simply remove settings.php using the following steps:
+Drupal Gardens may include one or more copies of the file `settings.php` in the archive. Pantheon does not need the `settings.php` file to import the site; to prevent import problems, it is best to simply remove `settings.php` using the following steps:
 
-- tar xzvf gardenssite.tar.gz 
-- rm docroot/sites/default/settings.php 
-- tar cvzf gardenssite-for-pantheon.tar.gz docroot/
+```bash
+tar xzvf gardenssite.tar.gz 
+rm docroot/sites/default/settings.php 
+tar cvzf gardenssite-for-pantheon.tar.gz docroot/
+```
 
 ## Import Your Site to Pantheon
 There are two ways to import your site: using our Importer tool in the Dashboard or manually importing the site. 

--- a/source/_docs/migrate-drupal-gardens.md
+++ b/source/_docs/migrate-drupal-gardens.md
@@ -17,7 +17,7 @@ Drupal Gardens is ending support on August 1, 2016. This article walks you throu
 6. Once it's finished exporting, save the file (.tar.gz archive) to your computer.
 7. Verify that all files are included in the site archive. If any files are missing, download them from Drupal Gardens as instructed in their [export documentation](https://www.drupalgardens.com/documentation/site-export).
 
-Drupal Gardens may include one or more copies of the file `settings.php` in the archive. Pantheon does not need the `settings.php` file to import the site; to prevent import problems, it is best to simply remove `settings.php` using the following steps:
+Drupal Gardens may include one or more copies of the `settings.php` file in the archive. Pantheon does not need the `settings.php` file to import the site, but to prevent import problems, it's best to simply remove `settings.php` by running the following commands:
 
 ```bash
 tar xzvf gardenssite.tar.gz 


### PR DESCRIPTION
Currently no open issues on this; related to #1646.

## Effect
PR includes the following changes:
- Instructions on removing settings.php from Drupal Gardens archives prior to importing on Pantheon.

Drupal Gardens actually includes **two** copies of settings.php in each site archive.  This can be confirmed via `tar tzvf drupalgardenssite.tar.gz | settings.php`; you will see two listings with the same path and filename.

Removing just one copy would probably be sufficient (untar and then tar again), but I did not test this, as removing settings.php entirely is more straightforward and safer, not to mention easier to explain.