### PR TITLE
Updating D8 Composer guidance

### DIFF
--- a/source/_docs/composer-drupal-8.md
+++ b/source/_docs/composer-drupal-8.md
@@ -53,10 +53,10 @@ Both of the commands mentioned above, `composer install` and `composer update`, 
 
 Composer assumes that packages use semantic versioning where releases have three numbers signifying `MAJOR.MINOR.PATCH` releases. Drupal modules however have release numbers like `8.x-1.2`. This pattern indicates that the release is the third official release (`8.x-1.0` and `8.x-1.1` being the first two) made from the `8.x-1.x` branch. The `8.x` indicates that the release is compatible with Drupal 8. Drupal needs an alternative to packagist.org in order to map Drupal release numbers to Composer-compatible semantic versions.
 
-The first step to installing Drupal modules with Composer is to ensure that the `composer.json` in your Drupal site knows about an alternative to packagist.org where Drupal modules can be found. [Eventually, drupal.org will provide this information](https://www.drupal.org/node/2718229). For now, use https://packagist.drupal-composer.org.
+The first step to installing Drupal modules with Composer is to ensure that the `composer.json` in your Drupal site knows about an alternative to packagist.org where Drupal modules can be found. Around the time of Drupal 8's release, primary Drupal Packagist site was packagist.drupal-composer.org. [You can now use Drupal.org itself.](https://www.drupal.org/node/2718229).
 
 ```
-composer config repositories.drupal composer https://packagist.drupal-composer.org
+composer config repositories.drupal composer https://packages.drupal.org/8
 ```
 
 Once Composer knows where to find modules, they can be added easily with `composer require`. For instance, [address module](https://www.drupal.org/project/address) could be installed via Composer with


### PR DESCRIPTION
[Prompted by Tony Klose](https://pantheon.io/blog/fixing-shortcomings-composer-update-process-drupal-composer#comment-2809016460), I'm updating a section on using Composer with Drupal 8. Drupal.org's packagist support recently went from Alpha to Beta. [Just yesterday I updated the tests for search_api_pantheon to use Drupal.org's info](https://github.com/pantheon-systems/search_api_pantheon/pull/29/files).