### PR TITLE
clarify CNAME reqs for auto-cert renewal

### DIFF
--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,6 +1,6 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All A/AAAA/CNAME/DNAME DNS records must point to Pantheon's servers so Let's Encrypt can verify domain ownership. MX/NS and similar records can point to other addresses.</li>
+  <li>All A/AAAA/CNAME/DNAME DNS records must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
   <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,8 +1,8 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
   <li>All A/AAAA/CNAME/DNAME DNS records must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
+  <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
-  <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
 </ul>
 <p>Please check this doc periodically as requirements may be added or removed.</p>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -4,7 +4,7 @@
   <li>Authority Name Servers must serve mixed-case lookups.</li>
   <li>Authority Name Servers must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
-  <li>CNAMEs must follow the above requirements.</li>
+  <li>CNAMEs records must point to Pantheon's provided <a href="/docs/domains/#platform-domains">platform domain</a> for the target environment. Subdomains such as <code>www.example.com</code> do not require A/AAAA records.</li>
   <li>DNAMEs must not be used.</li>
 </ul>
 <p>Please check this doc periodically as requirements may be added or removed.</p>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,9 +1,8 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All DNS records, whether A/AAAA/CNAME, must point to Pantheon's servers so Let's Encrypt can verify domain ownership. Verification is performed via a special file hosted on the platform (e.g., <code>http://example.com/.well-known/acme-challenge/[variableDataHere]</code>)</li>
+  <li>All A/AAAA/CNAME/DNAME DNS records must point to Pantheon's servers so Let's Encrypt can verify domain ownership. MX/NS and similar records can point to other addresses.</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
   <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
-  <li>DNAMEs must not be used.</li>
 </ul>
 <p>Please check this doc periodically as requirements may be added or removed.</p>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,9 +1,9 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All A/AAAA records must point to a server that serves Pantheon's acme-challenge response (e.g., <code>http://23.185.0.1/.well-known/acme-challenge/[variableDataHere]</code>).</li>
-  <li>Authority Name Servers must serve mixed-case lookups.</li>
-  <li>Authority Name Servers must not fail CAA lookups.</li>
+  <li>All DNS records must point to Pantheon's servers, so Let's Encrypt can verify domain ownership. Verification is performed via a special file hosted on the platform (e.g., <code>http://example.com/.well-known/acme-challenge/[variableDataHere]</code>)</li>
+  <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
+  <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
   <li>CNAMEs records must point to Pantheon's provided <a href="/docs/domains/#platform-domains">platform domain</a> for the target environment. Subdomains such as <code>www.example.com</code> do not require A/AAAA records.</li>
   <li>DNAMEs must not be used.</li>
 </ul>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,10 +1,9 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All DNS records must point to Pantheon's servers, so Let's Encrypt can verify domain ownership. Verification is performed via a special file hosted on the platform (e.g., <code>http://example.com/.well-known/acme-challenge/[variableDataHere]</code>)</li>
+  <li>All DNS records, whether A/AAAA/CNAME, must point to Pantheon's servers so Let's Encrypt can verify domain ownership. Verification is performed via a special file hosted on the platform (e.g., <code>http://example.com/.well-known/acme-challenge/[variableDataHere]</code>)</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>
   <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
-  <li>CNAMEs records must point to Pantheon's provided <a href="/docs/domains/#platform-domains">platform domain</a> for the target environment. Subdomains such as <code>www.example.com</code> do not require A/AAAA records.</li>
   <li>DNAMEs must not be used.</li>
 </ul>
 <p>Please check this doc periodically as requirements may be added or removed.</p>


### PR DESCRIPTION
Closes #3216 

## Effect
PR includes the following changes:
- Adjusts CNAME requirements for certificate renewal.

The concern posed was:

> Customer wanted to be clear if A and AAAA records are actually needed for automated certificate renewal

Per @kf6nux:

> Yes, at least one A/AAAA is required, but can be found via CNAME chasing. If they CNAME to their platform-domain, our platform's A/AAAA records will be used. 

This attempts to clarify the point based on the above concern and clarification.

## Remaining Work
- [ ] Review from @eabquina and/or @kf6nux 
- [ ] Copy Review
