### PR TITLE
Upcoming price increase for legacy SSL

### DIFF
--- a/source/_docs/global-cdn.md
+++ b/source/_docs/global-cdn.md
@@ -39,7 +39,7 @@ Open a support chat to enable the upgrade.
   <tbody>
     <tr>
       <th>Price</th>
-      <td>$30/mo surcharge for HTTPS</td>
+      <td>$60/mo surcharge for HTTPS</td>
       <td>Included</td>
     </tr>
     <tr>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Update price of legacy SSL from $30/mo to $60/mo
-


## Remaining Work
- [ ] Does this need to be changed anywhere else in docs? (don't think so)
