### PR TITLE
Adapt SimpleSAMLphp doc to include WP configuration details

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -29,9 +29,9 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
     git commit -am "Adding SimpleSAML symlink"
     ```
 3. [Generate or install certs](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to Git in `/private/simplesamlphp-1.14.x/cert`.
-4. Set up your `config.php` as follows:
+4. Set up your SimpleSAMLphp `config.php` as follows:
 
-    Enable local sessions to ensure that SimpleSaml can keep a session when used in standalone mode:
+    Enable local sessions to ensure that SimpleSAMLphp can keep a session when used in standalone mode:
 
     ```
     if (!ini_get('session.save_handler')) {

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -44,7 +44,6 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
     ```
     $ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
     $host = $_SERVER['HTTP_HOST'];
-    $drop_id = $ps['conf']['pantheon_binding'];
     $db = $ps['databases']['default']['default'];
     ```
 
@@ -52,7 +51,6 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 
     ```
     $host = $_SERVER['HTTP_HOST'];
-    $drop_id = '';
     $db = array(
       'host'      => $_ENV['DB_HOST'],
       'database'  => $_ENV['DB_NAME'],
@@ -70,7 +68,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
       'certdir' => 'cert/',
       'loggingdir' => 'log/',
       'datadir' => 'data/',
-      'tempdir' => '/srv/bindings/'. $drop_id .'/tmp/simplesaml',
+      'tempdir' => $_ENV['HOME'] . '/tmp/simplesaml',
       Your $config array continues for a while...
       until we get to the "store.type" value, where we put in DB config...
       'store.type' => 'sql',

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -99,6 +99,24 @@ $conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.
 
+## WordPress Configuration
+
+To use SimpleSAMLphp with WordPress, first install and activate the [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) plugin.
+
+Then, to configure the WP SAML Auth plugin to work with SimpleSAMLphp, add the following filter to your theme's `functions.php` file:
+
+```php
+add_filter( 'wp_saml_auth_option', function( $value, $option ){
+  if ( 'simplesamlphp_autoload' === $option ) {
+    // Note: Your path may differ, if you've installed a later SimpleSAMLphp version
+    $value = ABSPATH . '/private/simplesamlphp-1.14.11/lib/_autoload.php';
+  }
+  return $value;
+}, 10, 2 );
+```
+
+For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md).
+
 ## Troubleshooting
 ### Varnish Not Working/Cookie Being Set for Anonymous Users
 

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -39,7 +39,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
     }
     ```
 
-    Load necessary environmental data:
+    Load necessary environmental data. For a Drupal site, you can access `$_SERVER['PRESSFLOW_SETTINGS']`:
 
     ```
     $ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
@@ -48,7 +48,21 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
     $db = $ps['databases']['default']['default'];
     ```
 
-    Set up base config:
+    For a WordPress site, you can access the Pantheon environment variables:
+
+    ```
+    $host = $_SERVER['HTTP_HOST'];
+    $drop_id = '';
+    $db = array(
+      'host'      => $_ENV['DB_HOST'],
+      'database'  => $_ENV['DB_NAME'],
+      'username'  => $_ENV['DB_USER'],
+      'password'  => $_ENV['DB_PASSWORD'],
+      'port'      => $_ENV['DB_PORT'],
+    );
+    ```
+
+    Then, with the basic variables defined, set up base config:
 
     ```
     $config = array (

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -9,7 +9,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 <h3 class="info">Note</h3>
 <p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal site using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p></div>
 
-1. Download [SimpleSAMLphp version 1.11.x](http://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`.
+1. Download [SimpleSAMLphp version 1.11.x](https://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`.
 2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.11.x/www`:
 
     ```

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -77,7 +77,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
       'store.sql.password' => $db['password'],
     ```
 
-5. With configuration completed, add SimpleSaml files to your repository:
+5. With configuration completed, commit the changes to your SimpleSAMLphp files:
 
     ```
     git add private/simplesamlphp-1.14.x

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -35,8 +35,8 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 
     ```
     if (!ini_get('session.save_handler')) {
-  ini_set('session.save_handler', 'file');
-   }
+      ini_set('session.save_handler', 'file');
+    }
     ```
 
     Load necessary environmental data:

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -1,13 +1,13 @@
 ---
 title: Using SimpleSAMLphp with Shibboleth SSO
-description: Using SimpleSAMLphp to configure a single sign-on system for your Drupal site.
+description: Using SimpleSAMLphp to configure a single sign-on system for your Drupal or WordPress site.
 tags: [automate]
 categories: [automate]
 ---
-Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.11/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon.
+Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.11/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
 <div class="alert alert-info" role="alert">
 <h3 class="info">Note</h3>
-<p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal sites on Pantheon using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from drupal.org.</p></div>
+<p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal site using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p></div>
 
 1. Download [SimpleSAMLphp version 1.11.x](http://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`.
 2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.11.x/www`:

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -12,6 +12,15 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 </div>
 
 1. Download [SimpleSAMLphp version 1.14.x](https://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.14.x`.
+
+    ```
+    wget https://simplesamlphp.org/download\?latest -O simplesamlphp-latest.tar.gz
+    mkdir private
+    tar -zxvf simplesamlphp-latest.tar.gz -C private
+    git add private
+    git commit -am "Adding SimpleSAML"
+    ```
+
 2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.14.x/www`:
 
     ```

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -4,20 +4,20 @@ description: Using SimpleSAMLphp to configure a single sign-on system for your D
 tags: [automate]
 categories: [automate]
 ---
-Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.11/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
+Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.14/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
 <div class="alert alert-info" role="alert">
 <h3 class="info">Note</h3>
 <p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal site using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p></div>
 
-1. Download [SimpleSAMLphp version 1.11.x](https://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.11.x`.
-2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.11.x/www`:
+1. Download [SimpleSAMLphp version 1.14.x](https://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.14.x`.
+2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.14.x/www`:
 
     ```
-    ln -s ./private/simplesamlphp-1.11.x/www ./simplesaml
+    ln -s ./private/simplesamlphp-1.14.x/www ./simplesaml
     git add simplesaml
     git commit -am "Adding SimpleSAML symlink"
     ```
-3. [Generate or install certs](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to Git in `/private/simplesamlphp-1.11.x/cert`.
+3. [Generate or install certs](http://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to Git in `/private/simplesamlphp-1.14.x/cert`.
 4. Set up your `config.php` as follows:
 
     Enable local sessions to ensure that SimpleSaml can keep a session when used in standalone mode:
@@ -57,7 +57,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 5. With configuration completed, add SimpleSaml files to your repository:
 
     ```
-    git add private/simplesamlphp-1.11.x
+    git add private/simplesamlphp-1.14.x
     git commit -am "Adding SimpleSaml config files."
     ```
 
@@ -71,7 +71,7 @@ Add the following lines to your `settings.php` so that the Drupal module can loc
 # Decode Pantheon Settings
 $ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
 # Provide universal absolute path to the installation.
-$conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon_binding'] .'/code/private/simplesamlphp-1.11.0';
+$conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon_binding'] .'/code/private/simplesamlphp-1.14.x';
 ```
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -5,9 +5,11 @@ tags: [automate]
 categories: [automate]
 ---
 Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.14/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
+
 <div class="alert alert-info" role="alert">
-<h3 class="info">Note</h3>
-<p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal site using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p></div>
+  <h3 class="info">Note</h3>
+  <p>This is only for advanced users working on integrating a Shibboleth single-sign on system with their Drupal site using the <a href="http://drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p>
+</div>
 
 1. Download [SimpleSAMLphp version 1.14.x](https://simplesamlphp.org/) and add it to your Git repository as `/private/simplesamlphp-1.14.x`.
 2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.14.x/www`:


### PR DESCRIPTION
PR includes the following changes:
- Expands scope of document to include WordPress, in addition to Drupal.
- Updates referenced SimpleSAMLphp version to 1.14.11 (latest stable).
- Includes literal steps for downloading SimpleSAMLphp latest stable.
- Includes WP environment settings and basic configuration instructions, including a pointer to more info.
- Variety of small readability edits.