### PR TITLE
Issue 1848 troubleshooting migrations

### DIFF
--- a/source/_docs/migrate-troubleshooting.md
+++ b/source/_docs/migrate-troubleshooting.md
@@ -54,6 +54,69 @@ If multiple SQL files are present the import will fail. Only provide one `.sql` 
 #### Can I use multiple settings.php files per site archive?
 If multiple `settings.php` files are present the import will fail. Pantheon does not need the `settings.php` file to import the site. To prevent import problems, it's best to remove `settings.php`.
 
+## Troubleshooting ##
+
+This section describes the causes of, and solution to the error messages that are displayed on the dashboard if the migration fails to complete.
+
+### Could not import code, the import file does not appear to contain a valid code directory. ###
+
+**Cause:** The migration tool could not find the core Drupal or WordPress files. This prevents the migration from completing because the site modules and themes cannot be imported.
+
+**Solution:** Check that the archive includes a code root with the core files.
+
+For Drupal 8 sites the archive should include index.php and associated files at the code root level, and the following directories:
+
+`  core
+  modules
+  profiles
+  sites
+  themes`
+		
+For Drupal 7 sites the archive should include index.php and associated files at the code root level, and the following directories:
+
+`  misc
+  modules
+  profiles
+  scripts
+  sites
+  themes`
+
+### Could not import database, unable to locate a database dump. ###
+
+**Cause:** The migration tool could not locate a MySQL database dump within the archive.
+
+**Solution:** Ensure that the archive contains a valid MySQL database dump.
+
+### Multiple file directories found within the import archive. ###
+	
+**Cause:** The migration tool found more than one potential sites/default/files directories found in the archive.
+
+**Solution:** Ensure that the archive only contains one file directory by removing the unnecessary folders.
+
+### Multiple site directories found within the import archive. ###
+
+**Cause:** The migration tool found a multisite installation which is not supported on the platform.
+
+**Solution:** Extract the sites froma Druapl multisite using [these steps](/docs/unwind-multisite/).
+
+### Multiple database dumps found within the import archive. ###
+
+**Cause:** The migration tool detected muliple MySQL database dumps within the archive.
+
+**Solution:** Ensure that only the MySQL dump to be imported is included in the archive by removing the unnecessary files.
+
+### Multiple code roots found within the import archive. ###
+
+**Cause:**  The migration tool detected multiple potential code root directories in the archive.
+
+**Solution:** Ensure that only the code root to be imported is included in the archive by removing the uneeded additional code root sirectories.
+
+### Multiple file directories found within the import archive. ###
+
+**Cause:** The migration tool detected multiple files directories within the archive.
+
+**Solution:** Ensure that only the file directory to be imported is included in the archive. If there is a separate directory for private files outside of sites/default/files (e.g. `sites/default/private/`) it will need to be moved into sites/default/files (e.g. `sites/default/files/private`).
+
 ## See Also
  * [Migrate Sites to Pantheon](/docs/migrate)
  * [Log Files on Pantheon](/docs/logs/)

--- a/source/_docs/migrate-troubleshooting.md
+++ b/source/_docs/migrate-troubleshooting.md
@@ -7,21 +7,120 @@ keywords: migrate, migrating site, migrate from remote host, migrate existing si
 ---
 
 ## Migrated Site Not Working as Expected
+This section describes the causes of, and solution to the error messages that are displayed on the Site Dashboard if the migration fails to complete.
 
 If your code, database, and files have completed migrating, but your site is not working as you'd expect, please review [Pantheon Platform Considerations](/docs/platform-considerations/). For example, if your site uses PHP short tags, you'll need to convert them to standard PHP tags.
 
 Next, check [log files](https://pantheon.io/docs/logs/) to help identify and fix errors. Drupal or WordPress core is upgraded as part of migration, so you may have additional work to complete the upgrade.
 
-## One Application per Site
-Each site supports a single Drupal or WordPress application. Placing a WordPress application inside a Drupal site, for example, is unsupported. Drupal multisite is also not supported. If your existing Drupal site is a multisite installation, see [Extracting Sites from a Drupal Multisite](https://pantheon.io/docs/unwind-multisite/).
 
-## Multiple File Directories Found within the Import Archive
-The import will fail if Drupal's private files directory is not placed within the public directory, resulting in the following error message:
-<div class="alert alert-danger">
-Multiple file directories found within the import archive. sites/default/private sites/default/files
+### Could not import code, the import file does not appear to contain a valid code directory. ###
+
+**Cause:** The migration tool could not find Drupal or WordPress core files. This prevents the migration from completing because the site modules, plugins, and/or themes cannot be imported. This error also occurs when multiple `settings.php` files are present.
+
+**Solution:** Check that the archive includes a valid code root with all core files. If multiple `settings.php` files are present, delete them from the archive.
+<!-- Nav tabs -->
+<ul class="nav nav-tabs" role="tablist">
+  <li role="presentation" class="active"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
+  <li role="presentation"><a href="#d7" aria-controls="d7" role="tab" data-toggle="tab">Drupal 7</a></li>
+  <li role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+</ul>
+
+<!-- Tab panes -->
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="d8">
+  <p>Archives for Drupal 8 sites should include <code>index.php</code> at the code root level, along with the following directories:</p>
+  <pre><code class="nohighlight">
+  ├── core
+  ├── index.php
+  ├── modules
+  ├── profiles
+  ├── sites
+      └── all
+         ├── modules
+         └── themes
+      └── default
+         └── settings.php
+  └── themes
+  </code></pre>
+  </div>
+  <div role="tabpanel" class="tab-pane" id="d7">
+  <p>Archives for Drupal 7 sites should include <code>index.php</code> at the code root level, along with the following directories:</p>
+  <pre><code class="nohighlight">
+  ├── includes
+  ├── index.php
+  ├── misc
+  ├── modules
+  ├── profiles
+  ├── scripts
+  ├── sites
+      └── all
+         ├── modules
+         └── themes
+      └── default
+         └── settings.php
+  └── themes
+  </code></pre>
+  </div>
+  <div role="tabpanel" class="tab-pane" id="wp">
+  <p>Archives for WordPress sites should include <code>index.php</code> at the code root level, along with the following directories:</p>
+  <pre><code class="nohighlight">
+  ├── index.php
+  ├── wp-activate.php
+  ├── wp-config.php
+  ├── wp-comments-post.php
+  ├── wp-blog-header.php
+  ├── wp-admin
+  ├── wp-cron.php
+  ├── wp-load.php
+  ├── wp-links-opml.php
+  ├── wp-includes
+  ├── xmlrpc.php
+  ├── wp-trackback.php
+  ├── wp-signup.php
+  ├── wp-settings.php
+  ├── wp-mail.php
+  ├── wp-login.php
+  ├── wp-content
+      ├── index.php
+      ├── mu-plugins
+      ├── themes
+      ├── plugins
+
+  </code></pre>
+  </div>
 </div>
-To resolve this issue, move the `private` sub-directory under the public directory: `sites/default/files/private`. Create a site new archive and select **Migrate Existing Site** from your User Dashboard.
 
+
+### Could not import database, unable to locate a database dump. ###
+
+**Cause:** The migration tool could not locate a MySQL database dump within the archive.
+
+**Solution:** Ensure that the archive contains a valid MySQL database dump.
+
+### Multiple file directories found within the import archive. ###
+
+**Cause:** The migration tool found more than one potential location for files within the archive. This error also occurs if Drupal's private files directory is not placed within the public directory (`sites/default/files/private`).
+
+**Solution:** All files must be moved into the standard location for your site's CMS (`/sites/default/files` for Drupal, and `/wp-content/uploads` for WordPress). For more details, see [Non-Standard Files Locations](/docs/non-standard-file-paths).
+
+### Multiple site directories found within the import archive. ###
+
+**Cause:** The migration tool found a multisite installation, which is not supported on the platform.
+
+**Solution:** Refer to [Extracting Sites from a Drupal Multisite](/docs/unwind-multisite/).
+
+### Multiple database dumps found within the import archive. ###
+
+**Cause:** The migration tool detected multiple MySQL database dumps within the archive.
+
+**Solution:** Ensure that a single MySQL dump is included within the archive.
+
+### Multiple code roots found within the import archive. ###
+
+**Cause:**  The migration tool detected more than one potential location for the code root in the archive.
+
+**Solution:** Ensure that a single code root is included within the archive.
 
 ## Frequently Asked Questions (FAQs)
 
@@ -53,69 +152,6 @@ If multiple SQL files are present the import will fail. Only provide one `.sql` 
 
 #### Can I use multiple settings.php files per site archive?
 If multiple `settings.php` files are present the import will fail. Pantheon does not need the `settings.php` file to import the site. To prevent import problems, it's best to remove `settings.php`.
-
-## Troubleshooting ##
-
-This section describes the causes of, and solution to the error messages that are displayed on the dashboard if the migration fails to complete.
-
-### Could not import code, the import file does not appear to contain a valid code directory. ###
-
-**Cause:** The migration tool could not find the core Drupal or WordPress files. This prevents the migration from completing because the site modules and themes cannot be imported.
-
-**Solution:** Check that the archive includes a code root with the core files.
-
-For Drupal 8 sites the archive should include index.php and associated files at the code root level, and the following directories:
-
-`  core
-  modules
-  profiles
-  sites
-  themes`
-		
-For Drupal 7 sites the archive should include index.php and associated files at the code root level, and the following directories:
-
-`  misc
-  modules
-  profiles
-  scripts
-  sites
-  themes`
-
-### Could not import database, unable to locate a database dump. ###
-
-**Cause:** The migration tool could not locate a MySQL database dump within the archive.
-
-**Solution:** Ensure that the archive contains a valid MySQL database dump.
-
-### Multiple file directories found within the import archive. ###
-	
-**Cause:** The migration tool found more than one potential sites/default/files directories found in the archive.
-
-**Solution:** Ensure that the archive only contains one file directory by removing the unnecessary folders.
-
-### Multiple site directories found within the import archive. ###
-
-**Cause:** The migration tool found a multisite installation which is not supported on the platform.
-
-**Solution:** Extract the sites froma Druapl multisite using [these steps](/docs/unwind-multisite/).
-
-### Multiple database dumps found within the import archive. ###
-
-**Cause:** The migration tool detected muliple MySQL database dumps within the archive.
-
-**Solution:** Ensure that only the MySQL dump to be imported is included in the archive by removing the unnecessary files.
-
-### Multiple code roots found within the import archive. ###
-
-**Cause:**  The migration tool detected multiple potential code root directories in the archive.
-
-**Solution:** Ensure that only the code root to be imported is included in the archive by removing the uneeded additional code root sirectories.
-
-### Multiple file directories found within the import archive. ###
-
-**Cause:** The migration tool detected multiple files directories within the archive.
-
-**Solution:** Ensure that only the file directory to be imported is included in the archive. If there is a separate directory for private files outside of sites/default/files (e.g. `sites/default/private/`) it will need to be moved into sites/default/files (e.g. `sites/default/files/private`).
 
 ## See Also
  * [Migrate Sites to Pantheon](/docs/migrate)


### PR DESCRIPTION
Closes #1848 

## Effect
PR includes the following changes:
## d7-files-nohtaccess.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-files-nohtaccess.tar.gz) 
* Migration failed
* [Dashboard](https://admin.dashboard.pantheon.io/sites/1ba9df81-8046-4a44-804c-43522b6c7f5f/migrate)
* Troubleshooting
	* Error message
		*  `Could not import code, the import file does not appear to contain a valid code directory.`
	* The migration tool could not find the core Drupal or WordPress files. This prevents the migration from completing because the site modules and themes cannot be imported.
	* Check that the archive includes a code root with the core files.
	* For Drupal 8 sites the archive should include index.php and associated files at the code root level, and the following directories:
		* `core`
		* `modules`
		* `profiles`
		* `sites`
		* `themes`
	* For Drupal 7 sites the archive should include index.php and associated files at the code root level, and the following directories:
		* `includes`
		* `misc`
		* `modules`
		* `profiles`
		* `scripts`
		* `sites`
		* `themes`

## d7-manual-nodb.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-nodb.tar.gz) 
* Migration failed
* [Dashboard](https://admin.dashboard.pantheon.io/sites/7b2a6bf9-f398-4e9e-be95-86a727c4b3a7/migrate)
* Troubleshooting
	* Error message 
		* `Could not import database, unable to locate a database dump.`
	* The migration tool could not locate a MySQL database dump within the archive.
	* Ensure that the archive contains a valid MySQL database dump.


## d7-manual-nondefaultsite.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-nondefaultsite.tar.gz) 
* Migration failed:
* [Dashboard](https://admin.dashboard.pantheon.io/sites/6897f249-3c30-4cb5-9958-2933e7a780f1/migrate)
* Troubleshooting
	* Error message
		* `Multiple file directories found within the import archive. webroot/sites/site1/default/files webroot/sites/default/files`
	* The migration tool found more than one potential sites/default/files directories found in the archive.
	* Ensure that the archive only contains one file directory.


## d7-manual-multisite.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-multisite.tar.gz) 
* Migration failed:
* [Dashboard](https://admin.dashboard.pantheon.io/sites/9371e9b2-7d3d-480a-8c48-ce3b307ed8df/migrate)
* Troubleshooting
	* Error message
		* `Multiple site directories found within the import archive. webroot/sites/site2/default webroot/sites/site1/default webroot/sites/default`
		* The migration tool found a multisite installation which is not supported on the platform.
		* Extract the sites froma Druapl multisite using [these steps](/docs/unwind-multisite/).


## d7-manual-multipledbs.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-multipledbs.tar.gz) 
* Migration failed
* [Dashboard](https://admin.dashboard.pantheon.io/sites/fae4cad0-197c-4bde-98f2-c95718c0a232/migrate)
* Troubleshooting
	* Error message
		* `Multiple database dumps found within the import archive. db.sql db2.sql`
		* The migration tool detected muliple MySQL database dumps within the archive.
		* Ensure that only the MySQL dump to be imported is included by removing the unecessary files.

## d7-manual-multiplecoderoots.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-multiplecoderoots.tar.gz) 
* Migration failed
* [Dashboard](https://admin.dashboard.pantheon.io/sites/f39ca5d5-2702-4ad7-98b5-a687b2862820/migrate)
* Troubleshooting
	* Error message
		* `Multiple code roots found within the import archive. webroot2/ webroot/`
		* The migration tool detected multiple potential code root directories in the archive.
		* Ensure that only the code root to be imported is included in the archive by removing the uneeded additional code root sirectories.
		

## d7-manual-separate-privatefiles.tar.gz ##
* [Source](https://pantheon-migration-test.s3.amazonaws.com/archives/unsupported/d7-manual-separate-privatefiles.tar.gz) 
* Migration failed
* [Dashboard](https://admin.dashboard.pantheon.io/sites/bc51aa52-b72d-4a88-9d57-b5ef15797411/migrate)
* Troubleshooting
	* Error message
		* `Multiple file directories found within the import archive.`
		* The migration tool detected multiple files directories within the archive.
		* Ensure that only the file directory to be imported is included in the archive. If there is a separate directory for private files outside of sites/default/files (e.g. `sites/default/private/`) it will need to be moved into sites/default/files (e.g. `sites/default/files/private`).