### PR TITLE
Replace DocSearch with Google's Site Search

### DIFF
--- a/source/_partials/footer_scripts.html
+++ b/source/_partials/footer_scripts.html
@@ -34,23 +34,6 @@
   }
   window.onload = setActive;
   </script>
-  <!--DocSearch JS Configuration-->
-  <script type="text/javascript" src="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.js"></script>
-  <script type="text/javascript">
-  docsearch({
-    apiKey: '68209e7d940c2210c9a045c08838b691',
-    indexName: 'pantheon-io',
-    inputSelector: '#docsearch',
-    debug: false, // Set debug to true if you want to inspect the dropdown
-    algoliaOptions: {
-      hitsPerPage: 7
-    },
-    autocompleteOptions: {
-      autoselect: false,
-    }
-  });
-  </script>
-
   <!-- Marketo Munchkin -->
   <script type="text/javascript">
   document.write(unescape("%3Cscript src='//munchkin.marketo.net/munchkin.js' type='text/javascript'%3E%3C/script%3E"));

--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -62,6 +62,6 @@
   <div class="navsearch form-group has-feedback">
       {% include("search_box.html") %}
       <span class="glyphicon glyphicon-search form-control-feedback" aria-hidden="true"></span>
-      <span id="docsearchicon" class="sr-only">(search)</span>
+      <span class="sr-only">(search)</span>
   </div>
 </div>

--- a/source/_partials/search_box.html
+++ b/source/_partials/search_box.html
@@ -1,5 +1,17 @@
-  <form id="searchform">
-    <div>
-      <input type="search" placeholder="Search Pantheon Docs" id="docsearch" />
-    </div>
-  </form>
+<script>
+  (function() {
+    var cx = '003083871467663611719:moj1j4obfwm';
+    var gcse = document.createElement('script');
+    gcse.type = 'text/javascript';
+    gcse.async = true;
+    gcse.src = '//cse.google.com/cse.js?cx=' + cx;
+    var s = document.getElementsByTagName('script')[0];
+    s.parentNode.insertBefore(gcse, s);
+  })();
+</script>
+
+<form id="searchform" action="/docs/search" accept-charset="UTF-8" enctype="application/x-www-form-urlencoded">
+  <div>
+    <input type="search" placeholder="Search Pantheon Docs"value="" name="term" id="piodocsearch" autocomplete="on" />
+  </div>
+</form>

--- a/source/_views/default.html
+++ b/source/_views/default.html
@@ -63,8 +63,6 @@
     <meta property="og:description" content="{{ page.description }}" />
     <meta property="og:site_name" content="Pantheon Documentation" />
     <!--<meta property="fb:admins" content="Facebook numberic ID" />-->
-    <!-- DocSearch CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="/docs/assets/compiled/compiled.css?v={{ site.assets_version }}">
     <script src="//www.google-analytics.com/analytics.js"></script>

--- a/source/_views/posts.html
+++ b/source/_views/posts.html
@@ -72,8 +72,6 @@
     <meta property="og:description" content="{{ page.description }}" />
     <meta property="og:site_name" content="Pantheon Documentation" />
     <!--<meta property="fb:admins" content="Facebook numberic ID" />-->
-    <!-- DocSearch CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="/docs/assets/compiled/compiled.css?v={{ site.assets_version }}">
     <script src="//www.google-analytics.com/analytics.js"></script>

--- a/source/_views/taxon.html
+++ b/source/_views/taxon.html
@@ -72,8 +72,6 @@
     <meta property="og:description" content="{{ page.description }}" />
     <meta property="og:site_name" content="Pantheon Documentation" />
     <!--<meta property="fb:admins" content="Facebook numberic ID" />-->
-    <!-- DocSearch CSS -->
-    <link rel="stylesheet" href="https://cdn.jsdelivr.net/docsearch.js/2/docsearch.min.css" />
     <!-- Latest compiled and minified CSS -->
     <link rel="stylesheet" href="/docs/assets/compiled/compiled.css?v={{ site.assets_version }}">
     <script src="//www.google-analytics.com/analytics.js"></script>

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -163,29 +163,6 @@ body.row.main {
   transition: 200ms all;
 
 }
-.algolia-autocomplete.algolia-autocomplete-right .ds-dropdown-menu {
-  right: auto !important;
-left: auto !important;
-width: 100% !important;
-
-}
-.algolia-autocomplete {
-  display: block !important;
-}
-.algolia-autocomplete .algolia-docsearch-suggestion--highlight{
-  background-color: #EFD01B;
-  color: #222;
-}
-.algolia-autocomplete .algolia-docsearch-suggestion--text .algolia-docsearch-suggestion--highlight{
-  box-shadow:inset 0 -2px 0 0 #EFD01B;
-}
-/**DocSearch Result Hover**/
-.algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion.suggestion-layout-simple,.algolia-autocomplete .ds-dropdown-menu .ds-suggestion.ds-cursor .algolia-docsearch-suggestion:not(.suggestion-layout-simple) .algolia-docsearch-suggestion--content{
-  background: #DDE5E7;
-}
-.docsearch {
-  margin-right: 20px;
-}
 
 input[type="search"] {
   width: 100%;

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -1,0 +1,18 @@
+---
+use: [articles]
+title: Search
+layout: default
+---
+<div class="col-md-8 search-results" style="margin-left: 50px;">
+  <script>
+    function parseParamsFromUrl() {
+    var queryString = window.location.search;
+        queryString = queryString.substring(6);
+        queryString = queryString.split("+").join(" ");
+    return queryString;
+    }
+    var urlParams = parseParamsFromUrl();
+    document.getElementById('piodocsearch').setAttribute('value', urlParams);
+  </script>
+  <gcse:searchresults-only linkTarget="_self"></gcse:searchresults-only>
+ </div>


### PR DESCRIPTION
Closes #1919 

## Effect
PR includes the following changes:
- Delete DocSearch js and css
- Restore custom styling and js for Google's Custom Search
- Use new index cx

cc @allenfear 