### PR TITLE
PHP Memory Limit = Application Memory Limit

### DIFF
--- a/source/_docs/platform-resources.md
+++ b/source/_docs/platform-resources.md
@@ -105,7 +105,7 @@ The platform resources provided to your website depend on your current plan. Pan
 <hr>
 **PHP Concurrency**: The amount of simultaneous processes PHP can run within a given container. The number of requests your website can handle is a product of the number of containers, and each containers' concurrency, as well as your application performance (see below).
 <hr>
-**PHP Memory Limit**: The maximum amount of memory a single PHP process can use. Exceeding this limit will kill the process, resulting in a failed request from the user's perspective.
+**PHP Memory Limit (Application Memory Limit)**: The maximum amount of memory a single PHP process can use. Exceeding this limit will kill the process, resulting in a failed request from the user's perspective.
 <hr>
 **MySQL Buffer Pool**: The buffer pool is InnoDB's cache for frequently-accessed data in your database. If queries can run out of the buffer alone, they will be dramatically accelerated.
 <hr>


### PR DESCRIPTION
The marketing page, https://pantheon.io/pricing-comparison, refers to PHP Memory Limit as Application Memory Limit. This change just clarifies that they refer to the same thing.

## Effect
PR includes the following changes:
- Clarifying language


## Remaining Work
 - [ ] Consider homogenous language throughout docs

