### PR TITLE
#3057 - update eligibility information

### DIFF
--- a/source/_docs/pantheon-enterprise-gateway.md
+++ b/source/_docs/pantheon-enterprise-gateway.md
@@ -4,7 +4,7 @@ description: Configuring your Drupal or WordPress site to use the Pantheon Enter
 tags: [infrastructure, security]
 categories: []
 ---
-[Pantheon Enterprise Gateway](https://pantheon.io/features/secure-integration) creates a secure tunnel between your firewall and your public facing website. This is available for customers with an Elite plan. [Contact us](https://pantheon.io/why-pantheon-enterprise) for more information.
+[Pantheon Enterprise Gateway](https://pantheon.io/features/secure-integration) creates a secure tunnel between your firewall and your public facing website. This is available for sites within Enterprise and EDU+ organizations. [Contact us](https://pantheon.io/pantheon-enterprise) for more information.
 
 ![pantheon enterprise gateway](/source/docs/assets/images/PEG_diagram.png)
 


### PR DESCRIPTION
Closes #3057 

## Effect
PR includes the following changes:
- updates to state sites must be in Enterprise or EDU+ org (PantheonOne too - but I think we aren't mentioning those any more?)
- updates url to currently enterprise url


## Remaining Work
- [ ] Should we mention "contact us (link to enterprise page) - or your account manager for more information!" We can't know who their account manager is...it isn't anywhere on the org for them to know either...so I left it as is with just the link to the form, anticipating they'll sift through the requests there.
