### PR TITLE
adjust vagrant sync type

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,7 +17,7 @@ Vagrant.configure("2") do |config|
   path                  = "/vagrant"
 
   config.vm.synced_folder ".", "/vagrant", :disabled => true
-  config.vm.synced_folder ".", path, :nfs => true
+  config.vm.synced_folder ".", path, :rsync => true
   config.vm.network "private_network", :auto_network => true
   config.hostmanager.enabled = true
   config.hostmanager.manage_host = true


### PR DESCRIPTION
PR includes the following changes:
This change adjusts the way vagrant syncs files from the host. By using rsync intead of NFS Sculpin will recognize file changes and live-update.
