### PR TITLE
Developer timeouts section

### DIFF
--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -8,7 +8,7 @@ categories: [platform]
 
 ![pantheon enterprise gateway](/source/docs/assets/images/PEG_diagram.png)
 
-## How do I configure my Pantheon site to use the Pantheon Enterprise Gateway?
+## Configure Your Pantheon Site to Use the Pantheon Enterprise Gateway
 [Contact support](/docs/getting-support) and follow the one-time setup, then provide the following for each of your remote services:
 
 * IP address
@@ -20,6 +20,8 @@ categories: [platform]
 Once setup is complete on our end, we'll provide you with the information you need to use the Pantheon Enterprise Gateway.
 
 Please note that any code you're using to connect to the remote service must accept a PHP Constant for the port number. For example: If you have two LDAP servers, one for staff and another for students, you may choose LDAP_STAFF and LDAP_STUDENTS as names to identify the connections.
+
+## Example
 
 Direct connection, no Pantheon Enterprise Gateway:
 ```nohighlight
@@ -34,17 +36,20 @@ Secure integration with Pantheon Enterprise Gateway:
 ```
 
 <div class="alert alert-info" markdown="1">
-###Note {.info}
+### Note {.info}
 It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway since [normal PHP timeouts](http://php.net/manual/en/function.set-time-limit.php) are not considered on external requests. Outages can occur when timeouts are not appropriately set due to failing gateway connection requests that build up and consume resources.
 </div>
+
 Set reasonable timeouts using [PHP's cURL functions](http://php.net/manual/en/function.curl-setopt.php) by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
 
 WordPress and Drupal both work with the Pantheon Enterprise Gateway. If you’re using the Drupal 7 LDAP module, apply the [patch](https://www.drupal.org/files/issues/ldap_php-constant-port_1.patch) prepared by one of our engineers [listed on Drupal.org](https://www.drupal.org/node/2283273). The patch allows the use of a PHP constant for the port number, and gives a good example should you need to write a similar patch for another module.
 
-## Does the Pantheon Enterprise Gateway work from all site environments?
+## FAQ
+
+### Does the Pantheon Enterprise Gateway work from all site environments?
 
 Yes, it's configured on a site-by-site basis and works from all environments (Dev, Test, Live, and Multidev).
 
-## Is Pantheon Enterprise Gateway a replacement for authentication?
+### Is Pantheon Enterprise Gateway a replacement for authentication?
 
 No, Pantheon Enterprise Gateway is not a replacement for authentication, but rather is a [defense-in-depth](http://en.wikipedia.org/wiki/Defense_in_depth_%28computing%29) measure.

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -8,7 +8,7 @@ categories: [platform]
 
 ![pantheon enterprise gateway](/source/docs/assets/images/PEG_diagram.png)
 
-### How do I configure my Pantheon site to use the Pantheon Enterprise Gateway?
+## How do I configure my Pantheon site to use the Pantheon Enterprise Gateway?
 [Contact support](/docs/getting-support) and follow the one-time setup, then provide the following for each of your remote services:
 
 * IP address
@@ -41,10 +41,10 @@ Set reasonable timeouts using [PHP's cURL functions](http://php.net/manual/en/fu
 
 WordPress and Drupal both work with the Pantheon Enterprise Gateway. If you’re using the Drupal 7 LDAP module, apply the [patch](https://www.drupal.org/files/issues/ldap_php-constant-port_1.patch) prepared by one of our engineers [listed on Drupal.org](https://www.drupal.org/node/2283273). The patch allows the use of a PHP constant for the port number, and gives a good example should you need to write a similar patch for another module.
 
-### Does the Pantheon Enterprise Gateway work from all site environments?
+## Does the Pantheon Enterprise Gateway work from all site environments?
 
 Yes, it's configured on a site-by-site basis and works from all environments (Dev, Test, Live, and Multidev).
 
-### Is Pantheon Enterprise Gateway a replacement for authentication?
+## Is Pantheon Enterprise Gateway a replacement for authentication?
 
 No, Pantheon Enterprise Gateway is not a replacement for authentication, but rather is a [defense-in-depth](http://en.wikipedia.org/wiki/Defense_in_depth_%28computing%29) measure.

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -33,11 +33,11 @@ Secure integration with Pantheon Enterprise Gateway:
 127.0.0.1:PANTHEON_SOIP_LDAP_STAFF
 ```
 
-**Developer Note:**
-
-It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway because the normal PHP timeouts do not count time spent in external requests.  Failure to set reasonable timeouts can cause failing gateway connection requests to use up and block all of your site's your PHP worker processes and lead to an outage.  
-
-This can be done in cURL, for example, by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
+<div class="alert alert-info" markdown="1">
+###Note {.info}
+It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway since [normal PHP timeouts](http://php.net/manual/en/function.set-time-limit.php) are not considered on external requests. Outages can occur when timeouts are not appropriately set due to failing gateway connection requests that build up and consume resources.
+</div>
+Set timeouts for requests sent via the Pantheon Enterprise Gateway with cURL by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
 
 WordPress and Drupal both work with the Pantheon Enterprise Gateway. If you’re using the Drupal 7 LDAP module, apply the [patch](https://www.drupal.org/files/issues/ldap_php-constant-port_1.patch) prepared by one of our engineers [listed on Drupal.org](https://www.drupal.org/node/2283273). The patch allows the use of a PHP constant for the port number, and gives a good example should you need to write a similar patch for another module.
 

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -33,7 +33,11 @@ Secure integration with Pantheon Enterprise Gateway:
 127.0.0.1:PANTHEON_SOIP_LDAP_STAFF
 ```
 
-For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
+**Developer Note:**
+
+It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway because the normal PHP timeouts do not count time spent in external requests.  Failure to set reasonable timeouts can cause failing gateway connection requests to use up and block all of your site's your PHP worker processes and lead to an outage.  
+
+This can be done in cURL, for example, by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
 
 WordPress and Drupal both work with the Pantheon Enterprise Gateway. If you’re using the Drupal 7 LDAP module, apply the [patch](https://www.drupal.org/files/issues/ldap_php-constant-port_1.patch) prepared by one of our engineers [listed on Drupal.org](https://www.drupal.org/node/2283273). The patch allows the use of a PHP constant for the port number, and gives a good example should you need to write a similar patch for another module.
 

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -37,7 +37,7 @@ Secure integration with Pantheon Enterprise Gateway:
 
 <div class="alert alert-info" markdown="1">
 ### Note {.info}
-It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway since [normal PHP timeouts](http://php.net/manual/en/function.set-time-limit.php) are not considered on external requests. Outages can occur when timeouts are not appropriately set due to failing gateway connection requests that build up and consume resources.
+It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway, since [normal PHP timeouts](http://php.net/manual/en/function.set-time-limit.php) are not considered on external requests. Outages can occur when timeouts are not appropriately set, due to failing gateway connection requests that build up and consume resources.
 </div>
 
 Set reasonable timeouts using [PHP's cURL functions](http://php.net/manual/en/function.curl-setopt.php) by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -37,7 +37,7 @@ Secure integration with Pantheon Enterprise Gateway:
 ###Note {.info}
 It is very important to set reasonable timeouts for requests sent via the Pantheon Enterprise Gateway since [normal PHP timeouts](http://php.net/manual/en/function.set-time-limit.php) are not considered on external requests. Outages can occur when timeouts are not appropriately set due to failing gateway connection requests that build up and consume resources.
 </div>
-Set timeouts for requests sent via the Pantheon Enterprise Gateway with cURL by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
+Set reasonable timeouts using [PHP's cURL functions](http://php.net/manual/en/function.curl-setopt.php) by setting `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT`. For a more complete example, see: [Single-origin IP example code](https://github.com/pantheon-systems/soip-example).
 
 WordPress and Drupal both work with the Pantheon Enterprise Gateway. If you’re using the Drupal 7 LDAP module, apply the [patch](https://www.drupal.org/files/issues/ldap_php-constant-port_1.patch) prepared by one of our engineers [listed on Drupal.org](https://www.drupal.org/node/2283273). The patch allows the use of a PHP constant for the port number, and gives a good example should you need to write a similar patch for another module.
 

--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -8,7 +8,7 @@ categories: [platform]
 
 ![pantheon enterprise gateway](/source/docs/assets/images/PEG_diagram.png)
 
-## Configure Your Pantheon Site to Use the Pantheon Enterprise Gateway
+## Configure
 [Contact support](/docs/getting-support) and follow the one-time setup, then provide the following for each of your remote services:
 
 * IP address
@@ -19,9 +19,9 @@ categories: [platform]
 
 Once setup is complete on our end, we'll provide you with the information you need to use the Pantheon Enterprise Gateway.
 
-Please note that any code you're using to connect to the remote service must accept a PHP Constant for the port number. For example: If you have two LDAP servers, one for staff and another for students, you may choose LDAP_STAFF and LDAP_STUDENTS as names to identify the connections.
+###  Example Connections with PHP Constants
 
-## Example
+Please note that any code you're using to connect to the remote service must accept a PHP Constant for the port number. For example: If you have two LDAP servers, one for staff and another for students, you may choose `LDAP_STAFF` and `LDAP_STUDENTS` as names to identify the connections.
 
 Direct connection, no Pantheon Enterprise Gateway:
 ```nohighlight
@@ -34,6 +34,8 @@ Secure integration with Pantheon Enterprise Gateway:
 127.0.0.1:PANTHEON_SOIP_LDAP_STUDENTS
 127.0.0.1:PANTHEON_SOIP_LDAP_STAFF
 ```
+
+## Considerations
 
 <div class="alert alert-info" markdown="1">
 ### Note {.info}


### PR DESCRIPTION
Closes #2046

## Effect
PR includes the following changes:
- Explains importance of reasonable timeouts for PEG/Stunnel, mentioning `cURL`'s `CURLOPT_TIMEOUT` and `CURLOPT_CONNECTTIMEOUT` settings.

## Remaining Work
- [x] I separately submitted [PR#8](https://github.com/pantheon-systems/soip-example/pull/8/files) to update our [examples](github.com/pantheon-systems/soip-example/) that should be merged in to line up with this PR's suggestions.
