### PR TITLE
Remove question marks from TOC hashValues

### DIFF
--- a/source/docs/assets/js/jquery.tocify.js
+++ b/source/docs/assets/js/jquery.tocify.js
@@ -376,7 +376,7 @@
 
             }
 
-            hashValue = this._generateHashValue(arr, self, index);
+            hashValue = this._generateHashValue(arr, self, index).replace(/\?/g, "");
 
             // Appends a list item HTML element to the last unordered list HTML element found within the HTML element calling the plugin
             item = $("<li/>", {


### PR DESCRIPTION

## Effect
PR includes the following changes:
- Regex jquery function to remove question marks from TOC hashValues so FAQ anchor links are clickable when shared

## Remaining Work
- [ ] @alexfornuto please review and merge