### PR TITLE
Removing info rollovers for GCDN invite only.

### DIFF
--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -43,17 +43,17 @@ Rules are for the good of the group, and timeouts are no exception. We've config
 		</tr>
 	</thead><tbody>
 			<tr>
-				<td>Connection Timeout <a rel="popover" data-toggle="tooltip" data-proofer-ignore data-html="true" data-content="For sites upgraded to the new Pantheon Global Edge (invite only)."><em class="fa fa-info-circle"></em></a></td>
+				<td>Connection Timeout</td>
 				<td>60 seconds</td>
 				<td>Number of seconds to wait for a timeout.</td>
 			</tr>
 			<tr>
-				<td>First Byte Timeout <a rel="popover" data-toggle="tooltip" data-proofer-ignore data-html="true" data-content="For sites upgraded to the new Pantheon Global Edge (invite only)."><em class="fa fa-info-circle"></em></a></td>
+				<td>First Byte Timeout</td>
 				<td>60 seconds</td>
 				<td>Number of seconds to wait for the first byte.</td>
 			</tr>
 			<tr>
-			<td>Between Bytes Timeout <a rel="popover" data-toggle="tooltip" data-proofer-ignore data-html="true" data-content="For sites upgraded to the new Pantheon Global Edge (invite only)."><em class="fa fa-info-circle"></em></a></td>
+			<td>Between Bytes Timeout</td>
 			<td>60 seconds</td>
 			<td>Number of seconds to wait for between bytes.</td>
 			</tr>


### PR DESCRIPTION
##Closes
N/A

## Effect
Removes info rollover text indicating GCDN is invite only.
