### PR TITLE
Sendgrid module no longer requires Composer Manager.

### DIFF
--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -46,14 +46,14 @@ Install and activate the latest release through the WordPress dashboard or place
 Your WordPress application is now set up to send email through SendGrid! Complete the fields in the SendGrid Test section of the Settings page and watch the magic work its way to your inbox. For guidance on checking deliverability in SendGrid, see [Checking Deliverability in SendGrid](#deliverability).
 
 ## Drupal
+
 Two methods can be used to integrate SendGrid with your Drupal site: API or SMTP.
 #### Considerations
 - SMTP requests are associated with dynamic outgoing IPs, which can have a negative impact on deliverability.
-- API integration can be problematic on Pantheon due to [Composer Manager](https://www.drupal.org/project/composer_manager) (required by [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration)).
- For more details, see [Modules and Plugins with Known Issues](/docs/unsupported-modules-plugins/#composer-manager).
+- API integration using the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module is recommended; however, installation of this module is slightly more complicated, as it requires the use of [Composer](https://pantheon.io/docs/composer/).
 
 ### SendGrid API Integration
-The SendGrid Integration module is not supported on Drupal 8 sites at this time. This method can be problematic on Pantheon due to [Composer Manager](https://www.drupal.org/project/composer_manager) (required by [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration)).
+A stable release for Drupal 8 is not yet available for the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module. However, the development release seems to work fairly well. Use with caution.
 
 1.  Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
 
@@ -65,17 +65,10 @@ The SendGrid Integration module is not supported on Drupal 8 sites at this time.
 
 3.  Visit `/admin/config/services/sendgrid` once you've logged into your Drupal site as administrator. Paste your API Key and click **Save Settings**.
 
-4.  Implement the suggested [Composer Manager solution](/docs/unsupported-modules-plugins/#composer-manager) to address known issues with the required Composer Manager module.
-
-
-5.  Run the following [Terminus](/docs/terminus) command to install SendGrid Integration dependencies with Composer Manager:
-
-        terminus drush <site>.<env> -- composer-manager install -y
-
 Your Drupal application on Pantheon is now set up to send email through SendGrid's API. Test your configuration from `/admin/config/services/sendgrid/test`.
 
 ### SendGrid SMTP Integration
-Support for Drupal 8 is not yet available for the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module. However, [some users](https://groups.google.com/a/pantheon.io/forum/#!topic/power-users/HxvK7T0MPEM) have reported success with the pre-release version.
+A stable release for Drupal 8 is not yet available for the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module. However, [some users](https://groups.google.com/a/pantheon.io/forum/#!topic/power-users/HxvK7T0MPEM) have reported success with the beta version.
 
 1. Install the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
 


### PR DESCRIPTION
Closes #n/a

## Effect
PR includes the following changes:
- Updates the documentation on the SendGrid module to remove warnings about the Composer Manager module, which is no longer used.
- Makes note that there is a beta release of the SMTP module for Drupal 8 now.

## Remaining Work
- [x] Review and merge
