### PR TITLE
D7 conf override for file_temporary_path

### DIFF
--- a/source/_docs/temp-files.md
+++ b/source/_docs/temp-files.md
@@ -8,7 +8,11 @@ Live sites on Business and Elite plans have multiple [application containers](/d
 
 Pantheon's upstream for [WordPress](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php#L83-L86) and [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/master/sites/default/settings.pantheon.php#L146-L154) configures the temporary directory path dynamically based on the application container processing the request. This ensures the accessibility of temporary files generated for a given task until the request has been complete.
 
-Drupal 7 sites do not have the option to set or override the system `/tmp` path.
+Drupal 7 sites can override the system `/tmp` path in `settings.php`, like so: 
+```
+$conf['file_temporary_path'] = 'sites/default/files/tmp';
+```
+
 
 ## Modules/Plugins/Themes Override
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Correct D7 content for overriding the tmp file path 

@erik-pantheon can you review? 
