### PR TITLE
Deploy AddSearch alongside existing GSS

### DIFF
--- a/source/_partials/dash_search_box.html
+++ b/source/_partials/dash_search_box.html
@@ -1,0 +1,6 @@
+
+    <form id="searchform" action="/docs/dash-search" accept-charset="UTF-8" enctype="application/x-www-form-urlencoded">
+      <div>
+        <input type="search" placeholder="Search Pantheon Documentation"value="" name="addsearch" id="piodocsearch" autocomplete="on" />
+      </div>
+    </form>

--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -469,7 +469,11 @@ terminusCompareApp.filter('search', function() {
                 {% else %}
                   <div class="container container-navsearch-box">
                 {% endif %}
+                {% if page.dashsearch %}
+                  {% include("dash_search_box.html") %}
+                {% else %}
                   {% include("search_box.html") %}
+                {% endif %}
                   <span class="glyphicon glyphicon-search form-control-feedback" aria-hidden="true"></span>
                   <span class="sr-only">(search)</span>
                 </div>

--- a/source/docs/dash-search.html
+++ b/source/docs/dash-search.html
@@ -1,0 +1,47 @@
+---
+use: [articles]
+title: Search
+dashsearch: true
+permalink: docs/dash-search/
+layout: default
+---
+{% block content_wrapper %}
+<div class="container-fluid">
+  <div class="row">
+    <div class="col-md-8 search-results" style="margin-left: 50px;">
+
+      <!-- Show a search field above results as well -->
+      <!--input type="text" class="addsearch" placeholder="Search Pantheon Docs" /-->
+
+      <!-- Custom script to grab query from URL and put into search bar -->
+      <script>
+        function parseParamsFromUrl() {
+        var queryString = window.location.search;
+            queryString = queryString.substring(11);
+            queryString = queryString.split("+").join(" ");
+        return queryString;
+        }
+        var urlParams = parseParamsFromUrl();
+        document.getElementById('piodocsearch').setAttribute('value', urlParams);
+      </script>
+
+      <!-- Search results will be rendered to this div -->
+      <div id="addsearch-results"></div>
+
+      <!-- AddSearch settings -->
+      <script>
+      window.addsearch_settings = {
+        display_url: true,
+        display_resultscount: true,
+        display_date: true,
+        display_sortby: true,
+        display_category: true
+      }
+      </script>
+
+      <!-- Script must be below search field and addsearch-results div -->
+      <script src="https://addsearch.com/js/?key=a7b957b7a8f57f4cc544c54f289611c6&type=resultpage"></script>
+    </div>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Targeted AddSearch on `/docs/dash-search/` running side by side with GSS

## Considerations
- When the user leaves`/docs/dash-search/` by selecting a result item, subsequent searches return GSS results on `/docs/search/`


cc @allenfear 