### PR TITLE
Remove EWWW Image Optimizer from unsupported plugins

### DIFF
--- a/source/_docs/unsupported-modules-plugins.md
+++ b/source/_docs/unsupported-modules-plugins.md
@@ -283,10 +283,6 @@ For more details, see [SERVER_NAME and SERVER_PORT on Pantheon](/docs/server_nam
 **Solution**: See [Caching: Advanced Topics](/docs/caching-advanced-topics/) for details on how to bypass Varnish.
 <hr>
 
-### [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
-**Issue**: EWWW Image Optimizer stores the absolute file paths for optimized images in the `wp_ewwwio_images` table, which includes the application container's ID. These paths will change from time to time due to routine platform maintenance. You can rebuild the optimized images to refresh the absolute path, however the problem will persist next time there are container changes. Additionally, sites served by [multiple application containers](/docs/application-containers/#multiple-application-containers) may experience unexpected behavior as the absolute path may differ from one request to another.
-<hr>
-
 ### [Instashow](https://elfsight.com/instagram-feed-instashow/)
 **Issue**: The Instashow plugin relies on query parameters that are not compatible with Pantheon's Edge Cache. See [PANTHEON_STRIPPED](https://pantheon.io/docs/pantheon_stripped/) for more information. This inhibits the ability to set the authorization token required to make the plugin function.
 <hr>


### PR DESCRIPTION
In version 3.3.0, the EWWW plugin changelog says:

```
* added: relative file location support, automatically enabled for Pantheon, use EWWW_IMAGE_OPTIMIZER_RELATIVE and EWWW_IMAGE_OPTIMIZER_RELATIVE_FOLDER to enable elsewhere
```

Therefore it seems as though EWWW should function normally in the Pantheon environment.

## Effect
PR includes the following changes:
- Update documentation