### PR TITLE
Custom upstream vanilla site usage example

### DIFF
--- a/source/_docs/custom-upstream.md
+++ b/source/_docs/custom-upstream.md
@@ -89,16 +89,25 @@ Create a vanilla Drupal or WordPress site using a unique site name that is assoc
 
 
 <ul class="nav nav-tabs" role="tablist">
-  <li id="wptab" role="presentation" class="active"><a href="#drupal" aria-controls="drupal" role="tab" data-toggle="tab">Drupal</a></li>
-  <li id="drupaltab" role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+  <li id="drupal8" role="presentation" class="active"><a href="#drupal8" aria-controls="drupal8" role="tab" data-toggle="tab">Drupal 8</a></li>
+  <li id="drupal7" role="presentation"><a href="#drupal7" aria-controls="drupal7" role="tab" data-toggle="tab">Drupal 7</a></li>    
+  <li id="wp" role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
 </ul>
 <div class="tab-content">
-  <div role="tabpanel" class="tab-pane active" id="drupal">
+    <div role="tabpanel" class="tab-pane active" id="drupal8">
     <!-- Drupal Content -->
-    <p class="instruction">Create a Drupal site associated with your organization:</p>
+    <p class="instruction">Create a Drupal 8 site associated with your organization:</p>
     <div class="copy-snippet">
-    <button class="btn btn-default btn-clippy" data-clipboard-target="#vanilla-site-drupal">Copy</button>
-    <figure><pre id="vanilla-site-drupal"><code class="command nohighlight" data-lang="bash">terminus site:create unique-site-name "site label" Drupal --org="org name or UUID"</code></pre></figure>
+    <button class="btn btn-default btn-clippy" data-clipboard-target="#vanilla-site-drupal-8">Copy</button>
+    <figure><pre id="vanilla-site-drupal-8"><code class="command nohighlight" data-lang="bash">terminus site:create &lt;unique-site-name&gt; "Unique Site Label" "Drupal 8" --org="Org Name or UUID"</code></pre></figure>
+    </div>
+  </div>
+  <div role="tabpanel" class="tab-pane" id="drupal7">
+    <!-- Drupal Content -->
+    <p class="instruction">Create a Drupal 7 site associated with your organization:</p>
+    <div class="copy-snippet">
+    <button class="btn btn-default btn-clippy" data-clipboard-target="#vanilla-site-drupal-7">Copy</button>
+    <figure><pre id="vanilla-site-drupal-7"><code class="command nohighlight" data-lang="bash">terminus site:create &lt;unique-site-name&gt; "Unique Site Label" "Drupal 7" --org="Org Name or UUID"</code></pre></figure>
     </div>
   </div>
   <div role="tabpanel" class="tab-pane" id="wp">

--- a/source/_docs/custom-upstream.md
+++ b/source/_docs/custom-upstream.md
@@ -89,9 +89,9 @@ Create a vanilla Drupal or WordPress site using a unique site name that is assoc
 
 
 <ul class="nav nav-tabs" role="tablist">
-  <li id="drupal8" role="presentation" class="active"><a href="#drupal8" aria-controls="drupal8" role="tab" data-toggle="tab">Drupal 8</a></li>
-  <li id="drupal7" role="presentation"><a href="#drupal7" aria-controls="drupal7" role="tab" data-toggle="tab">Drupal 7</a></li>    
-  <li id="wp" role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+  <li id="drupal8tab" role="presentation" class="active"><a href="#drupal8" aria-controls="drupal8" role="tab" data-toggle="tab">Drupal 8</a></li>
+  <li id="drupal7tab" role="presentation"><a href="#drupal7" aria-controls="drupal7" role="tab" data-toggle="tab">Drupal 7</a></li>    
+  <li id="wp-newtab" role="presentation"><a href="#wp-new" aria-controls="wp-new" role="tab" data-toggle="tab">WordPress</a></li>
 </ul>
 <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="drupal8">
@@ -110,7 +110,7 @@ Create a vanilla Drupal or WordPress site using a unique site name that is assoc
     <figure><pre id="vanilla-site-drupal-7"><code class="command nohighlight" data-lang="bash">terminus site:create &lt;unique-site-name&gt; "Unique Site Label" "Drupal 7" --org="Org Name or UUID"</code></pre></figure>
     </div>
   </div>
-  <div role="tabpanel" class="tab-pane" id="wp">
+  <div role="tabpanel" class="tab-pane" id="wp-new">
     <!-- WordPress Content -->
     <p class="instruction">Create a WordPress site associated with your organization:</p>
     <div class="copy-snippet">

--- a/source/_docs/custom-upstream.md
+++ b/source/_docs/custom-upstream.md
@@ -85,11 +85,30 @@ Push the repository to your upstream's remote location.
 
 ### Create the Testing Site
 
-Create a vanilla Drupal or WordPress site associated with your partner organization so you can test the upstream using [Terminus](/docs/terminus/):
+Create a vanilla Drupal or WordPress site using a unique site name that is associated with your partner organization so you can test the upstream using [Terminus](/docs/terminus/):
 
-<div class="copy-snippet">
-  <button class="btn btn-default btn-clippy" data-clipboard-target="#site-create-upstream">Copy</button>
-  <figure><pre id="site-create-upstream"><code class="command nohighlight" data-lang="bash">terminus site:create &lt;site&gt; &lt;label&gt; &lt;upstream&gt; --org=&lt;org&gt;</code></pre></figure>
+
+<ul class="nav nav-tabs" role="tablist">
+  <li id="wptab" role="presentation" class="active"><a href="#drupal" aria-controls="drupal" role="tab" data-toggle="tab">Drupal</a></li>
+  <li id="drupaltab" role="presentation"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+</ul>
+<div class="tab-content">
+  <div role="tabpanel" class="tab-pane active" id="drupal">
+    <!-- Drupal Content -->
+    <p class="instruction">Create a Drupal site associated with your organization:</p>
+    <div class="copy-snippet">
+    <button class="btn btn-default btn-clippy" data-clipboard-target="#vanilla-site-drupal">Copy</button>
+    <figure><pre id="vanilla-site-drupal"><code class="command nohighlight" data-lang="bash">terminus site:create unique-site-name "site label" Drupal --org="org name or UUID"</code></pre></figure>
+    </div>
+  </div>
+  <div role="tabpanel" class="tab-pane" id="wp">
+    <!-- WordPress Content -->
+    <p class="instruction">Create a WordPress site associated with your organization:</p>
+    <div class="copy-snippet">
+    <button class="btn btn-default btn-clippy" data-clipboard-target="#vanilla-site-wordpress">Copy</button>
+    <figure><pre id="vanilla-site-wordpress"><code class="command nohighlight" data-lang="bash">terminus site:create unique-site-name "site label" WordPress --org="org name or UUID"</code></pre></figure>
+    </div>
+  </div>
 </div>
 
 [Clone the Pantheon repository](/docs/git/#clone-your-site-codebase):


### PR DESCRIPTION
https://pantheon.io/docs/custom-upstream/

Updated to demonstrate how to create vanilla WordPress / Drupal site when setting up custom upstream.

