### PR TITLE
Markdown Tables

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 10.14
+assets_version: 10.15
 
 #######################################################################################################
 # The contributors. Include your info here, under the "contributors" key, using the following template:

--- a/source/_docs/php-errors.md
+++ b/source/_docs/php-errors.md
@@ -15,6 +15,7 @@ For more in-depth information, see [Error Handling and Logging](https://secure.p
 Each of the PHP errors are handled differently depending on the site environment. On Dev, they are shown directly to the user in the browser. On Test and Live, PHP errors are not displayed to users, but they'll still be logged. Notices and warnings are logged in the database logs if `db\_log` is enabled for Drupal. The PHP constants `WP_DEBUG` and `WP_DEBUG_LOG` can be enabled for WordPress to save errors to wp-content/debug.log. PHP errors are also logged on the application server at `logs/php-error.log`.
 
 Here's a breakdown of what errors are shown and where:
+
 <table>
 <thead>
 		<tr>
@@ -28,69 +29,68 @@ Here's a breakdown of what errors are shown and where:
 		<tr>
 			<td align="left" rowspan="3" style="vertical-align:middle; border-bottom:1px solid black">Dev</td>
 			<td align="left">notice</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left">warning</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left" style="border-bottom:1px solid black;">error</td>
-			<td align="left" style="border-bottom:1px solid black;"><strong>Y</strong></td>
-			<td align="left" style="border-bottom:1px solid black;">N</td>
-			<td align="left" style="border-bottom:1px solid black;"><strong>Y</strong></td>
+			<td align="left" style="border-bottom:1px solid black;"><strong>✓</strong></td>
+			<td align="left" style="border-bottom:1px solid black;"> </td>
+			<td align="left" style="border-bottom:1px solid black;"><strong>✓</strong></td>
 		</tr>
 		<tr>
 			<td align="left" rowspan="3" style="vertical-align:middle; border-bottom:1px solid black">Test</td>
 			<td align="left">notice</td>
-			<td align="left">N</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"> </td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left">warning</td>
-			<td align="left">N</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"> </td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left" style="border-bottom:1px solid black;">error</td>
-			<td align="left" style="border-bottom:1px solid black;">N</td>
-			<td align="left" style="border-bottom:1px solid black;">N</td>
-			<td align="left" style="border-bottom:1px solid black;"><strong>Y</strong></td>
+			<td align="left" style="border-bottom:1px solid black;"> </td>
+			<td align="left" style="border-bottom:1px solid black;"> </td>
+			<td align="left" style="border-bottom:1px solid black;"><strong>✓</strong></td>
 		</tr>
 		<tr>
 			<td align="left" rowspan="3" style="vertical-align:middle;">Live</td>
 			<td align="left">notice</td>
-			<td align="left">N</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"> </td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left">warning</td>
-			<td align="left">N</td>
-			<td align="left"><strong>Y</strong></td>
-			<td align="left">N</td>
+			<td align="left"> </td>
+			<td align="left"><strong>✓</strong></td>
+			<td align="left"> </td>
 		</tr>
 		<tr>
 			<td align="left">error</td>
-			<td align="left">N</td>
-			<td align="left">N</td>
-			<td align="left"><strong>Y</strong></td>
+			<td align="left"> </td>
+			<td align="left"> </td>
+			<td align="left"><strong>✓</strong></td>
 		</tr>
 	</tbody>
 </table>
-
 
 To learn more about PHP error logs, see [Log Files on Pantheon](/docs/logs).
 
 ## Performance Hits
 
-An error, no matter what severity, is a problem that needs to be addressed. Any PHP error, even a notice, will drastically reduce the speed of PHP execution. Even if you don't see the error in your browser, and even if you explicitly disable logging, every single PHP error will slow your site down.  
+An error, no matter what severity, is a problem that needs to be addressed. Any PHP error, even a notice, will drastically reduce the speed of PHP execution. Even if you don't see the error in your browser, and even if you explicitly disable logging, every single PHP error will slow your site down.
 
 
 
@@ -98,7 +98,7 @@ If database logging is enabled, your site will be even slower, requiring a datab
 
 
 
-Best practice is to fix every notice, warning, and error as you discover them. If they're in an extension (WordPress plugin or Drupal module), roll a patch and submit it to the project's issue queue.  
+Best practice is to fix every notice, warning, and error as you discover them. If they're in an extension (WordPress plugin or Drupal module), roll a patch and submit it to the project's issue queue.
 
 
 See [this stackoverflow thread](https://stackoverflow.com/questions/1868874/does-php-run-faster-without-warnings/1869185#1869185) for some more details, including benchmarks that compare the differences between suppressing notices and actually eliminating the root cause.

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -18,16 +18,14 @@ Redis provides an alternative caching backend, taking that work off the database
 ## Enable Redis
 All plans except for a Personal plan can use Redis. Redis is available to Sandbox plans for developmental purposes, but Redis will not be available going live on a Personal plan.
 
-| Plans         | Redis Support
-| ------------- |:------- |
+| Plans         | Redis Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
+| ------------- | ------- |
 | Sandbox       | ✓       |
 | Personal      |         |
 | Professional  | ✓       |
 | Business      | ✓       |
 | Elite         | ✓       |
 
----
-<br>
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">
 <!-- Active tab -->

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -19,15 +19,15 @@ Redis provides an alternative caching backend, taking that work off the database
 All plans except for a Personal plan can use Redis. Redis is available to Sandbox plans for developmental purposes, but Redis will not be available going live on a Personal plan.
 
 | Plans         | Supported
-| ------------- |:-------------:|
-| Sandbox       | **Yes**       |
-| Personal      | No            |
-| Professional  | **Yes**       |
-| Business      | **Yes**       |
-| Elite         | **Yes**       |
+| ------------- |:------- |
+| Sandbox       | ✓       |
+| Personal      |         |
+| Professional  | ✓       |
+| Business      | ✓       |
+| Elite         | ✓       |
 
 ---
-
+<br>
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">
 <!-- Active tab -->

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -18,7 +18,7 @@ Redis provides an alternative caching backend, taking that work off the database
 ## Enable Redis
 All plans except for a Personal plan can use Redis. Redis is available to Sandbox plans for developmental purposes, but Redis will not be available going live on a Personal plan.
 
-| Plans         | Supported
+| Plans         | Redis Support
 | ------------- |:------- |
 | Sandbox       | ✓       |
 | Personal      |         |

--- a/source/_docs/solr.md
+++ b/source/_docs/solr.md
@@ -15,14 +15,13 @@ Apache Solr is a system for indexing and searching site content. Pantheon provid
 
 All plans except for a Personal plan can use Solr. Solr is available to Sandbox plans for developmental purposes, but Solr will not be available going live on a Personal plan.
 
-| Plans        | Supported
-| ------------- |:-------------:|
-| Sandbox      | **Yes, for all environments** |
-| Personal      | No      |
-| Professional | **Yes, for all environments**      |
-| Business | **Yes, for all environments**      |
-| Elite | **Yes, for all environments**      |
-
+| Plans         | Supported <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Environments" data-content="Solr is enabled for all environments"><em class="fa fa-info-circle"></em></a> |
+| ------------- |:------ |
+| Sandbox       | ✓      |
+| Personal      |        |
+| Professional  | ✓      |
+| Business      | ✓      |
+| Elite         | ✓      |
 
 ## Using Solr with WordPress or Drupal
 
@@ -41,7 +40,7 @@ For installation instructions and additional details, see [Enabling Solr for Wor
 
 While Pantheon provides a stable, reliable, and basic Solr service, your individual site needs may require something more robust and customizable. In those cases, a dedicated hosted Solr service may be a better solution for your needs. Given that Solr can tolerate higher latency (one query per request vs hundreds of database queries), Solr servers do not need to be in the same data center to provide fast and responsive results.
 
-Some customers have reported success using external Solr service providers for their Solr indexing:  
+Some customers have reported success using external Solr service providers for their Solr indexing:
 
  - [IndexDepot](https://www.indexdepot.com/en/). For more information, see [Using IndexDepot With Pantheon Sites](/docs/indexdepot/).
  - [OpenSolr](https://opensolr.com/)
@@ -73,7 +72,7 @@ Are you only indexing only 50 items at a time and wondering why hundreds of new 
 
 ### Apache Spatial Search on Pantheon
 
-Pantheon's Solr configuration does not support geospatial indexing and searching and there are currently no plans to add it.  
+Pantheon's Solr configuration does not support geospatial indexing and searching and there are currently no plans to add it.
 As an alternative, there are several external Solr service providers that do support spatial searching. Pantheon doesn’t do any blocking/filtering, so you’re welcome to use an externally hosted Solr index – and in a case where you’re looking for a more complex configuration, that might be optimal.
 
 ### Specify Query Parsers to Allow Fields
@@ -82,7 +81,7 @@ Pantheon's Solr configuration uses the [DisMax](https://cwiki.apache.org/conflue
 The solution is to specify the parser in the request. Both the [Lucene](https://cwiki.apache.org/confluence/display/solr/The+Standard+Query+Parser) and [eDisMax](https://cwiki.apache.org/confluence/display/solr/The+Extended+DisMax+Query+Parser) parsers support the required field:value syntax. You can add them to a query by adding `&defType=lucene` or `&defType=edismax` to the end. For example:
 ```
 /select?q=ts_ol_full_text:property&fl=label,bundle,ts_ol_full_text&wt=json&defType=edismax
-```  
+```
 For details on supported query parsers, see [Query Syntax and Parsing]( https://cwiki.apache.org/confluence/display/solr/Query+Syntax+and+Parsing) and [Common Query Parameters](https://cwiki.apache.org/confluence/display/solr/Common+Query+Parameters#CommonQueryParameters-ThedefTypeParameter).
 
 ### Supported Search Components

--- a/source/_docs/solr.md
+++ b/source/_docs/solr.md
@@ -15,7 +15,7 @@ Apache Solr is a system for indexing and searching site content. Pantheon provid
 
 All plans except for a Personal plan can use Solr. Solr is available to Sandbox plans for developmental purposes, but Solr will not be available going live on a Personal plan.
 
-| Plans         | Supported <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Environments" data-content="Solr is enabled for all environments"><em class="fa fa-info-circle"></em></a> |
+| Plans         | Solr Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Environments" data-content="Solr is enabled for all environments"><em class="fa fa-info-circle"></em></a> |
 | ------------- |:------ |
 | Sandbox       | ✓      |
 | Personal      |        |

--- a/source/_docs/solr.md
+++ b/source/_docs/solr.md
@@ -15,8 +15,8 @@ Apache Solr is a system for indexing and searching site content. Pantheon provid
 
 All plans except for a Personal plan can use Solr. Solr is available to Sandbox plans for developmental purposes, but Solr will not be available going live on a Personal plan.
 
-| Plans         | Solr Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Environments" data-content="Solr is enabled for all environments"><em class="fa fa-info-circle"></em></a> |
-| ------------- |:------ |
+| Plans         | Solr Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
+| ------------- | ------ |
 | Sandbox       | ✓      |
 | Personal      |        |
 | Professional  | ✓      |

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -471,33 +471,42 @@ Use panels for extraneous but useful information such as troubleshooting section
 
 ## Tables
 
-Markdown tables are defined like this:
+Tables are used to describe feature availability based on site plan. For example:
 
 <div class="style-example" markdown="1">
-| Table Header 1     | Table Header 2 |
-| ------------------ | :------------: |
-| Table Data 1.1     | Table Data 2.1 |
-| Table Data 1.2     | Table Data 2.2 |
-| Table Data 1.3     | Table Data 2.3 |
+| Plans         | Redis Support
+| ------------- |:------- |
+| Sandbox       | ✓       |
+| Personal      |         |
+| Professional  | ✓       |
+| Business      | ✓       |
+| Elite         | ✓       |
 <hr class="source-code">
 ```markdown
-| Table Header 1     | Table Header 2 |
-| ------------------ | -------------- |
-| Table Data 1.1     | Table Data 2.1 |
-| Table Data 1.2     | Table Data 2.2 |
-| Table Data 1.3     | Table Data 2.3 |
+| Plans         | Redis Support
+| ------------- |:------- |
+| Sandbox       | ✓       |
+| Personal      |         |
+| Professional  | ✓       |
+| Business      | ✓       |
+| Elite         | ✓       |
 ```
 </div>
+
+The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
 
 ## Tooltips
 
 Tooltips are a great way to add additional information without cluttering up a section:
 
-```markdown
-Tooltips can be added anywhere, like this <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Title" data-content="Here's some additional information that can help the reader."><em class="fa fa-info-circle"></em></a> .
-```
+<div class="style-example" markdown="1">
+In early testing we saw multi-second speedups in Visual Progress <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Visual Progress" data-content="The pace at which content renders on the visible page"><em class="fa fa-info-circle"></em></a> even within the continental US. International users will benefit even more:
+<hr class="source-code">
 
-Tooltips can be added anywhere, like this <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Title" data-content="Here's some additional information that can help the reader."><em class="fa fa-info-circle"></em></a> .
+```markdown
+In early testing we saw multi-second speedups in Visual Progress <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Visual Progress" data-content="The pace at which content renders on the visible page"><em class="fa fa-info-circle"></em></a> even within the continental US. International users will benefit even more:
+```
+</div>
 
 ## See Also
 

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -489,6 +489,16 @@ Markdown tables are defined like this:
 
 The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
 
+## Tooltips
+
+Tooltips are a great way to add additional information without cluttering up a section:
+
+```markdown
+Tooltips can be added anywhere, like this <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Title" data-content="Here's some additional information that can help the reader."><em class="fa fa-info-circle"></em></a> .
+```
+
+Tooltips can be added anywhere, like this <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Title" data-content="Here's some additional information that can help the reader."><em class="fa fa-info-circle"></em></a> .
+
 ## See Also
 
 This is the optimal place to provide links to external resources on the subject, or internal docs on common processes to follow after completing those above.

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -469,6 +469,25 @@ Use panels for extraneous but useful information such as troubleshooting section
 ```
 </div>
 
+## Tables
+
+Markdown tables are defined like this:
+
+```markdown
+| Header 1     | Header 2 |
+| ------------ |:--------:|
+| Content      | Content  |
+| Content      | Content  |
+| Content      | Content  |
+```
+
+| Header 1     | Header 2 |
+| ------------ |:--------:|
+| Content      | Content  |
+| Content      | Content  |
+| Content      | Content  |
+
+The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
 
 ## See Also
 

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -474,18 +474,18 @@ Use panels for extraneous but useful information such as troubleshooting section
 Markdown tables are defined like this:
 
 <div class="style-example" markdown="1">
-| Header 1     | Header 2 |
-| ------------ |:--------:|
-| Content      | Content  |
-| Content      | Content  |
-| Content      | Content  |
+| Table Header 1     | Table Header 2 |
+| ------------------ | :------------: |
+| Table Data 1.1     | Table Data 2.1 |
+| Table Data 1.2     | Table Data 2.2 |
+| Table Data 1.3     | Table Data 2.3 |
 <hr class="source-code">
 ```markdown
-| Header 1     | Header 2 |
-| ------------ |:--------:|
-| Content      | Content  |
-| Content      | Content  |
-| Content      | Content  |
+| Table Header 1     | Table Header 2 |
+| ------------------ | :------------: |
+| Table Data 1.1     | Table Data 2.1 |
+| Table Data 1.2     | Table Data 2.2 |
+| Table Data 1.3     | Table Data 2.3 |
 ```
 </div>
 

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -482,14 +482,12 @@ Markdown tables are defined like this:
 <hr class="source-code">
 ```markdown
 | Table Header 1     | Table Header 2 |
-| ------------------ | :------------: |
+| ------------------ | -------------- |
 | Table Data 1.1     | Table Data 2.1 |
 | Table Data 1.2     | Table Data 2.2 |
 | Table Data 1.3     | Table Data 2.3 |
 ```
 </div>
-
-The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
 
 ## Tooltips
 

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -470,12 +470,14 @@ Use panels for extraneous but useful information such as troubleshooting section
 </div>
 
 ## Tables
-
-Tables are used to describe feature availability based on site plan. For example:
+You can use markdown tables to describe availability based on service levels before providing instructions on how to enable or use a given feature. For example:
 
 <div class="style-example" markdown="1">
-| Plans         | Redis Support
-| ------------- |:------- |
+## Enable Redis {.info}
+All plans except for a Personal plan can use Redis. Redis is available to Sandbox plans for developmental purposes, but Redis will not be available going live on a Personal plan.
+
+| Plans         | Redis Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
+| ------------- | ------- |
 | Sandbox       | ✓       |
 | Personal      |         |
 | Professional  | ✓       |
@@ -483,8 +485,11 @@ Tables are used to describe feature availability based on site plan. For example
 | Elite         | ✓       |
 <hr class="source-code">
 ```markdown
-| Plans         | Redis Support
-| ------------- |:------- |
+## Enable Redis
+All plans except for a Personal plan can use Redis. Redis is available to Sandbox plans for developmental purposes, but Redis will not be available going live on a Personal plan.
+
+| Plans         | Redis Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
+| ------------- | ------- |
 | Sandbox       | ✓       |
 | Personal      |         |
 | Professional  | ✓       |
@@ -493,18 +498,24 @@ Tables are used to describe feature availability based on site plan. For example
 ```
 </div>
 
-The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
+Use `✓` to indicate yes and leave the table data blank to indicate no.
 
 ## Tooltips
 
-Tooltips are a great way to add additional information without cluttering up a section:
+Tooltips are a great way to add additional information without cluttering up a section. For example, you can define jargon and even link out to an external resource without being distracting to the reader:
 
 <div class="style-example" markdown="1">
-In early testing we saw multi-second speedups in Visual Progress <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Visual Progress" data-content="The pace at which content renders on the visible page"><em class="fa fa-info-circle"></em></a> even within the continental US. International users will benefit even more:
+Given two new sites with slugs <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-title="Slugs" data-content="Generally, <a class='external' href='https://codex.wordpress.org/Glossary#Slug'>slugs</a> are URL friendly descriptions for a post or a page in WordPress. In the context of WordPress Site Networks, a slug is a URL friendly description for a network site."><em class="fa fa-info-circle"></em></a> `first-site` and `second-site`, each configuration will result in the following URLs:
+
+* Subdirectories: `example.com/first-site` and `example.com/second-site`.
+* Subdomains: `first-site.example.com` and `second-site.example.com`.
 <hr class="source-code">
 
 ```markdown
-In early testing we saw multi-second speedups in Visual Progress <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Visual Progress" data-content="The pace at which content renders on the visible page"><em class="fa fa-info-circle"></em></a> even within the continental US. International users will benefit even more:
+Given two new sites with slugs <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-title="Slugs" data-content="Generally, <a class='external' href='https://codex.wordpress.org/Glossary#Slug'>slugs</a> are URL friendly descriptions for a post or a page in WordPress. In the context of WordPress Site Networks, a slug is a URL friendly description for a network site."><em class="fa fa-info-circle"></em></a> `first-site` and `second-site`, each configuration will result in the following URLs:
+
+* Subdirectories: `example.com/first-site` and `example.com/second-site`.
+* Subdomains: `first-site.example.com` and `second-site.example.com`.
 ```
 </div>
 

--- a/source/_docs/style-guide.md
+++ b/source/_docs/style-guide.md
@@ -473,6 +473,13 @@ Use panels for extraneous but useful information such as troubleshooting section
 
 Markdown tables are defined like this:
 
+<div class="style-example" markdown="1">
+| Header 1     | Header 2 |
+| ------------ |:--------:|
+| Content      | Content  |
+| Content      | Content  |
+| Content      | Content  |
+<hr class="source-code">
 ```markdown
 | Header 1     | Header 2 |
 | ------------ |:--------:|
@@ -480,12 +487,7 @@ Markdown tables are defined like this:
 | Content      | Content  |
 | Content      | Content  |
 ```
-
-| Header 1     | Header 2 |
-| ------------ |:--------:|
-| Content      | Content  |
-| Content      | Content  |
-| Content      | Content  |
+</div>
 
 The colons (`:`) define text alignment; one on each side of the column header dashes will center text. A single `:` on the left or right will align the text to that side.
 

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -5728,3 +5728,41 @@ hr.source-code::after {
 .cdn-map-container {
   background-color: #313945;
 }
+
+/* Override Tables with table-responsive and table-bordered */
+
+table{
+  display: table;
+  width: 100%;
+  max-width: 100%;
+  margin-bottom: 20px;
+  border: 1px solid #dee2e6;
+  -ms-overflow-style: -ms-autohiding-scrollbar;
+  border-collapse: collapse;
+  min-height: .01%;
+  overflow-x: auto;
+  box-sizing: border-box;
+}
+
+thread {
+  display: table-header-group;
+  vertical-align: middle;
+  border-color: inherit;
+}
+
+th {
+  border: 1px solid #dee2e6;
+  display: table-cell;
+  vertical-align: bottom;
+  border-bottom: 2px solid #ddd;
+  font-weight: bold;
+  border-collapse: collapse;
+}
+
+td{
+  border: 1px solid #dee2e6;
+  display: table-cell;
+  padding: 8px;
+  line-height: 1.42857143;
+  vertical-align: top;
+}

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -5757,6 +5757,7 @@ th {
   border-bottom: 2px solid #ddd;
   font-weight: bold;
   border-collapse: collapse;
+  padding: 8px;
 }
 
 td{


### PR DESCRIPTION
Closes #3249

## Effect
PR includes the following changes:
- New CSS so markdown tables will use the styles from `table-bordered` and `table-responsive`
- Defined tables and tooltips in style guide
- Used tooltip and check marks in solr table
- Aligned markdown table in Solr guide (not required, but easier on my eyes)

## Remaining Work
- [x] Review from @rachelwhitton 

