### PR TITLE
Use json_decode instead of json_load

### DIFF
--- a/source/_docs/private-paths.md
+++ b/source/_docs/private-paths.md
@@ -31,7 +31,7 @@ Alternatively, you can store sensitive data in a JSON or ini-style text file wit
 ```
 if (isset($_ENV['PANTHEON_ENVIRONMENT']) && $_ENV['PANTHEON_ENVIRONMENT'] == 'live') {
   $json_text = file_get_contents('sites/default/files/private/stripe_live.json');
-  $stripe_data = json_load($json_text, 1);
+  $stripe_data = json_decode($json_text, TRUE);
   $conf['stripe_key'] = $stripe_data['key'];
 }
 else {


### PR DESCRIPTION
## Effect
PR includes the following changes:
- update to code example, switches json_load for valid PHP function json_decode()

json_load is not a valid php function. php.net/json_load. The example here should probably use [json_decode()](https://php.net/json_decode) instead.