### PR TITLE
adding google tfa info

### DIFF
--- a/source/_docs/guides/two-factor-authentication.md
+++ b/source/_docs/guides/two-factor-authentication.md
@@ -141,7 +141,7 @@ Two-factor authentication is a helpful security practice because it prevents att
 
 ## Pantheon Platform TFA
 ### Log in with Google
-The Pantheon Dashboard offers social login with Google:
+The Pantheon Dashboard offers social login with Google, which can be configured to use [Google TFA](https://www.google.com/landing/2step/):
 
 ![Connect with Google](/source/docs/assets/images/log-in-with-google.png)
 


### PR DESCRIPTION
Closes #
N/A
## Effect
Makes it clearer that 2FA is done through Google. From question in Slack:
https://pantheon.slack.com/archives/C03SRV7HB/p1516396709000259
