### PR TITLE
Rewrite Git History Contraindicated

### DIFF
--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -105,8 +105,8 @@ For sites using a distribution other than the ones listed above, go to <strong>S
 
 ## Troubleshooting
 
-## Rewriting Git History by Squashing Core Commits for a Cleaner History Breaks One-click Updates
-Instead of squashing and rewriting git history, use git log --first-parent locally when reviewing history to ignore individual commits from merges.
+### One-Click Updates Do Not Appear After Rewriting Git History
+Squashing and rewritting history may cause one-click updates to break, meaning updates will no longer appear on your Site Dashboard once available. Instead of using squash and rebase to clean up commits from merges occurring upstream, we recommend reviewing history locally with `git log --first-parent`. This provides the same history shown on the Site Dashbord, and prevents conflicts with our one-click updates. 
 
 ### Manually Resolving Conflicts
 

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -105,6 +105,9 @@ For sites using a distribution other than the ones listed above, go to <strong>S
 
 ## Troubleshooting
 
+## Rewriting Git History by Squashing Core Commits for a Cleaner History Breaks One-click Updates
+Instead of squashing and rewriting git history, use git log --first-parent locally when reviewing history to ignore individual commits from merges.
+
 ### Manually Resolving Conflicts
 
 Conflicts can occur when the upstream you are trying to merge your code with has made alterations to files.


### PR DESCRIPTION
Closes #1839 
## Effect
PR includes the following changes:
- Clarifies why to not rewrite git history

## Remaining Work
- Review for clarity, language

Rewriting git history breaks one-click upstream updates