### PR TITLE
Legacy DNS settings issue

### DIFF
--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -149,8 +149,8 @@ Yes, see [above](/docs/domains/#develop-using-a-domain-without-changing-dns) for
 ### Why isn't my site loaded when I ping the provided Pantheon IP?
 The provided IP address resolves to our load balancers. When a request comes in, it is automatically routed to the proper site.
 
-### My current DNS settings in use at the DNS provider don’t match my Dashboard recommeded DNS settings anymore. What changed?
-If your site is over two years old your site may be using original DNS settings that were since updated in the Dashboard when the *.pantheonsite.io default domains were introduced in March 2016. The old DNS settings will continue to work. 
+### Why don't the DNS values for my previously configured domain match the recommended values currently shown on the Site Dashboard? Did something change?
+Domains configured before March 2016 may be using our legacy DNS values. While these values do not match the current recommendations shown within the target environment of the Site Dashboard, they will continue to work and route requests accordingly.  
 
 ### A contrib module that I use for my Drupal site does not support IPv6; how should I proceed?
 [Use the issue queue](https://drupal.org/node/317) of the module in question to communicate with the module maintainers.

--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -149,6 +149,9 @@ Yes, see [above](/docs/domains/#develop-using-a-domain-without-changing-dns) for
 ### Why isn't my site loaded when I ping the provided Pantheon IP?
 The provided IP address resolves to our load balancers. When a request comes in, it is automatically routed to the proper site.
 
+### My current DNS settings in use at the DNS provider don’t match my Dashboard recommeded DNS settings anymore. What changed?
+If your site is over two years old your site may be using original DNS settings that were since updated in the Dashboard when the *.pantheonsite.io default domains were introduced in March 2016. The old DNS settings will continue to work. 
+
 ### A contrib module that I use for my Drupal site does not support IPv6; how should I proceed?
 [Use the issue queue](https://drupal.org/node/317) of the module in question to communicate with the module maintainers.
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Clarifies legacy DNS settings vs current DNS settings recommendations

## Remaining Work
- [x] Review and polish copy changes

An old site may be using legacy DNS recommended settings that no longer match the current recommended settings displayed in the Dashboard.