### PR TITLE
Recommend SSH key as workaround for un/pw failures across an Org

### DIFF
--- a/source/_docs/organization-faq.md
+++ b/source/_docs/organization-faq.md
@@ -35,6 +35,12 @@ See [Role-Based Permissions & Change Management](/docs/change-management) for de
 When you or the administrators, team members, or developers in your agency [create sites](https://dashboard.pantheon.io/sites/create), you have the option of associating it with your organization. Once there, all members of the organization can access the Site's Dashboard from the Organization Dashboard.
 
 ## Support
+### Why do login attempts fail for all users across my organization simultaneously?
+Any large agency that has multiple developers who login frequently via username/password will trigger failed logins for everyone else who works on the site. This occurs despite everyone using the right password and even when one user logins in and out successfully 3 times.
+
+As a workaround, we recommend following development best practice workflows by [authenticating via SSH key for password-less access](/docs/ssh-keys).
+
+
 
 ### Why can't I access Multidev on my site when the Supporting Organization can use it?
 Only organizational team members and administrators of an Supporting Organization with Multidev will be able to use this feature. If you would like to add Multidev at the site level, you can do so by upgrading to a Business or Elite plan. Site team members who are associated with site but not the agency can access Multidev environments via the unique URL, but will not be able to commit code to them.

--- a/source/_docs/sftp.md
+++ b/source/_docs/sftp.md
@@ -56,8 +56,7 @@ Get the instructions for other [SFTP clients](/docs/sftp#sftp-clients).
 
 
 ## Authenticating
-
-There are two ways to get access to your Pantheon site via SFTP. One method is by using your Pantheon Dashboard password. Alternatively, you can connect via SFTP using the public SSH key you uploaded to your account. This allows password-less authentication. Learn how to [generate a SSH key](/docs/ssh-keys).
+Follow development best practice workflows by [authenticating via SSH key for password-less access](/docs/ssh-keys). Alternatively, you may use your Pantheon Dashboard password when prompted, however larger agencies with multiple developers who login frequently may cause access issues across the organization. To avoid potential authentication failures, we strongly recommend using SSH keys. For details, see <a href="/docs/organization-faq#why-do-login-attempts-fail-for-all-users-across-my-organization-simultaneously?" data-proofer-ignore>Pantheon Organizations FAQs</a>.
 
 ## Committing SFTP Changes
 


### PR DESCRIPTION
Closes #1961 

## Effect
PR includes the following changes:
- Add question on access issues for users across an entire Org when authenticating via un/pw, recommends SSH keys as a workaround.
- Stronger recommendation for SSH keys within the SFTP doc

@dustinleblanc can you review for accuracy?

cc @joshkoenig 

