### PR TITLE
remove extra argument to git remote

### DIFF
--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -146,7 +146,7 @@ Automatic merge went well; stopped before committing as requested
 
 ### Add the Pantheon Site as a Git Remote
 
-1. From your terminal within the site directory, use the Git `remote add` command with an remote name (such as "pantheon") to make sure you know when you are moving code to or from Pantheon.
+1. From your terminal within the site directory, use the Git `remote add` command with a remote name (such as "pantheon") to make sure you know when you are moving code to or from Pantheon.
   ```nohighlight
   git remote add pantheon ssh://codeserver.dev.{site-id}@codeserver.dev.{site-id}.drush.in:2222/~/repository.git
   ```

--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -146,7 +146,7 @@ Automatic merge went well; stopped before committing as requested
 
 ### Add the Pantheon Site as a Git Remote
 
-1. From your terminal within the site directory, use the Git `remote add` command with an alias to make sure you know when you are moving code to or from Pantheon.
+1. From your terminal within the site directory, use the Git `remote add` command with an remote name (such as "pantheon") to make sure you know when you are moving code to or from Pantheon.
   ```nohighlight
   git remote add pantheon ssh://codeserver.dev.{site-id}@codeserver.dev.{site-id}.drush.in:2222/~/repository.git
   ```

--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -148,7 +148,7 @@ Automatic merge went well; stopped before committing as requested
 
 1. From your terminal within the site directory, use the Git `remote add` command with an alias to make sure you know when you are moving code to or from Pantheon.
   ```nohighlight
-  git remote add pantheon ssh://codeserver.dev.{site-id}@codeserver.dev.{site-id}.drush.in:2222/~/repository.git pantheon-new-site-import
+  git remote add pantheon ssh://codeserver.dev.{site-id}@codeserver.dev.{site-id}.drush.in:2222/~/repository.git
   ```
 
 2. Run a Git add and commit to prepare the Pantheon core merge for pushing to the repository:


### PR DESCRIPTION
Re: https://pantheon.io/docs/guides/collaborative-development/#add-the-pantheon-site-as-a-git-remote

the `git remote add` command has a site name/label of `pantheon-new-site-import` tacked on the end, which is invalid.  This PR removes the trailing parameter.


> git remote add pantheon ssh://codeserver.dev.{site-id}@codeserver.dev.{site-id}.drush.in:2222/~/repository.git **pantheon-new-site-import**

I also clarified the use of a remote name "pantheon" in the instructions.  It was called an alias, but git docs simply call it a "remote name."