### PR TITLE
Add watch.php

### DIFF
--- a/watch.php
+++ b/watch.php
@@ -1,0 +1,47 @@
+<?php
+
+$buildScriptPath = __DIR__.'/bin/sculpin generate --env=dev';
+
+$startPaths = [
+    __DIR__.'/app/config/*',
+    __DIR__.'/source/*',
+];
+
+$lastTime = time();
+
+while (true) {
+    $files = recursiveGlob($startPaths);
+
+    foreach ($files as $file) {
+        $time = filemtime($file);
+
+        if ($time > $lastTime) {
+            $lastTime = time();
+
+            echo sprintf("%s was changed. Building...\n", $file);
+
+            echo shell_exec($buildScriptPath)."\n";
+        }
+    }
+}
+
+function recursiveGlob(array $paths)
+{
+    $files = [];
+
+    foreach ($paths as $path) {
+        $files = array_merge($files, glob($path));
+
+        foreach ($files as $file) {
+            if (is_dir($file)) {
+                $dirPath = $file.'/*';
+
+                $dirFiles = recursiveGlob([$dirPath]);
+
+                $files = array_merge($files, $dirFiles);
+            }
+        }
+    }
+
+    return $files;
+}


### PR DESCRIPTION
This file is a workaround to an infinite loop issue with Sculpin, provided by @beryllium. Use it by running `php watch.php & php -S0.0.0.0:8000 -t output_dev/`

If you cancel that process and want to restart it, you must first kill the first `watch` process with `killall php`.