### PR TITLE
Improve Nav: Legacy Terminus Versions

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -55,10 +55,10 @@ if [ "$CIRCLE_BRANCH" != "master" ] && [ "$CIRCLE_BRANCH" != "dev" ] && [ "$CIRC
 
   # Update CTA edit link so that the current branch is used
   sed -i '18s/master/'"$CIRCLE_BRANCH"'/g' source/_views/doc.html
-  sed -i '26s/master/'"$CIRCLE_BRANCH"'/g' source/_views/terminuspage.html
+  sed -i '33s/master/'"$CIRCLE_BRANCH"'/g' source/_views/terminuspage.html
   sed -i '15s/master/'"$CIRCLE_BRANCH"'/g' source/_views/video.html
   sed -i '20i\'"<li><a href="https://github.com/pantheon-systems/documentation/upload/$CIRCLE_BRANCH/source/docs/assets/images" target="blank">Upload New Images</a></li>"'\' source/_views/doc.html
-  sed -i '28i\'"<li><a href="https://github.com/pantheon-systems/documentation/upload/$CIRCLE_BRANCH/source/docs/assets/images" target="blank">Upload New Images</a></li>"'\' source/_views/terminuspage.html
+  sed -i '35i\'"<li><a href="https://github.com/pantheon-systems/documentation/upload/$CIRCLE_BRANCH/source/docs/assets/images" target="blank">Upload New Images</a></li>"'\' source/_views/terminuspage.html
   sed -i '17i\'"<li><a href="https://github.com/pantheon-systems/documentation/upload/$CIRCLE_BRANCH/source/docs/assets/images" target="blank">Upload New Images</a></li>"'\' source/_views/video.html
 
 

--- a/source/_changelogs/2016-12-01-December.md
+++ b/source/_changelogs/2016-12-01-December.md
@@ -4,7 +4,7 @@ changelog: true
 ---
 ## Platform Improvements
 ####Terminus Manual and Terminus 1.0 Beta Releases
-Terminus 1.0 is now available as a public beta, complete with a [new manual](https://pantheon.io/docs/terminus). In this release, we’ve updated the command structures and transitioned from a PHP based framework to Symfony Console. You can [compare differences here](https://pantheon.io/docs/terminus/commands/compare). If you find bugs in the latest version, please [submit them along with feature requests here](http://goto.pantheon.io/wSoVedkGd0000Jcp00C1X05).
+Terminus 1.0 is now available as a public beta, complete with a [new manual](https://pantheon.io/docs/terminus). In this release, we’ve updated the command structures and transitioned from a PHP based framework to Symfony Console. You can [compare differences here](https://pantheon.io/docs/terminus/get-started/legacy). If you find bugs in the latest version, please [submit them along with feature requests here](http://goto.pantheon.io/wSoVedkGd0000Jcp00C1X05).
 
 ####Documentation and Trailing Relaunch
 We've categorized our existing documentation by common user objectives to make resources easier to find. Also included in this relaunch is the groundwork for our all new video training. [Explore introductory videos](https://pantheon.io/docs) and stay tuned for more video content coming soon!

--- a/source/_docs/new-relic.md
+++ b/source/_docs/new-relic.md
@@ -11,7 +11,7 @@ Select the **New Relic** tab on your Site Dashboard, and click **Activate New Re
 
 <div class="alert alert-info">
 <h3 class="info">Note</h3>
-<p>At this time, the <a href="https://github.com/rvtraveller/terminus-omniscient">Terminus Omniscient</a> plugin supports <a href="/docs/terminus/commands/compare">0.13.x versions</a> and below, and has not yet been ported over to Terminus 1.x.</p>
+<p>At this time, the <a href="https://github.com/rvtraveller/terminus-omniscient">Terminus Omniscient</a> plugin supports <a href="/docs/terminus/get-started/legacy">0.13.x versions</a> and below, and has not yet been ported over to Terminus 1.x.</p>
 </div>
 
 Visit your site in the browser a couple of times to generate data in New Relic. After a few minutes pass, go to the New Relic workspace on your Dashboard, and click **Go to New Relic**.

--- a/source/_docs/terminus.md
+++ b/source/_docs/terminus.md
@@ -10,7 +10,7 @@ permalink: docs/:basename/
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-<a href="/docs/terminus/install">Install Terminus</a> on Linux, Mac OSX or Windows. For details on legacy versions of terminus, see [Legacy Terminus Versions](/docs/terminus/commands/compare).
+<a href="/docs/terminus/install">Install Terminus</a> on Linux, Mac OSX or Windows. For details on legacy versions of terminus, see [Legacy Terminus Versions](/docs/terminus/get-started/legacy).
 
 ## Usage
 
@@ -26,7 +26,7 @@ Use Terminus to perform these and other operations:
 
 <div class="alert alert-info">
 <h3 class="info">Note</h3>
-<p>If you are a plugin author, you will need to update your plugin to the Terminus 1.0 syntax. See <a href="/docs/terminus/commands/compare">Legacy Terminus Versions</a> to compare the difference in command syntax.</p>
+<p>If you are a plugin author, you will need to update your plugin to the Terminus 1.0 syntax. See <a href="/docs/terminus/get-started/legacy">Legacy Terminus Versions</a> to compare the difference in command syntax.</p>
 </div>
 
 Terminus is open source! View the project on [GitHub](https://github.com/pantheon-systems/terminus) to contribute, file issues, and submit feature requests.

--- a/source/_docs/terminus/get-started/legacy.md
+++ b/source/_docs/terminus/get-started/legacy.md
@@ -1,10 +1,12 @@
 ---
-title: Legacy Terminus Versions
+title: Terminus Legacy Terminus Versions
 tags: [automate, develop]
 categories: [automate]
 terminuslegacy: true
-layout: taxon
-permalink: docs/terminus/commands/:basename/
+terminuspage: true
+type: terminuspage
+layout: terminuspage
+permalink: docs/terminus/get-started/:basename/
 ---
 <p class="instruction">Install <a href="https://github.com/pantheon-systems/terminus/releases/tag/0.13.6">legacy version 0.13.6</a> of Terminus using the following command:</p>
 <div class="copy-snippet">

--- a/source/_docs/terminus/plugins.md
+++ b/source/_docs/terminus/plugins.md
@@ -8,7 +8,7 @@ permalink: docs/terminus/:basename/
 Extend the functionality of Terminus and add commands by installing third party plugins.
 <div class="alert alert-info">
 <h3 class="info">Note</h3>
-<p>If you are a plugin author, you will need to update your plugin to the Terminus 1.0 syntax. See <a href="/docs/terminus/commands/compare">Legacy Terminus Versions</a> to compare the difference in command syntax.</p>
+<p>If you are a plugin author, you will need to update your plugin to the Terminus 1.0 syntax. See <a href="/docs/terminus/get-started/legacy">Legacy Terminus Versions</a> to compare the difference in command syntax.</p>
 </div>
 ## Install Plugins
 <p class="instruction">Add plugins within the <code>$HOME/.terminus/plugins</code> directory on your local workstation. You may need to create the <code>$HOME/.terminus/plugins</code> directory if it does not already exist:</p>

--- a/source/_views/terminuspage.html
+++ b/source/_views/terminuspage.html
@@ -10,6 +10,13 @@
   <div class="col-xs-12 col-md-10 manual-doc">
   {% endif %}
     <header>
+      {% if page.terminuslegacy %}
+      <div style="row">
+            <ul class="pio-breadcrumb" style="margin-top:30px;">
+                <a id="back" href="/docs/terminus"> Back</a>
+              </ul>
+      </div>
+      {% endif %}
       <h1>{{ page.title[9:] }}</h1>
       {% if page.contributors %}
       {% set contributor_list = page.contributors %}

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -3377,6 +3377,11 @@ display: block;
 
 
 }
+#back:before {
+  content: "\f053";
+  font-family: "FontAwesome";
+  margin-right: 10px;
+}
 li.terminus-usage {
   list-style:none !important;
 }


### PR DESCRIPTION
Closes #2111 

## Effect
PR includes the following changes:
- Move legacy doc under get started
- Apply terminus manual layout to legacy doc
- Remove breadcrumbs and apply suggested nav

@kimby77 can you review? 


- [ ] Add redirect to `/docs/terminus/commands/compare` once deployed 