### PR TITLE
ignore vim swp files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ shots/
 npm-debug.log
 /source/docs/assets/terminus/commands.json
 /source/docs/assets/terminus/releases.json
+*.swp

--- a/app/config/sculpin_kernel.yml
+++ b/app/config/sculpin_kernel.yml
@@ -1,4 +1,5 @@
 sculpin:
+    ignore: ["*.swp"]
 sculpin_theme:
     theme: sculpin/bootstrap-3-blog-theme
 sculpin_content_types:


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds `*.swp` to `.gitignore`
- Adds `*.swp` to Sculpin's ignore, to prevent the dev environment from crashing when the file is removed.
- These files are created while editing in `vim.

## Remaining Work
- [x] Peer review
