### PR TITLE
Update platform-considerations.md

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -185,17 +185,13 @@ $databases['default']['default']['charset'] = 'utf8mb4';
 $databases['default']['default']['collation'] = 'utf8mb4_general_ci';
 ```
 
-For existing sites that already have an active database, you then have to install the [UTF8MB4 Convert](https://www.drupal.org/project/utf8mb4_convert){.external} Drush command and convert the database. 
-
-Note that UTF8MB4 Convert is not a Drupal module that can be enabled. It is a Drush command and can be placed inside the  /sites/all/drush folder. Drush cache will need to be cleared before the command can be run.
-
-Drush cache can be cleared using the following Terminus command, replacing `<site>` with your site name, and `<env>` with the environment (usually `dev`):
+Existing sites that already have an active database must install the [UTF8MB4 Convert](https://www.drupal.org/project/utf8mb4_convert){.external} Drush command and convert the database. Note that this is not a Drupal module that can be enabled, it's a Drush command that should be placed within `/sites/all/drush`. Once you've installed the command in `/sites/all/drush`, you must clear Drush cache for the new command to run. Clear Drush cache using [Terminus](/docs/terminus/):
 
 ```bash
 terminus drush <site>.<env> -- cc drush
 ```
 
-Start by making a [backup](/docs/backups/) of the site database, then place the site in maintenance mode. When ready, run the following command, replacing `<site>` with your site name, and `<env>` with the environment (usually `dev`):
+Start by making a [backup](/docs/backups/) of the site database, then place the site in maintenance mode and run the following:
 
 ```bash
 terminus drush <site>.<env> -- utf8mb4-convert-databases

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -185,11 +185,20 @@ $databases['default']['default']['charset'] = 'utf8mb4';
 $databases['default']['default']['collation'] = 'utf8mb4_general_ci';
 ```
 
-For existing sites that already have an active database, you then have to install the [UTF8MB4 Convert](https://www.drupal.org/project/utf8mb4_convert){.external} module and convert the database. Start by making a [backup](/docs/backups/) of the site database, then place the site in maintenance mode. When ready, run the following command, replacing `<site>` with your site name, and `<env>` with the environment (usually `dev`):
+For existing sites that already have an active database, you then have to install the [UTF8MB4 Convert](https://www.drupal.org/project/utf8mb4_convert){.external} Drush command and convert the database. 
+
+Note that UTF8MB4 Convert is not a Drupal module that can be enabled. It is a Drush command and can be placed inside the  /sites/all/drush folder. Drush cache will need to be cleared before the command can be run.
+
+Drush cache can be cleared using the following Terminus command, replacing `<site>` with your site name, and `<env>` with the environment (usually `dev`):
+
+```bash
+terminus drush <site>.<env> -- cc drush
+```
+
+Start by making a [backup](/docs/backups/) of the site database, then place the site in maintenance mode. When ready, run the following command, replacing `<site>` with your site name, and `<env>` with the environment (usually `dev`):
 
 ```bash
 terminus drush <site>.<env> -- utf8mb4-convert-databases
 ```
-
 
 This will convert the database tables in the existing installation to the proper encoding to support emoji characters. After making the conversion, test it out by placing an emoji in the site text.


### PR DESCRIPTION
UTF8MB4 Convert is not a module that can be enabled. Downloading via the normal method will place the command in $HOME/.drush but it will need to be moved to the proper location so that Drush can find it.
