### PR TITLE
remove WP_SITEURL and WP_HOME due to warnings

### DIFF
--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -11,7 +11,7 @@
 <div role="tabpanel" class="tab-pane active" id="wp">
 <p markdown="1">Add the following to <code>wp-config.php</code> (replace <code>www.example.com</code>):</p>
 <pre id="git-pull-wp"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
-  // Redirect to https://$primary_domain/ in the Live environment
+  // Redirect to https://$primary_domain in the Live environment
   if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live') {
     /** Replace www.example.com with your registered domain name */
     $primary_domain = 'www.example.com';
@@ -20,9 +20,7 @@
     // Redirect to HTTPS on every Pantheon environment.
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
-  $base_url = 'https://'. $primary_domain;
-  define('WP_SITEURL', $base_url);
-  define('WP_HOME', $base_url);
+
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
@@ -33,7 +31,7 @@
     }
 
     header('HTTP/1.0 301 Moved Permanently');
-    header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
+    header('Location: https://'. $primary_domain . $_SERVER['REQUEST_URI']);
     exit();
   }
 }</code></pre>
@@ -41,7 +39,7 @@
 <div role="tabpanel" class="tab-pane" id="d8">
 <p markdown="1">Add the following to the end of your <code>settings.php</code> file (replace <code>www.example.com</code>):</p>
 <pre id="git-pull-drops-8"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
-  // Redirect to https://$primary_domain/ in the Live environment
+  // Redirect to https://$primary_domain in the Live environment
   if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live') {
     /** Replace www.example.com with your registered domain name */
     $primary_domain = 'www.example.com';
@@ -50,6 +48,7 @@
     // Redirect to HTTPS on every Pantheon environment.
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
+
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {
@@ -60,7 +59,7 @@
     }
 
     header('HTTP/1.0 301 Moved Permanently');
-    header('Location: '. 'https://'. $primary_domain . $_SERVER['REQUEST_URI']);
+    header('Location: https://'. $primary_domain . $_SERVER['REQUEST_URI']);
     exit();
   }
   // Drupal 8 Trusted Host Settings
@@ -72,7 +71,7 @@
 <div role="tabpanel" class="tab-pane" id="d7">
 <p markdown="1">Add the following to the end of your <code>settings.php</code> file (replace <code>www.example.com</code>):</p>
 <pre id="git-pull-drops-7"><code class="php hljs" data-lang="hljs">if (isset($_SERVER['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
-  // Redirect to https://$primary_domain/ in the Live environment
+  // Redirect to https://$primary_domain in the Live environment
   if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live') {
     /** Replace www.example.com with your registered domain name */
     $primary_domain = 'www.example.com';
@@ -92,7 +91,7 @@
     }
 
     header('HTTP/1.0 301 Moved Permanently');
-    header('Location: '. $base_url . $_SERVER['REQUEST_URI']);
+    header('Location: https://'. $primary_domain . $_SERVER['REQUEST_URI']);
     exit();
   }
 }</code></pre>

--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -80,7 +80,7 @@
     // Redirect to HTTPS on every Pantheon environment.
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
-  $base_url = 'https://'. $primary_domain;
+
   if ($_SERVER['HTTP_HOST'] != $primary_domain
       || !isset($_SERVER['HTTP_X_SSL'])
       || $_SERVER['HTTP_X_SSL'] != 'ON' ) {


### PR DESCRIPTION
Removed `WP_SITEURL` and `WP_HOME` from our redirect snippet as the constants are already defined in our [stock wp-config.php](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php#L78-L79):

```
        define('WP_HOME', $scheme . '://' . $_SERVER['HTTP_HOST']);
        define('WP_SITEURL', $scheme . '://' . $_SERVER['HTTP_HOST']);
```

Including them here is not necessary and is introducing PHP warnings.

If the $primary_domain doesn't match on live it'll do a redirect, and then the next run will set WP_SITEURL and WP_HOME just fine.

Also removed $base_url as it is only used once and can be simplified in the code by updating the Location header.