### PR TITLE
Update php-versions.md to note PHP 7.1 support

### DIFF
--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -16,7 +16,7 @@ Older software is more likely to contain code that is incompatible with recent P
 Verify current PHP settings from the Site Dashboard by clicking **Settings** > **PHP version**.
 
 ### Available PHP Versions
-Available PHP versions are 5.3, 5.5, 5.6, and 7.0.
+Available PHP versions are 5.3, 5.5, 5.6, 7.0, and 7.1.
 
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>


### PR DESCRIPTION
I just set up xdebug locally in PHP 7.0 because I thought Pantheon didn't support 7.1 because it wasn't listed in the docs, but it is actually supported (it even shows 7.1 in a screenshot, but it's not listed under supported versions).

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
