### PR TITLE
Add example of site parameter in backup command

### DIFF
--- a/source/_docs/local-development.md
+++ b/source/_docs/local-development.md
@@ -78,9 +78,10 @@ Replace <code>database.sql.gz</code> with the name of the database archive downl
 Create and export the database by running the following Terminus commands:
 
 ```nohighlight
-terminus site backups create --element=database
-terminus site backups get --element=database --to=$HOME/Desktop/ --latest
+terminus site backups create --element=database --site=[site] --env=[env]
+terminus site backups get --element=database --to=$HOME/Desktop/ --latest --site=[site] --env=[env]
 ```
+
 
 Import the archive into your local MySQL database using the following command:
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

Site parameters missing from backup command, bit overkill, but running the command without them may cause unexpected behavior. It may also be worth adding the full available parameters here: eg terminus site backups <get|load|create|list|get-schedule|set-schedule|cancel-schedule> [--site=<site>] [--env=<env>] [--element=<code|files|db|all>] [--to=<directory|file>] [--file=<filename>] [--latest] [--keep-for] [--day] [--username] [--password] [--database]