### PR TITLE
Reference Slack Channel Name

### DIFF
--- a/source/_docs/power-users.md
+++ b/source/_docs/power-users.md
@@ -5,7 +5,7 @@ contributors:
   - joshkoenig
 date: 7/27/2015
 ---
-Pantheon fosters a community for those actively making use of the platform, primarily website development professionals. If you are an active developer on the Pantheon platform, you may benefit from joining our [Power Users Slack channel](https://slackin.pantheon.io/) or [Power Users mailing list](https://groups.google.com/a/pantheon.io/forum/#!forum/power-users).
+Pantheon fosters a community for those actively making use of the platform, primarily website development professionals. If you are an active developer on the Pantheon platform, you may benefit from joining our [Power Users Slack channel](https://slackin.pantheon.io/){.external} or [Power Users mailing list](https://groups.google.com/a/pantheon.io/forum/#!forum/power-users){.external}.
 
 ## Power User Topics
 
@@ -21,11 +21,11 @@ The community is an excellent way to bounce ideas off other expert developers. I
 
 ## Joining the Community
 
-You can get access to the Slack community [by clicking here](https://slackin.pantheon.io/).
+You can join the Slack community [by clicking here](https://slackin.pantheon.io/){.external}. The Slack Community can also be accessed at [pantheon-community.slack.com](https://pantheon-community.slack.com/){.external}.
 
-If you have a Google account you can join Power Users mailing list via the [group page](https://groups.google.com/a/pantheon.io/forum/#!forum/power-users), which also allows you to browse and interact via the web.
+If you have a Google account you can join Power Users mailing list via the [group page](https://groups.google.com/a/pantheon.io/forum/#!forum/power-users){.external}, which also allows you to browse and interact via the web.
 
-You can also subscribe with any email address by sending a message to [power-users+subscribe@pantheon.io](mailto:power-users+subscribe@pantheon.io).
+You can also subscribe with any email address by sending a message to [power-users+subscribe@pantheon.io](mailto:power-users+subscribe@pantheon.io){.external}.
 
 ## Code of Conduct
 


### PR DESCRIPTION
Closes #3119 

## Effect
PR includes the following changes:
- Provide the Slack channel name, for those who have signed up already and only need to regain access.
- Also adds external link markers.

## Remaining Work
- [ ] Copy review
