### PR TITLE
Fixes #2005: Describe cause of intermittent PHP notices

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -188,7 +188,7 @@ contributors:
     github: //github.com/cellar-door
     twitter: technerdteitzel
     linkedin: //www.linkedin.com/in/christeitzel
-    drupal: https://www.drupal.org/user/658076
+    drupal: //www.drupal.org/user/658076
     wordpress: https://profiles.wordpress.org/cteitzel
     bio: Seattle based developer and entrepreneur | Founder of @keylockr and Cellar Door Media
   bwood:
@@ -209,3 +209,10 @@ contributors:
     avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Peter%20Sawczynec.jpg
     bio: Senior Customer Success Engineer
     github: //github.com/peter-pantheon
+  greg-1-anderson:
+    name: Greg Anderson
+    avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Greg_Anderson.jpg
+    bio: Open Source Contribution Engineer
+    twitter: greg_1_anderson
+    github: //github.com/greg-1-anderson
+    drupal: //www.drupal.org/u/greg1anderson

--- a/source/_docs/deprecated-constructor-notices.md
+++ b/source/_docs/deprecated-constructor-notices.md
@@ -3,6 +3,7 @@ title: Deprecated Constructor Notices in PHP
 description: Debug and fix "Deprecated Constructor" notices in your Pantheon site.
 categories: [developing]
 tags: [code, php]
+contributors: greg-1-anderson
 keywords: debug, php 7, php error, php errors, php fpm error log, fpm error log, php log, php execution, execute php, caching, cache, php exception, exceptions, errors
 ---
 
@@ -10,7 +11,7 @@ PHP notices are usually handled automatically by the Pantheon Platform as descri
 
 An example notice might look like this:
 ```nohighlight
-Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_display has a deprecated constructor in /srv/bindings/46027a30ca4c4980a7188036eb2fcea5/code/sites/all/modules/views/includes/view.inc on line 2553 
+Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_display has a deprecated constructor in /srv/bindings/46027a30ca4c4980a7188036eb2fcea5/code/sites/all/modules/views/includes/view.inc on line 2553
 Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_many_to_one_helper has a deprecated constructor in /srv/bindings/46027a30ca4c4980a7188036eb2fcea5/code/sites/all/modules/views/includes/handlers.inc on line 753
 ```
 
@@ -34,9 +35,13 @@ if (!isset($_ENV['PANTHEON_ENVIRONMENT']) || ($_ENV['PANTHEON_ENVIRONMENT'] != '
     ini_set("opcache.enable", 0);
 }
 ```
-**IMPORTANT:** Disabling opcache has a sever impact on performance, so care should be taken not to do this on a production system. Note that `display_errors` is set to `off` on Pantheon live environments, so there is no motivation to disable opcache in production anyway. When disabling opcache in dev and multi-dev environments, be sure to re-enable it again once you are done debugging.
+<div class="alert alert-danger">
+<h4>Warning</h4>
+<p>Disabling opcache has a sever impact on performance, so care should be taken not to do this on a production system. Note that <code>display_errors</code> is set to <code>off</code> on Pantheon live environments, so there is no motivation to disable opcache in production anyway. When disabling opcache in dev and multi-dev environments, be sure to re-enable it again once you are done debugging.
+</p>
+</div>
 
-Note that you may also search for deprecated constructors using the PHP linter on the command line. First, create a local copy of your site as described in [Local Development](/docs/local-development); then, run:
+You may also search for deprecated constructors using the PHP linter on the command line (requires PHP 7.0 to be installed locally). First, create a local copy of your site as described in [Local Development](/docs/local-development); then, run:
 ```nohighlight
 $ php -l sites/all/modules/views/includes/handlers.inc
 PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; views_many_to_one_helper has a deprecated constructor in sites/all/modules/views/includes/handlers.inc on line 753
@@ -53,10 +58,14 @@ Adjust the regular expression as needed to scan other file extensions that may c
 
 ## Explanation
 
-Deprecation notices for deprecated constructors are emitted if a class contains a method with the same name as the class name. This was the recommended way to declare class constructors in PHP 4, but it was not until PHP 7 that this form actually started producing a notice. At this time, the PHP-4-style constructor is the only deprecation notice that is reported during source code parsing. In theory, this structure should only be encountered in very old code; in practice, though, some projects may have continued using the deprecated form, so it may be encountered from time to time.
+[Deprecation notices for deprecated constructors](http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors) are emitted if a class contains a method with the same name as the class name. This was the recommended way to declare class constructors in PHP 4, but it was not until PHP 7 that this form actually started producing a notice. At this time, the PHP-4-style constructor is the only deprecation notice that is reported during source code parsing. In theory, this structure should only be encountered in very old code; in practice, though, some projects may have continued using the deprecated form, so it may be encountered from time to time.
 
 Opcache is always enabled on Pantheon. When opcache is in use, PHP will print any notice emitted during source code processing directly to the standard output, ignoring any error handler that may be set. These notices may still be disabled by setting `error_reporting` to ignore E_DEPRECATED; however, Drupal always enables E_DEPRECATED in `error_reporting` early in its bootstrap process, so these notices will be printed if `display_errors` is set to `on`.
 
-Opcache also influences when this error is displayed. Since opcache caches the compiled form (opcodes) of the PHP that is being executed, the deprecation notices will not be printed when the PHP opcodes are fetched from the opcache. This is what leads to the intermittant nature of this problem. 
+Opcache also influences when this error is displayed. Since opcache caches the compiled form (opcodes) of the PHP that is being executed, the deprecation notices will not be printed when the PHP opcodes are fetched from the opcache. This is what leads to the intermittant nature of this problem.
 
-**Note:** The deprecation notices used in the examples on this page appeared in an old version of the Drupal [views](https://www.drupal.org/project/views) module for Drupal 7.x. This was fixed in issue [#2579819](https://www.drupal.org/node/2579819), and included in the [7.x-3.12](https://www.drupal.org/project/views/releases/7.x-3.12) release.
+<div class="alert alert-info">
+<h4>Note</h4>
+<p>The deprecation notices used in the examples on this page appeared in an old version of the Drupal <a href="https://www.drupal.org/project/views">views</a> module for Drupal 7.x. This was fixed in issue <a href="https://www.drupal.org/node/2579819">#2579819</a>, and included in the <a href="https://www.drupal.org/project/views/releases/7.x-3.12">7.x-3.12</a> release.
+</p>
+</div>

--- a/source/_docs/deprecated_constructor_notices.md
+++ b/source/_docs/deprecated_constructor_notices.md
@@ -25,7 +25,7 @@ This error is caused by a combination of two factors:
 
 To fix these errors, convert your class constructor to `__construct()`. See [deprecation notice for PHP-4-style constructors](http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors) for more information.
 
-## Finding PHP Files Containing 
+## Finding PHP Files Containing Parse-Time Notices
 
 To make it easier to find and debug intermittent notices, **temporarily** disable the opcache in your settings.php file:
 ```php

--- a/source/_docs/deprecated_constructor_notices.md
+++ b/source/_docs/deprecated_constructor_notices.md
@@ -1,0 +1,52 @@
+---
+title: Deprecated Constructor Notices in PHP
+description: Debug and fix "Deprecated Constructor" notices in your Pantheon site.
+categories: [developing]
+tags: [code, php]
+keywords: debug, php 7, php error, php errors, php fpm error log, fpm error log, php log, php execution, execute php, caching, cache, php exception, exceptions, errors
+---
+
+PHP notices are usually handled automatically by the Pantheon Platform as described on the page [PHP Errors and Exceptions](/docs/php-errors); however, occasionally a PHP notice might be emitted directly into the web page content.
+
+An example notice might look like this:
+```nohighlight
+Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_display has a deprecated constructor in /srv/bindings/46027a30ca4c4980a7188036eb2fcea5/code/sites/all/modules/views/includes/view.inc on line 2553 
+Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_many_to_one_helper has a deprecated constructor in /srv/bindings/46027a30ca4c4980a7188036eb2fcea5/code/sites/all/modules/views/includes/handlers.inc on line 753
+```
+
+When an error like this is encountered, it will usually only appear intermitantly; most page loads will come up correctly until, after a period of inactivity on the site, the same message will appear again.
+
+This error is caused by a combination of two factors:
+
+- PHP notices generated during source code parsing
+- PHP opcache is in use
+
+Starting with PHP 7, a [deprecation notice for PHP-4-style constructors](http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors) is emitted if a method with the same name as its class is used. This was the recommended way to declare class constructors in PHP 4, but it was not until PHP 7 that this form actually started producing a notice. At this time, the PHP-4-style constructor is the only deprecation notice that is reported during source code parsing. In theory, this structure should only be encountered in very old code; in practice, though, some projects may have continued using the deprecated form, so it may be encountered from time to time.
+
+Opcache is always enabled on Pantheon. When opcache is in use, PHP will print any notice emitted during source code processing directly to the standard output, ignoring any error handler that may be set. These notices may still be disabled by setting `error_reporting` to ignore E_DEPRECATED; however, Drupal always enables E_DEPRECATED in `error_reporting` early in its bootstrap process, so these notices will be printed if `display_errors` is set to `on`.
+
+Opcache also influences when this error is displayed. Since opcache caches the compiled form (opcodes) of the PHP that is being executed, the deprecation notices will not be printed when the PHP opcodes are fetched from the opcache. This is what leads to the intermittant nature of this problem. To make it easier to find and debug PHP 4 constructors, you may disable the opcache in your settings.php file:
+```php
+if (!isset($_ENV['PANTHEON_ENVIRONMENT']) || ($_ENV['PANTHEON_ENVIRONMENT'] != 'live'))
+{
+    ini_set("opcache.enable", 0);
+}
+```
+*IMPORTANT:* Disabling opcache has a sever impact on performance, so care should be taken not to do this on a production system. Note that `display_errors` is set to `off` on Pantheon live environments, so there is no motivation to disable opcache in production anyway. When disabling opcache in dev and multi-dev environments, be sure to re-enable it again once you are done debugging.
+
+Note that you may also search for deprecated constructors using the PHP linter on the command line. First, create a local copy of your site as described in [Local Development](/docs/local-development); then, run:
+```nohighlight
+$ php -l sites/all/modules/views/includes/handlers.inc
+PHP Deprecated:  Methods with the same name as their class will not be constructors in a future version of PHP; views_many_to_one_helper has a deprecated constructor in sites/all/modules/views/includes/handlers.inc on line 753
+
+Deprecated: Methods with the same name as their class will not be constructors in a future version of PHP; views_many_to_one_helper has a deprecated constructor in sites/all/modules/views/includes/handlers.inc on line 753
+
+No syntax errors detected in sites/all/modules/views/includes/handlers.inc
+```
+Replace the path to the file you would like to check. To check every .php, .inc and .module file in a Drupal site, run:
+```nohighlight
+find -E . -iregex ".*\.(inc|php|module)$" -exec php -l {} \; | grep -v 'No syntax errors'
+```
+Adjust the regular expression as needed to scan other file extensions that may contain php code.
+
+*Note:* The deprecation notices used in the examples on this page appeared in an old version of the Drupal [views](https://www.drupal.org/project/views) module for Drupal 7.x. This was fixed in issue [#2579819|https://www.drupal.org/node/2579819], and included in the [7.x-3.12|https://www.drupal.org/project/views/releases/7.x-3.12] release.

--- a/source/_docs/deprecated_constructor_notices.md
+++ b/source/_docs/deprecated_constructor_notices.md
@@ -16,16 +16,18 @@ Deprecated: Methods with the same name as their class will not be constructors i
 
 When an error like this is encountered, it will usually only appear intermitantly; most page loads will come up correctly until, after a period of inactivity on the site, the same message will appear again.
 
+## Cause and Remediation
+
 This error is caused by a combination of two factors:
 
 - PHP notices generated during source code parsing
 - PHP opcache is in use
 
-Starting with PHP 7, a [deprecation notice for PHP-4-style constructors](http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors) is emitted if a method with the same name as its class is used. This was the recommended way to declare class constructors in PHP 4, but it was not until PHP 7 that this form actually started producing a notice. At this time, the PHP-4-style constructor is the only deprecation notice that is reported during source code parsing. In theory, this structure should only be encountered in very old code; in practice, though, some projects may have continued using the deprecated form, so it may be encountered from time to time.
+To fix these errors, convert your class constructor to `__construct()`. See [deprecation notice for PHP-4-style constructors](http://php.net/manual/en/migration70.deprecated.php#migration70.deprecated.php4-constructors) for more information.
 
-Opcache is always enabled on Pantheon. When opcache is in use, PHP will print any notice emitted during source code processing directly to the standard output, ignoring any error handler that may be set. These notices may still be disabled by setting `error_reporting` to ignore E_DEPRECATED; however, Drupal always enables E_DEPRECATED in `error_reporting` early in its bootstrap process, so these notices will be printed if `display_errors` is set to `on`.
+## Finding PHP Files Containing 
 
-Opcache also influences when this error is displayed. Since opcache caches the compiled form (opcodes) of the PHP that is being executed, the deprecation notices will not be printed when the PHP opcodes are fetched from the opcache. This is what leads to the intermittant nature of this problem. To make it easier to find and debug PHP 4 constructors, you may disable the opcache in your settings.php file:
+To make it easier to find and debug intermittent notices, **temporarily** disable the opcache in your settings.php file:
 ```php
 if (!isset($_ENV['PANTHEON_ENVIRONMENT']) || ($_ENV['PANTHEON_ENVIRONMENT'] != 'live'))
 {
@@ -48,5 +50,13 @@ Replace the path to the file you would like to check. To check every .php, .inc 
 find -E . -iregex ".*\.(inc|php|module)$" -exec php -l {} \; | grep -v 'No syntax errors'
 ```
 Adjust the regular expression as needed to scan other file extensions that may contain php code.
+
+## Explanation
+
+Deprecation notices for deprecated constructors are emitted if a class contains a method with the same name as the class name. This was the recommended way to declare class constructors in PHP 4, but it was not until PHP 7 that this form actually started producing a notice. At this time, the PHP-4-style constructor is the only deprecation notice that is reported during source code parsing. In theory, this structure should only be encountered in very old code; in practice, though, some projects may have continued using the deprecated form, so it may be encountered from time to time.
+
+Opcache is always enabled on Pantheon. When opcache is in use, PHP will print any notice emitted during source code processing directly to the standard output, ignoring any error handler that may be set. These notices may still be disabled by setting `error_reporting` to ignore E_DEPRECATED; however, Drupal always enables E_DEPRECATED in `error_reporting` early in its bootstrap process, so these notices will be printed if `display_errors` is set to `on`.
+
+Opcache also influences when this error is displayed. Since opcache caches the compiled form (opcodes) of the PHP that is being executed, the deprecation notices will not be printed when the PHP opcodes are fetched from the opcache. This is what leads to the intermittant nature of this problem. 
 
 **Note:** The deprecation notices used in the examples on this page appeared in an old version of the Drupal [views](https://www.drupal.org/project/views) module for Drupal 7.x. This was fixed in issue [#2579819](https://www.drupal.org/node/2579819), and included in the [7.x-3.12](https://www.drupal.org/project/views/releases/7.x-3.12) release.

--- a/source/_docs/deprecated_constructor_notices.md
+++ b/source/_docs/deprecated_constructor_notices.md
@@ -32,7 +32,7 @@ if (!isset($_ENV['PANTHEON_ENVIRONMENT']) || ($_ENV['PANTHEON_ENVIRONMENT'] != '
     ini_set("opcache.enable", 0);
 }
 ```
-*IMPORTANT:* Disabling opcache has a sever impact on performance, so care should be taken not to do this on a production system. Note that `display_errors` is set to `off` on Pantheon live environments, so there is no motivation to disable opcache in production anyway. When disabling opcache in dev and multi-dev environments, be sure to re-enable it again once you are done debugging.
+**IMPORTANT:** Disabling opcache has a sever impact on performance, so care should be taken not to do this on a production system. Note that `display_errors` is set to `off` on Pantheon live environments, so there is no motivation to disable opcache in production anyway. When disabling opcache in dev and multi-dev environments, be sure to re-enable it again once you are done debugging.
 
 Note that you may also search for deprecated constructors using the PHP linter on the command line. First, create a local copy of your site as described in [Local Development](/docs/local-development); then, run:
 ```nohighlight
@@ -49,4 +49,4 @@ find -E . -iregex ".*\.(inc|php|module)$" -exec php -l {} \; | grep -v 'No synta
 ```
 Adjust the regular expression as needed to scan other file extensions that may contain php code.
 
-*Note:* The deprecation notices used in the examples on this page appeared in an old version of the Drupal [views](https://www.drupal.org/project/views) module for Drupal 7.x. This was fixed in issue [#2579819|https://www.drupal.org/node/2579819], and included in the [7.x-3.12|https://www.drupal.org/project/views/releases/7.x-3.12] release.
+**Note:** The deprecation notices used in the examples on this page appeared in an old version of the Drupal [views](https://www.drupal.org/project/views) module for Drupal 7.x. This was fixed in issue [#2579819](https://www.drupal.org/node/2579819), and included in the [7.x-3.12](https://www.drupal.org/project/views/releases/7.x-3.12) release.

--- a/source/_docs/php-errors.md
+++ b/source/_docs/php-errors.md
@@ -134,3 +134,7 @@ When this error surfaces, it simply means that the file in question is not where
 Fatal error: require_once(): Failed opening required ‘/srv/bindings/xxxxx/code/sites/all/modules/redis/redis.autoload.inc’ (include_path=‘.:/usr/share/pear:/usr/share/php’) in /srv/bindings/xxxxxx/code/includes/bootstrap.inc on line 2394
 ```
 To fix this error, look for the correct path to the file and update the require\_once().
+
+## Intermittent Notices
+
+If you are encountering intermittent notices that are not behaving as described on this page, see [Deprecated Constructor Notices](/docs/deprecated_constructor_notices) for additional information. This is not common.

--- a/source/_docs/php-errors.md
+++ b/source/_docs/php-errors.md
@@ -137,4 +137,4 @@ To fix this error, look for the correct path to the file and update the require\
 
 ## Intermittent Notices
 
-If you are encountering intermittent notices that are not behaving as described on this page, see [Deprecated Constructor Notices](/docs/deprecated_constructor_notices) for additional information. This is not common.
+If you are encountering intermittent notices that are not behaving as described on this page, see [Deprecated Constructor Notices](/docs/deprecated-constructor-notices) for additional information. This is not common.

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -54,3 +54,4 @@ If you see errors on the Pantheon Dashboard when trying to auto-run `update.php`
 * [The pantheon.yml Configuration File](/docs/pantheon-yml/)
 * [Securely Working with phpinfo](/docs/phpinfo/)
 * [php.net - Backward Incompatible Changes](http://php.net/manual/en/migration70.incompatible.php)
+* [Deprecated Constructor Notices in PHP](/docs/deprecated-constructor-notices)


### PR DESCRIPTION
Closes #2005

## Effect
PR includes the following changes:
- Adds a new page on deprecated constructor notices.
- Adds a cross-link from the php errors page to the new page.

## Remaining Work
- [x] Review wording

Caused by notices generated during PHP code parsing (deprecated constructor notices) when opcache is enabled.