### PR TITLE
Clarify procedure to maintain custom upstreams

### DIFF
--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -4,14 +4,20 @@ description: Detailed information on how to maintain Custom Upstreams and distri
 tags: [tools, workflow]
 categories: []
 ---
-Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. We recommend the following workflow to maintain Custom Upstreams on Pantheon.
+Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of what type of update you're preparing for release, you'll want to test things out before you distribute them out to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon.
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
 <p markdown="1">Failure to run the most up-to-date version of core based on upstreams maintained by Pantheon ([WordPress](https://github.com/pantheon-systems/wordpress), [Drupal 7](https://github.com/pantheon-systems/drops-7), and [Drupal 8](https://github.com/pantheon-systems/drops-8)) may cause incompatibilities with the platform (e.g. clear cache button, launch checks, cron, etc.).</p>
 </div>
 
-Regardless of what type of update you're preparing for release, you'll want to test things out before you distribute them out to your sites. You should have a remote repository for your Custom Upstream already in place and connected to Pantheon. If you do not, please [do so now](/docs/create-custom-upstream).
+## Before You Begin
+Follow the procedure to [create a custom upstream](/docs/create-custom-upstream) so that you have:
+
+- A repository for your Custom Upstream hosted with your preferred provider (GitLab, BitBucket)
+- A local clone of that repository that tracks Pantheon's upstream as a remote
+- Pantheon's core code merged into your Custom Upstream repository
+- Your Custom Upstream repository connected to Pantheon
 
 ## Create a Test Site on Pantheon
 
@@ -103,7 +109,15 @@ Regardless of what type of update you're preparing for release, you'll want to t
 
 7. Click the **Create Environment** button next to the `core-update` branch.
 
-8. Use this new Multidev environment to evaluate your `core-update` branch. When you're ready to release, merge the branch into master and push to your remote repository on GitHub or Bitbucket.  
+8. Use this new Multidev environment to evaluate your `core-update` branch. When you're ready to release, merge the branch into master and push to your remote repository on GitHub or Bitbucket:
+
+    ```command
+    git checkout master
+    git merge --no-ff core-update
+    git push origin master
+    ```
+
+    This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
 Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/upstream-updates).
 

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -4,18 +4,18 @@ description: Detailed information on how to maintain Custom Upstreams and distri
 tags: [tools, workflow]
 categories: []
 ---
-Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of what type of update you're preparing for release, you'll want to test things out before you distribute them out to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon.
+Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon.
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
-<p markdown="1">Failure to run the most up-to-date version of core based on upstreams maintained by Pantheon ([WordPress](https://github.com/pantheon-systems/wordpress), [Drupal 7](https://github.com/pantheon-systems/drops-7), and [Drupal 8](https://github.com/pantheon-systems/drops-8)) may cause incompatibilities with the platform (e.g. clear cache button, launch checks, cron, etc.).</p>
+<p markdown="1">Failure to run the most up-to-date version of core based on upstreams maintained by Pantheon ([WordPress](https://github.com/pantheon-systems/wordpress){.external}, [Drupal 7](https://github.com/pantheon-systems/drops-7){.external}, and [Drupal 8](https://github.com/pantheon-systems/drops-8){.external}) may cause incompatibilities with the platform (e.g. clear cache button, launch checks, cron, etc.).</p>
 </div>
 
 ## Before You Begin
 Follow the procedure to [create a custom upstream](/docs/create-custom-upstream) so that you have:
 
-- A repository for your Custom Upstream hosted with your preferred provider (GitLab, BitBucket)
-- A local clone of that repository that tracks Pantheon's upstream as a remote
+- A repository for your Custom Upstream hosted with your preferred provider (GitLab, BitBucket, etc)
+- A local clone of that repository, which tracks Pantheon's upstream as a remote
 - Pantheon's core code merged into your Custom Upstream repository
 - Your Custom Upstream repository connected to Pantheon
 
@@ -31,7 +31,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 
 ## Test and Release Pantheon Core Updates
 
-1. Add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote) within a local clone of your Custom Upstream repository if you haven't done so already:
+1. Add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} within a local clone of your Custom Upstream repository if you haven't done so already:
 
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
@@ -59,7 +59,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
     terminus connection:info <site>.dev --field=git_url
     ```
 
-3. Replace `<git_url>` in the following command to add your new test site as a [remote](https://git-scm.com/docs/git-remote):
+3. Replace `<git_url>` in the following command to add your new test site as a [remote](https://git-scm.com/docs/git-remote){.external}:
 
     ```command
     git remote add pantheon-test <git_url>
@@ -99,17 +99,17 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
      </div>
      </div><br>
 
-5. Push to your new test site on Pantheon:
+6. Push to your new test site on Pantheon:
 
   ```command
   git push pantheon-test core-update
   ```
 
-6. Back on the Site Dashboard for your test site, navigate to the Multidev overview tab and click **Git Branches**.
+7. Back on the Site Dashboard for your test site, navigate to the Multidev overview tab and click **Git Branches**.
 
-7. Click the **Create Environment** button next to the `core-update` branch.
+8. Click the **Create Environment** button next to the `core-update` branch.
 
-8. Use this new Multidev environment to evaluate your `core-update` branch. When you're ready to release, merge the branch into master and push to your remote repository on GitHub or Bitbucket:
+9. Use this new Multidev environment to evaluate your `core-update` branch. When you're ready to release, merge the branch into master and push to your remote repository on GitHub or Bitbucket:
 
     ```command
     git checkout master
@@ -119,7 +119,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 
     This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
-Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/upstream-updates).
+Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/upstream-updates).
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>
@@ -143,7 +143,7 @@ Use the `pantheon.upstream.yml` file when working with Custom Upstreams to set d
 #### Automatically Resolve from the Command Line
 If you receive the error that you have conflicts while updating core, the fastest resolution is often the `-Xtheirs` flag. This will attempt to automatically resolve the conflicts with a preference for upstream changes and is safe to run if you don't have your own changes in any of the conflicting files (e.g. problems with `.gitignore`).
 
-1. Navigate to the Custom Upstream's root directory using the command line and add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote), if you haven't done so already:
+1. Navigate to the Custom Upstream's root directory using the command line and add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external}, if you haven't done so already:
 
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
@@ -197,7 +197,7 @@ Double-check the conflicted files before going forward to make sure no bugs were
 If attempts to automatically resolve conflicts fail or if you want your changes to persist instead of the upstreams, you'll need to manually resolve the conflict using the command line and a text editor.
 
 
-1. Navigate to the Custom Upstream's root directory using the command line and add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote), if you haven't done so already:
+1. Navigate to the Custom Upstream's root directory using the command line and add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external}, if you haven't done so already:
 
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">


### PR DESCRIPTION
Closes #3072 

## Effect
PR includes the following changes:
- Add before you begin section so that users start in the expected state
- Provide commands to merge and push to the canonical repository 
  - Note that `origin` is the expected remote for the GitHub/BitBucket repo

