### PR TITLE
Upgrade to Terminus 1.8.0

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -2501,16 +2501,17 @@
             "source": {
                 "type": "git",
                 "url": "https://github.com/pantheon-systems/terminus.git",
-                "reference": "2591157da7383a88d26285ca9608a36b4d884377"
+                "reference": "5cdab290f4690f74630e238e434cc5d7c0a2e0e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/pantheon-systems/terminus/zipball/2591157da7383a88d26285ca9608a36b4d884377",
-                "reference": "2591157da7383a88d26285ca9608a36b4d884377",
+                "url": "https://api.github.com/repos/pantheon-systems/terminus/zipball/5cdab290f4690f74630e238e434cc5d7c0a2e0e0",
+                "reference": "5cdab290f4690f74630e238e434cc5d7c0a2e0e0",
                 "shasum": ""
             },
             "require": {
                 "composer/semver": "^1.4",
+                "consolidation/output-formatters": "^3.2",
                 "consolidation/robo": "^1.1.0",
                 "guzzlehttp/guzzle": "^6.2",
                 "php": ">=5.5.9",
@@ -2555,7 +2556,7 @@
                 "terminus",
                 "wordpress"
             ],
-            "time": "2018-01-30T01:05:43+00:00"
+            "time": "2018-03-30T07:56:54+00:00"
         },
         {
             "name": "phpdocumentor/reflection-common",


### PR DESCRIPTION

## Upgrade to Terminus 1.8.0
```
$ bin/terminus self:info
 ------------------------- -------------------------------------------------------------------------------------------------
  PHP binary                /usr/local/Cellar/php71/7.1.13_24/bin/php
  PHP version               7.1.13
  php.ini used              /usr/local/etc/php/7.1/php.ini
  Terminus project config
  Terminus root dir         /Users/rachel/sites/documentation/vendor/pantheon-systems/terminus
  Terminus version          1.8.0
  Operating system          Darwin Kernel Version 17.4.0: Sun Dec 17 09:19:54 PST 2017; root:xnu-4570.41.2~1/RELEASE_X86_64
 ------------------------- -------------------------------------------------------------------------------------------------
```
