### PR TITLE
SendGrid composer-manager required private directories

### DIFF
--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -65,7 +65,7 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 
 3.  Visit `/admin/config/services/sendgrid` once you've logged into your Drupal site as administrator. Paste your API Key and click **Save Settings**.
 
-4.  Implement the [Composer Manager solution](/docs/unsupported-modules-plugins/#composer-manager) from our guide on unsupported modules to address issues with the required Composer Manager module.
+4.  Implement the suggested [Composer Manager solution](/docs/unsupported-modules-plugins/#composer-manager) to address known issues with the required Composer Manager module.
 
 
 5.  Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -67,7 +67,7 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 
 4. Add the provided [code block](/docs/unsupported-modules-plugins/#composer-manager) within `settings.php` to address issues with the required Composer Manager module.
 
-Note: You will need to create a `composer` directory and a subfolder in it for the `PANTHEON_ENVIRONMENT` that matches the
+Note: You will need to create a `composer` directory and a subfolder in it for your `PANTHEON_ENVIRONMENT` per:
 
 ```nohighlight
 $conf['composer_manager_file_dir'] = 'private://composer/'.$_ENV['PANTHEON_ENVIRONMENT'];

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -55,33 +55,22 @@ Two methods can be used to integrate SendGrid with your Drupal site: API or SMTP
 ### SendGrid API Integration
 The SendGrid Integration module is not supported on Drupal 8 sites at this time. This method can be problematic on Pantheon due to [Composer Manager](https://www.drupal.org/project/composer_manager) (required by [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration)).
 
-1. Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
+1.  Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
 
  ```nohighlight
  terminus drush <site>.<env> -- en sendgrid_integration -y
  ```
 
-2. From within your SendGrid account, navigate to **Settings** > **API Keys** and create a site-specific API Key. Click the key to copy it to your keyboard.
+2.  From within your SendGrid account, navigate to **Settings** > **API Keys** and create a site-specific API Key. Click the key to copy it to your keyboard.
 
-3. Visit `/admin/config/services/sendgrid` once you've logged into your Drupal site as administrator. Paste your API Key and click **Save Settings**.
+3.  Visit `/admin/config/services/sendgrid` once you've logged into your Drupal site as administrator. Paste your API Key and click **Save Settings**.
 
-4. Add the provided [code block](/docs/unsupported-modules-plugins/#composer-manager) within `settings.php` to address issues with the required Composer Manager module.
+4.  Implement the [Composer Manager solution](/docs/unsupported-modules-plugins/#composer-manager) from our guide on unsupported modules to address issues with the required Composer Manager module.
 
-Note: You will need to create a `composer` working directory:
 
-```nohighlight
-$conf['composer_manager_file_dir'] = 'private://composer;
-```
+5.  Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
 
-For example, the directories you will need to create via SFTP or via Git command-line are:
-
-* `files/private/composer`
-
-5. Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
-
- ```
- terminus drush <site>.<env> -- composer-manager install -y
- ```
+        terminus drush <site>.<env> -- composer-manager install -y
 
 Your Drupal application on Pantheon is now set up to send email through SendGrid's API. Test your configuration from `/admin/config/services/sendgrid/test`.
 

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -67,16 +67,15 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 
 4. Add the provided [code block](/docs/unsupported-modules-plugins/#composer-manager) within `settings.php` to address issues with the required Composer Manager module.
 
-Note: You will need to create a `composer` directory and a subfolder in it for your `PANTHEON_ENVIRONMENT` per:
+Note: You will need to create a `composer` working directory:
 
 ```nohighlight
-$conf['composer_manager_file_dir'] = 'private://composer/'.$_ENV['PANTHEON_ENVIRONMENT'];
+$conf['composer_manager_file_dir'] = 'private://composer;
 ```
 
-For example, on your Dev environment the directories you will need to create via SFTP or via Git command-line are:
+For example, the directories you will need to create via SFTP or via Git command-line are:
 
 * `files/private/composer`
-* `files/private/composer/dev`
 
 5. Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
 

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -67,10 +67,21 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 
 4. Add the provided [code block](/docs/unsupported-modules-plugins/#composer-manager) within `settings.php` to address issues with the required Composer Manager module.
 
+Note: You will need to create a `composer` directory and a subfolder in it for the `PANTHEON_ENVIRONMENT` that matches the
+
+```nohighlight
+$conf['composer_manager_file_dir'] = 'private://composer/'.$_ENV['PANTHEON_ENVIRONMENT'];
+```
+
+For example, on your Dev environment the directories you will need to create via SFTP or via Git command-line are:
+
+* `files/private/composer`
+* `files/private/composer/dev`
+
 5. Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
 
  ```
- terminus drush <site>.<env> -- composer-manager install
+ terminus drush <site>.<env> -- composer-manager install -y
  ```
 
 Your Drupal application on Pantheon is now set up to send email through SendGrid's API. Test your configuration from `/admin/config/services/sendgrid/test`.

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -79,7 +79,7 @@ This module has been deprecated by its authors. The suggestions made below are n
 
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   # Set appropriate paths for Composer Manager
-  $conf['composer_manager_file_dir'] = 'private://composer/'.$_ENV['PANTHEON_ENVIRONMENT'];
+  $conf['composer_manager_file_dir'] = 'private://composer/';
   $conf['composer_manager_vendor_dir'] = $_SERVER['HOME'] . '/code/vendor';
   # Disable autobuild on Pantheon
   $conf['composer_manager_autobuild_file'] = 0;

--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -75,18 +75,18 @@ This module has been deprecated by its authors. The suggestions made below are n
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
 **Solution**: As suggested within the [module documentation](https://www.drupal.org/node/2405805), manage dependencies in Dev exclusively. Place the following configuration within `settings.php` to disable autobuild on Pantheon. This will also set appropriate file paths for Composer so that checks to see if the path is writable will not fail. Packages, however, are stored within the root directory of the site's codebase and version controlled:
-```
 
-if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  # Set appropriate paths for Composer Manager
-  $conf['composer_manager_file_dir'] = 'private://composer/';
-  $conf['composer_manager_vendor_dir'] = $_SERVER['HOME'] . '/code/vendor';
-  # Disable autobuild on Pantheon
-  $conf['composer_manager_autobuild_file'] = 0;
-  $conf['composer_manager_autobuild_packages'] = 0;
-}
+    if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+      # Set appropriate paths for Composer Manager
+      $conf['composer_manager_file_dir'] = 'private://composer';
+      $conf['composer_manager_vendor_dir'] = $_SERVER['HOME'] . '/code/vendor';
+      # Disable autobuild on Pantheon
+      $conf['composer_manager_autobuild_file'] = 0;
+      $conf['composer_manager_autobuild_packages'] = 0;
+    }
 
-```
+You also need to create the directory path `sites/default/files/private/composer`.
+
 This disables auto-building in all Pantheon environments. This will allow Drush commands such as `pm-enable` and `pm-disable` to function correctly in both Git and SFTP modes as Composer Manager will only update packages and the autoloader when _explicitly_ told to do so via `drush composer-manager [COMMAND] [OPTIONS]` or `drush composer-json-rebuild`. This is the setting recommended by Pantheon.  While `composer.json` can be rebuilt via [Terminus](/docs/terminus) while the DEV site is in SFTP mode, `composer install` must be run locally, committed via Git, and pushed back to Pantheon.
 <hr>
 ### [Fast 404](https://www.drupal.org/project/fast_404)  


### PR DESCRIPTION

PR includes the following changes:
- User will need to create `files/private/composer` and `files/private/composer/{ENV}`