### PR TITLE
Update Terminus syntax for WP Cron

### DIFF
--- a/source/_docs/clear-caches.md
+++ b/source/_docs/clear-caches.md
@@ -10,7 +10,7 @@ Pantheon extends the core functionality of caching mechanisms within WordPress a
 Drupal 6/7 sites must enable the [pantheon_api](/docs/pantheon_api-module/) module to send clear cache requests to Varnish within Drupal's Admin interface. Drupal 8 sites must clear Varnish via the Pantheon Dashboard.
 
 - From Drupal: `/admin/config/devel/performance` and click **Clear all Caches**
-- Via [Terminus](/docs/terminus/): `terminus drush <site_name>.<environment> 'cc all'`
+- Via [Terminus](/docs/terminus/): `terminus drush <site>.<env> -- cc all`
 - From the Pantheon Dashboard on the target environment: Click **Clear Caches**
 
 ## Clear Caches: WordPress

--- a/source/_docs/clone-site.md
+++ b/source/_docs/clone-site.md
@@ -17,7 +17,7 @@ For more information see: [Migrate to Pantheon: WordPress](/docs/migrate-wordpre
 After selecting **[Migrate Existing Site](https://dashboard.pantheon.io/sites/migrate/)**, you'll create a new Pantheon site. During the **Create Site Archive** step of the migration process, use [Terminus](/docs/terminus) to create an archive of your existing Pantheon site:
 
 ```bash
-terminus drush <site_name>.<environment> 'ard --destination=code/sites/default/files/<RANDOM_HASH>.tgz'
+terminus drush <site>.<env> -- ard --destination=code/sites/default/files/<RANDOM_HASH>.tgz
 ```
 
 This operation writes the archive to Pantheon's filesystem in a web accessible location (e.g. `http://env-site-name.pantheonsite.io/sites/default/files/<RANDOM_HASH>.tgz`). Click **Continue Migration** and follow all remaining instructions within the guided migration process.
@@ -32,7 +32,7 @@ Connection to appserver.<ENV>.<Site UUID>.drush.in closed by remote host.
 If your database and code compressed are less than 256MB you can exclude the files directory from export using the following steps, otherwise [manually migrate](/docs/migrate-manual) the site.
 
 <ol><li>Use <a href="/docs/terminus">Terminus</a> and the <code>--tar-options</code> flag:<br><br>
-<pre><code class="bash hljs">terminus drush &lt;site_name&gt;.&lt;environment&gt; <span class="hljs-string">'ard <b>--tar-options="--exclude=code/sites/default/files"</b> --destination=code/sites/default/files/&lt;RANDOM_HASH&gt;.tgz'</span></code></pre></li></ol>
+<pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; <span class="hljs-string">ard <b>--tar-options="--exclude=code/sites/default/files"</b> --destination=code/sites/default/files/&lt;RANDOM_HASH&gt;.tgz</span></code></pre></li></ol>
 
 2. Click **Continue Migration**.
 3. Provide the web accessible URL for your site archive (e.g. `http://env-site-name.pantheonsite.io/sites/default/files/<RANDOM_HASH>.tgz`) and select **Import Archive**.

--- a/source/_docs/create-wordpress-site-networks.md
+++ b/source/_docs/create-wordpress-site-networks.md
@@ -23,7 +23,7 @@ Install WordPress and enable the Multisite feature with the [`wp core multisite-
 
 This command installs and enables multisite by default with the subdirectory configuration. To create your network with the subdomain configuration, add the `--subdomains` option.
 ```bash
-terminus wp <site>.<env> 'core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>'
+terminus wp <site>.<env> -- core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>
 ```
 If you've already installed WordPress, you can convert it to a network with: [`wp core multisite-convert`](http://wp-cli.org/commands/core/multisite-convert).
 
@@ -128,7 +128,7 @@ When logged in to the WordPress Dashboard, you'll see a new “My Sites” menu 
 You will have one site. To add another, use [`wp site create`](http://wp-cli.org/commands/site/create/).
 ```bash
 # Create the site on dev.
-terminus wp <site>.dev 'site create --slug=$SLUG'
+terminus wp <site>.dev -- site create --slug=$SLUG
 ```
 For subdomain networks, add hostnames to Dev, Test, and Live.
 ```bash

--- a/source/_docs/drupal-8-configuration-management.md
+++ b/source/_docs/drupal-8-configuration-management.md
@@ -23,13 +23,13 @@ Using Terminus, you can complete the above process from the command line.
 
 ### Workflow Example
 
-1. `terminus drush <site>.dev 'cex -y'
+1. `terminus drush <site>.dev -- cex -y
 2. `terminus env:commit <site>.dev --message="Export configuration to code"`
 3. `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
-4. `terminus drush <site>.<env> 'cim -y'
+4. `terminus drush <site>.<env> -- cim -y
 5. `open http://test-mysite.pantheonsite.io`
 6. `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
-7. `terminus drush <site>.live 'cim -y'
+7. `terminus drush <site>.live -- cim -y
 8. `open live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8

--- a/source/_docs/drupal-cron.md
+++ b/source/_docs/drupal-cron.md
@@ -35,7 +35,7 @@ Click **Run cron** to run all scheduled tasks.
 ![Click Run Cron](/source/docs/assets/images/run-cron.png)
 Alternatively, you can run all scheduled cron tasks with the following [Terminus](/docs/terminus/) command:
 ```bash
-terminus drush <site>.<env> "cron"
+terminus drush <site>.<env> -- cron
 ```
 
 To ensure that cron tasks have been run, check the reports via the Drupal Admin interface at Reports > Recent Log Messages. 
@@ -82,7 +82,7 @@ You can check the log messages through the Drupal Admin interface.
 
 You can also use [Terminus](/docs/terminus/) to see when cron was last run with the following command:
 ```bash
-terminus drush <site>.<env> "wd-show --type='cron'"
+terminus drush <site>.<env> -- wd-show --type='cron'
 ```
 ### Can I prevent Drupal Cron from running?
 

--- a/source/_docs/drupal-launch-check.md
+++ b/source/_docs/drupal-launch-check.md
@@ -44,12 +44,12 @@ The Dashboard integration is intended to provide developers with the most action
 
 You can get a list of all available site audit reports using [Terminus](/docs/terminus/):
 ```nohighlight
-terminus drush <site>.<env> "help --filter=site_audit"
+terminus drush <site>.<env> -- help --filter=site_audit
 ```
 
 You can also execute a full report in HTML format.
 ```bash
-terminus drush <site>.<env> "aa --skip=insights --html --bootstrap --detail --vendor=pantheon" > report.html
+terminus drush <site>.<env> -- aa --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
 ```
 #### Is Launch Check available for Drupal 8 sites?
 Launch Check for Drupal 8 is currently in development and will be available at a later date.
@@ -77,7 +77,7 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/docs/terminus/) command to execute Site Audit directly on your Pantheon site:
 ```bash
-terminus drush <site>.<env> "-vd @pantheon.SITENAME.ENV aa --skip=insights --detail --vendor=pantheon --strict=0"
+terminus drush <site>.<env> -- -vd @pantheon.SITENAME.ENV aa --skip=insights --detail --vendor=pantheon --strict=0
 ```
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 

--- a/source/_docs/drupal-s3.md
+++ b/source/_docs/drupal-s3.md
@@ -112,12 +112,12 @@ Before you begin:
   <div role="tabpanel" class="tab-pane active" id="d7s3fs">
   <br/>
   Install the <a href="https://www.drupal.org/project/libraries">Libraries API</a> and <a href="https://www.drupal.org/project/s3fs">S3 File System</a> modules:
-  <pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; 'en libraries s3fs -y'</code></pre>
+  <pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- en libraries s3fs -y</code></pre>
 
   Get the <a href="https://github.com/aws/aws-sdk-php/releases">AWS SDK Library 2.x</a>:
-  <pre><code class="php hljs">terminus drush &lt;site&gt;.&lt;env&gt; 'make --no-core ~/code/sites/all/modules/s3fs/s3fs.make ~/code/'
+  <pre><code class="php hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core ~/code/sites/all/modules/s3fs/s3fs.make ~/code/
   //or if you have a contrib subfolder for modules use:
-  //terminus drush &lt;site&gt;.&lt;env&gt; 'make --no-core ~/code/sites/all/modules/contrib/s3fs/s3fs.make ~/code/'</code></pre>
+  //terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core ~/code/sites/all/modules/contrib/s3fs/s3fs.make ~/code/</code></pre>
   The above command will add the AWS SDK version 2.x library into the <code>sites/all/libraries/awssdk2</code> directory.
  </div>
   <div role="tabpanel" class="tab-pane" id="d8s3fs">
@@ -143,7 +143,7 @@ Use the [S3 File System CORS Upload](https://www.drupal.org/project/s3fs_cors) m
   <div role="tabpanel" class="tab-pane active" id="d7s3fscors">
   <br/>
   Install s3fs_cors module using Drush:
-  <pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; 'en jquery_update s3fs_cors -y'</code></pre>
+  <pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- en jquery_update s3fs_cors -y</code></pre>
  </div>
   <div role="tabpanel" class="tab-pane" id="d8s3fscors">
    <br/>
@@ -174,14 +174,14 @@ Periodically, you'll need to run Actions provided by the S3 File System module e
 ####If you have files on S3 already that are not known to Drupal, refresh the files metadata cache:
 
 ```
-terminus drush <site>.<env> 's3fs-refresh-cache'
+terminus drush <site>.<env> -- s3fs-refresh-cache
 ```
 
 
 ####If you have files in Drupal that need inclusion with S3 run:
 
 ```
-terminus drush drush <site>.<env> 's3fs-copy-local'
+terminus drush drush <site>.<env> -- s3fs-copy-local
 ```
 
 If you receive an access denied error message from Amazon, check the permissions on your bucket and policies. Verify all your configuration settings in Drupal are complete and accurate.

--- a/source/_docs/drush-versions.md
+++ b/source/_docs/drush-versions.md
@@ -12,7 +12,7 @@ By default, Pantheon runs Drush 8.x on newly created Drupal sites and 5.x on sit
 ## Verify Current Drush Version
 Verify the current version of Drush running remotely on Pantheon using [Terminus](/docs/terminus):
 ```bash
-terminus drush <site>.<env> 'status' | grep "Drush version"
+terminus drush <site>.<env> -- status | grep "Drush version"
 ```
 
 ## Configure Drush Version

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -175,7 +175,7 @@ echo 'print "hello world";' | drush @pantheon.SITENAME.ENV php-script -
 ```
 Also, the interactive PHP shell works as well:
 ```bash
-terminus drush SITENAME.ENV core-cli
+terminus drush <site>.<env> -- core-cli
 ```
 
 ## Drush Commands That Alter Site Code

--- a/source/_docs/email.md
+++ b/source/_docs/email.md
@@ -37,7 +37,7 @@ This is a common error with the SMTP Authentication Support module. It can be fi
 1. Copy the file from .../files/mailsystem/filename.inc
 2. Place in a custom module's includes dir and .info file using files[] = includes/filename.inc
 3. Remove original file from {registry} table DELETE FROM registry WHERE name='[appropriate-name]' AND module='mailsystem';
-4. [`terminus drush <site>.<env> "cc all"`](https://github.com/pantheon-systems/cli)
+4. [`terminus drush <site>.<env> -- cc all`](https://github.com/pantheon-systems/cli)
 
 See [available patch](https://drupal.org/node/1369736#comment-5644064).
 

--- a/source/_docs/environment-indicator.md
+++ b/source/_docs/environment-indicator.md
@@ -76,7 +76,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 2. Install and enable the [Environment Indicator](https://www.drupal.org/project/environment_indicator) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with Terminus:
 
  ```nohighlight
- terminus drush <site>.dev 'en environment_indicator'
+ terminus drush <site>.dev -- en environment_indicator
  ```
 
 3. Add the following within `settings.php`:

--- a/source/_docs/environment-indicator.md
+++ b/source/_docs/environment-indicator.md
@@ -20,7 +20,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 2. Install and activate [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=pantheon+hud`) or with Terminus:
 
  ```nohighlight
- terminus wp <site>.<env> 'plugin install pantheon-hud --activate'
+ terminus wp <site>.<env> -- plugin install pantheon-hud --activate
  ```
 
 3. Deploy the plugin to the Test environment within the Site Dashboard or with Terminus:
@@ -32,7 +32,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 4. Activate the plugin within the WordPress Dashboard on the Test environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```nohighlight
- terminus wp <site>.test 'plugin activate pantheon-hud'
+ terminus wp <site>.test -- plugin activate pantheon-hud
  ```
 
 5. Deploy the plugin to the Live environment within the Site Dashboard or with Terminus:
@@ -44,7 +44,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 6. Activate the plugin within the WordPress Dashboard on the Live environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```nohighlight
- terminus wp <site>.live 'plugin activate pantheon-hud'
+ terminus wp <site>.live -- plugin activate pantheon-hud
  ```
 
 All environments will now show the following indicator for logged-in users with the `manage_options` capability:

--- a/source/_docs/environment-specific-config-d8.md
+++ b/source/_docs/environment-specific-config-d8.md
@@ -101,9 +101,9 @@ For more information on Pantheon's service configuration files for Drupal, refer
 
 
 <ol start="3"><li>Verify overridden configurations for each config.name on the Dev environment within the Drupal UI using the Configuration Manager core module (<code>/admin/config/development/configuration/single/export</code>) or via <a href="/docs/terminus">Terminus</a>:
-<pre><code>terminus drush &lt;site&gt;.&lt;env&gt; 'config-get system.performance --include-overidden'
-terminus drush &lt;site&gt;.&lt;env&gt; 'config-get system.logging --include-overidden'
-terminus drush &lt;site&gt;.&lt;env&gt; 'config-get views.settings --include-overidden'
+<pre><code>terminus drush &lt;site&gt;.&lt;env&gt; -- config-get system.performance --include-overidden
+terminus drush &lt;site&gt;.&lt;env&gt; -- config-get system.logging --include-overidden
+terminus drush &lt;site&gt;.&lt;env&gt; -- config-get views.settings --include-overidden
 </code></pre>
 <div class="alert alert-info">
 <h3 class="info">Note</h3>

--- a/source/_docs/guides/cloudflare-enable-https.md
+++ b/source/_docs/guides/cloudflare-enable-https.md
@@ -128,7 +128,7 @@ Also, you may have a number of stored references to `http` links stored in your 
 
 
 ```bash
-terminus wp <site>.<env> 'search-replace http://www.mysite.com https://www.mysite.com'
+terminus wp <site>.<env> -- search-replace http://www.mysite.com https://www.mysite.com
 ```
 
 You can find more about the power of WP-CLI's features at [wp-cli.org](http://wp-cli.org/).

--- a/source/_docs/guides/lockr.md
+++ b/source/_docs/guides/lockr.md
@@ -116,18 +116,18 @@ Lockr is currently available for Drupal 7 and Drupal 8 (development release). Se
 Use Drush to download and install Lockr in a few simple commands.
 
 ```nohighlight
-terminus drush <site>.<env> 'dl lockr'
+terminus drush <site>.<env> -- dl lockr
 ```
 ```nohighlight
-terminus drush <site>.<env> 'en lockr'
+terminus drush <site>.<env> -- en lockr
 ```
 ```nohighlight
-terminus drush <site>.<env> 'lockr-register --email=[<Lockr account email >] --password=[<Lockr account password>]'
+terminus drush <site>.<env> -- lockr-register --email=[<Lockr account email >] --password=[<Lockr account password>]
 ```
 This command registers the site with Lockr to the email address provided. The password is only necessary for email addresses already with a Lockr account. This is useful for automated deployment from a custom upstream using Quicksilver.
 
 ```nohighlight
-terminus drush <site>.<env> 'lockr-lockdown'
+terminus drush <site>.<env> -- lockr-lockdown
 ```
 Run this command and Lockr will go to a [patch library](https://github.com/lockr/lockr-patches/tree/drupal7) and automatically patch your existing plugins that do not currently integrate natively with Lockr.
 

--- a/source/_docs/guides/lockr.md
+++ b/source/_docs/guides/lockr.md
@@ -46,7 +46,7 @@ Visit the [GitHub page](https://github.com/lockr/lockr-patches/tree/wp) for a li
 2. Install and activate the [Lockr](https://wordpress.org/plugins/lockr) plugin from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=lockr`) or with [Terminus](/docs/terminus):
 
  ```nohighlight
- terminus wp <site>.<env> 'plugin install lockr --activate'
+ terminus wp <site>.<env> -- plugin install lockr --activate
  ```
 3. Click **Lockr** from within the WordPress Dashboard to visit the Lockr Configuration page  (`/wp-admin/admin.php?page=lockr-site-config`):
 
@@ -57,7 +57,7 @@ Visit the [GitHub page](https://github.com/lockr/lockr-patches/tree/wp) for a li
 6. Visit the [Lockr patch library](https://github.com/lockr/lockr-patches/tree/wp) for the latest patches to your favorite plugins or apply patches with [Terminus](/docs/terminus):
 
  ```
- terminus wp <site>.<env> 'lockr lockdown'
+ terminus wp <site>.<env> -- lockr lockdown
  ```
 
 ### WP-CLI Commands
@@ -65,25 +65,25 @@ Visit the [GitHub page](https://github.com/lockr/lockr-patches/tree/wp) for a li
 The Lockr plugin contains a number of WP-CLI commands to quickly register a site and get a key through the command line.
 
 ```nohighlight
-terminus wp <site>.<env> 'lockr register-site --email=[<Lockr email address>] --password=[<Lockr account password>]'
+terminus wp <site>.<env> -- lockr register-site --email=[<Lockr email address>] --password=[<Lockr account password>]
 ```
 This command will register the site with Lockr to the email address provided. The password is only necessary for existing Lockr accounts. This is useful for automated deployment from a custom upstream using [Quicksilver](/docs/quicksilver).
 
 
 ```nohighlight
-terminus wp <site>.<env> 'lockr lockdown'
+terminus wp <site>.<env> -- lockr lockdown
 ```
 Run this command and Lockr will go to the [patch library](https://github.com/lockr/lockr-patches/tree/wp) and automatically patch your existing plugins that do not currently integrate natively with Lockr.
 
 
 ```nohighlight
-terminus wp <site>.<env> 'lockr get-key [key name]'
+terminus wp <site>.<env> -- lockr get-key [key name]
 ```
 Run this command to get and decrypt a key from Lockr. This is a useful command to program in automated functionality in Quicksilver.
 
 
 ```nohighlight
-terminus wp <site>.<env> 'lockr set-key --name=[key name] --label=[key label] --value=[key value]'
+terminus wp <site>.<env> -- lockr set-key --name=[key name] --label=[key label] --value=[key value]
 ```
 This command encrypts a key and sends it to Lockr. This is useful during site migrations or automated deployments of new sites through Quicksilver.
 

--- a/source/_docs/guides/rerouting-outbound-email.md
+++ b/source/_docs/guides/rerouting-outbound-email.md
@@ -126,11 +126,11 @@ Push the code to Test and Live and enable the module in all environments.
 You can do this through the Site Dashboard and the Drupal Admin UI (/admin/modules) or by using [Terminus](/docs/terminus) and drush:
 ```
 $ terminus auth:login
-$ terminus drush <site>.test "en reroute_email -y"
+$ terminus drush <site>.test -- en reroute_email -y
 $ terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Intial deploy. Reroute Email demo"
 $ terminus env:deploy <site>.live --cc --updatedb --note="Intial deploy. Reroute Email demo"
-$ terminus drush <site>.test "en reroute_email -y"
-$ terminus drush <site>.live "en reroute_email -y"
+$ terminus drush <site>.test -- en reroute_email -y
+$ terminus drush <site>.live -- en reroute_email -y
 ```
 Now the Dev environment’s settings page for reroute_email (/admin/config/development/reroute_email) should look something like this:
 

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -58,7 +58,7 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 1. Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
 
  ```nohighlight
- terminus drush <site>.<env> 'en sendgrid_integration -y'
+ terminus drush <site>.<env> -- en sendgrid_integration -y
  ```
 
 2. From within your SendGrid account, navigate to **Settings** > **API Keys** and create a site-specific API Key. Click the key to copy it to your keyboard.
@@ -70,7 +70,7 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 5. Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
 
  ```
- terminus drush <site>.<env> 'composer-manager install'
+ terminus drush <site>.<env> -- composer-manager install
  ```
 
 Your Drupal application on Pantheon is now set up to send email through SendGrid's API. Test your configuration from `/admin/config/services/sendgrid/test`.
@@ -81,7 +81,7 @@ Support for Drupal 8 is not yet available for the [SMTP Authentication Support](
 1. Install the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
 
  ```nohighlight
- terminus drush <site>.<env> 'en smtp -y'
+ terminus drush <site>.<env> -- en smtp -y
  ```
 2. Visit `/admin/config/system/smtp` once you've logged in as administrator.
 3. From within Install Options, select **On**.

--- a/source/_docs/guides/terminus-drupal-site-management.md
+++ b/source/_docs/guides/terminus-drupal-site-management.md
@@ -66,7 +66,7 @@ $ terminus site:list
 Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal set ready to go for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
 
 ```nohighlight
-$ terminus drush <site>.<env> "site-install"
+$ terminus drush <site>.<env> -- site-install
 Running drush site-install  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Could not find a Drupal settings.php file at ./sites/default/settings.php.
@@ -108,13 +108,13 @@ $ terminus env:list <site>
 While the site's Dev environment is still in SFTP mode, we can use Drush to download and install some Drupal contrib modules, such as Views and Administration Menu.
 
 ```nohighlight
-$ terminus drush <site>.<env> "dl admin_menu"
+$ terminus drush <site>.<env> -- dl admin_menu
 Running drush dl admin_menu  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project admin_menu (7.x-3.0-rc5) downloaded to                         [success]
 /srv/bindings/c183403f14224eac8471ec0000f9e653/code/sites/all/modules/admin_menu.
 Project admin_menu contains 3 modules: admin_devel, admin_menu_toolbar, admin_menu.
-tests-MacBook-Pro:~ erikmathy$ terminus drush <site>.<env> "en admin_menu,admin_menu_toolbar"
+tests-MacBook-Pro:~ erikmathy$ terminus drush <site>.<env> -- en admin_menu,admin_menu_toolbar
 Running drush en admin_menu,admin_menu_toolbar  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 The following extensions will be enabled: admin_menu, admin_menu_toolbar
@@ -146,7 +146,7 @@ Open the Pantheon Dashboard, and you'll see the new files are shown in the Git c
 To see what a commit message looks like, let's download Bootstrap and then commit it as well.
 
 ```nohighlight
-$ terminus drush <site>.<env> "dl bootstrap"
+$ terminus drush <site>.<env> -- dl bootstrap
 Running drush dl bootstrap  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project bootstrap (7.x-3.0) downloaded to                              [success]

--- a/source/_docs/guides/wordpress-automated-testing.md
+++ b/source/_docs/guides/wordpress-automated-testing.md
@@ -175,10 +175,10 @@ Although not shown above, the output will be color-coded so you can quickly see 
 After seeing that the test failed, I visited the home page and realized it was because WordPress isn't installed yet. Even though I created the Dev environment I never actually installed WordPress. I could visit the home page to do the famous 5-minute install, but I decided to use [terminus and wp cli](/docs/guides/wordpress-commandline/) to install from the command line:
 
 ```nohighlight
-terminus wp <site>.<env> 'core install --url=http://test-withrobots.pantheonsite.io \
+terminus wp <site>.<env> -- core install --url=http://test-withrobots.pantheonsite.io \
                            --title="Test With Robots" \
                            --admin_user=admin --admin_password=something_incredibly_secure \  
-                           --admin_email=test@example.com'
+                           --admin_email=test@example.com
 ```
 I get the following output:
 

--- a/source/_docs/guides/wordpress-commandline.md
+++ b/source/_docs/guides/wordpress-commandline.md
@@ -101,7 +101,7 @@ Now that WordPress code is there, it's time for step five of the "[Famous 5-minu
 All you need to do now is populate the database and your site will be ready to use. Using Terminus and WP-CLI running on the server, use the `wp core install` command. For this to work, it's necessary that you understand the [wp-cli core install](http://wp-cli.org/commands/core/install/) command:
 
 ```nohighlight
-terminus wp 'core install --url=http://dev-cli-test.pantheion.io --title="WP-CLI-Test" --admin_user=admin --admin_password=something_incredibly_secure --admin_email=your@emailaddress.tld'
+terminus wp -- core install --url=http://dev-cli-test.pantheion.io --title="WP-CLI-Test" --admin_user=admin --admin_password=something_incredibly_secure --admin_email=your@emailaddress.tld
 Success: WordPress installed successfully.
 ```
 
@@ -119,7 +119,7 @@ Return to the terminal, we don't need no stinking mouse.
 
 I use a few plugins on every site, but  [WP-CFM](https://github.com/forumone/wp-cfm) is the most important. It allows me to track configuration changes, export them to code, deploy them as code, and import the config to my database without disrupting the content coming into the **Live Environment**. For more information on using WP-CFM on Pantheon, please see our article on [WordPress Configuration Management](/docs/wp-cfm).
 ```nohighlight
-$ terminus wp <site>.<env> 'plugin install wp-cfm --activate'
+$ terminus wp <site>.<env> -- plugin install wp-cfm --activate
 ```
 Results in
 ```bash
@@ -185,9 +185,9 @@ Using WP-CLI gives us the ability to upload images and modify posts. In this cas
 
 You can see the full documentation for `media import` on the [wp-cli media import documentation page](http://wp-cli.org/commands/media/import/). Since you're using the `--featured_image` flag, you also need to pass the `post_id`. You can pass in either the URL of an image or a local filename to `media import.` Understand that in this case, "local" means it's already uploaded to your site. Our command to upload an image and set it as the featured image of post #1 looks like this:
 ```
-$ terminus wp <site>.<env> 'media import https://farm8.staticflickr.com/7355/16204225167_1e1bb198e5_b.jpg \
+$ terminus wp <site>.<env> -- media import https://farm8.staticflickr.com/7355/16204225167_1e1bb198e5_b.jpg \
            --post_id=\"1\" \  
-           --featured_image'  \  
+           --featured_image  \  
 ```
 
 After a successful upload you'll see this message:
@@ -211,7 +211,7 @@ Position your Pantheon Dashboard window where you can see it while working in th
 
 
 ```nohighlight
-$ terminus wp <site>.<env> 'theme install pinboard --activate'
+$ terminus wp <site>.<env> -- theme install pinboard --activate
 ```
 
 Watch your Dashboard. It recognizes your uncommitted changes.
@@ -233,7 +233,7 @@ Now that we've committed our changes, go back to your test site in the browser a
 No WordPress site is ready for development without a child theme. Let's create one:
 
 ```nohighlight
-$ terminus wp <site>.<env> 'scaffold child-theme --parent-theme=pinboard --theme-name=cli-test-theme'
+$ terminus wp <site>.<env> -- scaffold child-theme --parent-theme=pinboard --theme-name=cli-test-theme
 ```
 Next, we'll commit it.
 

--- a/source/_docs/ldap-and-ldaps.md
+++ b/source/_docs/ldap-and-ldaps.md
@@ -76,7 +76,7 @@ The majority of problems with LDAP on Pantheon come from misconfigurations. Pant
 
 Use the following script to troubleshoot a variety of configuration problems. Customize it with your settings, then place it in your site root with a name like ldap-test.php. You can execute it remotely using [Terminus](/docs/terminus/) to fully bootstrap Drupal and include the environmental configurations from your settings.php:
 ```bash
-terminus drush <site>.<en> "scr ldap-test.php"
+terminus drush <site>.<env> -- scr ldap-test.php
 ```
 
 The entire script:

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -185,7 +185,7 @@ By default, Drupal logs events using the Database Logging module (dblog). PHP fa
 2. Using [Terminus](/docs/terminus/):  
 
 ```bash
-terminus drush <site>.<env> "watchdog-show"
+terminus drush <site>.<env> -- watchdog-show
 ```
 
 Terminus can invoke Drush commands to "watch" events in real-time; tail can be used to continuously show new watchdog messages until interrupted (Control+C).  
@@ -196,7 +196,7 @@ terminus drush "watchdog-show --tail"
 
 <div class="alert alert-info">
 <h3 class="info">Note</h3>
-<p>At this time, <code>terminus drush 'watchdog-show --tail' is supported in 0.13.x versions and below, and not yet supported in Terminus 1.x.</p>
+<p>At this time, <code>terminus drush "watchdog-show --tail"</code> is supported in 0.13.x versions and below, and not yet supported in Terminus 1.x.</p>
 </div>
 
 #### My Drupal database logs are huge. Should I disable dblog?

--- a/source/_docs/managing-wordpress-site-networks.md
+++ b/source/_docs/managing-wordpress-site-networks.md
@@ -12,7 +12,7 @@ Code development and deployment will use the same [Pantheon Workflow](/docs/pant
 
 As long as the primary site on Dev, Test, and Live have the same subdomain pattern (`www.` or bare), the only operation necessary to view all sites with hostnames present on the target environment is, where `DOMAIN=example.com` and `TESTDOMAIN=test.example.com`:
 ```bash
-terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --network'
+terminus wp <site>.test -- search-replace $DOMAIN $TESTDOMAIN --network
 ```
 ## Flushing Cache Globally After Search and Replace
 
@@ -21,7 +21,7 @@ If you use Redis as a persistent storage backend for your object cache, you’ll
 With Terminus and WP-CLI, you can flush cache globally with one operation:
 
 ```bash
-terminus wp <site>.test 'cache flush'
+terminus wp <site>.test -- cache flush
 ```
 The Terminus command to clear all caches for an environment is:
 ```bash
@@ -38,14 +38,14 @@ terminus env:clear-cache <site>.test
 Code that has been committed to master and is running on the Dev environment:
 ```bash
 terminus env:deploy <site>.test --sync-content --cc --updatedb --note=<note>
-terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --url=$DOMAIN --network'
+terminus wp <site>.test -- search-replace $DOMAIN $TESTDOMAIN --url=$DOMAIN --network
 terminus env:clear-cache <site>.test
 ```
 ## Clone Content from Live to Test
 Restore the Test database and files to the state of the Live environment.
 ```bash
 env:clone <site>.live test
-terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --url=$DOMAIN --network' --env=test
+terminus wp <site>.test -- search-replace $DOMAIN $TESTDOMAIN --url=$DOMAIN --network
 terminus env:cc <site>.test
 ```
 
@@ -53,7 +53,7 @@ terminus env:cc <site>.test
 Catch up Dev to Live before you start development. The first command will overwrite the DB in Dev.
 ```bash
 env:clone <site>.live dev
-terminus wp <site>.dev 'search-replace $DOMAIN $DEVDOMAIN --url=$DOMAIN --network'
+terminus wp <site>.dev -- search-replace $DOMAIN $DEVDOMAIN --url=$DOMAIN --network
 terminus env:cc <site>.dev
 ```
 
@@ -62,12 +62,12 @@ terminus env:cc <site>.dev
 Subdomain-style networks require custom hostnames added to all environments for all sub-sites they will be used on. Add hostnames to live for all subdomain sites.
 
 ```bash
-terminus wp <site>.live 'site create --slug=$SLUG'
+terminus wp <site>.live -- site create --slug=$SLUG
 terminus domain:add <site>.live $SLUG.$DOMAIN
 ```
 Add hostnames to Dev and Test environments for all subdomain sites necessary for development and testing.  
 ```bash
-terminus wp <site>.live 'site create --slug=$SLUG'
+terminus wp <site>.live -- site create --slug=$SLUG
 terminus domain:add <site>.live $SLUG.$DOMAIN
 terminus domain:add <site>.test $SLUG.$TESTDOMAIN
 terminus domain:add <site>.dev $SLUG.$DEVDOMAIN
@@ -76,7 +76,7 @@ The next time you clone content from Live to Test or Dev, this sub-site will be 
 
 ```bash
 terminus env:clone <site>.live test
-terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --url=www.$DOMAIN --network'
+terminus wp <site>.test -- search-replace $DOMAIN $TESTDOMAIN --url=www.$DOMAIN --network
 terminus env:cc <site>.test
 ```
 
@@ -107,7 +107,7 @@ You can handle the mapping above in three operations. There are two very importa
 The first operation will map the primary site and all of its subsites:
 given `DOMAIN=example-network.com`, `TESTDOMAIN=test.example-network.com`, and `DEVDOMAIN=dev.example-network.com`
 ```bash
-terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --url=www.$DOMAIN --network'
+terminus wp <site>.test -- search-replace $DOMAIN $TESTDOMAIN --url=www.$DOMAIN --network
 ```
 - `www.$DOMAIN` -> `www.$TESTDOMAIN`
 - `second-site.$DOMAIN` -> `second-site.$TESTDOMAIN`
@@ -116,8 +116,8 @@ terminus wp <site>.test 'search-replace $DOMAIN $TESTDOMAIN --url=www.$DOMAIN --
 The site URL will become `www.$TESTDOMAIN`.
 Then we can to replace the aliases in the database with their test-environment URLs.
 ```bash
-terminus wp <site>.test 'search-replace second-site.com  second-site.$TESTDOMAIN'
-terminus wp <site>.test 'search-replace third-site.com third-site.$TESTDOMAIN'
+terminus wp <site>.test -- search-replace second-site.com  second-site.$TESTDOMAIN
+terminus wp <site>.test -- search-replace third-site.com third-site.$TESTDOMAIN
 ```
 ### Preserve Domain-Mapped URLs
 
@@ -133,9 +133,9 @@ After each clone from Live to Test, performing the first search and replace, map
 - `second-site.com` -> `test.second-site.com`
 - `third-site.com` -> `test.third-site.com`
 ```bash
-terminus wp <site>.test 'search-replace $DOMAIN test.$DOMAIN --url=www.$DOMAIN'
-terminus wp <site>.test 'search-replace $DOMAIN2 test.$DOMAIN2 --url=www.$TESTDOMAIN'
-terminus wp  <site>.test 'search-replace $DOMAIN3 test.$DOMAIN3 --url=www.$TESTDOMAIN'
+terminus wp <site>.test -- search-replace $DOMAIN test.$DOMAIN --url=www.$DOMAIN
+terminus wp <site>.test -- search-replace $DOMAIN2 test.$DOMAIN2 --url=www.$TESTDOMAIN
+terminus wp  <site>.test -- search-replace $DOMAIN3 test.$DOMAIN3 --url=www.$TESTDOMAIN
 ```
 
 ## Network Tips and Tricks with WP-CLI

--- a/source/_docs/migrate-wordpress-site-networks.md
+++ b/source/_docs/migrate-wordpress-site-networks.md
@@ -136,7 +136,7 @@ When you imported your database, all of the URLs remained active at the previous
 
 **Pro Tip**: Include the `--dry-run` flag to get a preview of the changes without destructively transforming the database and use `--verbose` to receive additional details in the output (optional).
 ```bash
-terminus wp <site>.<env> 'search-replace example.com dev-example-network.pantheonsite.io --url=example.com --network'
+terminus wp <site>.<env> -- search-replace example.com dev-example-network.pantheonsite.io --url=example.com --network
 ```
 
 Visit the Development environment and confirm your site was imported correctly!

--- a/source/_docs/more-sftp.md
+++ b/source/_docs/more-sftp.md
@@ -82,7 +82,7 @@ That just downloaded five modules and a theme in under a minute. Pretty cool.
 WordPress has a similar capability:
 
 ```nohighlight
-joshk@steppinrazor ~$ terminus wp <site>.<env> "plugin install akismet wordpress-seo jetpack google-sitemap-generator"
+joshk@steppinrazor ~$ terminus wp <site>.<env> -- plugin install akismet wordpress-seo jetpack google-sitemap-generator
 Running wp plugin install akismet wordpress-seo jetpack google-sitemap-generator on bensons-big-demo-dev
 dev.f8277b1a-ed45-4390-a257-8d@appserver.dev.f8277b1a-ed45-4390-a257-8dda0b50ff21.drush.in's password:
 Installing Akismet (3.0.0)

--- a/source/_docs/more-sftp.md
+++ b/source/_docs/more-sftp.md
@@ -57,7 +57,7 @@ joshk@steppinrazor ~$ terminus site:list
 ### Drush Example
 
 ```nohighlight
-joshk@steppinrazor ~$ terminus drush <site>.<env> "dl pathauto devel admin_menu zen search_api search_api_solr"
+joshk@steppinrazor ~$ terminus drush <site>.<env> -- dl pathauto devel admin_menu zen search_api search_api_solr
 Running drush dl pathauto devel admin_menu zen search_api search_api_solr on community-plumbing-20-dev
 Project pathauto (7.x-1.2) downloaded to [success]
 /srv/bindings/.../code/sites/all/modules/pathauto.

--- a/source/_docs/private-paths.md
+++ b/source/_docs/private-paths.md
@@ -75,10 +75,10 @@ This can be done via [Terminus](/docs/terminus/):
 
 ```nohighlight
 # Set this to Test/Live
-$: terminus drush <site>.<env> "vset uc_credit_encryption_path 'private'"
+$: terminus drush <site>.<env> -- vset uc_credit_encryption_path 'private'
 # verify the path is set on Test/Live
-$: terminus drush <site>.<env> "vget uc_credit_encryption_path
-uc_credit_encryption_path: 'private'"
+$: terminus drush <site>.<env> -- vget uc_credit_encryption_path
+uc_credit_encryption_path: 'private'
 ```
 
 <div class="alert alert-info" role="alert">

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -20,13 +20,13 @@ Please keep in mind that your site password is stored in a database, so whatever
 If you still can’t get access to your site using password reset, for example if you don't have access to the corresponding email address for the account, you can still generate a one-time password reset link by using the following [Terminus](/docs/terminus/) command for generating one-time login links:
 
 ```bash
-$ terminus drush <site>.<env> "user-login"
+$ terminus drush <site>.<env> -- user-login
 ```
 
 Or you can reset any user's password from the command line by running the [`user-password` Drush command](https://drushcommands.com/drush-8x/user/user-password/) via [Terminus](/docs/terminus):
 
 ```bash
-$ terminus drush <site>.<env> "user-password user_name --password='Astr0nGP455w0rD'"
+$ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
 ## WordPress User Login

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -40,7 +40,7 @@ You will receive an email that contains a link you can use one time to reset you
 Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/) via [Terminus](/docs/terminus):
 
 ```nohighlight
-$ terminus wp <site>.<env> 'user update 1234 --user_pass=NEWPASSWORD'
+$ terminus wp <site>.<env> -- user update 1234 --user_pass=NEWPASSWORD
 ```
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.

--- a/source/_docs/settings-php.md
+++ b/source/_docs/settings-php.md
@@ -49,7 +49,7 @@ The `HASH_SALT` value should also be set within `settings.local.php`. See Drush 
 
 To use the Pantheon `HASH_SALT` in your local site (not necessary), you can get it via [Terminus](/docs/terminus):
 ```
-terminus drush <site>.<env> "ev 'return getenv("DRUPAL_HASH_SALT")'"
+terminus drush <site>.<env> -- ev 'return getenv("DRUPAL_HASH_SALT")'
 ```
 
 Drupal 8 sites have reportedly solved local development errors by adding the following within `settings.local.php` :
@@ -232,7 +232,7 @@ Pantheon automatically injects database credentials into the site environment; i
 
 #### Where do I set or modify the `drupal_hash_salt` value in Drupal 7?
 
-There can be an occassion when you may need to set the hash salt to a specific value. If you install Drupal 7, it will create a `drupal_hash_salt` value for you, but if you want to use a different one, you can edit `settings.php` before installation. Pantheon uses Pressflow to automatically read the environmental configuration and the Drupal 7 hash salt is stored as part of the Pressflow settings. 
+There can be an occassion when you may need to set the hash salt to a specific value. If you install Drupal 7, it will create a `drupal_hash_salt` value for you, but if you want to use a different one, you can edit `settings.php` before installation. Pantheon uses Pressflow to automatically read the environmental configuration and the Drupal 7 hash salt is stored as part of the Pressflow settings.
 ```   
    // All Pantheon Environments.
    if (defined('PANTHEON_ENVIRONMENT')) {
@@ -240,7 +240,7 @@ There can be an occassion when you may need to set the hash salt to a specific v
      $custom_hash_salt = '';
      // Extract Pressflow settings into a php object.
      $pressflow_settings = extract(json_decode($_SERVER['PRESSFLOW_SETTINGS']));
-     $pressflow_settings->drupal_hash_salt = $custom_hash_salt; 
+     $pressflow_settings->drupal_hash_salt = $custom_hash_salt;
      $SERVER['PRESSFLOW_SETTINGS'] = jsonencode($pf);
     }
 ```

--- a/source/_docs/solr-drupal.md
+++ b/source/_docs/solr-drupal.md
@@ -118,12 +118,12 @@ Keep in mind that newly indexed items have a 2-minute delay until cron has been 
 ####apachesolr.module
 If you're using the Apache Solr module, you can check for the existence of this variable using [Terminus](https://github.com/pantheon-systems/cl):
 ```bash
-terminus drush <site>.<env> "vget apachesolr_service_class"
+terminus drush <site>.<env> -- vget apachesolr_service_class
 ```
 ####search_api_solr.module
 If you are using search_api_solr.module, you can check it with the command:
 ```bash
-terminus drush <site>.<env> "vget search_api_solr_connection_class"
+terminus drush <site>.<env> -- vget search_api_solr_connection_class
 ```
 
 ### Error During Search API Solr Installation

--- a/source/_docs/terminus/examples.md
+++ b/source/_docs/terminus/examples.md
@@ -58,7 +58,7 @@ Apply updates to all contributed modules, themes, and plugins via Terminus by se
     <p class="instruction">Apply updates to all contrib projects:</p>
     <div class="copy-snippet">
     <button class="btn btn-default btn-clippy" data-clipboard-target="#drupal-update-contrib"><img class="clippy" src="/source/docs/assets/images/clippy.svg" width="17" alt="Copy to clipboard"></button>
-    <figure><pre id="drupal-update-contrib"><code class="command bash" data-lang="bash">terminus drush my-site.dev 'pm-updatecode --no-core'</code></pre></figure>
+    <figure><pre id="drupal-update-contrib"><code class="command bash" data-lang="bash">terminus drush my-site.dev -- pm-updatecode --no-core</code></pre></figure>
     </div>
     <p class="instruction">Commit contrib updates to the Dev environment:</p>
     <div class="copy-snippet">

--- a/source/_docs/terminus/examples.md
+++ b/source/_docs/terminus/examples.md
@@ -76,12 +76,12 @@ Apply updates to all contributed modules, themes, and plugins via Terminus by se
     <p class="instruction">Apply updates to all plugins:</p>
     <div class="copy-snippet">
     <button class="btn btn-default btn-clippy" data-clipboard-target="#wp-update-plugins"><img class="clippy" src="/source/docs/assets/images/clippy.svg" width="17" alt="Copy to clipboard"></button>
-    <figure><pre id="wp-update-plugins"><code class="command bash" data-lang="bash">terminus wp my-site.dev 'plugin update --all'</code></pre></figure>
+    <figure><pre id="wp-update-plugins"><code class="command bash" data-lang="bash">terminus wp my-site.dev -- plugin update --all</code></pre></figure>
     </div>
     <p class="instruction">Apply updates to all themes:</p>
     <div class="copy-snippet">
     <button class="btn btn-default btn-clippy" data-clipboard-target="#wp-update-themes"><img class="clippy" src="/source/docs/assets/images/clippy.svg" width="17" alt="Copy to clipboard"></button>
-    <figure><pre id="wp-update-themes"><code class="command bash" data-lang="bash">terminus wp my-site.dev 'theme update --all'</code></pre></figure>
+    <figure><pre id="wp-update-themes"><code class="command bash" data-lang="bash">terminus wp my-site.dev -- theme update --all</code></pre></figure>
     </div>
     <p class="instruction">Commit plugin and theme updates to the Dev environment:</p>
     <div class="copy-snippet">

--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -97,7 +97,7 @@ Rules are for the good of the group, and timeouts are no exception. We've config
 
 #### Can I manually run Drupal cron for longer than the Pantheon executed Drupal cron?
 
-Yes, just use `terminus drush <site>.<env> "cron"` using [Terminus](/docs/terminus/). With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an inefficient process, determine why it's slow and fix the root cause.
+Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/terminus/). With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an inefficient process, determine why it's slow and fix the root cause.
 
 #### What if I run into a timeout when using the Drupal Migrate UI?
 

--- a/source/_docs/unwind-multisite.md
+++ b/source/_docs/unwind-multisite.md
@@ -23,9 +23,9 @@ This method will safely migrate a single site out of your Drupal Multisite and i
 
 6. [Backup the site](/docs/create-backups/#create-a-backup) in the Dashboard, just in case.
 
-7. Run `terminus drush <site>.<env> "sar --dry-run sites/sitename1 sites/default"` to test the search and replace. This exact command can change depending on the name of your site, and broken assets in step 3.
+7. Run `terminus drush <site>.<env> -- sar --dry-run sites/sitename1 sites/default` to test the search and replace. This exact command can change depending on the name of your site, and broken assets in step 3.
 
-8. Once the dry run looks good, do it for real, e.g. `terminus drush <site>.<env> "sar sites/sitename1 sites/default"`.
+8. Once the dry run looks good, do it for real, e.g. `terminus drush <site>.<env> -- sar sites/sitename1 sites/default`.
 
 9. Check your site again for broken links and images. We recommend using a link checker.
 

--- a/source/_docs/wordpress-cloudfront.md
+++ b/source/_docs/wordpress-cloudfront.md
@@ -55,14 +55,14 @@ There are a few different ways you can install a plugin on a Pantheon hosted Wor
 Execute the following [Terminus](/docs/terminus/) command to install and activate the Amazon S3 and CloudFront plugin:
 
 ```bash
-terminus wp <site>.<env> 'plugin install amazon-s3-and-cloudfront --activate'
+terminus wp <site>.<env> -- plugin install amazon-s3-and-cloudfront --activate
 ```
 
 
 In order for the Amazon S3 and CloudFront plugin to function, you also need to install the Amazon Web Services plugin:
 
 ```bash
-terminus wp <site>.<env> 'plugin install amazon-web-services --activate'
+terminus wp <site>.<env> -- plugin install amazon-web-services --activate
 ```
 
 ### Install via the WordPress Dashboard

--- a/source/_docs/wordpress-cron.md
+++ b/source/_docs/wordpress-cron.md
@@ -45,7 +45,7 @@ You can also schedule your own jobs, execute existing jobs, and manage just abou
 One of the first things you'll want to do is test WP-Cron to make sure everything is working correctly. When you execute the command below, make sure to replace SITE_NAME with your site's name from your Pantheon Dashboard and replace ENV_NAME with the desired environment ("dev", "test", "live", or multidev branch name).
 
 ````nohighlight
-$ terminus wp <site>.<env> cron test
+$ terminus wp <site>.<env> -- cron test
 ````
 
 If everything works correctly, the result looks like this:
@@ -57,7 +57,7 @@ Success: WP-Cron spawning is working as expected.
 This lets you know that WP-Cron is working properly on your site. From here, you can run any cron-related command with [WP-CLI](http://wp-cli.org/commands/cron/ "wp-cli web site"). When using WP-CLI to manage your Pantheon hosted WordPress site, you should be using [Terminus](/docs/terminus/). The command format is as follows:
 
 ````nohighlight
-$ terminus wp <site>.<env> cron <your wp-cron command and switches here>
+$ terminus wp <site>.<env> -- cron <your wp-cron command and switches here>
 ````
 
 All `terminus wp` commands require a site name and environment to operate.

--- a/source/_docs/wordpress-cron.md
+++ b/source/_docs/wordpress-cron.md
@@ -45,7 +45,7 @@ You can also schedule your own jobs, execute existing jobs, and manage just abou
 One of the first things you'll want to do is test WP-Cron to make sure everything is working correctly. When you execute the command below, make sure to replace SITE_NAME with your site's name from your Pantheon Dashboard and replace ENV_NAME with the desired environment ("dev", "test", "live", or multidev branch name).
 
 ````nohighlight
-$ terminus wp <site>.<env> "cron test"
+$ terminus wp <site>.<env> cron test
 ````
 
 If everything works correctly, the result looks like this:
@@ -57,7 +57,7 @@ Success: WP-Cron spawning is working as expected.
 This lets you know that WP-Cron is working properly on your site. From here, you can run any cron-related command with [WP-CLI](http://wp-cli.org/commands/cron/ "wp-cli web site"). When using WP-CLI to manage your Pantheon hosted WordPress site, you should be using [Terminus](/docs/terminus/). The command format is as follows:
 
 ````nohighlight
-$ terminus wp <site>.<env> 'cron <your wp-cron command and switches here>'
+$ terminus wp <site>.<env> cron <your wp-cron command and switches here>
 ````
 
 All `terminus wp` commands require a site name and environment to operate.

--- a/source/_docs/wordpress-development-versions.md
+++ b/source/_docs/wordpress-development-versions.md
@@ -21,7 +21,7 @@ Pantheon provides [one-click updates](/docs/upstream-updates/) for WordPress cor
 2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress Dashboard or with Terminus:
 
  ```
- terminus wp <site>.<env> 'plugin install wordpress-beta-tester --activate' --yes
+ terminus wp <site>.<env> -- plugin install wordpress-beta-tester --activate --yes
  ```
 
 3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you want to use, then click **Save**:
@@ -30,7 +30,7 @@ Pantheon provides [one-click updates](/docs/upstream-updates/) for WordPress cor
 
 
 4. Go to **Dashboard** > **Updates** and click **Update Now**.
-5. Verify the WordPress version using `terminus wp 'core version'` or check the bottom of any WordPress Dashboard page:
+5. Verify the WordPress version using `terminus wp <site>.<env> -- core version` or check the bottom of any WordPress Dashboard page:
 
   > You are using a development version (4.5-beta1-36808). Cool! Please stay updated.
 

--- a/source/_docs/wordpress-redis.md
+++ b/source/_docs/wordpress-redis.md
@@ -29,7 +29,7 @@ This method will store object cache values persistently in Redis while preservin
 1. Install the [WP Redis](https://wordpress.org/plugins/wp-redis/) plugin via SFTP, Git, or the following [Terminus](/docs/terminus) command:
 
  ```
- terminus wp <site>.<env> 'plugin install wp-redis'
+ terminus wp <site>.<env> -- plugin install wp-redis
  ```
 2. Using SFTP or Git, create a new file named `wp-content/object-cache.php` that contains the following:
 
@@ -43,7 +43,7 @@ This method will store object cache values persistently in Redis while preservin
 When a new version of the WP Redis plugin is released, you can upgrade by the normal Plugin update mechanism in WordPress or via Terminus:
 
 ```
-terminus wp <site>.<env> 'plugin update wp-redis'
+terminus wp <site>.<env> -- plugin update wp-redis
 ```
 
 ### Install via Composer

--- a/source/_docs/wordpress-solr.md
+++ b/source/_docs/wordpress-solr.md
@@ -20,7 +20,7 @@ Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https:/
 
 2. Install and activate the [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/) plugin on the Dev or Multidev environment using the WordPress Dashboard or with Terminus:
  ```bash
- terminus wp <site>.<env> 'plugin install --activate solr-power --activate'
+ terminus wp <site>.<env> -- plugin install --activate solr-power --activate
  ```
 3. From the WordPress Dashboard, navigate to **Settings** > **Solr Options**. You should see your site's Solr Server details within the **Info** tab.
 4. Select the **Indexing** tab and configure desired indexing options for Solr. Click **Save Changes** after making modifications.
@@ -30,7 +30,7 @@ Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https:/
 5. Index all publicly queryable post types by navigating to the **Actions** tab and clicking **Execute** next to "Index Searchable Post Types", or via Terminus:
 
  ```bash
- terminus wp <site>.<env> 'solr index'
+ terminus wp <site>.<env> -- solr index
  ```
 
 6. Use the **Query** tab to quickly validate Solr's indexing configuration. You can also install and activate the [Debug Bar](https://wordpress.org/plugins/debug-bar/) plugin to debug and validate Solr queries (optional):

--- a/source/_docs/wp-cfm.md
+++ b/source/_docs/wp-cfm.md
@@ -18,7 +18,7 @@ Each of the following steps can be done using the Pantheon and WordPress Dashboa
 
 2. Install the [WP-CFM](https://wordpress.org/plugins/wp-cfm/) plugin on the Dev Environment using the WordPress Dashboard or with Terminus:
  ```bash
- terminus wp <site>.<env> 'plugin install --activate wp-cfm'
+ terminus wp <site>.<env> -- plugin install --activate wp-cfm
  ```
 
 3. Commit this change using the Site Dashboard or with Terminus:
@@ -35,8 +35,8 @@ Each of the following steps can be done using the Pantheon and WordPress Dashboa
 
 5. Activate the plugin on the Test and Live environments using the WordPress Dashboard or with Terminus:
  ```bash
- terminus wp <site>.test 'plugin activate wp-cfm'
- terminus wp <site>.live 'plugin activate wp-cfm'
+ terminus wp <site>.test -- plugin activate wp-cfm
+ terminus wp <site>.live -- plugin activate wp-cfm
  ```
 
 ## Configuration Bundling
@@ -64,7 +64,7 @@ To create a bundle:
  This creates a new file (e.g. `wp-content/config/bundle_name.json`) where configurations are stored for the bundle. Once the file exists, you can run the **Push** operation with Terminus, if preferred:
 
  ```bash
- terminus wp <site>.dev 'config push <bundle_name>'
+ terminus wp <site>.dev -- config push <bundle_name>
  ```
 
 3. Commit your configuration to the codebase (`.json` bundle file) using the Site Dashboard or Terminus:
@@ -86,7 +86,7 @@ To create a bundle:
 2. Import configuration from the codebase into the database by clicking **Pull** for your bundle(s) within the Test environment's WordPress Dashboard (`/wp-admin/options-general.php?page=wpcfm`) or with Terminus:
 
  ```
- terminus wp <site>.test 'config pull <bundle_name>'
+ terminus wp <site>.test -- config pull <bundle_name>
  ```
 3. Test configuration on the Test environment URL with the content copied from Live.
 
@@ -100,7 +100,7 @@ To create a bundle:
 2. Import configuration from the codebase into the database by clicking **Pull** within the Live environment's WordPress Dashboard (`/wp-admin/options-general.php?page=wpcfm`) or with Terminus:
 
  ```
- terminus wp <site>.live 'config pull <bundle_name>'
+ terminus wp <site>.live -- config pull <bundle_name>
  ```
 3. Test the configuration on Live.
 

--- a/source/_docs/wp-cli.md
+++ b/source/_docs/wp-cli.md
@@ -25,7 +25,7 @@ Each of these global parameters define the **context** under which the command i
 
 Now that we've covered the most important basics, let's run a command:
 
-    $ terminus wp pantheon-demo.dev 'option get home'
+    $ terminus wp pantheon-demo.dev -- option get home
     [2015-11-25 02:42:12] [info] Running wp option get home  on pantheon-demo
         cmd: 'option get home'
         flags: ''


### PR DESCRIPTION
Terminus no longer works appropriately if you quote the command string passed to `terminus wp`.

## Remaining Work
- [x] check for other references to Terminus commands that use quotes.
