### PR TITLE
Overwriting WP core via WP Dashboard is not supported

### DIFF
--- a/source/_docs/database-connection-errors.md
+++ b/source/_docs/database-connection-errors.md
@@ -25,7 +25,7 @@ To see if this is the case, examine your `includes/bootstrap.inc` file, and veri
 If you don't see that, look in to recent changes and revert or remove whatever overwrote your core.
 
 ### WordPress Core
-Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
+Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/scope-of-support) and [Applying Upstream Updates](/docs/upstream-updates).
 
 ## Drupal Non-Standard Bootstraps
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.

--- a/source/_docs/database-connection-errors.md
+++ b/source/_docs/database-connection-errors.md
@@ -25,7 +25,7 @@ To see if this is the case, examine your `includes/bootstrap.inc` file, and veri
 If you don't see that, look in to recent changes and revert or remove whatever overwrote your core.
 
 ### WordPress Core
-Only use the one-click updates provided within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Other methods of applying upstream updates are not supported. Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
+Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
 
 ## Drupal Non-Standard Bootstraps
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.

--- a/source/_docs/database-connection-errors.md
+++ b/source/_docs/database-connection-errors.md
@@ -25,7 +25,7 @@ To see if this is the case, examine your `includes/bootstrap.inc` file, and veri
 If you don't see that, look in to recent changes and revert or remove whatever overwrote your core.
 
 ### WordPress Core
-Pantheon currently uses the stock WordPress core. The additional functionality that we require to operate on the platform is achieved by several pre-installed "must use" plugins. You can safely overwrite the WordPress core if you like; however, it is unnecessary. When new versions are released, we push them into your Dev environment, ready for you to commit and test.
+Only use the one-click updates provided within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Other methods of applying upstream updates are not supported. Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
 
 ## Drupal Non-Standard Bootstraps
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -6,7 +6,7 @@ tags: [code]
 keywords: upstream, update upstream, apply updates, apply update, update core, update plugin, update module, update theme, update distribution, distribution, deploy update, deploy updates, update, updates, security update, apply security update, patch
 ---
 
-Only use the one-click updates on the Dashboard to update your site's core. Do not update core using Drush or WP-CLI; you will overwrite your core.
+Only use the one-click updates provided within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Other methods of applying upstream updates are not supported. Do not update core using the WordPress Dashboard, Drush, or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/scope-of-support).
 
 ## Apply Upstream Updates via the Dashboard
 

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -5,7 +5,7 @@ categories: [developing]
 tags: [code]
 keywords: upstream, update upstream, apply updates, apply update, update core, update plugin, update module, update theme, update distribution, distribution, deploy update, deploy updates, update, updates, security update, apply security update, patch
 ---
-Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard, Drush, or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
+Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard, Drush, or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/scope-of-support).
 
 ## Apply Upstream Updates via the Dashboard
 

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -5,8 +5,7 @@ categories: [developing]
 tags: [code]
 keywords: upstream, update upstream, apply updates, apply update, update core, update plugin, update module, update theme, update distribution, distribution, deploy update, deploy updates, update, updates, security update, apply security update, patch
 ---
-
-Only use the one-click updates provided within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Other methods of applying upstream updates are not supported. Do not update core using the WordPress Dashboard, Drush, or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/scope-of-support).
+Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard, Drush, or WP-CLI; you will overwrite your core. For additional details, see [Applying Upstream Updates](/docs/upstream-updates).
 
 ## Apply Upstream Updates via the Dashboard
 


### PR DESCRIPTION
Closes #1897 

## Effect
PR includes the following changes:
- Rephrase references to updating WordPress core so that only Terminus and one-click updates are recommended and supported. 

@ttrowell can you review?
