### PR TITLE
Target edge position for TOC

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -5404,3 +5404,8 @@ width: 100% !important;
 .docsearch {
   margin-right: 20px!important;
 }
+@supports (-ms-ime-align: auto){
+  .pio-docs-sidebar {
+    right: 0px;
+  }
+}


### PR DESCRIPTION
Microsoft Edge does not support position sticky (yet) - workaround is to target some edge specific property and set right 0