### PR TITLE
Update change-management.md to show developer site role is Enterprise only

### DIFF
--- a/source/_docs/change-management.md
+++ b/source/_docs/change-management.md
@@ -81,7 +81,7 @@ In some Dashboards, you may notice the "User in Charge" label applied to a user.
         <th>Permissions</th>
         <th>User in Charge / Owner <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Owner" data-content="Partner orgs only"><em class="fa fa-info-circle"></em></a></th>
         <th>Team Member </th>
-        <th>Developer </th>
+        <th>Developer <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Enterprise orgs only"><em class="fa fa-info-circle"></em></a> </th>
       </tr>
     </thead>
     <tbody>


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Clarification that only Enterprise Orgs can assign Developer Roles on Sites


## Remaining Work
- [ ] Check with @1dwaynemcdaniel to make sure this is accurate

