### PR TITLE
Fix overlap in copy button

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -2570,7 +2570,6 @@ a.btn-primary-inverse:hover:after  {
   position: absolute;
   right: 3px;
   top: 3px;
-  bottom: 3px;
   border-radius: 0 4px 4px 0;
 }
 


### PR DESCRIPTION
Closes #3066 

## Effect
PR includes the following changes:
- Remove bottom set in .btn-clippy

cc @kimby77 