### PR TITLE
Configuration changes not detected on Multidev

### DIFF
--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -66,7 +66,7 @@ For more information, see [Automate your Workflow with Quicksilver Platform Inte
 ## Troubleshooting
 
 We will reject a commit that includes a `pantheon.yml` error, with a message like:
-```
+```nohighlight
 remote: PANTHEON ERROR:
 remote:
 remote: Changes to `pantheon.yml` detected, but there was an error while processing it:
@@ -78,6 +78,23 @@ remote: Valid versions are: 1
 
 While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax.
 
-### See Also
+### Deploying Configuration Changes to Multidev
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected upon initial commit to a Multidev environment.
+
+As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
+
+```nohighlight
+remote:
+remote: PANTHEON NOTICE:
+remote:
+remote: Changes to `pantheon.yml` detected.
+remote:
+remote: Successfully applied `pantheon.yml` to the 'new-feature' environment.
+remote:
+remote:
+```
+
+
+## See Also
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver)  
 - [Upgrade PHP Versions](/docs/php-versions)

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -79,7 +79,7 @@ remote: Valid versions are: 1
 While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment from an existing git branch that includes a `pantheon.yml` file.
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment.
 
 As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -79,7 +79,7 @@ remote: Valid versions are: 1
 While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected upon initial commit to a Multidev environment.
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment from an existing git branch that includes a `pantheon.yml` file.
 
 As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -79,9 +79,7 @@ remote: Valid versions are: 1
 While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment.
-
-As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment. As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 
 ```nohighlight
 remote:

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -113,7 +113,7 @@ List and show previous workflows and their corresponding Quicksilver operations 
 If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected upon initial commit to a Multidev environment.
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment from an existing git branch that includes a `pantheon.yml` file.
 
 As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -110,7 +110,23 @@ List and show previous workflows and their corresponding Quicksilver operations 
 
 ## Troubleshooting
 
-If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
+If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into the Dev environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
+
+### Deploying Configuration Changes to Multidev
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected upon initial commit to a Multidev environment.
+
+As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
+
+```nohighlight
+remote:
+remote: PANTHEON NOTICE:
+remote:
+remote: Changes to `pantheon.yml` detected.
+remote:
+remote: Successfully applied `pantheon.yml` to the 'new-feature' environment.
+remote:
+remote:
+```
 
 ## See Also
 

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -110,7 +110,7 @@ List and show previous workflows and their corresponding Quicksilver operations 
 
 ## Troubleshooting
 
-If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into the Dev environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
+If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
 
 ### Deploying Configuration Changes to Multidev
 If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected upon initial commit to a Multidev environment.

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -113,9 +113,7 @@ List and show previous workflows and their corresponding Quicksilver operations 
 If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment.
-
-As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment. As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 
 ```nohighlight
 remote:

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -111,6 +111,8 @@ List and show previous workflows and their corresponding Quicksilver operations 
 ## Troubleshooting
 
 If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
+### Hooking into the Multidev Creation Workflow
+Quicksilver hooks for the `create_cloud_development_environment` workflow will not be detected when creating a Multidev environment if the `pantheon.yml` file **does not** exist on the Dev environment. As a workaround, commit the `pantheon.yml` file on Dev before creating a Multidev environment.
 
 ### Deploying Configuration Changes to Multidev
 If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment. As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -113,7 +113,7 @@ List and show previous workflows and their corresponding Quicksilver operations 
 If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
 
 ### Deploying Configuration Changes to Multidev
-If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment from an existing git branch that includes a `pantheon.yml` file.
+If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment.
 
 As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 

--- a/source/_docs/quicksilver.md
+++ b/source/_docs/quicksilver.md
@@ -111,10 +111,10 @@ List and show previous workflows and their corresponding Quicksilver operations 
 ## Troubleshooting
 
 If you want to hook into deploy workflows, you'll need to deploy your `pantheon.yml` into an environment first. Likewise, if you are adding new operations or changing the script an operation will target, the deploy containing those adjustments to `pantheon.yml` will not self-referentially exhibit the new behavior. Only subsequent deploys will be affected.
-### Hooking into the Multidev Creation Workflow
+### MultiDev Creation Hook Does Not Run When Expected
 Quicksilver hooks for the `create_cloud_development_environment` workflow will not be detected when creating a Multidev environment if the `pantheon.yml` file **does not** exist on the Dev environment. As a workaround, commit the `pantheon.yml` file on Dev before creating a Multidev environment.
 
-### Deploying Configuration Changes to Multidev
+### Deploying Configuration Changes or Quicksilver Hooks to Multidev
 If a `pantheon.yml` file **does not** exist on the Dev environment, configuration changes will not be detected when creating a Multidev environment. As a workaround, make some modification the `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:
 
 ```nohighlight


### PR DESCRIPTION
Closes #1822 

## Effect
PR includes the following changes:
- Add sub-section within troubleshooting of quicksilver and pantheon.yml docs. Provide workaround for deploying configuration changes to Multidev environments on sites where `pantheon.yml` does not exist on the master branch.

cc @ataylorme 
@ari-gold @nataliejeremy please review
