### PR TITLE
Updated email recommendations

### DIFF
--- a/source/_docs/email.md
+++ b/source/_docs/email.md
@@ -49,7 +49,7 @@ Here are some popular email services you can use on the platform and their corre
 ### SMTP Providers & Configurations
 Customers have successfully used [SendGrid](/docs/guides/sendgrid/), Gmail, Amazon SES, Mandrill, and other externally hosted SMTP based email providers.
 
-Configuring mail to use port 25, 465 and/or 587 is strongly discouraged because they attract SPAM activities. Here’s a list of popular email providers and the additional ports which Pantheon recommends:
+Configuring mail to use port 25, 465 or 587 is strongly discouraged because they attract SPAM activities. Here’s a list of popular email providers and the alternate ports which Pantheon recommends:
 
 <table class="table table-responsive table-bordered">
     <thead class="thead-inverse">
@@ -130,7 +130,7 @@ See [available patch](https://drupal.org/node/1369736#comment-5644064).
 We strongly recommend that you do not use the local MTA (postfix) as described [above](#outgoing-email). Instead, we recommend using a third-party email service provider.
 
 ### What ports are recommended by Pantheon?
-Configuring mail to use port 25, 465 and/or 587 is strongly discouraged because they attract SPAM activities. Make sure that your service provider allows traffic on a port other than those mentioned and that you have correctly configured your site to use that port.
+Configuring mail to use port 25, 465 or 587 is strongly discouraged because they attract SPAM activities. Make sure that your service provider allows traffic on a port other than those mentioned and that you have correctly configured your site to use that port.
 
 ### Can Pantheon provide, publish, or support SPF records?
 

--- a/source/_docs/email.md
+++ b/source/_docs/email.md
@@ -49,7 +49,7 @@ Here are some popular email services you can use on the platform and their corre
 ### SMTP Providers & Configurations
 Customers have successfully used [SendGrid](/docs/guides/sendgrid/), Gmail, Amazon SES, Mandrill, and other externally hosted SMTP based email providers.
 
-Since we block traffic on ports 25, 465 and 587, here’s a list of popular email providers and the additional ports which will work on Pantheon. We suggest you refer to the corresponding documentation for any updated information.
+Ports 25, 465 and 587 are the most popular email ports to attract SPAM activities. We discourage our customers to use these ports. Here’s a list of popular email providers and the additional ports which Pantheon recoomends. We suggest you refer to the corresponding documentation for any updated information.
 
 <table class="table table-responsive table-bordered">
     <thead class="thead-inverse">
@@ -129,8 +129,8 @@ See [available patch](https://drupal.org/node/1369736#comment-5644064).
 ### Can I use Pantheon's local MTA (postfix)?
 We strongly recommend that you do not use the local MTA (postfix) as described [above](#outgoing-email). Instead, we recommend using a third-party email service provider.
 
-### What ports are blocked by Pantheon?
-In order to fight spam, Pantheon blocks traffic on popular email ports 25, 465, and 587. Your emails will not be processed if you use any of these ports. Make sure that your service provider allows traffic on a port other than 25, 465 and 587 and that you have correctly configured your site to use that port.
+### What ports are recommended by Pantheon?
+Email ports 25, 465, and 587 attract a lot of spam. Pantheon recommends you to configure your email settings to use a port other than these 3. Make sure that your service provider allows traffic on a port other than 25, 465 and 587 and that you have correctly configured your site to use that port.
 
 ### Can Pantheon provide, publish, or support SPF records?
 

--- a/source/_docs/email.md
+++ b/source/_docs/email.md
@@ -49,7 +49,7 @@ Here are some popular email services you can use on the platform and their corre
 ### SMTP Providers & Configurations
 Customers have successfully used [SendGrid](/docs/guides/sendgrid/), Gmail, Amazon SES, Mandrill, and other externally hosted SMTP based email providers.
 
-Ports 25, 465 and 587 are the most popular email ports to attract SPAM activities. We discourage our customers to use these ports. Here’s a list of popular email providers and the additional ports which Pantheon recoomends. We suggest you refer to the corresponding documentation for any updated information.
+Configuring mail to use port 25, 465 and/or 587 is strongly discouraged because they attract SPAM activities. Here’s a list of popular email providers and the additional ports which Pantheon recommends:
 
 <table class="table table-responsive table-bordered">
     <thead class="thead-inverse">
@@ -130,7 +130,7 @@ See [available patch](https://drupal.org/node/1369736#comment-5644064).
 We strongly recommend that you do not use the local MTA (postfix) as described [above](#outgoing-email). Instead, we recommend using a third-party email service provider.
 
 ### What ports are recommended by Pantheon?
-Email ports 25, 465, and 587 attract a lot of spam. Pantheon recommends you to configure your email settings to use a port other than these 3. Make sure that your service provider allows traffic on a port other than 25, 465 and 587 and that you have correctly configured your site to use that port.
+Configuring mail to use port 25, 465 and/or 587 is strongly discouraged because they attract SPAM activities. Make sure that your service provider allows traffic on a port other than those mentioned and that you have correctly configured your site to use that port.
 
 ### Can Pantheon provide, publish, or support SPF records?
 

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -87,7 +87,7 @@ A stable release for Drupal 8 is not yet available for the [SMTP Authentication 
 
      <div class="alert alert-info" role="alert">
        <h4 class="info">Note</h4>
-       <p markdown="1">Pantheon blocks ports `25`, `465`, and `587` to fight spam. For details, see <a href="/docs/email/#what-ports-are-blocked-by-pantheon" data-proofer-ignore>Email on Pantheon</a>. </p>
+       <p markdown="1">Configuring mail to use port 25, 465 or 587 is strongly discouraged because they attract SPAM activities. For details, see [Email on Pantheon](/docs/email/) </p>
      </div>
 
 5. Provide your site-specific SendGrid credentials and click **Save configuration**.  


### PR DESCRIPTION
Discourage use of popular ports - 25, 465 and 587 instead of Pantheon blocking them.

Closes IO-2469

## Effect
PR includes the following changes:
- We do not block traffic on 3 ports anymore
- We discourage use of those 3 ports and suggest to use a different port for emails

