### PR TITLE
Drush ard and nested docroot

### DIFF
--- a/source/_docs/migrate.md
+++ b/source/_docs/migrate.md
@@ -260,7 +260,7 @@ terminus drush <site>.<env> -- ard --destination=sites/default/files/<RANDOM_HAS
 ```
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
-<p markdown="1">Your files need to be in the `/files` directory. This directory maps to `sites/default/files` for Drupal. Adjust paths as needed to include `web` (e.g., `web/sites/default/files`) for [sites configured to use a nested docroot](/docs/nested-docroot/).</p>
+<p markdown="1">Adjust paths as needed to include `web` (e.g., `web/sites/default/files`) for [sites configured to use a nested docroot](/docs/nested-docroot/).</p>
 </div>
 
 <div class="alert alert-danger" role="alert">

--- a/source/_docs/migrate.md
+++ b/source/_docs/migrate.md
@@ -258,14 +258,15 @@ For Drupal sites, during the **Create Site Archive** step of the migration proce
 ```bash
 terminus drush <site>.<env> -- ard --destination=sites/default/files/<RANDOM_HASH>.tgz
 ```
-<div class="alert alert-info" role="alert">
-<h4 class="info">Note</h4>
-<p markdown="1">Adjust paths as needed to include `web` (e.g., `web/sites/default/files`) for [sites configured to use a nested docroot](/docs/nested-docroot/).</p>
-</div>
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>
 <p markdown="1">We recommend using a random hash for the archive filename for security. Archive dumps contain sensitive information, so they should not be exposed using guessable filename patterns (like `BACKUP` or recent dates).</p>
+</div>
+
+<div class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">Adjust paths as needed for sites with a [nested docroot](/docs/nested-docroot/) (e.g., `web/sites/default/files`).</p>
 </div>
 
 Click **Continue Migration** and follow all remaining instructions within the guided migration process.

--- a/source/_docs/migrate.md
+++ b/source/_docs/migrate.md
@@ -258,6 +258,10 @@ For Drupal sites, during the **Create Site Archive** step of the migration proce
 ```bash
 terminus drush <site>.<env> -- ard --destination=sites/default/files/<RANDOM_HASH>.tgz
 ```
+<div class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">Your files need to be in the `/files` directory. This directory maps to `sites/default/files` for Drupal. Adjust paths as needed to include `web` (e.g., `web/sites/default/files`) for [sites configured to use a nested docroot](/docs/nested-docroot/).</p>
+</div>
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Includes reference to nested docroot when issuing `drush ard`. Pulled Note from https://pantheon.io/docs/rsync-and-sftp/. 

## Remaining Work
- [ ] Consider also just include command showing nested docroot: 
```terminus drush <site>.<env> -- ard --destination=web/sites/default/files/<RANDOM_HASH>.tgz```
