### PR TITLE
Update Documentation - Fix code snippet of updating drupal_hash_salt.

### DIFF
--- a/source/_docs/settings-php.md
+++ b/source/_docs/settings-php.md
@@ -239,9 +239,9 @@ There can be an occassion when you may need to set the hash salt to a specific v
      // Set your custom hash salt value.
      $custom_hash_salt = '';
      // Extract Pressflow settings into a php object.
-     $pressflow_settings = extract(json_decode($_SERVER['PRESSFLOW_SETTINGS']));
+     $pressflow_settings = json_decode($_SERVER['PRESSFLOW_SETTINGS']);
      $pressflow_settings->drupal_hash_salt = $custom_hash_salt;
-     $SERVER['PRESSFLOW_SETTINGS'] = jsonencode($pf);
+     $_SERVER['PRESSFLOW_SETTINGS'] = json_encode($pressflow_settings);
     }
 ```
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Changes the code snippet for updating `drupal_hash_salt` on this page https://pantheon.io/docs/settings-php/

Because:
- `json_decode($_SERVER['PRESSFLOW_SETTINGS'])` is an object but `extract()` requires an array so this will result in a warning.
- `$pf` variable is confused with `$pressflow_settings`
- `$SERVER` is confused with `$_SERVER`
- There is not such php function `jsonencode()`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/pantheon-systems/documentation/2128)
<!-- Reviewable:end -->
