### PR TITLE
Switch from bundle to bundler in Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
 gem 'html-proofer'
-gem 'bundle'
+gem 'bundler'
 gem 'rake'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,8 +2,6 @@ GEM
   remote: https://rubygems.org/
   specs:
     addressable (2.3.8)
-    bundle (0.0.1)
-      bundler
     colored (1.2)
     ethon (0.8.0)
       ffi (>= 1.3.0)
@@ -30,7 +28,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  bundle
+  bundler
   html-proofer
   rake
 


### PR DESCRIPTION
Whilst working on [Libraries.io](https://libraries.io) I noticed that this project depends on the [`bundle`](https://github.com/will/bundle) gem rather than [`bundler`](https://github.com/bundler/bundler/), this pull request fixes the typo and updates the Gemfile.lock