### PR TITLE
Replace pantheon-js-tracking.min.js with tag manager

### DIFF
--- a/source/_partials/footer_scripts.html
+++ b/source/_partials/footer_scripts.html
@@ -80,7 +80,7 @@
 
   </script>
 
-  <script src="//pantheon.io/sites/all/themes/zeus/js/pantheon-js-tracking.min.js"></script>
+  <script type="text/javascript" src="//d2qkfn813cyz6e.cloudfront.net/js/pantheon-js-tracking.min.js?d=e"></script>
   <script type="text/javascript">
   defaults = {'utm_content': window.location.pathname,
               'utm_source': document.referrer,


### PR DESCRIPTION
Closes #1957 

## Effect
PR includes the following changes:
- Replace pantheon-js-tracking.min.js with tag manager (`//d2qkfn813cyz6e.cloudfront.net/js/pantheon-js-tracking.min.js?d=e`)

cc @allenfear 
