### PR TITLE
Remove note and fix link to plugin.

### DIFF
--- a/source/_docs/new-relic.md
+++ b/source/_docs/new-relic.md
@@ -7,12 +7,7 @@ categories: [performance]
 [New Relic APM Pro](http://newrelic.com) offers a wide array of metrics that provide a nearly real-time look into the performance of a web application and is provided to all sites on Pantheon for free. Using New Relic not only makes it easy for you to monitor to your performance, but it can also speed up the support process by helping our support team visualize corresponding performance and symptoms.
 
 ## Activate New Relic APM Pro
-Select the **New Relic** tab on your Site Dashboard, and click **Activate New Relic Pro**. You can also use the [Terminus Omniscient](https://github.com/rvtraveller/terminus-omniscient) plugin to enable New Relic Pro for all sites you have access to by logging in to your Pantheon account and running `terminus sites omniscient`.
-
-<div class="alert alert-info">
-<h3 class="info">Note</h3>
-<p>At this time, the <a href="https://github.com/rvtraveller/terminus-omniscient">Terminus Omniscient</a> plugin supports <a href="/docs/terminus/get-started/legacy">0.13.x versions</a> and below, and has not yet been ported over to Terminus 1.x.</p>
-</div>
+Select the **New Relic** tab on your Site Dashboard, and click **Activate New Relic Pro**. You can also use the [Terminus Omniscient](https://github.com/terminus-plugin-project/terminus-omniscient-plugin/) plugin to enable New Relic Pro for all sites you have access to by logging in to your Pantheon account and running `terminus sites omniscient` for Terminus 0.13.x and `terminus omniscient` for Terminus 1.x.
 
 Visit your site in the browser a couple of times to generate data in New Relic. After a few minutes pass, go to the New Relic workspace on your Dashboard, and click **Go to New Relic**.
 


### PR DESCRIPTION
Closes #2260 

## Effect
PR includes the following changes:
- Removes note about plugin only being valid for Terminus 0.13.x
- Fixes link to plugin to reflect its new home in the Terminus Plugins Project
