### PR TITLE
Update logformat from "%h,%^" to ~h{," }

### DIFF
--- a/source/_docs/nginx-access-log.md
+++ b/source/_docs/nginx-access-log.md
@@ -32,7 +32,7 @@ Add the following lines to the `goaccess.conf` file, located in either `/etc/`, 
 ```
 time-format %H:%M:%S
 date-format %d/%b/%Y
-log-format %^ - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%h,%^"
+log-format %^ - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T ~h{," }
 ```
 ## Automate GoAccess Reports
 <p class="instruction">Download the following script to quickly pull a site's nginx log file and create an HTML report using GoAccess:</p>


### PR DESCRIPTION
Current logformat failing with:
Token for '%h' specifier is NULL.

Each row of the nginx-access.log varies the format for client IP address:

"5.156.73.38, 5.156.73.38"
"5.156.73.38, 5.156.73.38"
"76.72.172.208"
"159.8.146.132"

This means that the "%h,%^" will fail as the comma will not match on some log entries.
Changing the format to ~h{," } will fix the issue: https://goaccess.io/man#configuration