### PR TITLE
Workaround for D7 text challenge files.

### DIFF
--- a/source/_docs/https.md
+++ b/source/_docs/https.md
@@ -141,8 +141,8 @@ By default Sucuri blocks serving the challenges needed to verify domain ownershi
 ### Moz Pro 804 HTTPS SSL error
 Moz Pro is unable to crawl sites using Server Name Indication (SNI). For information on beta access to SNI support, see [Moz Pro, our web crawler, and sites that use SNI (804 HTTPS SSL) error](https://moz.com/community/q/moz-pro-our-web-crawler-and-sites-that-use-sni).
 
-### 403 Permission Denied (Drupal)
-The text challenge to pre-provision HTTPS on Pantheon requires adding a `.well-known` directory to the root of your site. However, Drupal core has a line in the `.htaccess` file that disallows Apache from serving dot files and folders, which returns a 403 permission denied response. If you see this error while trying to  pre-provision HTTPS on Drupal sites, use the [Let's Encrypt Challenge](https://www.drupal.org/project/letsencrypt_challenge) contrib module as a workaround.
+### Drupal text challenge file gets 403 - permission denied on Apache
+Drupal core has a line in the `.htaccess` file that disallows apache to serve files and folders starting with `.` (**dot files**).  The text challenge provided in the Pantheon dashboard to pre-provision the certificate requires that you add a `.well-known` folder into the root of your site.  We recommend using the [Let's Encrypt Challenge](https://www.drupal.org/project/letsencrypt_challenge){.external} contrib module to work around this issue.
 
 ## Glossary
 ### HTTPS


### PR DESCRIPTION
Closes #3020 
Supersedes: #3022 (came from another fork, so no CI tests were run on that branch)

## Effect
PR includes the following changes:
- New FAQ section on [HTTPS on Pantheon's Global CDN](/source/docs/https)
- Explains the issue.
- Suggests the same contrib module recommended in the Domains doc as a solution.

## Remaining Work
- [ ] 👍  from @bentekwork (optional)
- [ ] 👍  from @rachelwhitton  (optional)
