### PR TITLE
Drupal Gardens: Demote to Draft

### DIFF
--- a/source/_docs/migrate-drupal-gardens.md
+++ b/source/_docs/migrate-drupal-gardens.md
@@ -4,6 +4,7 @@ description: Get all the details you need to know to successfully migrate your s
 categories: [drupal]
 tags: [migrate]
 keywords: drupal, pantheon, drupal gardens, import
+draft: true
 ---
 Drupal Gardens is ending support on August 1, 2016. This article walks you through exporting and migrating your site from Drupal Gardens to Pantheon.
 


### PR DESCRIPTION
Closes #1975 

## Effect
PR includes the following changes:
- Mark `migrate-drupal-gardens.md` as draft to preserve content and delete from production builds

## Remaining Work
- [ ] Redirect to main migration doc. 


Thanks for the issue @1dwaynemcdaniel!

