### PR TITLE
Multiple improvements to HTTPS redirect instructions

### DIFF
--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -38,7 +38,7 @@ In this lesson, we'll redirect incoming requests to a primary domain name (e.g.,
     <!-- Tab panes -->
     <div class="tab-content">
     <div role="tabpanel" class="tab-pane active" id="wp">
-    <p markdown="1">Comment out existing code that sets `WP_SITEURL`, such as [Line 79 in Pantheon's WordPress upstream](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php#L79), otherwise you will get a PHP notice. Then add the following to the end of your `wp-config.php` file (replace `www.example.com`):</p>
+    <p markdown="1">Add the following to `wp-config.php` (replace `www.example.com`):</p>
     <pre id="git-pull-wp"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
       // Redirect to https://$primary_domain/ in the Live environment
       if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live'):

--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -47,7 +47,9 @@ In this lesson, we'll redirect incoming requests to a primary domain name (e.g.,
         header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
         exit();
       }
-      $settings['trusted_host_patterns'] = array('^'. preg_quote($canonical_domain) .'$');
+      if (is_array($settings)) {
+        $settings['trusted_host_patterns'] = array('^'. preg_quote($canonical_domain) .'$');
+      }
     }
     </code></pre>
 

--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -39,7 +39,7 @@ In this lesson, we'll redirect incoming requests to a primary domain name (e.g.,
         $canonical_domain = $_SERVER['HTTP_HOST'];
       }
       
-      $base_url = 'https://'. $canonical_domain;
+      $base_url = 'https://'. $canonical_domain;  // For the redirect and Drupal 7
       if ($_SERVER['HTTP_HOST'] != $canonical_domain
           || !isset($_SERVER['HTTP_X_SSL'])
           || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
@@ -47,8 +47,9 @@ In this lesson, we'll redirect incoming requests to a primary domain name (e.g.,
         header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
         exit();
       }
+      define('WP_SITEURL', $base_url);  // For WordPress
       if (is_array($settings)) {
-        $settings['trusted_host_patterns'] = array('^'. preg_quote($canonical_domain) .'$');
+        $settings['trusted_host_patterns'] = array('^'. preg_quote($canonical_domain) .'$');  // For Drupal 8
       }
     }
     </code></pre>

--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -25,34 +25,90 @@ In this lesson, we'll redirect incoming requests to a primary domain name (e.g.,
 
   If you run into issues, please refer to [this documentation](/docs/sftp/#sftp-connection-information).
 
-4. Now open the `code` folder in your SFTP client, and download your site's `settings.php` (Drupal) or `wp-config.php` (WordPress) file.
-5. Edit your configuration file by adding the following snippet for the desired redirect (replace `www.example.com`):
+4. Open the `code` folder in your SFTP client, and download your site's `settings.php` (Drupal) or `wp-config.php` (WordPress) file.
+5. Edit your configuration file as described for your site's framework:
 
-    <pre><code class="php hljs">
-    // Redirect to https://$canonical_domain/
-    if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
-      if ($_SERVER['PANTHEON_ENVIRONMENT'] === 'live') {
-        // Edit www.example.com to be the desired, canonical domain.
-        // Remove www to always redirect to non-www.
-        $canonical_domain = 'www.example.com';
-      } else {
-        $canonical_domain = $_SERVER['HTTP_HOST'];
-      }
-      
-      $base_url = 'https://'. $canonical_domain;  // For the redirect and Drupal 7
-      if ($_SERVER['HTTP_HOST'] != $canonical_domain
+    <!-- Nav tabs -->
+    <ul class="nav nav-tabs" role="tablist">
+      <li id="wptab" role="presentation" class="active"><a href="#wp" aria-controls="wp" role="tab" data-toggle="tab">WordPress</a></li>
+      <li id="d8tab" role="presentation"><a href="#d8" aria-controls="d8" role="tab" data-toggle="tab">Drupal 8</a></li>
+      <li id="d7tab" role="presentation"><a href="#d7" aria-controls="d7" role="tab" data-toggle="tab">Drupal 7</a></li>
+    </ul>
+
+    <!-- Tab panes -->
+    <div class="tab-content">
+    <div role="tabpanel" class="tab-pane active" id="wp">
+    <p markdown="1">Comment out existing code that sets `WP_SITEURL`, such as [Line 79 in Pantheon's WordPress upstream](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php#L79), otherwise you will get a PHP notice. Then add the following to the end of your `wp-config.php` file (replace `www.example.com`):</p>
+    <pre id="git-pull-wp"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
+      // Redirect to https://$primary_domain/ in the Live environment
+      if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live'):
+        /** Replace www.example.com with your registered domain name */
+        $primary_domain = 'www.example.com';
+      else:
+        // Redirect to HTTPS on every Pantheon environment.
+        $primary_domain = $_SERVER['HTTP_HOST'];
+      endif;
+      $base_url = 'https://'. $primary_domain;
+      define('WP_SITEURL', $base_url);
+      if ($_SERVER['HTTP_HOST'] != $primary_domain
           || !isset($_SERVER['HTTP_X_SSL'])
           || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
         header('HTTP/1.0 301 Moved Permanently');
         header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
         exit();
       }
-      define('WP_SITEURL', $base_url);  // For WordPress
-      if (is_array($settings)) {
-        $settings['trusted_host_patterns'] = array('^'. preg_quote($canonical_domain) .'$');  // For Drupal 8
+  }</code></pre>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="d8">
+    <p markdown="1">Add the following to the end of your `settings.php` file (replace `www.example.com`):</p>
+    <pre id="git-pull-drops-8"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
+      // Redirect to https://$primary_domain/ in the Live environment
+      if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live'):
+        /** Replace www.example.com with your registered domain name */
+        $primary_domain = 'www.example.com';
+      else:
+        // Redirect to HTTPS on every Pantheon environment.
+        $primary_domain = $_SERVER['HTTP_HOST'];
+      endif;
+      if ($_SERVER['HTTP_HOST'] != $primary_domain
+          || !isset($_SERVER['HTTP_X_SSL'])
+          || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+        header('HTTP/1.0 301 Moved Permanently');
+        header('Location: '. 'https://'. $primary_domain . $_SERVER['REQUEST_URI']);
+        exit();
       }
-    }
-    </code></pre>
+      // Drupal 8 Trusted Host Settings
+      if (is_array($settings)) {
+        $settings['trusted_host_patterns'] = array('^'. preg_quote($primary_domain) .'$');
+      }
+    }</code></pre>
+    </div>
+    <div role="tabpanel" class="tab-pane" id="d7">
+    <p markdown="1">Add the following to the end of your `settings.php` file (replace `www.example.com`):</p>
+    <pre id="git-pull-drops-7"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
+      // Redirect to https://$primary_domain/ in the Live environment
+      if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live'):
+        /** Replace www.example.com with your registered domain name */
+        $primary_domain = 'www.example.com';
+      else:
+        // Redirect to HTTPS on every Pantheon environment.
+        $primary_domain = $_SERVER['HTTP_HOST'];
+      endif;
+      $base_url = 'https://'. $primary_domain;
+      if ($_SERVER['HTTP_HOST'] != $primary_domain
+          || !isset($_SERVER['HTTP_X_SSL'])
+          || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+        header('HTTP/1.0 301 Moved Permanently');
+        header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
+        exit();
+      }
+    }</code></pre>
+    </div>
+    </div>
+
+
+
+
 
 6. Upload the configuration file to Pantheon using your SFTP client.
 


### PR DESCRIPTION
This updated guide:

* Dynamically defines `$canonical_domain` as either a specific value (for Live) or the current hostname (non-Live).
* Consolidates www and non-www cases by using a `$canonical_domain` variable.
* Redirects to `$canonical_domain` from every other subdomain, not just www.
* Redirects web requests to HTTPS on every Pantheon environment.
* Tells Drupal 7 to use `https://$canonical_domain` as the base for all absolute URLs.
* Tells Drupal 8 that the incoming domain is trusted (which is always true on Pantheon, anyway).
* Tells WordPress to use `https://$canonical_domain` as the base for all absolute URLs.

I haven't tested this yet, but feedback is welcome.