### PR TITLE
Correct WordPress files path

### DIFF
--- a/source/_docs/migrate-manual.md
+++ b/source/_docs/migrate-manual.md
@@ -31,7 +31,7 @@ From your Pantheon Dashboard:
 
 ## Step 2: Import your Code
 
-Your **code** is all custom and contributed modules or plugins, themes, and libraries. Code **does not** include files not under version control, like images uploaded to `sites/default/files` or `wp-uploads`.
+Your **code** is all custom and contributed modules or plugins, themes, and libraries. Code **does not** include files not under version control, like images uploaded to `sites/default/files` or `wp-content/uploads`.
 
 You can use either SFTP or Git to import your code. If you'd like to retain existing Git History, then please see [Migrating Sites to Pantheon: Preserve Existing Git History](/docs/migrate-preserve-history).
 


### PR DESCRIPTION
In step 2, importing code, the WordPress files path should be `wp-content/uploads` not `wp-uploads`.