### PR TITLE
Rename and move upstream updates for SEO

### DIFF
--- a/scripts/merge_conflicts.sh
+++ b/scripts/merge_conflicts.sh
@@ -4,11 +4,11 @@ path=$(dirname "$0")
 base=$(cd $path/.. && pwd)
 
 cd $base/output_dev/docs
-if grep -q --exclude="upstream-updates/index.html" --exclude="maintain-custom-upstream/index.html" "&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD" $(find . -type f); then
+if grep -q --exclude="core-updates/index.html" --exclude="maintain-custom-upstream/index.html" "&lt;&lt;&lt;&lt;&lt;&lt;&lt; HEAD" $(find . -type f); then
   echo 'Merge HEAD hash: fail' && exit 1
-elif grep -q --exclude="upstream-updates/index.html" --exclude="maintain-custom-upstream/index.html" "<<<<<<< HEAD" $(find . -type f); then
+elif grep -q --exclude="core-updates/index.html" --exclude="maintain-custom-upstream/index.html" "<<<<<<< HEAD" $(find . -type f); then
   echo 'Merge HEAD hash: fail' && exit 1
-elif grep -q --exclude="upstream-updates/index.html" --exclude="maintain-custom-upstream/index.html" "=======" $(find . -not -path "./assets/*" -type f ); then
+elif grep -q --exclude="core-updates/index.html" --exclude="maintain-custom-upstream/index.html" "=======" $(find . -not -path "./assets/*" -type f ); then
   echo 'Merge equal signs: fail' && exit 1
 else
   echo 'Merge conflict: pass' && exit 0

--- a/source/_changelogs/2017-11-01-November.md
+++ b/source/_changelogs/2017-11-01-November.md
@@ -16,7 +16,7 @@ On newly created sites, you are now directed to install your WordPress or Drupal
 [Drupal 8.4.2](https://www.drupal.org/project/drupal/releases/8.4.2){.external} has been [pushed](https://github.com/pantheon-systems/drops-8/pull/196){.external} to all Drupal 8 site dashboards.
 
 ### WordPress Core Upgrades
-[WordPress 4.9.1](https://codex.wordpress.org/Version_4.9.1){.external} has been [pushed](https://github.com/pantheon-systems/WordPress/pull/144){.external} to all WordPress site dashboards. This is a [security release](https://status.pantheon.io/incidents/ml7yn6xj8ffl){.external}, and we suggest everyone [upgrade immediately](/docs/upstream-updates/).
+[WordPress 4.9.1](https://codex.wordpress.org/Version_4.9.1){.external} has been [pushed](https://github.com/pantheon-systems/WordPress/pull/144){.external} to all WordPress site dashboards. This is a [security release](https://status.pantheon.io/incidents/ml7yn6xj8ffl){.external}, and we suggest everyone [upgrade immediately](/docs/core-updates/).
 
 ## Documentation
 

--- a/source/_docs/cms-admin.md
+++ b/source/_docs/cms-admin.md
@@ -26,7 +26,7 @@ WordPress' admin interface has built in tools to manage plugins and themes, allo
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>
-<p markdown="1">Do not update core using the WordPress Dashboard or WP-CLI. Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus/). For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [Applying Upstream Updates](/docs/upstream-updates).</p>
+<p markdown="1">Do not update core using the WordPress Dashboard or WP-CLI. Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus/). For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [WordPress and Drupal Core Updates](/docs/core-updates).</p>
 </div>
 
 ### Manage Plugins and Themes
@@ -59,7 +59,7 @@ Drupal also allows you to install modules or themes [using its administrative in
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>
-<p markdown="1">Do not update core using the Drupal Admin interface or Drush. Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus/). For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [Applying Upstream Updates](/docs/upstream-updates).</p>
+<p markdown="1">Do not update core using the Drupal Admin interface or Drush. Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus/). For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [WordPress and Drupal Core Updates](/docs/core-updates).</p>
 </div>
 
 ### Install a New Module

--- a/source/_docs/code.md
+++ b/source/_docs/code.md
@@ -73,7 +73,7 @@ You can also view the diff output for each individual file:
 ![Diff output](/source/docs/assets/images/dashboard/diff-screen.png)
 
 ### Upstream Updates
-The Dev environment provides [one-click updates](/docs/upstream-updates/) for your site's upstream. Updates will appear in the Code tool once they are committed to the upstream repository.
+The Dev environment provides [one-click updates](/docs/core-updates/) for your site's upstream. Updates will appear in the Code tool once they are committed to the upstream repository.
   <dl>
     <dt>Upstream</dt>
       <dd>A code repository that serves as a common package for your web application.</dd><br>

--- a/source/_docs/core-updates.md
+++ b/source/_docs/core-updates.md
@@ -1,5 +1,5 @@
 ---
-title: Apply Upstream Updates
+title: WordPress and Drupal Core Updates
 description: Detailed information on applying and debugging upstream updates from Pantheon or a Custom Upstream.
 tags: [dashboard, devterminus, git]
 categories: []

--- a/source/_docs/database-connection-errors.md
+++ b/source/_docs/database-connection-errors.md
@@ -24,7 +24,7 @@ To see if this is the case, examine your `includes/bootstrap.inc` file, and veri
 If you don't see that, look in to recent changes and revert or remove whatever overwrote your core.
 
 ### WordPress Core
-Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [Applying Upstream Updates](/docs/upstream-updates).
+Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](/docs/terminus). Do not update core using the WordPress Dashboard or WP-CLI; you will overwrite your core. For additional details, see [Scope of Support](/docs/getting-support/#scope-of-support) and [WordPress and Drupal Core Updates](/docs/core-updates).
 
 ## Drupal Non-Standard Bootstraps
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.

--- a/source/_docs/drupal-updates.md
+++ b/source/_docs/drupal-updates.md
@@ -6,7 +6,7 @@ categories: [drupal]
 ---
 To upgrade Drupal to a new major version (e.g. version 6 to version 7) you must create a new site. Do not perform a major version upgrade from within the original site. If you have a Drupal 6 site that you want to upgrade to Drupal 7, create a new Drupal 7 site and add content, files and modules into the new site. If you are upgrading from Drupal 6 or Drupal 7 to Drupal 8, create a new Drupal 8 site and add content, files and modules from the old site there.
 
-Migrating to a new site on the platform will provide you with the QA and deployment processes you need to test your upgrade and ensure everything works properly. It also ensures that your site will receive [upstream updates](/docs/upstream-updates/) once the upgrade is complete.
+Migrating to a new site on the platform will provide you with the QA and deployment processes you need to test your upgrade and ensure everything works properly. It also ensures that your site will receive [upstream updates](/docs/core-updates/) once the upgrade is complete.
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>

--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -62,7 +62,7 @@ drush @pantheon.SITENAME.ENV COMMAND
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>
-<p><strong>Do not use Drush to update Drupal core on Pantheon</strong>. Pantheon uses Pressflow and includes some additional functionality; Drush assumes that a site is using vanilla Drupal and erroneously overwrites Pressflow. For more details, see <a href="/docs/upstream-updates">Core Updates</a>.
+<p><strong>Do not use Drush to update Drupal core on Pantheon</strong>. Pantheon uses Pressflow and includes some additional functionality; Drush assumes that a site is using vanilla Drupal and erroneously overwrites Pressflow. For more details, see <a href="/docs/core-updates">Core Updates</a>.
 </p>
 </div>
 

--- a/source/_docs/getting-support.md
+++ b/source/_docs/getting-support.md
@@ -136,7 +136,7 @@ Priority Enterprise Support is a blanket support plan which can be purchased for
 We love helping developers succeed! We also have limits to the support we can provide. The key to a great relationship is clear expectations of our support scope.
 
 ### Code
-We don't touch client code. Your site code belongs to you. Pantheon provides updates to the upstream for the site, which only affect core files and Pantheon-specific additions. It is your responsibility not to overwrite the upstream. If you do, updates on the Dashboard will cause conflicts that you must [resolve manually](/docs/upstream-updates#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts) with Git.
+We don't touch client code. Your site code belongs to you. Pantheon provides updates to the upstream for the site, which only affect core files and Pantheon-specific additions. It is your responsibility not to overwrite the upstream. If you do, updates on the Dashboard will cause conflicts that you must [resolve manually](/docs/core-updates#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts) with Git.
 
 ### Outdated Core
 Outdated versions of core are not supported on the platform. This includes importing a site, then manually downgrading to an older version of core. Sites utilizing a [Custom Upstream must be updated](/docs/maintain-custom-upstream/) by the upstream maintainer each time the project releases a new version.

--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -108,7 +108,7 @@ CONFLICT (delete/modify): scripts/run-tests.sh deleted in HEAD and modified in 7
  git push origin master
  ```
 
-For more details, see [Applying Upstream Updates](/docs/upstream-updates).
+For more details, see [WordPress and Drupal Core Updates](/docs/core-updates).
 ## General Git Questions
 ### Does Pantheon support Git submodules?
 No, Git submodules are not supported at this time. We recommend maintaining custom modules, themes, and/or plugins within separate repositories.

--- a/source/_docs/guides/collaborative-development.md
+++ b/source/_docs/guides/collaborative-development.md
@@ -109,7 +109,7 @@ At our [site creation page](https://dashboard.pantheon.io/sites/create/ "Pantheo
 
 ### Pull in Pantheon's Upstream
 
-As long as you've chosen the same codebase (Drupal 7, WordPress, Commerce Kickstart, etc.) as the starting point of your Pantheon site, you can use Git to import your existing code with your commit history intact, while also preserving Pantheon's [upstream update](/docs/upstream-updates/) function.
+As long as you've chosen the same codebase (Drupal 7, WordPress, Commerce Kickstart, etc.) as the starting point of your Pantheon site, you can use Git to import your existing code with your commit history intact, while also preserving Pantheon's [upstream update](/docs/core-updates/) function.
 
 1. From your Site Dashboard, go to the Dev environment.
 2. Click **Settings**, then select **About Site**.

--- a/source/_docs/headless.md
+++ b/source/_docs/headless.md
@@ -52,7 +52,7 @@ Backend APIs running on Pantheon take advantage of the following platform featur
 
 
 ## Exposing the Backend API
-Running WordPress and Drupal as an API on Pantheon can be done on any Drupal or WordPress upstream. The process to [create](/docs/create-sites/), [update core](/docs/upstream-updates/), and [launch](/docs/guides/launch/) a backend API on Pantheon does not deviate from the standard procedures.
+Running WordPress and Drupal as an API on Pantheon can be done on any Drupal or WordPress upstream. The process to [create](/docs/create-sites/), [update core](/docs/core-updates/), and [launch](/docs/guides/launch/) a backend API on Pantheon does not deviate from the standard procedures.
 
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -119,7 +119,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 
     This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
-Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/upstream-updates).
+Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/core-updates).
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -119,7 +119,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 
     This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
-Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [Apply Upstream Updates](/docs/core-updates).
+Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [WordPress and Drupal Core Updates](/docs/core-updates).
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -9,7 +9,7 @@ Upgrading your site's PHP version will improve the security, performance, and su
 ## Before You Begin
 Older software is more likely to contain code that is incompatible with recent PHP versions. Before you change your PHP version:
 
-- Update core to the latest release. For details, see [Apply Upstream Updates](/docs/core-updates/).
+- Update core to the latest release. For details, see [WordPress and Drupal Core Updates](/docs/core-updates/).
 - Update themes, plugins, and modules. For details, see [Working in the WordPress Dashboard and Drupal Admin Interface](/docs/cms-admin/).
 
 ## Verify Current PHP Versions

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -9,7 +9,7 @@ Upgrading your site's PHP version will improve the security, performance, and su
 ## Before You Begin
 Older software is more likely to contain code that is incompatible with recent PHP versions. Before you change your PHP version:
 
-- Update core to the latest release. For details, see [Apply Upstream Updates](/docs/upstream-updates/).
+- Update core to the latest release. For details, see [Apply Upstream Updates](/docs/core-updates/).
 - Update themes, plugins, and modules. For details, see [Working in the WordPress Dashboard and Drupal Admin Interface](/docs/cms-admin/).
 
 ## Verify Current PHP Versions

--- a/source/_docs/plugins.md
+++ b/source/_docs/plugins.md
@@ -18,7 +18,7 @@ The functionality of this plugin is broken into two parts: Updates and Page Cach
 ### [Pantheon Updates](https://github.com/pantheon-systems/WordPress/tree/master/wp-content/mu-plugins/pantheon/pantheon-updates.php){.external}
 The plugin disables automatic updates of all plugins, themes, and WordPress core on Pantheon's Test and Live environments. We do this because it is unsafe to apply updates to production environments directly without first verifying updates on a development environment.
 
-The Test and Live environment codebases also cannot be written to, preventing automatic updates from downloading files from WordPress.org. Any plugin or theme updates must be performed in a development environment then committed and deployed to the Test and Live environments. WordPress core updates must be applied to a development environment via our Git-based [upstream core updates feature](/docs/upstream-updates/).
+The Test and Live environment codebases also cannot be written to, preventing automatic updates from downloading files from WordPress.org. Any plugin or theme updates must be performed in a development environment then committed and deployed to the Test and Live environments. WordPress core updates must be applied to a development environment via our Git-based [upstream core updates feature](/docs/core-updates/).
 
 ###[Pantheon Page Cache](https://github.com/pantheon-systems/WordPress/blob/master/wp-content/mu-plugins/pantheon/pantheon-page-cache.php){.external}
 Facilitates communication between Pantheon's Edge Cache layer and WordPress, allowing you to clear the entire site cache and set the default cache age.

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -336,7 +336,7 @@ Fatal error: Class 'Redis_Cache' not found in
 
 It is possible that your `.gitignore` file is not up to date with the most recent version of your CMS. To resolve this, make sure you do not have any pending core updates.
 
-The best and easiest way to update your core is by using Pantheon administration Dashboard. See [Applying Upstream Updates](/docs/upstream-updates) for the steps to update your project's code and get the most recent version of the `.gitignore`.
+The best and easiest way to update your core is by using Pantheon administration Dashboard. See [WordPress and Drupal Core Updates](/docs/core-updates) for the steps to update your project's code and get the most recent version of the `.gitignore`.
 
 ### Fatal Error: require\_once()
 

--- a/source/_docs/required-reading.md
+++ b/source/_docs/required-reading.md
@@ -29,7 +29,7 @@ Our tech includes NGINX, PHP, Redis, Varnish, Solr and Git&mdash;common tools in
 ## Run
 - [Optimization for Pantheon and the Cloud](/docs/cloud-optimization/)
 - [New Relic Pro](/docs/new-relic/)
-- [Applying Upstream Updates](/docs/upstream-updates/)
+- [Applying Upstream Updates](/docs/core-updates/)
 - [Global CDN Caching for High Performance](/docs/global-cdn-caching/)
 - [Installing Redis on Drupal or WordPress](/docs/redis/)
 - [Drupal 7 Performance and Varnish Caching Settings](/docs/drupal-cache/)

--- a/source/_docs/solr-drupal-7.md
+++ b/source/_docs/solr-drupal-7.md
@@ -17,7 +17,7 @@ For instructions on how to run Solr on Drupal 8, see [Enabling Solr on Drupal 8]
 
 ## Installing Solr for Drupal
 ### 1. Apply Upstream Updates
-Use [one-click updates](/docs/upstream-updates) to make sure you are running the latest version of Drupal core.
+Use [one-click updates](/docs/core-updates) to make sure you are running the latest version of Drupal core.
 
 ### 2. Add Either the Apache Solr Search or Search API Solr Search Module
 

--- a/source/_docs/terminus/examples.md
+++ b/source/_docs/terminus/examples.md
@@ -18,7 +18,7 @@ Quickly install updates to core, contributed modules, themes, and plugins from t
 ### Upstream Updates (Core)
 Pantheon maintains upstream updates for [WordPress](https://github.com/pantheon-systems/WordPress), [Drupal 8](https://github.com/pantheon-systems/drops-8), and [Drupal 7](https://github.com/pantheon-systems/drops-7). Updates can be applied once they have been merged into the upstream and become available for a site.
 
-<div class="alert alert-info"><h4 class="note">Note</h4><p markdown="1">For instructions on how to resolve merge conflicts, see [Upstream Updates](/docs/upstream-updates#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts)</p></div>
+<div class="alert alert-info"><h4 class="note">Note</h4><p markdown="1">For instructions on how to resolve merge conflicts, see [Upstream Updates](/docs/core-updates#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts)</p></div>
 
 <p class="instruction">List available upstream updates:</p>
 <div class="copy-snippet">
@@ -206,7 +206,7 @@ terminus dashboard:view $SITE.dev</code></pre>
 The Site Dashboard will open once the reset procedure has completed.
 
 ## Switch Upstreams
-Every site has an upstream assigned in order to deliver [one-click updates](/docs/upstream-updates/) in the Pantheon Site Dashboard. Terminus can be used to manage this site level configuration. There are a few scenarios where it may be useful to change a site's upstream:
+Every site has an upstream assigned in order to deliver [one-click updates](/docs/core-updates/) in the Pantheon Site Dashboard. Terminus can be used to manage this site level configuration. There are a few scenarios where it may be useful to change a site's upstream:
 
 * Convert existing sites from a default framework to a [Custom Upstream](/docs/custom-upstream/).
 * Convert existing sites from one Custom Upstream to another, for reasons like:

--- a/source/_docs/undo-commits.md
+++ b/source/_docs/undo-commits.md
@@ -4,7 +4,7 @@ description: Learn how to revert a Git commit before and after pushing to Panthe
 tags: [debugcode, git]
 categories: []
 ---
-We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem is overwriting Drupal or WordPress core. We try our [best to warn you ](/docs/upstream-updates) but it is still possible to overwrite core on a local environment and push to Pantheon. Fortunately, this is reversible, but will require a little work.
+We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem is overwriting Drupal or WordPress core. We try our [best to warn you ](/docs/core-updates) but it is still possible to overwrite core on a local environment and push to Pantheon. Fortunately, this is reversible, but will require a little work.
 
 <div class="alert alert-danger" role="alert">
   <h4 class="info">Warning</h4>

--- a/source/_docs/wordpress-development-versions.md
+++ b/source/_docs/wordpress-development-versions.md
@@ -4,7 +4,7 @@ description: Learn how to test WordPress core updates using nightly builds of th
 tags: [workflow]
 categories: [wordpress]
 ---
-Pantheon provides [one-click updates](/docs/upstream-updates/) for WordPress core within the Site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress Dashboard or via Git.
+Pantheon provides [one-click updates](/docs/core-updates/) for WordPress core within the Site Dashboard for officially launched versions once they have been merged into our [upstream](https://github.com/pantheon-systems/WordPress). You can test development versions of WordPress by updating through the WordPress Dashboard or via Git.
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>

--- a/source/_docs/wordpress-known-issues.md
+++ b/source/_docs/wordpress-known-issues.md
@@ -14,7 +14,7 @@ If you are importing a site and the database has custom prefixes for your DB tab
 
 WordPress's automatic update functionality will not work on Pantheon site environments. We disable all automatic updates by default with the [Pantheon Updates](https://github.com/pantheon-systems/WordPress/blob/master/wp-content/mu-plugins/pantheon/pantheon-updates.php) plugin, found within the mu-plugins directory of our WordPress upstream. This plugin disables core, theme, and plugin updates on all Pantheon environments. Attempting to override this functionality by editing or removing this file will break your Test and Live environments. The codebase for these environments is not writeable, and WordPress will continually attempt to download and unpack core updates, which it cannot do on these environments. For more information, see the following:
 
-- [Applying Upstream Updates](/docs/upstream-updates/ "How to apply core updates to sites on Pantheon")
+- [Applying Upstream Updates](/docs/core-updates/ "How to apply core updates to sites on Pantheon")
 - [Updating WordPress Plugins](/docs/cms-admin/#wordpress-dashboard "How to update plugins")
 
 ## PHP Sessions


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Moved `/docs/upstream-updates/` to `/docs/core-updates/` 
- Rename from **Apply Upstream Updates** to **WordPress and Drupal Core Updates**

## Post Launch
- [ ] Redirect `/docs/upstream-updates/` => `/docs/core-updates/`
- [ ] Include/exclude pages ^ respectively within docs search service provider


cc @erik-pantheon 