### PR TITLE
it's / its fix

### DIFF
--- a/source/_docs/composer.md
+++ b/source/_docs/composer.md
@@ -21,7 +21,7 @@ We recommend the Pull Request workflow for single site use cases, and for most u
 However, this method does not support One-click updates in the Site Dashboard. Adopting this workflow means forgoing all other update techniques in favor of Composer. If your use case requires a simpler update strategy for non-technical site admins, this workflow could present problems scaling or at the very least require additional training for your development team.
 
 ## Custom Upstream Workflow
-It is possible to preserve the functionality of Pantheon's One-click updates in the Site Dashboard for Composer managed sites created from a [Custom Upstream](/docs/custom-upstream/), however it's use case is quite narrow.
+It is possible to preserve the functionality of Pantheon's One-click updates in the Site Dashboard for Composer managed sites created from a [Custom Upstream](/docs/custom-upstream/), however its use case is quite narrow.
 
 A Custom Upstream based off Pantheon's example repositories would need to commit all dependencies. Updates via Composer would only happen at the Custom Upstream repository level by a single repository maintainer. Those updates would then trickle down to sites created from the Custom Upstream as One-click updates in the Pantheon Site Dashboard.
 


### PR DESCRIPTION
Fixes #3151 

**Effect:** corrects an "it's / its" typo on composer documentation