### PR TITLE
Update drupal-cache.md - removed ambiguity around longer expiration period

### DIFF
--- a/source/_docs/drupal-cache.md
+++ b/source/_docs/drupal-cache.md
@@ -14,7 +14,7 @@ Visit `/admin/config/development/performance` for Drupal's performance settings.
 ![Drupal 8 Caching options](/source/docs/assets/images/d8-cache-config.png)  
 **This is a key setting**. It determines what value Drupal delivers in its `max-age` header, which is how long the reverse-proxy layer will retain a cache.
 
-Performance is often a trade-off between how fresh your content is, and how fast you want to deliver it to the internet. A good value to start with is 15 minutes, but this is something to consider. If you can set it to an hour, that's great for performance. More than a day is usually excessive, since the edge cache will decay over that amount of time in most cases.
+Performance is often a trade-off between how fresh your content is, and how fast you want to deliver it to the internet. A good value to start with is 15 minutes, but this is something to consider. If you can set it to an hour, that's great for performance.
 
 On Pantheon, this value defaults to 15 minutes. This is done on the first cache-clear operation on the site; immediately after installing the site, you may see this set to `<no caching>`. In this case, press the "Clear all caches" button, or select the page cache maximum age from the available selections.
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- removed the following phrase "More than a day is usually excessive, since the edge cache will decay over that amount of time in most cases." which seems to create confusion.
- also, in some cases, it does make sense to have a long expiration period for pages that rarely change (e.g. Terms and Conditions or similar pages).

See chat conversation #11009562618.