### PR TITLE
Update a git command

### DIFF
--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -117,15 +117,21 @@ As long as you've chosen the same codebase (Drupal 7, WordPress, Commerce Kickst
  For example, a site running Drupal 7, `https://github.com/pantheon-systems/drops-7` will change to `git://github.com/pantheon-systems/drops-7.git master` in the Git command used to pull in the upstream.  
  ![Pantheon Dashboard about site tab](/source/docs/assets/images/dashboard/pantheon-dashboard-settings-about-site-upstream.png)
 4. At the root of your local clone of the site repository, run
-```nohighlight
-git pull --no-rebase -Xtheirs --squash git://github.com/pantheon-systems/drops-7.git master
-```
 
-NOTE: 
-For versions of Git 2.9+ the Git command above would be:
-```nohighlight
-git pull --no-rebase -Xtheirs --allow-unrelated-histories --squash git://github.com/pantheon-systems/drops-7.git master
-```
+  ```nohighlight
+  git pull --no-rebase -Xtheirs --allow-unrelated-histories --squash git://github.com/pantheon-systems/drops-7.git master
+  ```
+
+    <div class="alert alert-info">
+    <h4 class="info">Note</h4>
+    <p markdown="1">
+    For versions of Git 2.8 and below, the command is:
+
+    <pre><code class="nohighlight">git pull --no-rebase -Xtheirs --squash git://github.com/pantheon-systems/drops-7.git master</code></pre>
+
+    </p>
+    </div>
+
 
 If you need something other than Drupal 7 in the above command, replace the upstream URL with the one you copied from the Site Dashboard and modified.
 

--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -117,7 +117,17 @@ As long as you've chosen the same codebase (Drupal 7, WordPress, Commerce Kickst
  For example, a site running Drupal 7, `https://github.com/pantheon-systems/drops-7` will change to `git://github.com/pantheon-systems/drops-7.git master` in the Git command used to pull in the upstream.  
  ![Pantheon Dashboard about site tab](/source/docs/assets/images/dashboard/pantheon-dashboard-settings-about-site-upstream.png)
 4. At the root of your local clone of the site repository, run
-`git pull --no-rebase -Xtheirs --squash git://github.com/pantheon-systems/drops-7.git master`, replacing the upstream URL with the one you copied from the Site Dashboard and modified, if you need something other than Drupal 7.
+```nohighlight
+git pull --no-rebase -Xtheirs --squash git://github.com/pantheon-systems/drops-7.git master
+```
+
+NOTE: 
+For versions of Git 2.9+ the Git command above would be:
+```nohighlight
+git pull --no-rebase -Xtheirs --allow-unrelated-histories --squash git://github.com/pantheon-systems/drops-7.git master
+```
+
+If you need something other than Drupal 7 in the above command, replace the upstream URL with the one you copied from the Site Dashboard and modified.
 
 Once executed, that command will pull in the Pantheon core files, but not commit them; you will be able to do a final review before doing so. You will see this message when it's done:
 


### PR DESCRIPTION
The git command changes with Git 2.9+ versions

Closes #2247 

## Effect
PR includes the following changes:
- Added updated git command

## Remaining Work
- [ ] Needs copy review.
- [ ] Needs styling. The alternate git command needs to be put in Note or potentially in Tabs entitled "Git < 2.9" and "Git = 2.9+"
