### PR TITLE
Replace Docs Search Service

### DIFF
--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -471,6 +471,8 @@ terminusCompareApp.filter('search', function() {
                 {% endif %}
                 {% if page.dashsearch %}
                   {% include("dash_search_box.html") %}
+                {% elseif page.newdashsearch %}
+                  {% include("new_dash_search_box.html") %}
                 {% else %}
                   {% include("search_box.html") %}
                 {% endif %}

--- a/source/_partials/new_dash_search_box.html
+++ b/source/_partials/new_dash_search_box.html
@@ -1,0 +1,6 @@
+
+    <form id="searchform" action="/docs/search" accept-charset="UTF-8" enctype="application/x-www-form-urlencoded">
+      <div>
+        <input type="search" placeholder="Search Pantheon Documentation"value="" name="addsearch" id="piodocsearch" autocomplete="on" />
+      </div>
+    </form>

--- a/source/_partials/search_box.html
+++ b/source/_partials/search_box.html
@@ -1,17 +1,4 @@
-<script>
-  (function() {
-    var cx = '003083871467663611719:iwjn-dav4gm';
-    var gcse = document.createElement('script');
-    gcse.type = 'text/javascript';
-    gcse.async = true;
-    gcse.src = '//cse.google.com/cse.js?cx=' + cx;
-    var s = document.getElementsByTagName('script')[0];
-    s.parentNode.insertBefore(gcse, s);
-  })();
-</script>
-
 <form id="searchform" action="/docs/search" accept-charset="UTF-8" enctype="application/x-www-form-urlencoded">
-  <div>
-    <input type="search" placeholder="Search Pantheon Documentation"value="" name="term" id="piodocsearch" autocomplete="on" />
-  </div>
+  <input type="search" class="addsearch" disabled="disabled" placeholder="Search Pantheon Documentation" />
+  <script src="https://addsearch.com/js/?key=a7b957b7a8f57f4cc544c54f289611c6"></script>
 </form>

--- a/source/docs/search.html
+++ b/source/docs/search.html
@@ -3,22 +3,44 @@ use: [articles]
 title: Search
 permalink: docs/search/
 layout: default
+newdashsearch: true
 ---
 {% block content_wrapper %}
 <div class="container-fluid">
   <div class="row">
     <div class="col-md-8 search-results" style="margin-left: 50px;">
+
+      <!-- Show a search field above results as well -->
+      <!--input type="text" class="addsearch" placeholder="Search Pantheon Docs" /-->
+
+      <!-- Custom script to grab query from URL and put into search bar -->
       <script>
         function parseParamsFromUrl() {
         var queryString = window.location.search;
-            queryString = queryString.substring(6);
+            queryString = queryString.substring(11);
             queryString = queryString.split("+").join(" ");
         return queryString;
         }
         var urlParams = parseParamsFromUrl();
         document.getElementById('piodocsearch').setAttribute('value', urlParams);
       </script>
-      <gcse:searchresults-only linkTarget="_self"></gcse:searchresults-only>
+
+      <!-- Search results will be rendered to this div -->
+      <div id="addsearch-results"></div>
+
+      <!-- AddSearch settings -->
+      <script>
+      window.addsearch_settings = {
+        display_url: true,
+        display_resultscount: true,
+        display_date: true,
+        display_sortby: true,
+        display_category: true
+      }
+      </script>
+
+      <!-- Script must be below search field and addsearch-results div -->
+      <script src="https://addsearch.com/js/?key=a7b957b7a8f57f4cc544c54f289611c6&type=resultpage"></script>
     </div>
   </div>
 </div>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Delete Google's Site Search 
- Implement instant search using AddSearch

## Remaining Work
- [x] Preserve separate page results on `/docs/search` and `/docs/dash-search` for product use
