### PR TITLE
Correct -L flag in comment

### DIFF
--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -56,7 +56,7 @@ Substitute your target environment and site UUID to connect; copying/pasting thi
 
 
     # -r: Recurse into subdirectories
-    # -l: Check links
+    # -L: Check links
     # -v: Verbose output
     # -z: Compress during transfer
     # Other rsync flags may or may not be supported


### PR DESCRIPTION
According to `man rsync`, there's `-l, --links` (copy symlinks as symlinks) and there's `-L, --copy-links` (transform symlink into reference file/dir).

Closes ...well, there's a sense of closure.

## Effect
- Literally a one-character change in the docs

## Remaining Work
- Gosh, I hope not!

:smile: