### PR TITLE
Add Drupal 8 settings.php configuration snippet

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -94,13 +94,13 @@ Add the following lines to `settings.php` so that the Drupal module can locate S
 For Drupal 7 sites:
 ```php
 # Provide universal absolute path to the installation.
-$conf['simplesamlphp_auth_installdir'] = $_SERVER['HOME'] .'/code/private/simplesamlphp-1.14.x';
+$conf['simplesamlphp_auth_installdir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.14.x';
 ```
 
 For Drupal 8 sites:
 ```php
 # Provide universal absolute path to the installation.
-$settings['simplesamlphp_dir'] = $_SERVER['HOME'] .'/code/private/simplesamlphp-1.14.x';
+$settings['simplesamlphp_dir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.14.x';
 ```
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -91,11 +91,20 @@ You can now visit the subdirectory `/simplesaml` on your development site and co
 
 Add the following lines to `settings.php` so that the Drupal module can locate SimpleSAMLphp:
 
+For Drupal 7 sites:
 ```php
 # Decode Pantheon Settings
 $ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
 # Provide universal absolute path to the installation.
 $conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon_binding'] .'/code/private/simplesamlphp-1.14.x';
+```
+
+For Drupal 8 sites:
+```php
+# Decode Pantheon Settings
+$ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
+# Provide universal absolute path to the installation.
+$settings['simplesamlphp_dir'] = $_SERVER['HOME'] .'/code/private/simplesamlphp-1.14.x';
 ```
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -93,16 +93,12 @@ Add the following lines to `settings.php` so that the Drupal module can locate S
 
 For Drupal 7 sites:
 ```php
-# Decode Pantheon Settings
-$ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
 # Provide universal absolute path to the installation.
-$conf['simplesamlphp_auth_installdir'] = '/srv/bindings/'. $ps['conf']['pantheon_binding'] .'/code/private/simplesamlphp-1.14.x';
+$conf['simplesamlphp_auth_installdir'] = $_SERVER['HOME'] .'/code/private/simplesamlphp-1.14.x';
 ```
 
 For Drupal 8 sites:
 ```php
-# Decode Pantheon Settings
-$ps = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
 # Provide universal absolute path to the installation.
 $settings['simplesamlphp_dir'] = $_SERVER['HOME'] .'/code/private/simplesamlphp-1.14.x';
 ```


### PR DESCRIPTION
The Drupal configuration appears to be just for D7 sites. I had to tinker around/read the D8 module's README.md in order to get the module to recognize the library and become enabled. I am not sure this is the best/recommended method but it appears to work, at least for me.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
