### PR TITLE
remove relative path shortcuts from code snippet

### DIFF
--- a/source/_docs/drupal-s3.md
+++ b/source/_docs/drupal-s3.md
@@ -116,9 +116,9 @@ Before you begin:
   <pre><code class="bash hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- en libraries s3fs -y</code></pre>
 
   Get the <a href="https://github.com/aws/aws-sdk-php/releases">AWS SDK Library 2.x</a>:
-  <pre><code class="php hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core ~/code/sites/all/modules/s3fs/s3fs.make ~/code/
+  <pre><code class="php hljs">terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core code/sites/all/modules/s3fs/s3fs.make code/
   //or if you have a contrib subfolder for modules use:
-  //terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core ~/code/sites/all/modules/contrib/s3fs/s3fs.make ~/code/</code></pre>
+  //terminus drush &lt;site&gt;.&lt;env&gt; -- make --no-core code/sites/all/modules/contrib/s3fs/s3fs.make code/</code></pre>
   The above command will add the AWS SDK version 2.x library into the <code>sites/all/libraries/awssdk2</code> directory.
  </div>
   <div role="tabpanel" class="tab-pane" id="d8s3fs">


### PR DESCRIPTION
Closes #2546 

## Effect
PR includes the following changes:
- Removes `~/` from drush commands. OSX interprets the shortcut before passing the command to Terminus, replacing it with `/Users/...`. We can safely assume that Terminus commands are run from the "root" of the site directory on the platform, and remove the shortcut.

Tested:

```
$ terminus drush demosite.dev -- make --no-core code/sites/all/modules/s3fs/s3fs.make code/
Beginning to build code/sites/all/modules/s3fs/s3fs.make.                   [ok]
awssdk2 downloaded from                                                     [ok]
https://github.com/aws/aws-sdk-php/releases/download/2.7.25/aws.zip.


 [notice] Command: demosite.dev -- drush make [Exit: 0]
```

## Remaining Work
- [x] 👍 from @ttrowell and/or @greg-1-anderson 
