### PR TITLE
Recommend --temp-dir=~/tmp/ rather than ../tmp/

### DIFF
--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -52,7 +52,7 @@ export SITE=[YOUR SITE UUID]
 # Site UUID from dashboard URL: https://dashboard.pantheon.io/sites/<UUID>
 
 # To Upload/Import
-rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
+rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
 
 # To Download
 rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/ ~/files
@@ -121,7 +121,7 @@ If you need to upload the files directory from a local installation called Foo i
 ```nohighlight
 $: export ENV=test
 $: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
+$: rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/files/* --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
 ```
 ### Upload a Single File to Pantheon
 This example shows how to upload the logo.png file into a Pantheon site's theme folder.
@@ -129,7 +129,7 @@ This example shows how to upload the logo.png file into a Pantheon site's theme 
 ```nohighlight
 $: export ENV=dev
 $: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
+$: rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
 ```
 ## Known Issues
 


### PR DESCRIPTION
The relative path can cause problems when the target is somewhere other than `files/`. `~` is correctly evaluated as the home directory, e.g. the binding directory, and is therefore the better option.


## Effect
PR includes the following changes:
- Recommend an absolute path for the temporary directory
- see: [#power-users](https://pantheon-community.slack.com/archives/C2GJ3JG7Q/p1490889812894828)

## Remaining Work
- [ ] Review and merge