### PR TITLE
Correcting --destination and --exclude path

### DIFF
--- a/source/_docs/clone-site.md
+++ b/source/_docs/clone-site.md
@@ -18,7 +18,7 @@ For more information see: [Migrate to Pantheon: WordPress](/docs/migrate-wordpre
 After selecting **[Migrate Existing Site](https://dashboard.pantheon.io/sites/migrate/)**, you'll create a new Pantheon site. During the **Create Site Archive** step of the migration process, use [Terminus](/docs/terminus) to create an archive of your existing Pantheon site:
 
 ```bash
-terminus drush 'ard --destination=sites/default/files/<RANDOM_HASH>.tgz'
+terminus drush 'ard --destination=code/sites/default/files/<RANDOM_HASH>.tgz'
 ```
 
 This operation writes the archive to Pantheon's filesystem in a web accessible location (e.g. `http://env-site-name.pantheonsite.io/sites/default/files/<RANDOM_HASH>.tgz`). Click **Continue Migration** and follow all remaining instructions within the guided migration process.
@@ -33,7 +33,7 @@ Connection to appserver.<ENV>.<Site UUID>.drush.in closed by remote host.
 If your database and code compressed are less than 256MB you can exclude the files directory from export using the following steps, otherwise [manually migrate](/docs/migrate-manual) the site.
 
 <ol><li>Use <a href="/docs/terminus">Terminus</a> and the <code>--tar-options</code> flag:<br><br>
-<pre><code class="bash hljs">terminus drush <span class="hljs-string">'ard <b>--tar-options="--exclude=sites/default/files"</b> --destination=sites/default/files/&lt;RANDOM_HASH&gt;.tgz'</span></code></pre></li></ol>
+<pre><code class="bash hljs">terminus drush <span class="hljs-string">'ard <b>--tar-options="--exclude=code/sites/default/files"</b> --destination=code/sites/default/files/&lt;RANDOM_HASH&gt;.tgz'</span></code></pre></li></ol>
 
 2. Click **Continue Migration**.
 3. Provide the web accessible URL for your site archive (e.g. `http://env-site-name.pantheonsite.io/sites/default/files/<RANDOM_HASH>.tgz`) and select **Import Archive**.


### PR DESCRIPTION
## Effect
PR includes the following changes:

Initially @ruby found the bug and we've verified so here's our PR :D

Fixing --destination= path: 
`code/sites/default/files/<RANDOM_HASH>.tgz` instead of `/sites/default/files/<RANDOM_HASH>.tgz`

Another thing is on --exclude= path: 
`code/sites/default/files` instead of `sites/default/files`

POC: 
- https://monosnap.com/file/SCuayzJOmsmyph3XvJbTdewTC56vq9 without `code/`
- https://monosnap.com/file/1j1ufJiZRNev9lZW9u0QLPJNVDsk0n with `code/`