### PR TITLE
Correcting drush path in Migrate module timeouts workaround

### DIFF
--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -119,7 +119,7 @@ Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/termi
 
 As [strongly recommended by the Migrate module](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). You can even configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
 ```
-$conf['migrate_drush_path'] = '../drush';
+$conf['migrate_drush_path'] = $_ENV['HOME'] . '/drush';
 ```
 
 #### Can Pantheon change the non-configurable timeouts for my site?


### PR DESCRIPTION
Closes #2753 

## Effect
PR includes the following changes:
- Corrects drush path in example `settings.php` snippet for Migrate module timeouts workaround
