### PR TITLE
Public Distribution Update

### DIFF
--- a/source/_docs/drupal-export.md
+++ b/source/_docs/drupal-export.md
@@ -24,7 +24,7 @@ When preparing a site for export, there are a few best practices to follow:
 
 To log back into your imported site that is in maintenance mode, just go to /user/login and login as UID 1 (the first administrative user).
 
-<div class="alert alert-danger" role="alert"><h4 class="info">Warning </h4><p>Importing automatically upgrades to the latest version of core. It's a best practice to keep core up-to-date to benefit from security and bug fixes, but if you use a site or distribution that relies on an outdated version of core, you may experience incompatibilities. If you experience issues, see the troubleshooting documentation for your <a href="https://codex.wordpress.org/Updating_WordPress#Troubleshooting">WordPress</a> or <a href="https://www.drupal.org/troubleshooting"> Drupal</a> upstream.</p></div>
+<div class="alert alert-danger" role="alert"><h4 class="info">Warning </h4><p>Importing automatically upgrades to the latest version of core. It's a best practice to keep core up-to-date to benefit from security and bug fixes, but if your site relies on an outdated version of core, you may experience incompatibilities. If you experience issues, see the troubleshooting documentation for your <a href="https://codex.wordpress.org/Updating_WordPress#Troubleshooting">WordPress</a> or <a href="https://www.drupal.org/troubleshooting"> Drupal</a> upstream.</p></div>
 
 ## Create Archive Using Backup and Migrate
 Create single-file archives for sites hosted elsewhere or locally with the [Backup and Migrate](https://www.drupal.org/project/backup_migrate) module. When creating the archive, choose to backup your **entire site (code, files, & DB)**. Download the archive and/or send it to NodeSquirrel for a publicly accessible URL.

--- a/source/_docs/guides/getting-started/03-create-new-site.md
+++ b/source/_docs/guides/getting-started/03-create-new-site.md
@@ -36,7 +36,7 @@ In this lesson, we’re going to create and configure a new WordPress or Drupal 
 
 2. Select **<span class="glyphicons glyphicons-plus" aria-hidden="true"></span> Create New Site**. You’ll be asked to name this site and, if you’re part of an agency, associate this site with your organization.
 
-3. Select **Continue** to choose from the available default site frameworks and public distributions.
+3. Select **Continue** to choose from the available site frameworks.
 
     <div class="alert alert-info">
     <h4 class="info">Note</h4>

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -19,7 +19,7 @@ Regardless of what type of update you're preparing for release, you'll want to t
 2. Name your site.
 3. Select your organization from the dropdown menu.
 4. Click **Create Site**.
-5. Select your Custom Upstream from the Organization Distribution framework options.
+5. Select the desired repository from the Custom Upstream options.
 6. Click **Visit your Pantheon Dashboard**.
 7. Click **Visit Development Site** and complete the installation process for the selected framework.
 

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -111,8 +111,6 @@ For detailed information, see [Installing Redis on WordPress](/docs/wordpress-re
 
         }
 
-    <div class="alert alert-info">
-    <h4 class="info">Note</h4><p>Distributions may vary in their directory structure. You will need to check the path at which the Redis module resides and change any paths in the snippet above to match your path.</p></div>
 
 7. Enable the module via `admin/build/modules`. This is necessary for cache clearing to work in all cases.
 
@@ -239,7 +237,7 @@ The best and easiest way to update your core is by using Pantheon administration
 
 ### Fatal Error: require\_once()
 
-Distributions may vary in their directory structure. You will need to check the path at which the Redis module resides and change any paths in the example code snippet to match your path to the Redis module. The error would look something like this:
+This is likely due to some variance in your site's directory structure. You will need to check the path at which the Redis module resides and change any paths in the example code snippet to match your path to the Redis module. The error would look something like this:
 ```bash
 Fatal error: require_once(): Failed opening required
 '/srv/bindings/xxxxxxxxx/code/sites/all/modules/redis/redis.autoload.inc'
@@ -312,4 +310,3 @@ sftp> ls -la logs/
 #### I restored my site (or imported a database backup) and now my site won't come back.
 
 When you replace the database with one that doesn't match the redis cache, it can cause database errors on the site, and you may be unable to clear the cache via the dashboard. To resolve the issue, [flush your redis cache from the command line](#clear-cache).
-

--- a/source/_docs/start-state.md
+++ b/source/_docs/start-state.md
@@ -4,48 +4,14 @@ description: See available options for starting new Drupal or WordPress sites an
 tags: [create]
 categories: []
 ---
-The site's framework is designated during the creation process on Pantheon. Available installations include WordPress and Drupal core, in addition to several publicly maintained distributions. [Custom Upstreams](/docs/custom-upstream/) that have been added to the platform will be available to members when an organization affiliation has been set.
+The site's framework is selected during the creation process. Pantheon Upstreams provide default installations of WordPress, Drupal 8 and Drupal 7. [Custom Upstreams](/docs/custom-upstream/) are available to team members when the organization is associated during site creation.
 
-<div class="alert alert-info" role="alert">
-<h4 class="info">Note</h4>
-<p>It is not possible to change the upstream of an existing site. Instead, you must create a new site with the desired upstream.</p>
-</div>
-
-## Start with Core
-Starting with core gives you a blank site with the code pulled from the [Pantheon repository on GitHub](https://github.com/pantheon-systems). It's up to you to build from there.
-
-This is useful if you are starting a new project, or if you have sophisticated Git use case such as a site-build that uses drush_make or the desire to import an existing Git project to preserve its history. See the [import instructions](/docs/start-state#importing-an-existing-site) for more information.
-
-We base our repository on the canonical source from drupal.org, and then extend it with [Pressflow](http://pressflow.org/) modifications and additional features to take advantage of the Pantheon runtime environment. The WordPress repository includes platform integration plugins and a pre-configured wp-config.php.
+## Pantheon Upstreams
+We base our Drupal 7 repository on the canonical source from drupal.org, and then extend it with [Pressflow](http://pressflow.org/) modifications and additional features to take advantage of the Pantheon runtime environment. The WordPress repository includes platform integration plugins and a pre-configured `wp-config.php`.
 
 - [WordPress](https://github.com/pantheon-systems/WordPress)
 - [Drupal 8](https://github.com/pantheon-systems/drops-8) <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Install Requires SFTP Mode"><em class="fa fa-info-circle"></em></a>
 - [Drupal 7](https://github.com/pantheon-systems/drops-7)
-
-## Start with a Public Distribution
-We include a growing number of "Drupal products" as available start-states on Pantheon. These are also known as installation profiles or distributions and contain much more functionality than a Drupal core installation.
-
-Drupal distributions offer a much richer out of the box experience, but are more complex under the hood. You still have access to 100% of the code with a Drupal product, but the increased complexity means it can be more challenging to customize and extend.
-
-<div class="alert alert-info" role="alert">
-<h4 class="info">Note</h4>
-<p>Public distributions are not maintained by Pantheon. If the upstream is out of date, contact the maintainer through <a href="https://www.drupal.org">Drupal.org</a> or the distribution's GitHub issue queue.
-</p></div>
-
-
-- [CiviCRM Starter Kit](https://github.com/kreynen/civicrm-starterkit-drops-7) <a rel="popover" data-toggle="tooltip" data-proofer-ignore data-html="true" data-content="Install Requires SFTP Mode"><em class="fa fa-info-circle"></em></a>
-- [DKAN](https://github.com/NuCivic/dkan-drops-7)
-- [Commerce Kickstart](https://github.com/commerceguys/kickstart-drops-7)
-- [OpenAid](https://bitbucket.org/joelsteidl/openaid-drops-7)
-- [Atrium](https://github.com/phase2/openatrium-drops-6)
-- [OpenIdeaL](https://github.com/linnovate/openideal-on-drops-7)
-- [Open Outreach](https://github.com/nedjo/openoutreach-drops-7)
-- [OpenPublic](https://github.com/phase2/openpublic-drops-7)
-- [Panopoly](https://github.com/populist/panopoly-drops-7)
-- [Plato Típico](https://github.com/enzolutions/plato_tipico)
-- [Pushtape](https://github.com/zirafa/pushtape-drops-7)
-- [RedHen Raiser](https://github.com/thinkshout/redhenraiser-drops-7)
-
 
 ## Product UUID
 There is a UUID for all the different systems you can install on Pantheon. WordPress on Pantheon is `e8fe8550-1ab9-4964-8838-2b9abdccf4bf`. To see all available products, run the following [Terminus](/docs/terminus/) command:

--- a/source/_docs/upstream-updates.md
+++ b/source/_docs/upstream-updates.md
@@ -141,9 +141,9 @@ If the automated core update doesn't appear to be working, it's possible there a
 Squashing and rewriting history may cause one-click updates to break, meaning updates will no longer appear on your Site Dashboard once available. Instead of using squash and rebase to clean up commits from merges occurring upstream, we recommend reviewing history locally with `git log --first-parent`. This provides the same history shown on the Site Dashboard and prevents conflicts with our one-click updates.
 
 ### One-Click Update Not Available for Sites Using a Custom Upstream
-Core updates for public distributions (Open Atrium, Commerce Kickstart, etc.) are initiated by the maintainer, not Pantheon. Please report issues directly to the project maintainer for expected updates.
+Core updates for Custom Upstreams are initiated by the repository maintainer, not Pantheon. Please report issues directly to the project maintainer for expected updates.
 
-It's important to relay the need for updating core to distribution maintainers, even if you plan on manually pulling in core version updates. First, file an issue in the queue of your distribution and reach out to a maintainer. Even better - submit a pull request for the update.
+It's important to relay the need for updating core to maintainers, even if you plan on manually pulling in core version updates. First, file an issue in the queue of your repository and reach out to a maintainer. Even better - submit a pull request for the update.
 
 Once you have communicated the issue, you can [manually apply updates from the command line](#apply-upstream-updates-manually-from-the-command-line-and-resolve-merge-conflicts).
 


### PR DESCRIPTION
Closes #2567 

## Effect
PR includes the following changes:
- Remove references of Public Distributions (e.g. Open Atrium, Commerce Kickstart, etc.) to align docs with Dashboard during site creation. Pantheon Upstreams and Custom Upstreams are the only available start states at this time.

cc @twooten @ronan @kimby77 