### PR TITLE
Adding a missing directory for Terminus Composer Plugin

### DIFF
--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -109,7 +109,8 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
 
     <div class="copy-snippet">
       <button class="btn btn-default btn-clippy" data-clipboard-target="#composer-plugin">Copy</button>
-      <figure><pre id="composer-plugin"><code class="command bash" data-lang="bash">composer create-project -n -d $HOME/.terminus/plugins pantheon-systems/terminus-composer-plugin:~1</code></pre></figure>
+      <figure><pre id="composer-plugin"><code class="command bash" data-lang="bash">mkdir -p $HOME/.terminus/plugins
+composer create-project -n -d $HOME/.terminus/plugins pantheon-systems/terminus-composer-plugin:~1</code></pre></figure>
     </div>
 
 5. Install the [Terminus Drupal Console Plugin](https://github.com/pantheon-systems/terminus-drupal-console-plugin){.external}:


### PR DESCRIPTION
Without first creating this directory, user will receive this error message -
[RuntimeException]                                                                  
Invalid working directory specified, ~/.terminus/plugins does not exist.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed
