### PR TITLE
Terminus Commands: Note help option

### DIFF
--- a/source/_docs/terminus/commands.md
+++ b/source/_docs/terminus/commands.md
@@ -9,6 +9,11 @@ previousurl: terminus/examples/
 permalink: docs/terminus/:basename/
 image: terminus-thumbLarge
 ---
+<div class="alert alert-info" markdown="1">
+<h4 class="info">Note</h4>
+If you would like addition information for a given command (e.g., available `--fields` or `--format` options) run the command with the `--help` option in your terminal.
+</div>
+
 <!--Note: The contents of the command reference table cannot be edited in the docs project. This table is automatically generated using Terminus (terminus list --format=json). Submit feedback and report issues related to the contents of this table on the Terminus repo: https://github.com/pantheon-systems/terminus/issues -->
 
 <div class="container col-md-12" ng-app="terminusCommandsApp" ng-controller="mainController">

--- a/source/_docs/terminus/commands.md
+++ b/source/_docs/terminus/commands.md
@@ -11,7 +11,7 @@ image: terminus-thumbLarge
 ---
 <div class="alert alert-info" markdown="1">
 <h4 class="info">Note</h4>
-If you would like addition information for a given command (e.g., available `--fields` or `--format` options) run the command with the `--help` option in your terminal.
+If you would like additional information for a given command (e.g., available `--fields` or `--format` options) run the command with the `--help` option in your terminal.
 </div>
 
 <!--Note: The contents of the command reference table cannot be edited in the docs project. This table is automatically generated using Terminus (terminus list --format=json). Submit feedback and report issues related to the contents of this table on the Terminus repo: https://github.com/pantheon-systems/terminus/issues -->


### PR DESCRIPTION
Closes #2844 

## Effect
PR includes the following changes:
- Add a note to the top of the Command Reference page within the Terminus Manual directing users to run commands with the `--help` option for additional information like available fields. 

cc @eabquina @kimby77 