### PR TITLE
Clarify next steps after adding "web_docroot: true"

### DIFF
--- a/source/_docs/nested-docroot.md
+++ b/source/_docs/nested-docroot.md
@@ -40,13 +40,12 @@ Below we recommend using Git, but you can also use SFTP to set your site up for 
   ```
 
 5. Add, commit, and push the `pantheon.yml` file with Git.
+6. Follow the instructions in either [Create a New Site with a Nested Docroot](#create-a-new-site-with-a-nested-docroot) or [Convert an Existing Site to Use a Nested Docroot](#convert-an-existing-site-to-use-a-nested-docroot) below.
 
 ### Create a New Site with a Nested Docroot
 If your site utilizes a [Custom Upstream](/docs/custom-upstream/) with a `pantheon.yml` file that enables nested docroot and the CMS code is in a web subdirectory, you are good to go! Otherwise, create a new site and follow the steps below.
 
 ### Convert an Existing Site to Use a Nested Docroot
-
-
 You'll need to move the CMS code into the `web` subdirectory, either manually or by using one of the commands below:
 
 <!-- Nav tabs -->


### PR DESCRIPTION
When I tried following these with an existing Drupal 8 site, I got through step 5 and immediately started testing my site on the Pantheon dev environment. I could've used a step 6 that told me I would have to follow one of the headers that followed. I've added a suggestion for that step here. Hope it helps!

Closes #

## Effect
PR includes the following changes:
- Adds a "step 6" to make clear what one should do after "Add, commit, and push the pantheon.yml file with Git."

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
