### PR TITLE
Visual Composer unsupported WordPress plugin

### DIFF
--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -326,7 +326,9 @@ An alternative solution is to [create a symbolic link](/docs/assuming-write-acce
 
 **Solution**: [Upgrade your site's PHP version](/docs/php-versions) to 5.5, 5.6, or 7.0.
 <hr>
-
+### [Visual Composer: Page Builder](https://vc.wpbakery.com/)
+**Issue**: This plugin requires write access to the site's codebase for editing files, which is not granted on Test and Live environments by design.
+<hr>
 ### [Wordfence](https://wordpress.org/plugins/wordfence/)
 **Issue #1**: Enabling the Live Traffic tracking feature within Wordfence sends cookies which conflict with Varnish.
 


### PR DESCRIPTION
Visual Composer requires filesystem access (uses request_filesystem_credentials()) and is not supported on Pantheon.

![screenshot 2017-04-18 08 28 31](https://cloud.githubusercontent.com/assets/24276107/25133452/56409776-2412-11e7-8415-2a6633b7b9d0.png)

Live site gives this on site home page after enabling plugin:

![screenshot 2017-04-18 08 22 08](https://cloud.githubusercontent.com/assets/24276107/25133492/6e7f0e80-2412-11e7-8670-60a65629b8c5.png)
