### PR TITLE
Missing article before "linux container"

### DIFF
--- a/source/_docs/application-containers.md
+++ b/source/_docs/application-containers.md
@@ -9,7 +9,7 @@ Pantheon's infrastructure includes a number of layers. Our edge layer provides r
 
 ## Application Containers
 
-Pantheon's infrastructure is based on a grid model. We serve our customers by provisioning isolated linux container with an optimized PHP stack in place. Each container includes its own Nginx, APC cache, and PHP worker agent. They are deployed with a checkout of your codebase and service-bindings to use a dedicated MySQL container, networked file filesystem, and optionally Redis object cache and Apache Solr search indexing. See our [interactive diagram](https://pantheon.io/features/elastic-hosting) to learn more about Pantheon's infrastructure.
+Pantheon's infrastructure is based on a grid model. We serve our customers by provisioning isolated linux containers with an optimized PHP stack in place. Each container includes its own Nginx, APC cache, and PHP worker agent. They are deployed with a checkout of your codebase and service-bindings to use a dedicated MySQL container, networked file filesystem, and optionally Redis object cache and Apache Solr search indexing. See our [interactive diagram](https://pantheon.io/features/elastic-hosting) to learn more about Pantheon's infrastructure.
 
 Every environment for your site (Dev, Test, Live) runs on its own container. In the case of a Live site, at the Business level and above you can have [multiple containers](#multiple-application-containers) serving your site.
 


### PR DESCRIPTION
Text did not read well because of a missing article. I opted to pluralise "linux container" rather than insert an article because the language following this text makes reference to a multitude of containers rather than _the/a_ container.

Also: I just wanted to play with @rachelwhitton 's integration between Pantheon's docs and GitHub :)