### PR TITLE
Explicitly mention Varnish cookie whitelist

### DIFF
--- a/source/_docs/caching-advanced-topics.md
+++ b/source/_docs/caching-advanced-topics.md
@@ -87,7 +87,8 @@ A full list of the devices and their support for HTML5 is available on [https://
  - [Other browsers](https://html5test.com/results/other.html)
 
 ### Using STYXKEY
-You can set a cookie beginning with `STYXKEY` followed by one or more alphanumeric characters, hyphens, or underscores.
+
+Varnish only passes through a whitelisted set of cookies. To use custom cookies with Drupal or WordPress, you can set a cookie beginning with `STYXKEY` followed by one or more alphanumeric characters, hyphens, or underscores.
 
 For example, you could set a cookie named `STYXKEY-country` to `ca` or `de` and cache different page content for each country. A site can have any number of `STYXKEY` cookies for varying content.
 


### PR DESCRIPTION
Varnish only passes through a whitelisted set of cookies, not all cookies.

See Slack conversation: https://pantheon.slack.com/archives/C0D7KBQAY/p1500325678824796