### PR TITLE
Expand SFTP move limitation

### DIFF
--- a/source/_docs/sftp.md
+++ b/source/_docs/sftp.md
@@ -140,6 +140,8 @@ Do not specify a default remote directory within your SFTP client. When applicat
 ### I can't move files from one folder to another.
 This is a known limitation of using SFTP for on-server development on the platform. You can work around the limitation by transferring the files from your local machine or using rsync.
 
+Like file directories, files on Pantheon cannot be renamed or moved. Our SFTP mode doesn’t support the mv command, which is what most apps use when renaming or moving files. The workaround is to delete the old file and upload the new file.
+
 ### DNS Connection Issues
 
     Status:	Connecting to appserver.dev.dc82c743-3088-426f-bfcf-e388e4add2b3.drush.in:2222...

--- a/source/_docs/sftp.md
+++ b/source/_docs/sftp.md
@@ -137,10 +137,9 @@ This is caused by using the SFTP application's default connection settings. We r
 
 Do not specify a default remote directory within your SFTP client. When application servers are migrated, which can be done at anytime, the remote directory will change.
 
-### I can't move files from one folder to another.
-This is a known limitation of using SFTP for on-server development on the platform. You can work around the limitation by transferring the files from your local machine or using rsync.
+### I can't move files or folders from one directory to another?
+This is a known limitation of using SFTP for on-server development on the platform. Our SFTP mode doesn't support the `mv` command, which most SFTP applications use when moving or renaming files. You can work around the limitation by transferring the files from your local machine or using rsync.
 
-Like file directories, files on Pantheon cannot be renamed or moved. Our SFTP mode doesn’t support the mv command, which is what most apps use when renaming or moving files. The workaround is to delete the old file and upload the new file.
 
 ### DNS Connection Issues
 


### PR DESCRIPTION
Pulled in similar language from https://pantheon.io/docs/platform-considerations/#files

## Effect
PR includes the following changes:
- Expands limitations of moving files over SFTP 

## Remaining Work
- [x] Edit the two paragraphs into a single paragraph