### PR TITLE
Update Terminus composer requirement to 1.2.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "behat/mink-selenium2-driver": "1.2",
         "composer/composer": "^1.0@alpha",
         "guzzlehttp/guzzle": "6.2.*@stable",
-        "pantheon-systems/terminus": "1.1.2",
+        "pantheon-systems/terminus": "1.2.*",
         "dflydev/embedded-composer": "^1.0@dev"
     },
     "config": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "7a584c424c47eae518fa2e31acb235d3",
+    "content-hash": "26817e9f746cd2823f872a0121a148ca",
     "packages": [],
     "packages-dev": [
         {
@@ -145,7 +145,7 @@
                 "gherkin",
                 "parser"
             ],
-            "time": "2016-10-30 11:50:56"
+            "time": "2016-10-30T11:50:56+00:00"
         },
         {
             "name": "behat/mink",
@@ -432,12 +432,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/Behat/Transliterator.git",
-                "reference": "02fa32d26934f99cb8a3eff2fe065a1fd53f847b"
+                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/02fa32d26934f99cb8a3eff2fe065a1fd53f847b",
-                "reference": "02fa32d26934f99cb8a3eff2fe065a1fd53f847b",
+                "url": "https://api.github.com/repos/Behat/Transliterator/zipball/826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
+                "reference": "826ce7e9c2a6664c0d1f381cbb38b1fb80a7ee2c",
                 "shasum": ""
             },
             "require": {
@@ -468,7 +468,7 @@
                 "slug",
                 "transliterator"
             ],
-            "time": "2016-10-21 08:46:05"
+            "time": "2017-04-04T11:38:05+00:00"
         },
         {
             "name": "composer/ca-bundle",
@@ -527,7 +527,7 @@
                 "ssl",
                 "tls"
             ],
-            "time": "2017-03-06 11:59:08"
+            "time": "2017-03-06T11:59:08+00:00"
         },
         {
             "name": "composer/composer",
@@ -666,7 +666,7 @@
                 "validation",
                 "versioning"
             ],
-            "time": "2017-02-17 21:53:13"
+            "time": "2017-02-17T21:53:13+00:00"
         },
         {
             "name": "composer/spdx-licenses",
@@ -674,12 +674,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/spdx-licenses.git",
-                "reference": "7fc8d83fc28dd5aa039d5b2a936a7ccf62dd4c51"
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/7fc8d83fc28dd5aa039d5b2a936a7ccf62dd4c51",
-                "reference": "7fc8d83fc28dd5aa039d5b2a936a7ccf62dd4c51",
+                "url": "https://api.github.com/repos/composer/spdx-licenses/zipball/2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
+                "reference": "2603a0d7ddc00a015deb576fa5297ca43dee6b1c",
                 "shasum": ""
             },
             "require": {
@@ -727,7 +727,7 @@
                 "spdx",
                 "validator"
             ],
-            "time": "2017-01-03 08:35:48"
+            "time": "2017-04-03T19:08:52+00:00"
         },
         {
             "name": "consolidation/annotated-command",
@@ -735,22 +735,22 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/annotated-command.git",
-                "reference": "a5c2eb5e812b398188532d19a9d33051f7d92586"
+                "reference": "6672ea38212f8bffb71fec7eadc8b3372154b17e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/a5c2eb5e812b398188532d19a9d33051f7d92586",
-                "reference": "a5c2eb5e812b398188532d19a9d33051f7d92586",
+                "url": "https://api.github.com/repos/consolidation/annotated-command/zipball/6672ea38212f8bffb71fec7eadc8b3372154b17e",
+                "reference": "6672ea38212f8bffb71fec7eadc8b3372154b17e",
                 "shasum": ""
             },
             "require": {
                 "consolidation/output-formatters": "^3.1.5",
                 "php": ">=5.4.0",
                 "phpdocumentor/reflection-docblock": "^2.0|^3.0.2",
-                "psr/log": "~1",
-                "symfony/console": "^2.8 || >=3.0 <3.2.5",
-                "symfony/event-dispatcher": "^2.5|~3",
-                "symfony/finder": "^2.5|~3"
+                "psr/log": "^1",
+                "symfony/console": "^2.8|~3",
+                "symfony/event-dispatcher": "^2.5|^3",
+                "symfony/finder": "^2.5|^3"
             },
             "require-dev": {
                 "phpunit/phpunit": "^4.8",
@@ -779,7 +779,7 @@
                 }
             ],
             "description": "Initialize Symfony Console commands from annotated command class methods.",
-            "time": "2017-03-27 00:03:57"
+            "time": "2017-04-03T22:37:00+00:00"
         },
         {
             "name": "consolidation/log",
@@ -827,7 +827,7 @@
                 }
             ],
             "description": "Improved Psr-3 / Psr\\Log logger based on Symfony Console components.",
-            "time": "2016-07-06 18:40:16"
+            "time": "2016-07-06T18:40:16+00:00"
         },
         {
             "name": "consolidation/output-formatters",
@@ -876,7 +876,7 @@
                 }
             ],
             "description": "Format text by applying transformations provided by plug-in formatters.",
-            "time": "2017-03-19 14:39:43"
+            "time": "2017-03-19T14:39:43+00:00"
         },
         {
             "name": "consolidation/robo",
@@ -884,12 +884,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/consolidation/Robo.git",
-                "reference": "ef94ba90e03d031538f27d9962c34a815b5c39d2"
+                "reference": "619582fd45bf8aa5dc8115e47334aeb22a7ddad6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/consolidation/Robo/zipball/ef94ba90e03d031538f27d9962c34a815b5c39d2",
-                "reference": "ef94ba90e03d031538f27d9962c34a815b5c39d2",
+                "url": "https://api.github.com/repos/consolidation/Robo/zipball/619582fd45bf8aa5dc8115e47334aeb22a7ddad6",
+                "reference": "619582fd45bf8aa5dc8115e47334aeb22a7ddad6",
                 "shasum": ""
             },
             "require": {
@@ -955,7 +955,7 @@
                 }
             ],
             "description": "Modern task runner",
-            "time": "2017-03-31 18:38:39"
+            "time": "2017-04-11T16:25:27+00:00"
         },
         {
             "name": "container-interop/container-interop",
@@ -1090,7 +1090,7 @@
                 "mime",
                 "mimetypes"
             ],
-            "time": "2014-02-21 21:07:58"
+            "time": "2014-02-21T21:07:58+00:00"
         },
         {
             "name": "dflydev/canal",
@@ -1145,7 +1145,7 @@
                 "mime",
                 "type"
             ],
-            "time": "2013-05-14 05:22:25"
+            "time": "2013-05-14T05:22:25+00:00"
         },
         {
             "name": "dflydev/dot-access-configuration",
@@ -1205,7 +1205,7 @@
                 "config",
                 "configuration"
             ],
-            "time": "2016-12-12 17:43:40"
+            "time": "2016-12-12T17:43:40+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1383,7 +1383,7 @@
                 "placeholder",
                 "resolver"
             ],
-            "time": "2012-10-28 21:08:28"
+            "time": "2012-10-28T21:08:28+00:00"
         },
         {
             "name": "dflydev/symfony-finder-factory",
@@ -1436,7 +1436,7 @@
                 "finder",
                 "syfony"
             ],
-            "time": "2012-11-09 16:45:28"
+            "time": "2012-11-09T16:45:28+00:00"
         },
         {
             "name": "dnoegel/php-xdg-base-dir",
@@ -1536,7 +1536,7 @@
                 "singularize",
                 "string"
             ],
-            "time": "2014-12-20 21:24:13"
+            "time": "2014-12-20T21:24:13+00:00"
         },
         {
             "name": "evenement/evenement",
@@ -1582,7 +1582,7 @@
                 "event-dispatcher",
                 "event-emitter"
             ],
-            "time": "2014-07-09 21:08:03"
+            "time": "2014-07-09T21:08:03+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -1638,7 +1638,7 @@
             "keywords": [
                 "scraper"
             ],
-            "time": "2014-10-09 15:52:51"
+            "time": "2014-10-09T15:52:51+00:00"
         },
         {
             "name": "grasmash/yaml-expander",
@@ -1686,7 +1686,7 @@
                 }
             ],
             "description": "Expands internal property references in a yaml file.",
-            "time": "2017-03-24 20:31:04"
+            "time": "2017-03-24T20:31:04+00:00"
         },
         {
             "name": "guzzle/common",
@@ -2001,7 +2001,7 @@
             "keywords": [
                 "promise"
             ],
-            "time": "2017-03-28 16:54:57"
+            "time": "2017-03-28T16:54:57+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -2066,7 +2066,7 @@
                 "uri",
                 "url"
             ],
-            "time": "2017-03-20 17:10:46"
+            "time": "2017-03-20T17:10:46+00:00"
         },
         {
             "name": "instaclick/php-webdriver",
@@ -2124,7 +2124,7 @@
                 "webdriver",
                 "webtest"
             ],
-            "time": "2017-03-22 17:46:51"
+            "time": "2017-03-22T17:46:51+00:00"
         },
         {
             "name": "jakub-onderka/php-console-color",
@@ -2278,20 +2278,20 @@
                 "json",
                 "schema"
             ],
-            "time": "2017-03-22 22:43:35"
+            "time": "2017-03-22T22:43:35+00:00"
         },
         {
             "name": "league/container",
-            "version": "dev-master",
+            "version": "2.x-dev",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/container.git",
-                "reference": "2f3c02f78363b83062637c8aafada273fe2f07bb"
+                "reference": "5ec434f4760d83c2a479266b618fb3e3be24c974"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/container/zipball/2f3c02f78363b83062637c8aafada273fe2f07bb",
-                "reference": "2f3c02f78363b83062637c8aafada273fe2f07bb",
+                "url": "https://api.github.com/repos/thephpleague/container/zipball/5ec434f4760d83c2a479266b618fb3e3be24c974",
+                "reference": "5ec434f4760d83c2a479266b618fb3e3be24c974",
                 "shasum": ""
             },
             "require": {
@@ -2311,7 +2311,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev",
+                    "dev-2.x": "2.x-dev",
                     "dev-1.x": "1.x-dev"
                 }
             },
@@ -2343,7 +2343,7 @@
                 "provider",
                 "service"
             ],
-            "time": "2016-10-12 13:50:38"
+            "time": "2017-03-06T15:24:06+00:00"
         },
         {
             "name": "michelf/php-markdown",
@@ -2442,7 +2442,7 @@
                 "plaintext",
                 "textile"
             ],
-            "time": "2014-04-08 11:47:50"
+            "time": "2014-04-08T11:47:50+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -2450,12 +2450,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d"
+                "reference": "c3cbf079466fad893e576d072c1f9daebfe04f95"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
-                "reference": "2b9e2f71b722f7c53918ab0c25f7646c2013f17d",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c3cbf079466fad893e576d072c1f9daebfe04f95",
+                "reference": "c3cbf079466fad893e576d072c1f9daebfe04f95",
                 "shasum": ""
             },
             "require": {
@@ -2493,20 +2493,20 @@
                 "parser",
                 "php"
             ],
-            "time": "2017-03-05 18:23:57"
+            "time": "2017-04-09T17:49:47+00:00"
         },
         {
             "name": "pantheon-systems/terminus",
-            "version": "1.1.2",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/terminus.git",
-                "reference": "75b0b9951e4993d578ab5c8b7eee05b8aaf1f285"
+                "reference": "657e4d16eb20dc1f8dee6c10ac1ab10f1a20b5a3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/terminus/zipball/75b0b9951e4993d578ab5c8b7eee05b8aaf1f285",
-                "reference": "75b0b9951e4993d578ab5c8b7eee05b8aaf1f285",
+                "url": "https://api.github.com/repos/pantheon-systems/terminus/zipball/657e4d16eb20dc1f8dee6c10ac1ab10f1a20b5a3",
+                "reference": "657e4d16eb20dc1f8dee6c10ac1ab10f1a20b5a3",
                 "shasum": ""
             },
             "require": {
@@ -2555,7 +2555,7 @@
                 "terminus",
                 "wordpress"
             ],
-            "time": "2017-04-01T06:39:32+00:00"
+            "time": "2017-04-11T00:37:01+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",
@@ -2609,7 +2609,7 @@
                 "reflection",
                 "static analysis"
             ],
-            "time": "2015-12-27 11:43:31"
+            "time": "2015-12-27T11:43:31+00:00"
         },
         {
             "name": "phpdocumentor/reflection-docblock",
@@ -2750,7 +2750,7 @@
                 "container-interop",
                 "psr"
             ],
-            "time": "2017-02-14 16:28:37"
+            "time": "2017-02-14T16:28:37+00:00"
         },
         {
             "name": "psr/http-message",
@@ -2800,7 +2800,7 @@
                 "request",
                 "response"
             ],
-            "time": "2016-08-06 14:39:51"
+            "time": "2016-08-06T14:39:51+00:00"
         },
         {
             "name": "psr/log",
@@ -2847,7 +2847,7 @@
                 "psr",
                 "psr-3"
             ],
-            "time": "2016-10-10 12:19:37"
+            "time": "2016-10-10T12:19:37+00:00"
         },
         {
             "name": "psy/psysh",
@@ -2928,12 +2928,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/reactphp/event-loop.git",
-                "reference": "9504651a742f6204126f10201f26dad413406115"
+                "reference": "47fe726e8de359bc44d92630764023bdc2902a2e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/9504651a742f6204126f10201f26dad413406115",
-                "reference": "9504651a742f6204126f10201f26dad413406115",
+                "url": "https://api.github.com/repos/reactphp/event-loop/zipball/47fe726e8de359bc44d92630764023bdc2902a2e",
+                "reference": "47fe726e8de359bc44d92630764023bdc2902a2e",
                 "shasum": ""
             },
             "require": {
@@ -2962,7 +2962,7 @@
                 "asynchronous",
                 "event-loop"
             ],
-            "time": "2017-03-27 13:30:35"
+            "time": "2017-04-04T09:26:15+00:00"
         },
         {
             "name": "react/http",
@@ -3002,7 +3002,7 @@
             "keywords": [
                 "http"
             ],
-            "time": "2017-02-13 14:12:50"
+            "time": "2017-02-13T14:12:50+00:00"
         },
         {
             "name": "react/promise",
@@ -3048,7 +3048,7 @@
                 "promise",
                 "promises"
             ],
-            "time": "2017-03-25 12:08:31"
+            "time": "2017-03-25T12:08:31+00:00"
         },
         {
             "name": "react/socket",
@@ -3090,7 +3090,7 @@
             "keywords": [
                 "Socket"
             ],
-            "time": "2017-01-26 09:23:38"
+            "time": "2017-01-26T09:23:38+00:00"
         },
         {
             "name": "react/stream",
@@ -3134,7 +3134,7 @@
                 "pipe",
                 "stream"
             ],
-            "time": "2017-01-25 14:44:14"
+            "time": "2017-01-25T14:44:14+00:00"
         },
         {
             "name": "ringcentral/psr7",
@@ -3327,7 +3327,7 @@
             "license": [
                 "MIT"
             ],
-            "time": "2017-02-27 17:40:03"
+            "time": "2017-02-27T17:40:03+00:00"
         },
         {
             "name": "seld/cli-prompt",
@@ -3375,7 +3375,7 @@
                 "input",
                 "prompt"
             ],
-            "time": "2017-03-18 11:32:45"
+            "time": "2017-03-18T11:32:45+00:00"
         },
         {
             "name": "seld/jsonlint",
@@ -3468,7 +3468,7 @@
             "keywords": [
                 "phra"
             ],
-            "time": "2015-10-13 18:44:15"
+            "time": "2015-10-13T18:44:15+00:00"
         },
         {
             "name": "squizlabs/php_codesniffer",
@@ -3476,12 +3476,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "db16df76c10d9d665c5e3188a67a400555331610"
+                "reference": "f1511adad043edfd6d2e595e77385c32577eb2bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/db16df76c10d9d665c5e3188a67a400555331610",
-                "reference": "db16df76c10d9d665c5e3188a67a400555331610",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f1511adad043edfd6d2e595e77385c32577eb2bc",
+                "reference": "f1511adad043edfd6d2e595e77385c32577eb2bc",
                 "shasum": ""
             },
             "require": {
@@ -3546,7 +3546,7 @@
                 "phpcs",
                 "standards"
             ],
-            "time": "2017-04-03 05:23:47"
+            "time": "2017-04-10T05:00:20+00:00"
         },
         {
             "name": "symfony/browser-kit",
@@ -3603,7 +3603,7 @@
             ],
             "description": "Symfony BrowserKit Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21 08:33:48"
+            "time": "2017-02-21T08:33:48+00:00"
         },
         {
             "name": "symfony/class-loader",
@@ -3656,7 +3656,7 @@
             ],
             "description": "Symfony ClassLoader Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18 19:13:35"
+            "time": "2017-02-18T19:13:35+00:00"
         },
         {
             "name": "symfony/config",
@@ -3664,12 +3664,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/config.git",
-                "reference": "06ce6bb46c24963ec09323da45d0f4f85d3cecd2"
+                "reference": "35b7dfa089d7605eb1fdd46281b3070fb9f38750"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/config/zipball/06ce6bb46c24963ec09323da45d0f4f85d3cecd2",
-                "reference": "06ce6bb46c24963ec09323da45d0f4f85d3cecd2",
+                "url": "https://api.github.com/repos/symfony/config/zipball/35b7dfa089d7605eb1fdd46281b3070fb9f38750",
+                "reference": "35b7dfa089d7605eb1fdd46281b3070fb9f38750",
                 "shasum": ""
             },
             "require": {
@@ -3712,7 +3712,7 @@
             ],
             "description": "Symfony Config Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-01 18:13:50"
+            "time": "2017-04-04T15:24:26+00:00"
         },
         {
             "name": "symfony/console",
@@ -3720,12 +3720,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "3e0b0cb5d669a7d39dd85050910af6ee77e40e7e"
+                "reference": "1511d2677c1285d3450b6b2fb1f3c83c14e32ccc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/3e0b0cb5d669a7d39dd85050910af6ee77e40e7e",
-                "reference": "3e0b0cb5d669a7d39dd85050910af6ee77e40e7e",
+                "url": "https://api.github.com/repos/symfony/console/zipball/1511d2677c1285d3450b6b2fb1f3c83c14e32ccc",
+                "reference": "1511d2677c1285d3450b6b2fb1f3c83c14e32ccc",
                 "shasum": ""
             },
             "require": {
@@ -3773,7 +3773,7 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-27 14:49:15"
+            "time": "2017-04-11T09:19:47+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3826,7 +3826,7 @@
             ],
             "description": "Symfony CssSelector Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21 08:33:48"
+            "time": "2017-02-21T08:33:48+00:00"
         },
         {
             "name": "symfony/debug",
@@ -3834,12 +3834,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/debug.git",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc"
+                "reference": "58552db096415d1b052a05630db333c33923358f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/debug/zipball/e90099a2958d4833a02d05b504cc06e1c234abcc",
-                "reference": "e90099a2958d4833a02d05b504cc06e1c234abcc",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/58552db096415d1b052a05630db333c33923358f",
+                "reference": "58552db096415d1b052a05630db333c33923358f",
                 "shasum": ""
             },
             "require": {
@@ -3883,7 +3883,7 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-18 19:13:35"
+            "time": "2017-04-09T18:13:48+00:00"
         },
         {
             "name": "symfony/dependency-injection",
@@ -3891,12 +3891,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/dependency-injection.git",
-                "reference": "a5f3f1265731c33906a725c6f321cb93c2b49f67"
+                "reference": "e5a5c1c7b70649a356a53923c892156aea780c18"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/a5f3f1265731c33906a725c6f321cb93c2b49f67",
-                "reference": "a5f3f1265731c33906a725c6f321cb93c2b49f67",
+                "url": "https://api.github.com/repos/symfony/dependency-injection/zipball/e5a5c1c7b70649a356a53923c892156aea780c18",
+                "reference": "e5a5c1c7b70649a356a53923c892156aea780c18",
                 "shasum": ""
             },
             "require": {
@@ -3946,7 +3946,7 @@
             ],
             "description": "Symfony DependencyInjection Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-21 21:39:01"
+            "time": "2017-04-11T09:19:47+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -4002,7 +4002,7 @@
             ],
             "description": "Symfony DomCrawler Component",
             "homepage": "https://symfony.com",
-            "time": "2017-02-21 08:33:48"
+            "time": "2017-02-21T08:33:48+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -4010,12 +4010,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "cd88acb5563c690bb02c21b5d7aa801af2520095"
+                "reference": "88b65f0ac25355090e524aba4ceb066025df8bd2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/cd88acb5563c690bb02c21b5d7aa801af2520095",
-                "reference": "cd88acb5563c690bb02c21b5d7aa801af2520095",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/88b65f0ac25355090e524aba4ceb066025df8bd2",
+                "reference": "88b65f0ac25355090e524aba4ceb066025df8bd2",
                 "shasum": ""
             },
             "require": {
@@ -4062,7 +4062,7 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-21 21:39:01"
+            "time": "2017-04-03T20:37:06+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -4111,7 +4111,7 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-26 15:40:40"
+            "time": "2017-03-26T15:40:40+00:00"
         },
         {
             "name": "symfony/finder",
@@ -4160,7 +4160,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-20 08:46:40"
+            "time": "2017-03-20T08:46:40+00:00"
         },
         {
             "name": "symfony/http-foundation",
@@ -4213,7 +4213,7 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-01-08 20:43:43"
+            "time": "2017-01-08T20:43:43+00:00"
         },
         {
             "name": "symfony/http-kernel",
@@ -4221,12 +4221,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "8a8fb97a90670d909b1be5ce188970c94d179987"
+                "reference": "426cf280c4c4679268ba17050e2d0004e6a16517"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8a8fb97a90670d909b1be5ce188970c94d179987",
-                "reference": "8a8fb97a90670d909b1be5ce188970c94d179987",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/426cf280c4c4679268ba17050e2d0004e6a16517",
+                "reference": "426cf280c4c4679268ba17050e2d0004e6a16517",
                 "shasum": ""
             },
             "require": {
@@ -4295,7 +4295,7 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-22 20:13:53"
+            "time": "2017-04-05T04:19:23+00:00"
         },
         {
             "name": "symfony/polyfill-apcu",
@@ -4348,7 +4348,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -4407,7 +4407,7 @@
                 "portable",
                 "shim"
             ],
-            "time": "2016-11-14 01:06:16"
+            "time": "2016-11-14T01:06:16+00:00"
         },
         {
             "name": "symfony/process",
@@ -4456,7 +4456,7 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-04 12:20:59"
+            "time": "2017-03-04T12:20:59+00:00"
         },
         {
             "name": "symfony/translation",
@@ -4464,12 +4464,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "047e97a64d609778cadfc76e3a09793696bb19f1"
+                "reference": "d1775915626b647ce546aef97028a53ca32fe512"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/047e97a64d609778cadfc76e3a09793696bb19f1",
-                "reference": "047e97a64d609778cadfc76e3a09793696bb19f1",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/d1775915626b647ce546aef97028a53ca32fe512",
+                "reference": "d1775915626b647ce546aef97028a53ca32fe512",
                 "shasum": ""
             },
             "require": {
@@ -4520,7 +4520,7 @@
             ],
             "description": "Symfony Translation Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-21 21:39:01"
+            "time": "2017-04-05T21:34:00+00:00"
         },
         {
             "name": "symfony/var-dumper",
@@ -4528,12 +4528,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "b7864e4627e25f48d341558d7001c2e9ceacbc1c"
+                "reference": "04dde58b9d925d52e3301196ef2e83e81025c2f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/b7864e4627e25f48d341558d7001c2e9ceacbc1c",
-                "reference": "b7864e4627e25f48d341558d7001c2e9ceacbc1c",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/04dde58b9d925d52e3301196ef2e83e81025c2f5",
+                "reference": "04dde58b9d925d52e3301196ef2e83e81025c2f5",
                 "shasum": ""
             },
             "require": {
@@ -4586,7 +4586,7 @@
                 "debug",
                 "dump"
             ],
-            "time": "2017-03-25 14:07:47"
+            "time": "2017-04-10T06:31:22+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -4594,12 +4594,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "286d84891690b0e2515874717e49360d1c98a703"
+                "reference": "86219ff2bfc2fc0ce79860292eaea79f24469eda"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/286d84891690b0e2515874717e49360d1c98a703",
-                "reference": "286d84891690b0e2515874717e49360d1c98a703",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/86219ff2bfc2fc0ce79860292eaea79f24469eda",
+                "reference": "86219ff2bfc2fc0ce79860292eaea79f24469eda",
                 "shasum": ""
             },
             "require": {
@@ -4635,7 +4635,7 @@
             ],
             "description": "Symfony Yaml Component",
             "homepage": "https://symfony.com",
-            "time": "2017-03-20 09:41:44"
+            "time": "2017-04-11T09:19:47+00:00"
         },
         {
             "name": "twig/extensions",
@@ -4687,7 +4687,7 @@
                 "i18n",
                 "text"
             ],
-            "time": "2017-01-09 14:44:40"
+            "time": "2017-01-09T14:44:40+00:00"
         },
         {
             "name": "twig/twig",
@@ -4695,12 +4695,12 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/twigphp/Twig.git",
-                "reference": "c622995d6da98d41ad50b3c5d366b8ebf6491f27"
+                "reference": "dc70f3e826d8783b07eec2997dd3e6ca0b44ad1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/twigphp/Twig/zipball/c622995d6da98d41ad50b3c5d366b8ebf6491f27",
-                "reference": "c622995d6da98d41ad50b3c5d366b8ebf6491f27",
+                "url": "https://api.github.com/repos/twigphp/Twig/zipball/dc70f3e826d8783b07eec2997dd3e6ca0b44ad1f",
+                "reference": "dc70f3e826d8783b07eec2997dd3e6ca0b44ad1f",
                 "shasum": ""
             },
             "require": {
@@ -4749,7 +4749,7 @@
             "keywords": [
                 "templating"
             ],
-            "time": "2017-03-22 15:40:48"
+            "time": "2017-04-05T23:23:01+00:00"
         },
         {
             "name": "webignition/internet-media-type",
@@ -4931,7 +4931,7 @@
                 "check",
                 "validate"
             ],
-            "time": "2016-11-23 20:04:41"
+            "time": "2016-11-23T20:04:41+00:00"
         }
     ],
     "aliases": [


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Update to the most recent release of Terminus 1.2.x
 - Automatically updates the commands ref page (adds `backup:info`) and ups the current release from 1.1.2 to 1.2.1

@alexfornuto can you review and merge?
