### PR TITLE
Update sendgrid.md

### DIFF
--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -109,6 +109,9 @@ You can explore the Statistics and Email Reports from within your site's account
 
 You have now successfully integrated an industrial strength, simple to use, email delivery service into your website. If you have any questions, contact [SendGrid's support team](https://support.sendgrid.com/hc/en-us) or check out SendGrid’s [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/) for advanced tips on how to create and publish DNS records for increased deliverability.
 
+## Troubleshooting
+In some cases, other Wordpress plugins can conflict with the Sendgrid plugin and cause it to use PHPMailer instead of SendGrid.  One such plugin is called [iLightBox](https://codecanyon.net/item/ilightbox-revolutionary-lightbox-for-wordpress/3939523).
+
 ## See Also
 
 - [Prevent Spamming During Drupal Debugging and Testing](/docs/guides/rerouting-outbound-email)

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -110,7 +110,7 @@ You can explore the Statistics and Email Reports from within your site's account
 You have now successfully integrated an industrial strength, simple to use, email delivery service into your website. If you have any questions, contact [SendGrid's support team](https://support.sendgrid.com/hc/en-us) or check out SendGrid’s [Email Infrastructure Guide](http://resources.sendgrid.com/email-infrastructure-guide/) for advanced tips on how to create and publish DNS records for increased deliverability.
 
 ## Troubleshooting
-In some cases, other Wordpress plugins can conflict with the Sendgrid plugin and cause it to use PHPMailer instead of SendGrid.  One such plugin is called [iLightBox](https://codecanyon.net/item/ilightbox-revolutionary-lightbox-for-wordpress/3939523).
+In some cases, other WordPress plugins can conflict with the Sendgrid plugin and cause it to use PHPMailer instead of SendGrid.  One such plugin is called [iLightBox](https://codecanyon.net/item/ilightbox-revolutionary-lightbox-for-wordpress/3939523).
 
 ## See Also
 


### PR DESCRIPTION
From Nick:  Okay, I have isolated the issue. SendGrid breaks specifically when a plugin called "ilightbox" is installed (https://codecanyon.net/item/ilightbox-revolutionary-lightbox-for-wordpress/3939523).

This is a beautiful plugin that really handles photo galleries very well. I've contacted the author about the incompatibility, but have not yet heard back. I'm not sure how many people this would impact, but I suspect that Pantheon would have a vested interest in finding out WHY this incompatibility exists (i.e. what causes it) because it is likely the case that anyone having problems with SendGrid's plugin has another plugin installed that suffers from the same issue.


## Effect
PR includes the following changes:
- Adds a Troubleshooting section to the Sendgrid page

## Remaining Work
- [ ] Find out what exactly breaks the Sendgrid config

