### PR TITLE
Fix syntax error in setcookie() example.

### DIFF
--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -74,7 +74,7 @@ else{
   * $httponly = true;
   * @endcode
   **/
-  setcookie($name, $value $expire, $path, $domain, $secure, $httponly);
+  setcookie($name, $value, $expire, $path, $domain, $secure, $httponly);
 }
 ```
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds missing comma between arguments in the setcookie() function

## Remaining Work
- technical review