### PR TITLE
Typos on upstream updates and terminus reset dev script

### DIFF
--- a/source/_docs/terminus/examples.md
+++ b/source/_docs/terminus/examples.md
@@ -178,7 +178,7 @@ echo "Making sure the environment's connection mode is set to Git...";
 terminus connection:set $SITE.dev git
 
 #Identify the most recent commit deployed to Live and overwrite history on Dev's codebase to reflect Live
-echo "Rewritting history on the Dev environment's codebase...";
+echo "Rewriting history on the Dev environment's codebase...";
 git reset --hard `terminus env:code-log $SITE.live --format=string | grep -m1 'live' | cut -f 4`
 
 #Force push to Pantheon to rewrite history on Dev and reset codebase to Live

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -106,7 +106,7 @@ Select the appropriate framework below for your web application, then execute th
 ## Troubleshooting
 
 ### One-Click Updates Do Not Appear After Rewriting Git History
-Squashing and rewritting history may cause one-click updates to break, meaning updates will no longer appear on your Site Dashboard once available. Instead of using squash and rebase to clean up commits from merges occurring upstream, we recommend reviewing history locally with `git log --first-parent`. This provides the same history shown on the Site Dashbord, and prevents conflicts with our one-click updates.
+Squashing and rewriting history may cause one-click updates to break, meaning updates will no longer appear on your Site Dashboard once available. Instead of using squash and rebase to clean up commits from merges occurring upstream, we recommend reviewing history locally with `git log --first-parent`. This provides the same history shown on the Site Dashboard and prevents conflicts with our one-click updates.
 
 ### Manually Resolving Conflicts
 


### PR DESCRIPTION
Fixed typos at:

https://pantheon.io/docs/upstream-updates/#one-click-updates-do-not-appear-after-rewriting-git-history

* rewritting -> rewriting
* Dashbord -> Dashboard

https://pantheon.io/docs/terminus/examples/

* rewritting -> rewriting