### PR TITLE
Collect sitespeed.io Results Dir as Build Artifacts

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -48,3 +48,7 @@ experimental:
     branches:
       only:
         - master
+
+general: 
+  artifacts:
+    - sitespeed-result


### PR DESCRIPTION
After upgrading to sitespeed.io 4.0, CircleCI stopped collecting the sitespeed results as build artifacts for review. This PR instructs CircleCI to collect the sitespeed.io results dir (relative to the build dir) as artifacts.
