### PR TITLE
Reset Dev Env to Live only affects code

### DIFF
--- a/source/_docs/undo-commits.md
+++ b/source/_docs/undo-commits.md
@@ -84,7 +84,7 @@ git push origin master
 
 
 ## Reset Dev Environment to Live
-If the Dev environment gets tangled up with changes you wish to abandon, you can reset history to match the current state of Live using [Terminus](/docs/terminus). Again, this is destructive. If you're not comfortable with this technique, use one of the revert techniques.
+If the Dev environment gets tangled up with changes you wish to abandon, you can reset history to match the current state of Live using [Terminus](/docs/terminus). Again, this is destructive. If you're not comfortable with this technique, use one of the revert techniques. Also note, this resets the Dev environment's codebase only, it does not clone Live's database or files down to Dev. 
 
 Identify the most recent commit deployed to Live and overwrite history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
 ```


### PR DESCRIPTION
Clarification that the Reset Dev Env to Live does not clone down Live's db or files.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
