### PR TITLE
fix up heading typography

### DIFF
--- a/source/_docs/terminus/plugins/directory.md
+++ b/source/_docs/terminus/plugins/directory.md
@@ -17,7 +17,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Build Tools</h3>
+        <h3 class="plugin-title">Build Tools</h3>
           <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
           <p class="topic-info__description">Create a <a href="https://github.com">GitHub</a> PR Workflow to test Pantheon sites on <a href="https://circleci.com/">CircleCI</a> (or other CI services).</p>
           <a href="https://github.com/pantheon-systems/terminus-build-tools-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -31,7 +31,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Composer</h3>
+        <h3 class="plugin-title">Composer</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/rvtraveller">Brian Thompson</a></p>
         <p class="topic-info__description">Run <a href="https://getcomposer.org/">Composer</a> commands on Pantheon sites.</p>
         <a href="https://github.com/pantheon-systems/terminus-composer-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -45,7 +45,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-          <h3>Drupal Console</h3>
+          <h3 class="plugin-title">Drupal Console</h3>
           <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
           <p class="topic-info__description">Run Drupal Console commands on Pantheon sites.</p>
           <a href="https://github.com/pantheon-systems/terminus-drupal-console-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -57,7 +57,7 @@ The following plugins are supported for Terminus 1.0:
   <div style="margin-bottom:30px;" class="col-md-4">
     <div class="plugin-dir">
       <div class="terminus-plugin">
-        <h3>Filer</h3>
+        <h3 class="plugin-title">Filer</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/sean-e-dietrich">Sean Dietrich</a></p>
         <p class="topic-info__description">Open SFTP Connections to your Pantheon Sites.</p>
         <a href="https://github.com/terminus-plugin-project/terminus-filer-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -71,7 +71,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Mass Update</h3>
+        <h3 class="plugin-title">Mass Update</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/ronan">Ronan Dowling</a></p>
         <p class="topic-info__description">Apply upstream updates to a list of sites.</p>
         <a href="https://github.com/pantheon-systems/terminus-mass-update" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -81,7 +81,7 @@ The following plugins are supported for Terminus 1.0:
   <div style="margin-bottom:30px;" class="col-md-4">
     <div class="plugin-dir">
       <div class="terminus-plugin">
-        <h3>Pancakes</h3>
+        <h3 class="plugin-title">Pancakes</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/derimagia">Dave Wikoff</a></p>
         <p class="topic-info__description">Open Pantheon Site Databases in your favorite SQL Client.</p>
         <a href="https://github.com/terminus-plugin-project/terminus-pancakes-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -97,7 +97,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Quicksilver</h3>
+        <h3 class="plugin-title">Quicksilver</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
         <p class="topic-info__description">Install Quicksilver webhooks from the <a href="https://github.com/pantheon-systems/quicksilver-examples">Quicksilver examples</a>, or a personal collection.</p>
         <a href="https://github.com/pantheon-systems/terminus-quicksilver-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -111,7 +111,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Rsync</h3>
+        <h3 class="plugin-title">Rsync</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
         <p class="topic-info__description">Quickly copy files to and from a Pantheon site.</p>
         <a href="https://github.com/pantheon-systems/terminus-rsync-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -125,7 +125,7 @@ The following plugins are supported for Terminus 1.0:
         <p>Pantheon Official</p>
       </div>
       <div class="terminus-plugin">
-        <h3>Secrets</h3>
+        <h3 class="plugin-title">Secrets</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
         <p class="topic-info__description">Manage the <code>secrets.json</code> file for use with Quicksilver.</p>
         <a href="https://github.com/pantheon-systems/terminus-secrets-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
@@ -137,7 +137,7 @@ The following plugins are supported for Terminus 1.0:
   <div style="margin-bottom:30px;" class="col-md-4">
     <div class="plugin-dir">
       <div class="terminus-plugin">
-        <h3>Site Status</h3>
+        <h3 class="plugin-title">Site Status</h3>
         <p class="topic-info__description">Author: <a href="https://github.com/uberhacker">Ed Reel</a></p>
         <p class="topic-info__description">Displays the status of all available Pantheon site environments.</p>
         <a href="https://github.com/terminus-plugin-project/terminus-site-status-plugin" class="btn-primary btn get-plugin">Get Plugin</a>

--- a/source/_docs/terminus/updates.md
+++ b/source/_docs/terminus/updates.md
@@ -7,14 +7,14 @@ layout: terminuspage
 permalink: docs/terminus/:basename/
 ---
 <div class="container col-md-12" ng-app="terminusReleaseApp" ng-controller="terminusReleaseCtrl">
-  <h2> Update to the Current Release: {[{releases[0].name}]}</h2>
+  <h2>Update to the Current Release: {[{releases[0].name}]}</h2>
   <p class="instruction">Navigate to the directory where Terminus was originally installed, then run:</p>
   <div class="copy-snippet">
     <button class="btn btn-default btn-clippy" data-clipboard-target="#terminus-update">Copy</button>
     <figure><pre id="terminus-update"><code class="command bash" data-lang="bash">curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar update</code></pre></figure>
   </div>
   <h2>Troubleshooting</h2>
-  <h3>Nothing to install or update</h3>
+  <h3>Nothing to install or update</h2>
   <p class="instruction">If the update command above returns output indicating that no updates were found, delete the existing Terminus version (e.g. <code>$HOME/terminus</code>) and re-run the install command:</p>
   <div class="copy-snippet">
     <button class="btn btn-default btn-clippy" data-clipboard-target="#terminus-update-fail">Copy</button>
@@ -25,7 +25,7 @@ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/ma
   </div>
   <h2>Changelog</h2>
   <div ng-repeat="release in releases| filter: greaterThan('id', 5224487)">
-    <h2>{[{release.name}]}</h2>
+    <h3>{[{release.name}]}</h3>
     <md ng-model="release.body"></md>
     <hr>
   </div>

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -289,20 +289,24 @@ p{
 }
 
 h1{
+  margin-top: 35px;
   font-family: Avenir-Heavy;
   color: #313945;
   }
 
 h2 {
+  margin-top: 30px;
   font-family: Avenir-Heavy;
   color: #313945;
   }
 
 h3 {
+  margin-top: 25px;
   font-family: Avenir-Heavy;
   color: #44525E;
   }
 h4 {
+  margin-top: 20px;
   font-family: Avenir-Heavy;
   color: #313945;
 }
@@ -4327,6 +4331,9 @@ a.cta.cta-black-on-yellow:after:hover {
 .row-topics-list .topic-info {
   margin: 0 15px 30px;
 }
+.plugin-title {
+  margin-top: 20px;
+}
 
 /*.topic-info > a.topic-info-link {
   display:flex;
@@ -4363,7 +4370,7 @@ a.cta.cta-black-on-yellow:after:hover {
 .topic-info .topic-info__image {
   width: 30%;
   height: 136px;
-  background-size: 70%;
+  background-size: 75%;
   margin:0;
 }
 a.topic-info-link {


### PR DESCRIPTION
Closes #AL-834

## Effect
PR includes the following changes:
Fixed up heading typography to include margins
Also aligned topmost heading with the "contents" heading on the right sidebar
Added a new class for the plugin directory to use the bootstrap margin on its titles, because the new margins were interferring.

## Remaining Work
- [ ] On "version updates" page - adjust the changelog states like fixed, added, deprecated, etc, as those are dynamic and I couldn't affect those on my local version
