### PR TITLE
Update solr-drupal-8.md

### DIFF
--- a/source/_docs/solr-drupal-8.md
+++ b/source/_docs/solr-drupal-8.md
@@ -33,7 +33,8 @@ composer require "drupal/search_api_pantheon ~1.0" --prefer-dist
 You should now have the Search API Pantheon module installed along with it's dependencies. Commit the changes and push to Pantheon.
 
 ```
-git commit -am "Require drupal/search_api_pantheon ~1.0"
+git add .
+git commit -m "Require drupal/search_api_pantheon ~1.0"
 git push origin master
 ```
 


### PR DESCRIPTION
I was following these steps and noticed this didn't quite work. The `-am` flags on `git commit` will only stage modified files but not untracked ones. As I was following along, this added a number of new files which didn't get picked up by the `git add -am`:

```
➜  code git:(gjd-pantheon-solr) ✗ git commit -am "Require drupal/search_api_pantheon ~1.0 via composer"
[gjd-pantheon-solr 9f372acad] Require drupal/search_api_pantheon ~1.0 via composer
 11 files changed, 4122 insertions(+), 6666 deletions(-)
 rewrite vendor/composer/autoload_classmap.php (98%)
 rewrite vendor/composer/autoload_static.php (95%)

➜  code git:(gjd-pantheon-solr) ✗ git status
On branch gjd-pantheon-solr
Untracked files:
  (use "git add <file>..." to include in what will be committed)

	modules/contrib/search_api/
	modules/contrib/search_api_pantheon/
	modules/contrib/search_api_solr/
	vendor/behat/
	vendor/bin/phpcbf
	vendor/bin/phpcs
	vendor/bin/phpunit
	vendor/doctrine/instantiator/
	vendor/drupal/coder/
	vendor/fabpot/
	vendor/jcalderonzumba/
	vendor/mikey179/
	vendor/phpdocumentor/
	vendor/phpspec/
	vendor/phpunit/
	vendor/sebastian/
	vendor/solarium/
	vendor/squizlabs/
	vendor/symfony/browser-kit/
	vendor/symfony/css-selector/
	vendor/symfony/dom-crawler/
```

But adding them all first with `git add .` and _then_ committing works. I got to here from clicking the GitHub "Contribute" button on the top of the doc page. Please let me know if this should be contributed another way.