### PR TITLE
Force SimleSaml to always use port 443.

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -66,7 +66,7 @@ Set up your SimpleSAMLphp `config.php` as follows:
 3. With the basic variables defined, set up base config:
 
         $config = array (
-          'baseurlpath' => 'https://'. $host .'/simplesaml/',
+          'baseurlpath' => 'https://'. $host .':443/simplesaml/', // SAML should always connect via 443
           'certdir' => 'cert/',
           'loggingdir' => 'log/',
           'datadir' => 'data/',


### PR DESCRIPTION
Some customers have issues with SimpleSaml using the container port when attempting to post back to the site. Saml should always use port 443 in inbound requests to the edge network.

Closes #2468 

## Effect
PR includes the following changes:
- Explicitly set port 443 in SimpleSaml base url
