### PR TITLE
rename Helper Tools Drupal tab to Drupal 8

### DIFF
--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -250,7 +250,7 @@ There are toolbars for both Drupal and WordPress that provide stats like the num
   <li id="tab-1-id" role="presentation" class="active"><a href="#wp-helpers" aria-controls="wp-helpers" role="tab" data-toggle="tab">WordPress</a></li>
 
   <!-- 2nd Tab Nav -->
-  <li id="tab-2-id" role="presentation"><a href="#drupal-helpers" aria-controls="drupal-helpers" role="tab" data-toggle="tab">Drupal</a></li>
+  <li id="tab-2-id" role="presentation"><a href="#drupal-helpers" aria-controls="drupal-helpers" role="tab" data-toggle="tab">Drupal 8</a></li>
 </ul>
 
 <!-- Tab panes -->


### PR DESCRIPTION
webprofiler module is only available for D8.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
