### PR TITLE
Fixes terminus command to the correct site.env call

### DIFF
--- a/source/_docs/database-workflow.md
+++ b/source/_docs/database-workflow.md
@@ -31,13 +31,13 @@ The Site Dashboard runs `wp search-replace` during the cloning workflow to updat
 
 To resolve this issue, use [Terminus](/docs/terminus) to run an additional `wp search-replace` command on the target environment after cloning:
 ```
-terminus remote:wp <env>.<site> -- search-replace '://live-example.pantheonsite.io' '://test.example.com' --all-tables --verbose
+terminus remote:wp <site>.<env> -- search-replace '://live-example.pantheonsite.io' '://test.example.com' --all-tables --verbose
 ```
 
 The following example also converts the URL from HTTP to HTTPS, for situations where you might have HTTPS in one environment and not another:
 
 ```
-terminus remote:wp <env>.<site> -- search-replace 'https://live-example.pantheonsite.io' 'http://test.example.com' --all-tables --verbose
+terminus remote:wp <site>.<env> -- search-replace 'https://live-example.pantheonsite.io' 'http://test.example.com' --all-tables --verbose
 ```
 
 ### Base table or view not found


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Fixes terminus command to \<site\>.\<env\> instead of \<env\>.\<site\>
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
