### PR TITLE
Fix list of Drush commands that don't work

### DIFF
--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -364,7 +364,8 @@ See the [Drush Migrate documentation](https://drupal.org/node/1561820) for detai
 
 ## Known Limitations
 - Crontab: Currently, there is no way to manage Crontab on Pantheon. If you need a way to set up your own Cron interval, you can use an external cron service such as [Easy Cron](https://www.easycron.com/user/register).
-- The following Drush commands are not supported and will not work on Pantheon sites: `sql-sync-pipe`, `sql-cli` (`sqlc`), `php-eval` (`eval`, `ev`). An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
+- The `sql-sync-pipe` and `sql-cli` (`sqlc`) Drush commands are not supported and will not work on Pantheon sites. An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
+- The `php-eval` (`eval`, `ev`) command partially works on Pantheon since `pantheonssh` rejects any argument that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works because Drush provides a trailing `;` if needed.
 - Incorrect `['uri']` in `pantheon.aliases.drushrc.php` file. Drush may fail if the `['uri']` array key has a different domain than what is expected by Drupal, resulting in the following error:
 
  ```bash

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -364,8 +364,7 @@ See the [Drush Migrate documentation](https://drupal.org/node/1561820) for detai
 
 ## Known Limitations
 - Crontab: Currently, there is no way to manage Crontab on Pantheon. If you need a way to set up your own Cron interval, you can use an external cron service such as [Easy Cron](https://www.easycron.com/user/register).
-- The `sql-sync-pipe` and `sql-cli` (`sqlc`) Drush commands are not supported and will not work on Pantheon sites. An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
-- The `php-eval` (`eval`, `ev`) command only partially works on Pantheon. Pantheon rejects any incoming command-line request that has an argument or option that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works, because Drush provides a trailing `;` if needed.
+- The following Drush commands are not supported and will not work on Pantheon sites:`sql-sync-pipe`, `sql-cli` (`sqlc`), `php-eval` (`eval`, `ev`). An alternative to `drush sql-sync` is to use `drush sql-dump` instead. We recommend writing a script and executing via `php-script` (`scr`) as an alternative to `php-eval`.
 - Incorrect `['uri']` in `pantheon.aliases.drushrc.php` file. Drush may fail if the `['uri']` array key has a different domain than what is expected by Drupal, resulting in the following error:
 
  ```bash

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -364,7 +364,7 @@ See the [Drush Migrate documentation](https://drupal.org/node/1561820) for detai
 
 ## Known Limitations
 - Crontab: Currently, there is no way to manage Crontab on Pantheon. If you need a way to set up your own Cron interval, you can use an external cron service such as [Easy Cron](https://www.easycron.com/user/register).
-- The following Drush commands are not supported and will not work on Pantheon sites: `sql-sync-pipe`, `sql-sqlc`, `php-eval`. An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
+- The following Drush commands are not supported and will not work on Pantheon sites: `sql-sync-pipe`, `sql-cli` (`sqlc`), `php-eval` (`eval`, `ev`). An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
 - Incorrect `['uri']` in `pantheon.aliases.drushrc.php` file. Drush may fail if the `['uri']` array key has a different domain than what is expected by Drupal, resulting in the following error:
 
  ```bash

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -365,7 +365,7 @@ See the [Drush Migrate documentation](https://drupal.org/node/1561820) for detai
 ## Known Limitations
 - Crontab: Currently, there is no way to manage Crontab on Pantheon. If you need a way to set up your own Cron interval, you can use an external cron service such as [Easy Cron](https://www.easycron.com/user/register).
 - The `sql-sync-pipe` and `sql-cli` (`sqlc`) Drush commands are not supported and will not work on Pantheon sites. An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
-- The `php-eval` (`eval`, `ev`) command partially works on Pantheon since `pantheonssh` rejects any argument that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works because Drush provides a trailing `;` if needed.
+- The `php-eval` (`eval`, `ev`) command partially works on Pantheon. This is because `pantheonssh` rejects any argument that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works because Drush provides a trailing `;` if needed.
 - Incorrect `['uri']` in `pantheon.aliases.drushrc.php` file. Drush may fail if the `['uri']` array key has a different domain than what is expected by Drupal, resulting in the following error:
 
  ```bash

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -365,7 +365,7 @@ See the [Drush Migrate documentation](https://drupal.org/node/1561820) for detai
 ## Known Limitations
 - Crontab: Currently, there is no way to manage Crontab on Pantheon. If you need a way to set up your own Cron interval, you can use an external cron service such as [Easy Cron](https://www.easycron.com/user/register).
 - The `sql-sync-pipe` and `sql-cli` (`sqlc`) Drush commands are not supported and will not work on Pantheon sites. An alternative to `drush sql-sync` is to use `drush sql-dump` instead.
-- The `php-eval` (`eval`, `ev`) command partially works on Pantheon. This is because `pantheonssh` rejects any argument that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works because Drush provides a trailing `;` if needed.
+- The `php-eval` (`eval`, `ev`) command only partially works on Pantheon. Pantheon rejects any incoming command-line request that has an argument or option that contains characters such as `;` or `$`. As an example, `drush @pantheon.site.env ev 'return foo()` works, because Drush provides a trailing `;` if needed.
 - Incorrect `['uri']` in `pantheon.aliases.drushrc.php` file. Drush may fail if the `['uri']` array key has a different domain than what is expected by Drupal, resulting in the following error:
 
  ```bash


### PR DESCRIPTION
## Effect
PR includes the following changes:

- Replaced "sql-sqlc" which doesn't exist with "sql-cli" (a.k.a. "sqlc") which does.
  - https://drushcommands.com/drush-8x/sql/sql-cli/
- Added commanded aliases.