### PR TITLE
WIP - Updating Drupal 8 migration information

### DIFF
--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -6,7 +6,7 @@ categories: [develop]
 ---
 To upgrade Drupal to a new major version (e.g. version 6 to version 7) you must create a new site. Do not perform a major version upgrade from within the original site. If you have a Drupal 6 site that you want to upgrade to Drupal 7, create a new Drupal 7 site and add content, files and modules into the new site. If you are upgrading from Drupal 6 or Drupal 7 to Drupal 8, create a new Drupal 8 site and add content, files and modules from the old site there.
 
-Migrating to a new site on the platform will provide you with the QA and deployment processes you need to test your upgrade and ensure everything works properly. It also ensures that your site will recieve [upstream updates](https://pantheon.io/docs/upstream-updates/) once the upgrade is complete.
+Migrating to a new site on the platform will provide you with the QA and deployment processes you need to test your upgrade and ensure everything works properly. It also ensures that your site will receive [upstream updates](https://pantheon.io/docs/upstream-updates/) once the upgrade is complete.
 
 <div class="alert alert-danger" role="alert">
 <h3 class="info">Warning</h3>
@@ -16,7 +16,8 @@ Migrating to a new site on the platform will provide you with the QA and deploym
 
 1. Start a new site using Drupal 7 as the start state.
 2. Add the 7.x version of your contrib modules.
-3. Import your existing data.
+3. Import your existing database from Drupal 6 to the Drupal 7 site.
+4. Run the core upgrade process.
 4. Debug, QA, release.
 
 ### Content and Configuration
@@ -27,20 +28,54 @@ If you are not having much luck with update.php, consider setting up the new sit
 
 ## Upgrade to Drupal 8
 
-1. Start a new site using Drupal 8 as the start state.
-2. Add the 8.x version of your contrib modules.
-3. Import your existing data.
-4. Debug, QA, release.
+The details of executing an upgrade/migration to Drupal 8 have continued to shift since Drupal 8.0.0 was released. As such, this documentation will focus on the Pantheon-specific aspects. Read the [drupal.org documentation the migration process](https://www.drupal.org/docs/8/upgrade/brief-overview-and-history-of-automated-upgrading-to-drupal-8) before starting on your own migration on Pantheon. The basic steps you will follow to migrate to a Drupal 8 site on Pantheon are:
 
-### Content and Configuration
+1. Create a new Drupal 8 site from your Pantheon dashboard.
+2. Add the 8.x version of your contrib modules. Some of these modules will have built-in migrating functionality that will help move their data from Drupal 7 to Drupal 8.
+3. Use Migrate module to move over data and configuration from Drupal 6 or 7.
+4. Depending on the complexity of your site, you will likely want to review, revise, and rerun your migration.
 
-Drupal 8 migrations automatically create the needed content types and establish the mappings between the old and new fields by default.
+### Content and configuration
 
-If needed, you can customize your migration using the included hooks or use the configuration schema to use the included plugins with your custom data set. The hooks in Drupal 8 let you alter data in the prepareRow stage without creating a custom migration to handle the data.
+Drupal 8 migrations automatically create the needed content types and establish the mappings between the old and new fields by default. You should review the configuration produced by these migrations by exporting your configuration to `yml` files ([a best practice for any Drupal 8 site](https://pantheon.io/docs/drupal-8-configuration-management/)).
+
+### Customizing migrations
+
+If needed, you can customize your migration using hooks and plugins. See the [drupal.org developer documentation](https://www.drupal.org/node/2127611) for more details.
+
+
+### Scripting migrations
+
+Depending on the complexity of your site, there is a good chance you will need to script and rerun migrations.
+We have [an example repository](https://github.com/stevector/migrate_pantheon) that shows how all the steps of a migration (from first configuring the migration to running it) can be done with Drush.
+
+The critical commands are:
+
+
+```
+terminus drush my-drupal-8-site.dev -- migrate-upgrade --legacy-db-key=drupal_7 --configure-only --legacy-root=http://drupal7.example.com
+```
+This command configures (but does not run) the migrations from Drupal 6 or 7 to Drupal 8. In this example, the Drupal 8 site is named `my-drupal-8-site` and the command is running on the `dev` environment. The `--legacy-db-key` parameter indicates how to get the login credentials to the source Drupal 6 or 7 database. In our example, we use the [Terminus secrets](https://github.com/pantheon-systems/terminus-secrets-plugin) plugin to supply the connection info. [See our blog post for more information on how this flag is used](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush). The `--legacy-root` flag lets Drupal 8 know from where it can grab images and other uploaded media assets.
+
+```
+terminus drush my-drupal-8-site.dev -- migrate-status
+```
+This command gives a report on how many items have been imported by each migration.
+
+```
+terminus drush $SITE_ENV -- migrate-import --all
+```
+This command runs on of the migration that were configured with `drush migrate-upgrade`
+
 
 ## See Also
 View the following [Drupal.org](https://drupal.org) resources for more information:
 
+
 - [Commonly implemented Migration methods](https://www.drupal.org/node/1132582)
 - [Executing a Drupal 6/7 to Drupal 8 upgrade](https://www.drupal.org/node/2257723)
 - [Upgrading from Drupal 6 or 7 to Drupal 8](https://www.drupal.org/upgrade/migrate)
+- [Performing Drupal Content Migrations on Pantheon](https://pantheon.io/blog/performing-drupal-content-migrations-pantheon)
+- [Running Drupal 8 Data Migrations on Pantheon Through Drush](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush)
+- [Drupal 8 File Migrations
+](https://pantheon.io/blog/drupal-8-file-migrations)

--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -62,7 +62,7 @@ The following command generates a report on how many items have been imported by
 terminus drush my-drupal-8-site.dev -- migrate-status
 ```
 
-The following command runs the migration configured via `drush migrate-upgrade`:
+The following command runs the migration configured via `drush migrate-upgrade --configure-only`:
 ```
 terminus drush $SITE_ENV -- migrate-import --all
 ```

--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -64,7 +64,7 @@ terminus drush my-drupal-8-site.dev -- migrate-status
 
 The following command runs the migration configured via `drush migrate-upgrade --configure-only`:
 ```
-terminus drush $SITE_ENV -- migrate-import --all
+terminus drush my-drupal-8-site.dev -- migrate-import --all
 ```
 
 ## Updating DNS

--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -67,6 +67,10 @@ terminus drush $SITE_ENV -- migrate-import --all
 ```
 This command runs on of the migration that were configured with `drush migrate-upgrade`
 
+## Updating DNS
+
+If your source site is on Pantheon and has your domain name pointing to it, you will need to follow special steps to move the domain name to the new site. See our documentation on [Switching DNS From One Pantheon Site to Another](/docs/switching-dns/)
+
 
 ## See Also
 View the following [Drupal.org](https://drupal.org) resources for more information:

--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -30,14 +30,14 @@ If you are not having much luck with update.php, consider setting up the new sit
 
 The details of executing an upgrade/migration to Drupal 8 have continued to shift since Drupal 8.0.0 was released. As such, this documentation will focus on the Pantheon-specific aspects. Read the [drupal.org documentation the migration process](https://www.drupal.org/docs/8/upgrade/brief-overview-and-history-of-automated-upgrading-to-drupal-8) before starting on your own migration on Pantheon. The basic steps you will follow to migrate to a Drupal 8 site on Pantheon are:
 
-1. Create a new Drupal 8 site from your Pantheon dashboard.
+1. Create a new Drupal 8 site on Pantheon from your User Dashboard.
 2. Add the 8.x version of your contrib modules. Some of these modules will have built-in migrating functionality that will help move their data from Drupal 7 to Drupal 8.
-3. Use Migrate module to move over data and configuration from Drupal 6 or 7.
+3. Use the [Migrate](https://www.drupal.org/project/migrate) module to move over data and configuration from Drupal 6 or 7.
 4. Depending on the complexity of your site, you will likely want to review, revise, and rerun your migration.
 
 ### Content and configuration
 
-Drupal 8 migrations automatically create the needed content types and establish the mappings between the old and new fields by default. You should review the configuration produced by these migrations by exporting your configuration to `yml` files ([a best practice for any Drupal 8 site](https://pantheon.io/docs/drupal-8-configuration-management/)).
+Drupal 8 migrations automatically create the needed content types and establish the mappings between the old and new fields by default. You should review the configuration produced by these migrations by exporting your configuration to `yml` files ([a best practice for any Drupal 8 site](/docs/drupal-8-configuration-management/)).
 
 ### Customizing migrations
 
@@ -57,19 +57,19 @@ terminus drush my-drupal-8-site.dev -- migrate-upgrade --legacy-db-key=drupal_7 
 ```
 This command configures (but does not run) the migrations from Drupal 6 or 7 to Drupal 8. In this example, the Drupal 8 site is named `my-drupal-8-site` and the command is running on the `dev` environment. The `--legacy-db-key` parameter indicates how to get the login credentials to the source Drupal 6 or 7 database. In our example, we use the [Terminus secrets](https://github.com/pantheon-systems/terminus-secrets-plugin) plugin to supply the connection info. [See our blog post for more information on how this flag is used](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush). The `--legacy-root` flag lets Drupal 8 know from where it can grab images and other uploaded media assets.
 
+The following command generates a report on how many items have been imported by each migration:
 ```
 terminus drush my-drupal-8-site.dev -- migrate-status
 ```
-This command gives a report on how many items have been imported by each migration.
 
+The following command runs the migration configured via `drush migrate-upgrade`:
 ```
 terminus drush $SITE_ENV -- migrate-import --all
 ```
-This command runs on of the migration that were configured with `drush migrate-upgrade`
 
 ## Updating DNS
 
-If your source site is on Pantheon and has your domain name pointing to it, you will need to follow special steps to move the domain name to the new site. See our documentation on [Switching DNS From One Pantheon Site to Another](/docs/switching-dns/)
+If your source site is on Pantheon and has your domain name pointing to it, you will need to follow special steps to move the domain name to the new site. For details, see [Switching DNS From One Pantheon Site to Another](/docs/switching-dns/). Otherwise, follow instructions within the Site Dashboard when [adding a domain](/docs/domains).
 
 
 ## See Also


### PR DESCRIPTION
Closes https://github.com/pantheon-systems/documentation/issues/1386

## Effect
PR includes the following changes:
- Increases detail of information for Drupal 8 migrations.

## Remaining Work
- [x] Editorial review
- [x] Add information switching DNS from a Drupal 6 or 7 site live on Pantheon to the new Drupal 8 site.
