### PR TITLE
Update Sendgrid Integration module installation instructions

### DIFF
--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -53,6 +53,12 @@ Two methods can be used to integrate SendGrid with your Drupal site: API or SMTP
 - API integration using the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module is recommended; however, installation of this module is slightly more complicated, as it requires the use of [Composer](/docs/composer/).
 
 ### SendGrid API Integration
+
+<div class="alert alert-danger">
+<h4 class="info">Warning</h4>
+<p markdown="1">The SendGrid API Integration Module for Drupal 8 requires a Composer managed workflow, as described in our [Build Tools](/docs/guides/build-tools/) guide. We cannot support non-Composer workflows using this module. For details, see [the module readme](http://cgit.drupalcode.org/sendgrid_integration/tree/README.md?id=185c4ea){.external} file.</p>
+</div>
+
 1.  Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using Composer:
 
  ```nohighlight

--- a/source/_docs/guides/sendgrid.md
+++ b/source/_docs/guides/sendgrid.md
@@ -53,18 +53,10 @@ Two methods can be used to integrate SendGrid with your Drupal site: API or SMTP
 - API integration using the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module is recommended; however, installation of this module is slightly more complicated, as it requires the use of [Composer](/docs/composer/).
 
 ### SendGrid API Integration
-A stable release for Drupal 8 is not yet available for the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module. However, the development release seems to work fairly well. Use with caution.
-
-1.  Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/docs/terminus):
+1.  Install the [SendGrid Integration](https://www.drupal.org/project/sendgrid_integration) module using Composer:
 
  ```nohighlight
- terminus drush <site>.<env> -- en sendgrid_integration -y
- ```
-
- Access the composer manager page `/admin/config/system/composer-manager` and click "Reuild composer.json file" button.
-
- ```nohighlight
- terminus drush <site>.<env> -- composer-manager update --no-dev
+composer require drupal/sendgrid_integration
  ```
 
 2.  From within your SendGrid account, navigate to **Settings** > **API Keys** and create a site-specific API Key. Click the key to copy it to your keyboard.


### PR DESCRIPTION
Closes #2901

## Effect
PR includes the following changes:
- Remove warning about Sendgrid Integration only having a dev release (there's a stable version now: https://www.drupal.org/project/sendgrid_integration).
- Replace instructions about using Composer Manager with a command for regular Composer.

## Remaining Work
- [ ] Reference the need for a Composer managed site, and link to the build tools guide.
