### PR TITLE
Correct terminus syntax for exporting D8 config files

### DIFF
--- a/source/_docs/solr-drupal-8.md
+++ b/source/_docs/solr-drupal-8.md
@@ -69,7 +69,7 @@ After adding fields the configuration, make sure the index is full by clicking *
 It is a best practice in Drupal 8 to export your changes to `yml` files. You can quickly export configuration changes via [Terminus](/docs/terminus):
 
 ```
-terminus <site>.dev drush "config-export -y"
+terminus drush <site>.dev -- config-export -y
 ```
 
 #### Search the Index


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- corrects syntax found under 'Export Configuration' in https://pantheon.io/docs/solr-drupal-8/#3.-configure-solr
