### PR TITLE
Removing the extra ( before preg_match()

### DIFF
--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -9,7 +9,7 @@ categories: []
 You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response:
 ```
 //Set or replace $regex_path_match accordingly
-if ((preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
   $domain =  $_SERVER['HTTP_HOST'];
   setcookie('NO_CACHE', '1', time()+0, '/path-to-page', $domain);
 }


### PR DESCRIPTION
This is causing a syntax error.