### PR TITLE
Typo fix

### DIFF
--- a/source/_docs/reducing-large-repos.md
+++ b/source/_docs/reducing-large-repos.md
@@ -58,7 +58,7 @@ You can output the size of your repository by running [`git count-objects -vH`](
 7. Filter out files and directories according to problematic patterns:
 
  ```
- git filter-branch --force --index-filter 'git rm -rf --cached --ignore-unmatch my_directory\/*.sql myfile.txt' --prune-empty --tag-name-filter cat -- —all
+ git filter-branch --force --index-filter 'git rm -rf --cached --ignore-unmatch my_directory\/*.sql myfile.txt' --prune-empty --tag-name-filter cat -- --all
  ```
 
  This may take hours to complete.


### PR DESCRIPTION
The command in item number 7 is missing a dash and produces a fatal error.

`Tims-MBP:~ git filter-branch --force --index-filter 'git rm -rf --cached --ignore-unmatch my_directory\/*.sql myfile.txt' --prune-empty --tag-name-filter cat -- -all`

fatal: ambiguous argument '—all': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'

Adding a second dash fixes
