### PR TITLE
Disable Caching for Specific Pages example

### DIFF
--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -25,27 +25,37 @@ $build['#cache']['max-age'] = 0;
   Drupal 8 will "bubble up" this information so that if any small block on a page requires a cache max age of zero, the entire page will be uncacheable.
 Currently [Cache Control Override](https://www.drupal.org/project/cache_control_override) module is required for this feature to behave correctly.
   </div>
-  <div role="tabpanel" class="tab-pane" id="d7">
+  <div role="tabpanel" class="tab-pane" id="d7" markdown="1">
   <br>
-  <p>Here is an example of a global way to determine a Drupal response's cacheability. Use the <code>$conf</code> global variable to set <code>Cache-Control: max-age=0</code>:</p>
-  <pre><code class="php hljs">
-  // Set or replace $regex_path_match accordingly
-  // Example: anything in the /news/ directory
-  $regex_path_match = '#^/news/?#';
+  <p markdown="1">Here is an example of a global way to determine a Drupal response's cacheability. Use the `$conf` global variable to set `Cache-Control: max-age=0`:</p>
 
+  ```php
+  /*
+  Set or replace $regex_path_match accordingly
+  Example: to omit anything in the /news/ directory, set
+  $regex_path_match = '#^/news/?#';
+  We don't set this variable for you, so YOU MUST define it yourself.
+  */
   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
     drupal_page_is_cacheable(FALSE);
     $conf['page_cache_maximum_age'] = 0;
   }
-  </code></pre>
+  ```
+
+  <p markdown="1"> This example code will not work until you edit it to define `$regex_path_match`.</p>
+
   </div>
-  <div role="tabpanel" class="tab-pane" id="wp">
+  <div role="tabpanel" class="tab-pane" id="wp" markdown="1">
   <br>
-  <p>Set <code>Cache-Control: max-age=0</code> by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override <code>max-age</code> configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests: </p>
-  <pre><code class="php hljs">
-  // Set or replace $regex_path_match accordingly
-  // Example: anything in the /news/ directory
+  <p markdown="1">Set `Cache-Control: max-age=0` by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override `max-age` configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests: </p>
+
+  ```php
+  /*
+  Set or replace $regex_path_match accordingly
+  Example: to omit anything in the /news/ directory, set
   $regex_path_match = '#^/news/?#';
+  We don't set this variable for you, so YOU MUST define it yourself.
+  */
   
   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
   	add_action( 'send_headers', 'add_header_nocache', 15 );
@@ -53,7 +63,8 @@ Currently [Cache Control Override](https://www.drupal.org/project/cache_control_
   function add_header_nocache() {
   	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
   }
-  </code></pre>
+  ```
+  <p markdown="1"> This example code will not work until you edit it to define `$regex_path_match`.</p>
   </div>
 </div>
 

--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -29,7 +29,10 @@ Currently [Cache Control Override](https://www.drupal.org/project/cache_control_
   <br>
   <p>Here is an example of a global way to determine a Drupal response's cacheability. Use the <code>$conf</code> global variable to set <code>Cache-Control: max-age=0</code>:</p>
   <pre><code class="php hljs">
-  // Set or replace $regex_path_match accordingly.
+  // Set or replace $regex_path_match accordingly
+  // Example: anything in the /news/ directory
+  $regex_path_match = '#^/news/?#';
+
   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
     drupal_page_is_cacheable(FALSE);
     $conf['page_cache_maximum_age'] = 0;
@@ -40,7 +43,10 @@ Currently [Cache Control Override](https://www.drupal.org/project/cache_control_
   <br>
   <p>Set <code>Cache-Control: max-age=0</code> by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override <code>max-age</code> configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests: </p>
   <pre><code class="php hljs">
-  //Set or replace $regex_path_match accordingly
+  // Set or replace $regex_path_match accordingly
+  // Example: anything in the /news/ directory
+  $regex_path_match = '#^/news/?#';
+  
   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
   	add_action( 'send_headers', 'add_header_nocache', 15 );
   }

--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -16,55 +16,54 @@ You can use a variety of mechanisms to determine which responses from your Drupa
 <!-- Tab panes -->
 <div class="tab-content">
   <div role="tabpanel" class="tab-pane active" id="d8" markdown="1">
-  <br>
-  <p><a href="https://www.drupal.org/developing/api/8/render/arrays/cacheability">Drupal 8's system of cacheability metadata</a> is much more advanced than the tools available in Drupal 7 or WordPress. Drupal builds HTML out of render arrays, which are specially formed PHP arrays. If one layer of a render array cannot be cached (if it's cache max age should be zero) that cacheability metadata can be set with: </p>
-  <pre><code class="php hljs">
-// $build is a render array.
-$build['#cache']['max-age'] = 0;
-  </code></pre>
-  Drupal 8 will "bubble up" this information so that if any small block on a page requires a cache max age of zero, the entire page will be uncacheable.
-Currently [Cache Control Override](https://www.drupal.org/project/cache_control_override) module is required for this feature to behave correctly.
+  [Drupal 8's system of cacheability metadata](https://www.drupal.org/developing/api/8/render/arrays/cacheability) is much more advanced than the tools available in Drupal 7 or WordPress. Drupal builds HTML out of render arrays, which are specially formed PHP arrays. If one layer of a render array cannot be cached (if it's cache max age should be zero) that cacheability metadata can be set with:
+
+  ```php
+  // $build is a render array.
+  $build['#cache']['max-age'] = 0;
+  ```
+
+  Drupal 8 will "bubble up" this information so that if any small block on a page requires a cache max age of zero, the entire page will be uncacheable. Currently [Cache Control Override](https://www.drupal.org/project/cache_control_override) module is required for this feature to behave correctly.
   </div>
   <div role="tabpanel" class="tab-pane" id="d7" markdown="1">
-  <br>
-  <p markdown="1">Here is an example of a global way to determine a Drupal response's cacheability. Use the `$conf` global variable to set `Cache-Control: max-age=0`:</p>
+  Here is an example of a global way to determine a Drupal response's cacheability. Use the `$conf` global variable to set `Cache-Control: max-age=0`:
 
   ```php
-  /*
-  Set or replace $regex_path_match accordingly
-  Example: to omit anything in the /news/ directory, set
-  $regex_path_match = '#^/news/?#';
-  We don't set this variable for you, so YOU MUST define it yourself.
-  */
-  if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
-    drupal_page_is_cacheable(FALSE);
-    $conf['page_cache_maximum_age'] = 0;
-  }
+  /**
+  * Set $regex_path_match accordingly. For example, to exclude
+  * pages in the /news/ path from cache, set:
+  *
+  *   $regex_path_match = '#^/news/?#';
+  *
+  * We don't set this variable for you, so you must define it
+  * yourself per your specific use case before the following conditional.
+  **/
+   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+     drupal_page_is_cacheable(FALSE);
+     $conf['page_cache_maximum_age'] = 0;
+   }
   ```
-
-  <p markdown="1"> This example code will not work until you edit it to define `$regex_path_match`.</p>
-
   </div>
   <div role="tabpanel" class="tab-pane" id="wp" markdown="1">
-  <br>
-  <p markdown="1">Set `Cache-Control: max-age=0` by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override `max-age` configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests: </p>
+  Set `Cache-Control: max-age=0` by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override `max-age` configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests:
 
   ```php
-  /*
-  Set or replace $regex_path_match accordingly
-  Example: to omit anything in the /news/ directory, set
-  $regex_path_match = '#^/news/?#';
-  We don't set this variable for you, so YOU MUST define it yourself.
-  */
-  
-  if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
-  	add_action( 'send_headers', 'add_header_nocache', 15 );
-  }
-  function add_header_nocache() {
-  	header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
-  }
+  /**
+  * Set $regex_path_match accordingly. For example, to exclude
+  * pages in the /news/ path from cache, set:
+  *
+  *   $regex_path_match = '#^/news/?#';
+  *
+  * We don't set this variable for you, so you must define it
+  * yourself per your specific use case before the following conditional.
+  **/
+   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+     add_action( 'send_headers', 'add_header_nocache', 15 );
+   }
+   function add_header_nocache() {
+  	 header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+   }
   ```
-  <p markdown="1"> This example code will not work until you edit it to define `$regex_path_match`.</p>
   </div>
 </div>
 

--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -29,40 +29,48 @@ You can use a variety of mechanisms to determine which responses from your Drupa
   Here is an example of a global way to determine a Drupal response's cacheability. Use the `$conf` global variable to set `Cache-Control: max-age=0`:
 
   ```php
-  /**
-  * Set $regex_path_match accordingly. For example, to exclude
-  * pages in the /news/ path from cache, set:
-  *
-  *   $regex_path_match = '#^/news/?#';
-  *
-  * We don't set this variable for you, so you must define it
-  * yourself per your specific use case before the following conditional.
-  **/
-   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
-     drupal_page_is_cacheable(FALSE);
-     $conf['page_cache_maximum_age'] = 0;
-   }
+  /*
+   * Set $regex_path_match accordingly.
+   *
+   * We don't set this variable for you, so you must define it
+   * yourself per your specific use case before the following conditional.
+   *
+   * For example, to exclude pages in the /news/ path from cache, set:
+   *
+   *   $regex_path_match = '#^/news/?#';
+   */
+
+  $regex_path_match = '#^/some-directory-here/?#';
+
+  if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+    drupal_page_is_cacheable(FALSE);
+    $conf['page_cache_maximum_age'] = 0;
+  }
   ```
   </div>
   <div role="tabpanel" class="tab-pane" id="wp" markdown="1">
   Set `Cache-Control: max-age=0` by hooking into <a href="https://codex.wordpress.org/Plugin_API/Action_Reference/send_headers"><code>send_headers</code></a>. This will override `max-age` configured within the <a href="/docs/wordpress-cache-plugin">Pantheon Cache</a> plugin for all matching requests:
 
   ```php
-  /**
-  * Set $regex_path_match accordingly. For example, to exclude
-  * pages in the /news/ path from cache, set:
-  *
-  *   $regex_path_match = '#^/news/?#';
-  *
-  * We don't set this variable for you, so you must define it
-  * yourself per your specific use case before the following conditional.
-  **/
-   if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
-     add_action( 'send_headers', 'add_header_nocache', 15 );
-   }
-   function add_header_nocache() {
-  	 header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
-   }
+  /*
+   * Set $regex_path_match accordingly.
+   *
+   * We don't set this variable for you, so you must define it
+   * yourself per your specific use case before the following conditional.
+   *
+   * For example, to exclude pages in the /news/ path from cache, set:
+   *
+   *   $regex_path_match = '#^/news/?#';
+   */
+
+  $regex_path_match = '#^/some-directory-here/?#';
+
+  if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+    add_action( 'send_headers', 'add_header_nocache', 15 );
+  }
+  function add_header_nocache() {
+        header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
+  }
   ```
   </div>
 </div>

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -8,10 +8,13 @@ categories: []
 ## Disable Caching for Specific Pages
 You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response:
 ```
-//Set or replace $regex_path_match accordingly
+// Set or replace $regex_path_match accordingly
+// Example: anything in /news/ directory
+$regex_path_match = '#^/news/?#';
+
 if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
   $domain =  $_SERVER['HTTP_HOST'];
-  setcookie('NO_CACHE', '1', time()+0, '/path-to-page', $domain);
+  setcookie('NO_CACHE', '1', time()+0, '/news/', $domain);
 }
 ```
 As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -10,18 +10,30 @@ You can use regular expression(s) to determine if the current request (`$_SERVER
 
 For example, this block sets `NO_CACHE` for all pages in the `/news/` directory.
 
-**Be sure the path in your `setcookie()` line is properly set to restrict the cookie to the specific directory.**
 
 ```
-// Set or replace $regex_path_match accordingly
-// Example: anything in the /news/ directory
-$regex_path_match = '#^/news/?#';
+/*
+ * Set or replace $friendly_path accordingly.
+ *
+ * We don't set this variable for you, so you must define it
+ * yourself per your specific use case before the following conditional.
+ *
+ * Example: anything in the /news/ directory
+ *
+ * $friendly_path = '/news/';
+ */
 
-if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {
+$friendly_path = '/some-directory-here/';
+
+if (preg_match('#^' . $friendly_path . '#', $_SERVER['REQUEST_URI'])) {
   $domain =  $_SERVER['HTTP_HOST'];
-  setcookie('NO_CACHE', '1', time()+0, '/news/', $domain);
+  setcookie('NO_CACHE', '1', time()+0, $friendly_path, $domain);
 }
 ```
+
+
+**Be sure the `friendly_path` variable is properly set to restrict the cookie to the specific directory.**
+
 As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.
 
 ## Cache-varying Cookies
@@ -31,7 +43,7 @@ First, check to see if the cookie is set within the incoming request. If the coo
 
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
-<p>If the value has already been set, do not set the cookie again in the response. Varnish cannot cache a response that contains a <code>Set-Cookie:</code> header.
+<p markdown="1">If the value has already been set, do not set the cookie again in the response. Varnish cannot cache a response that contains a `Set-Cookie:` header.
 </p></div>
 
 If the value is **not** set, respond with `setcookie()` to serve cached content for subsequent requests within the defined cookie lifetime.

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -6,7 +6,12 @@ categories: []
 ---
 
 ## Disable Caching for Specific Pages
-You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response:
+You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response.
+
+For example, this block sets `NO_CACHE` for all pages in the `/news/` directory.
+
+**Be sure the path in your `setcookie()` line is properly set to restrict the cookie to the specific directory.**
+
 ```
 // Set or replace $regex_path_match accordingly
 // Example: anything in /news/ directory

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -14,7 +14,7 @@ For example, this block sets `NO_CACHE` for all pages in the `/news/` directory.
 
 ```
 // Set or replace $regex_path_match accordingly
-// Example: anything in /news/ directory
+// Example: anything in the /news/ directory
 $regex_path_match = '#^/news/?#';
 
 if (preg_match($regex_path_match, $_SERVER['REQUEST_URI'])) {


### PR DESCRIPTION
Update example to define $regex_path_match, as we're seeing multiple support cases recently where the example is simply cut-and-pasted, resulting in an error because `$regex_path_match` is not defined.
