### PR TITLE
Update 05-redirects.md

### DIFF
--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -20,6 +20,11 @@ image: getting-started-Largethumb
 ---
 In this lesson, we'll redirect all traffic to a primary domain via HTTPS, which is a best practice for security and SEO. This means if you choose `www.example.com` as your primary domain, then if a visitor types in `example.com` into their browser (or any other domain you have connected to your site), they will end up on `https://www.example.com`.
 
+<div class="alert alert-info" markdown="1">
+<h4 class="info">Note</h4>
+Be sure https has been successfully provisioned _before_ adding any code (like the sample below) that will redirect traffic to https!
+</div>
+
 1. Navigate to **<span class="glyphicons glyphicons-embed-close"></span> Code** in the **<span class="glyphicons glyphicons-wrench"></span> Dev** tab of your Site Dashboard. Confirm your Connection Mode is set to **SFTP**.
 2. Click **<span class="glyphicons glyphicons-info-sign"></span> SFTP Connection Info** to access the credentials for connecting to your preferred SFTP client.
 3. Click **Open in your default SFTP client**, and enter your User Dashboard password when prompted.

--- a/source/_docs/guides/launch/05-redirects.md
+++ b/source/_docs/guides/launch/05-redirects.md
@@ -22,7 +22,7 @@ In this lesson, we'll redirect all traffic to a primary domain via HTTPS, which 
 
 <div class="alert alert-info" markdown="1">
 <h4 class="info">Note</h4>
-Be sure https has been successfully provisioned _before_ adding any code (like the sample below) that will redirect traffic to https!
+Make sure HTTPS has been successfully provisioned *before* adding any code (like the sample below) that will redirect traffic to HTTPS.
 </div>
 
 1. Navigate to **<span class="glyphicons glyphicons-embed-close"></span> Code** in the **<span class="glyphicons glyphicons-wrench"></span> Dev** tab of your Site Dashboard. Confirm your Connection Mode is set to **SFTP**.


### PR DESCRIPTION
Add a note near the top of the page reminding users to wait until https has been successfully provisioned before deploying any code that will redirect traffic to https (based on a chat that simply followed the launch guide and did the things it recommended in order, without considering what each step would require to work).

## Effect
PR includes the following changes:
- Adds a "note" / reminder to be sure https has been provisioned before adding the code in the doc

## Remaining Work
- [ ] Editing / word-smithing...