### PR TITLE
New Relic Redirect Transactions

### DIFF
--- a/source/_docs/drupal-broken-links.md
+++ b/source/_docs/drupal-broken-links.md
@@ -35,6 +35,12 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+
+    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    if (extension_loaded('newrelic')) {
+      newrelic_name_transaction("redirect");
+    }
+
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
     exit();

--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -26,6 +26,12 @@
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+
+    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    if (extension_loaded('newrelic')) {
+      newrelic_name_transaction("redirect");
+    }
+
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
     exit();
@@ -47,6 +53,12 @@
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+
+    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    if (extension_loaded('newrelic')) {
+      newrelic_name_transaction("redirect");
+    }
+
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: '. 'https://'. $primary_domain . $_SERVER['REQUEST_URI']);
     exit();
@@ -73,6 +85,12 @@
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
+
+    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    if (extension_loaded('newrelic')) {
+      newrelic_name_transaction("redirect");
+    }
+
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
     exit();


### PR DESCRIPTION
Closes #2712 

## Effect
PR includes the following changes:
- Name redirect transactions so they can be filtered out of New Relic for simpler reporting (add to redirect snipets throughout) 

@tinefin I tested it on all three frameworks, and this snippet worked for me. Can you review?

