### PR TITLE
Note the dev movement from Kalabox to Lando

### DIFF
--- a/source/_docs/kalabox.md
+++ b/source/_docs/kalabox.md
@@ -4,6 +4,12 @@ description: Work locally and deploy to Pantheon using Kalabox.
 tags: [local]
 categories: []
 ---
+
+<div class="alert alert-info" role="alert">
+  <h4 class="info">Note</h4>
+  <p markdown="1">Active development has been halted in favor of its successor, [Lando](https://github.com/lando/lando){.external}. Please review the [Lando documentation](https://docs.devwithlando.io/){.external} for more information.</p>
+</div>
+
 [Kalabox](http://www.kalabox.io/) is a Free and Open Source project allows you to quickly create and manage local environments that mirror site environments on Pantheon with the press of a button, including add on services such as Redis and Solr. Kalabox includes both an intuitive GUI and  command-line interface, and is powered by [Docker](https://www.docker.com/) under the hood.
 
 Support for Kalabox is provided via their [GitHub issue queue](https://github.com/kalabox/kalabox).

--- a/source/_docs/kalabox.md
+++ b/source/_docs/kalabox.md
@@ -5,9 +5,9 @@ tags: [local]
 categories: []
 ---
 
-<div class="alert alert-info" role="alert">
-  <h4 class="info">Note</h4>
-  <p markdown="1">Active development has been halted in favor of its successor, [Lando](https://github.com/lando/lando){.external}. Please review the [Lando documentation](https://docs.devwithlando.io/){.external} for more information.</p>
+<div class="alert alert-danger" role="alert">
+  <h4 class="info">Warning</h4>
+  <p markdown="1">Active development for Kalabox has been halted in favor of its successor, Lando. For more details, refer to [Lando's documentation](https://docs.devwithlando.io/){.external}.</p>
 </div>
 
 [Kalabox](http://www.kalabox.io/) is a Free and Open Source project allows you to quickly create and manage local environments that mirror site environments on Pantheon with the press of a button, including add on services such as Redis and Solr. Kalabox includes both an intuitive GUI and  command-line interface, and is powered by [Docker](https://www.docker.com/) under the hood.


### PR DESCRIPTION
Closes #3056 

## Effect
PR includes the following changes:
- Adds a note at the top of the Kalabox doc, informing the reader of the move to Lando
- Links to both the Lando repository on GitHub, and their documentation.


## Remaining Work
- [x] Copy Review from @rachelwhitton 
