### PR TITLE
Be more explicit that /files is not web-addressable

### DIFF
--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -12,7 +12,7 @@ Files are user uploads, usually images or documents. They are excluded from vers
 
 The Pantheon architecture is comprised of highly available [application containers](/docs/application-containers/) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 
-Valhalla symbolically links the `wp-content/uploads` directory for WordPress and the `sites/default/files` directory for Drupal within the `/files` directory. Any [non-standard file locations](/docs/non-standard-file-paths/) should be symbolically linked to `/files` or moved manually.
+Valhalla symbolically links the `wp-content/uploads` directory for WordPress and the `sites/default/files` directory for Drupal to the Valhalla files directory mount point. Any [non-standard file locations](/docs/non-standard-file-paths/) should be symbolically linked to `/files` or moved manually.
 
 ## Access via SFTP
 You can connect directly to the filesystem by copying your [connection information](/docs/sftp#sftp-connection-information) into popular SFTP clients such as [Filezilla](/docs/filezilla/) and navigating to the `/files` directory.

--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -12,7 +12,7 @@ Files are user uploads, usually images or documents. They are excluded from vers
 
 The Pantheon architecture is comprised of highly available [application containers](/docs/application-containers/) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 
-Valhalla symbolically links the `wp-content/uploads` directory for WordPress and the `sites/default/files` directory for Drupal to the Valhalla files directory mount point. Any [non-standard file locations](/docs/non-standard-file-paths/) should be symbolically linked to `/files` or moved manually.
+Valhalla symbolically links the `wp-content/uploads` directory for WordPress and the `sites/default/files` directory for Drupal to the Valhalla files directory mount point, `/files` if viewed via an SFTP client. It is important to note that this directory is not part of the document root and is not directly web-accessible. Should you wish to make this accessible, you will need to create an additional symbolic link from within the document root.  Any [non-standard file locations](/docs/non-standard-file-paths/) should be symbolically linked to `/files` or moved manually.
 
 ## Access via SFTP
 You can connect directly to the filesystem by copying your [connection information](/docs/sftp#sftp-connection-information) into popular SFTP clients such as [Filezilla](/docs/filezilla/) and navigating to the `/files` directory.


### PR DESCRIPTION
Closes #n/a

## Effect
PR includes the following changes:
- Don't call the Valhalla mount-point `/files`, because that's confusing.

## Remaining Work
- [ ] Improve suggested text -- still needs some refining. @hengkit volunteered.  :)