### PR TITLE
Clarify nginx-access.log retention policy

### DIFF
--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -26,7 +26,7 @@ The server timezone and all log timestamps are in UTC (Coordinated Universal Tim
       </tr>
       <tr>
         <th>nginx-access.log</th>
-        <td>60 days of logs</td>
+        <td>Up to 60 days of logs</td>
         <td  markdown="1">Webserver access log. **Do not consider canonical**, as this will be wiped if the application server is reset or rebuilt. See <a href="/docs/nginx-access-log">Parsing nginx Access Logs with GoAccess</a>.</td>
       </tr>
       <tr>


### PR DESCRIPTION
Expand "60 days of logs" (line 29) to the more precise "Up to 60 days of logs".

A customer asked how they could access all 60 days of their nginx-access.log based on the information shown here, which is misleading / inaccurate information as we only keep the logs until the appserver they're on is migrated. If their appserver has just been migrated, they may only have a few hours (or less) of logs available.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
