### PR TITLE
Update create-wordpress-site-networks.md

### DIFF
--- a/source/_docs/create-wordpress-site-networks.md
+++ b/source/_docs/create-wordpress-site-networks.md
@@ -22,11 +22,7 @@ Before you begin, set the [connection mode to SFTP](/docs/sftp#sftp-mode) for th
 Install WordPress and enable the Multisite feature with the [`wp core multisite-install`](http://wp-cli.org/commands/core/multisite-install/) command.
 
 This command installs and enables multisite by default with the subdirectory configuration. To create your network with the subdomain configuration, add the `--subdomains` option.
-```bash
-terminus wp <site>.<env> -- core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>
-```
 
-For Terminus 1.x use
 ```bash
 terminus remote:wp <site>.<env> -- core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>
 ```

--- a/source/_docs/create-wordpress-site-networks.md
+++ b/source/_docs/create-wordpress-site-networks.md
@@ -25,6 +25,12 @@ This command installs and enables multisite by default with the subdirectory con
 ```bash
 terminus wp <site>.<env> -- core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>
 ```
+
+For Terminus 1.x use
+```bash
+terminus remote:wp <site>.<env> -- core multisite-install --title=<site-title> --admin_user=<username> --admin_password=<password> --admin_email=<email> --url=<url>
+```
+
 If you've already installed WordPress, you can convert it to a network with: [`wp core multisite-convert`](http://wp-cli.org/commands/core/multisite-convert).
 
 ## Add Custom Hostnames to Dev, Test, and Live


### PR DESCRIPTION
added Terminus 1.x version of a command - but maybe we should just remove the older syntax?

Closes #

## Effect
PR includes the following changes:
- syntax add
-
-

## Remaining Work
- [x] Technical Review