### PR TITLE
Adding common query parameters link

### DIFF
--- a/source/_docs/solr.md
+++ b/source/_docs/solr.md
@@ -77,4 +77,4 @@ The solution is to specify the parser in the request. Both the [Lucene](https://
 ```
 /select?q=ts_ol_full_text:property&fl=label,bundle,ts_ol_full_text&wt=json&defType=edismax
 ```  
-For details on supported query parsers, see [Query Syntax and Parsing]( https://cwiki.apache.org/confluence/display/solr/Query+Syntax+and+Parsing).
+For details on supported query parsers, see [Query Syntax and Parsing]( https://cwiki.apache.org/confluence/display/solr/Query+Syntax+and+Parsing) and [Common Query Parameters](https://cwiki.apache.org/confluence/display/solr/Common+Query+Parameters#CommonQueryParameters-ThedefTypeParameter).


### PR DESCRIPTION
Adding a link to make it easier for folks to configure the understand how to specify and use a query parser that is not our default parser. 
