### PR TITLE
Clarify Double-Dash Usage within Command Reference

### DIFF
--- a/source/_docs/terminus/commands.md
+++ b/source/_docs/terminus/commands.md
@@ -35,7 +35,7 @@ permalink: docs/terminus/:basename/
         <td><strong md-highlight-text="searchCommand">{[{ command.name }]}</strong><br><small md-highlight-text="searchCommand">{[{ command.description }]}</small></td>
         <td>
             <li class="terminus-usage">
-            <small md-highlight-text="searchCommand">{[{ command.usage[0] }]}</small>
+            <span style="white-space:pre-line;"><small md-highlight-text="searchCommand">{[{ command.usage[0] }]}</small></span>
             </li>
         </td>
       </tr>

--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -89,9 +89,11 @@ terminusCommandsApp.controller('mainController', function($scope, $http) {
   $http.get('/docs/assets/terminus/commands.json')
     .then(function (response) {
       var data = response.data;
-      var old = JSON.stringify(data).replace(/(<site_env>)/g, "<site>.<env>").replace(/(<site_env_id>)/g, "<site>.<env>").replace(/(<site_id>)/g, "<site>").replace(/(<site_name>)/g, "<site>").replace(/(\[<drush_command>\]\.\.\.)/g, "-- <drush_command>").replace(/(\[<wp_command>\]\.\.\.)/g, "-- <wp_command>");
+
+      var old = JSON.stringify(data).replace(/(<site_env>)/g, "<site>.<env>").replace(/(<site_env_id>)/g, "<site>.<env>").replace(/(<site_id>)/g, "<site>").replace(/(<site_name>)/g, "<site>").replace(/(\[<drush_command>\]\.\.\.)/g, "-- <drush_command>\\n\\nThe double-dash (--) signifies the end of the Terminus options. Everything that comes after the double-dash is interpreted as positional parameters (arguments) and passed to Drush.").replace(/(\[<wp_command>\]\.\.\.)/g, "-- <wp_command>\\n\\nThe double-dash (--) signifies the end of the Terminus options. Everything that comes after the double-dash is interpreted as positional parameters (arguments) and passed to WP-CLI.");
       var newArray = JSON.parse(old);
       $scope.terminus = newArray;
+
   });
   $scope.clearFilters = function(){
       $scope.searchCommand =  undefined;


### PR DESCRIPTION
Closes #2197 

## Effect
PR includes the following changes:
- Inject clarification for double-dash usage within `remote:drush` and `remote:wp` command usage cells.

cc @greg-1-anderson 