### PR TITLE
Clarify eligible free HTTPS sites

### DIFF
--- a/source/_docs/free-https.md
+++ b/source/_docs/free-https.md
@@ -5,7 +5,7 @@ tags: [dns, security]
 earlyaccess: true
 earlynote: The documentation on this page discusses features and options that are not available across the entire platform.
 ---
-Pantheon's new [Global CDN](/docs/global-cdn) (content delivery network) provides Free and Automated HTTPS for every site launched on the platform using [Let's Encrypt](https://letsencrypt.org). For instructions, see [Launch Essentials](/docs/guides/launch/).
+Pantheon's new [Global CDN](/docs/global-cdn) (content delivery network) provides Free and Automated HTTPS for every site on a Pro plan or above launched on the platform using [Let's Encrypt](https://letsencrypt.org). For instructions, see [Launch Essentials](/docs/guides/launch/).
 
 ## Free and Automated HTTPS vs Legacy
 <table class="table  table-bordered table-responsive">


### PR DESCRIPTION
Change language to more clearly state that free HTTPS is for sites on a Pro plan and above. Currently, the sentence says "every site" and the qualifier is in the table below.

## Blocked By
- [ ] Sign off from @ari-gold 