### PR TITLE
optoinal typo to optional

### DIFF
--- a/source/_docs/drupal-broken-links.md
+++ b/source/_docs/drupal-broken-links.md
@@ -36,7 +36,7 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
 
-    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    # Name transaction "redirect" in New Relic for improved reporting (optional)
     if (extension_loaded('newrelic')) {
       newrelic_name_transaction("redirect");
     }

--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -27,7 +27,7 @@
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
 
-    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    # Name transaction "redirect" in New Relic for improved reporting (optional)
     if (extension_loaded('newrelic')) {
       newrelic_name_transaction("redirect");
     }
@@ -54,7 +54,7 @@
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
 
-    # Name transaction "redirect" in New Relic for improved reporting (optoinal)
+    # Name transaction "redirect" in New Relic for improved reporting (optional)
     if (extension_loaded('newrelic')) {
       newrelic_name_transaction("redirect");
     }


### PR DESCRIPTION
Fixes "optoinal" typo to "optional" in the New Relic transaction name section:

```
    # Name transaction "redirect" in New Relic for improved reporting (optional)
    if (extension_loaded('newrelic')) {
      newrelic_name_transaction("redirect");
    }
```