### PR TITLE
Remove outdated section from Redis FAQ

### DIFF
--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -401,15 +401,5 @@ set-max-intset-entries 512
 activerehashing yes
 ```
 
-### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
-Yes. There is a `redis.log` file that is available on the Redis container for each environment. You can see where the log files and configuration reside:
-
-```nohighlight
-$ sftp -o Port=2222 live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg@cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in Connected to cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in.
-sftp> ls -la logs/
--rw-r--r-- 1 11455 11455 40674752 Mar 10 19:46 redis.log
-sftp>
-```
-
 ### Why won't my site work after importing a database backup?
 When you replace the database with one that doesn't match the Redis cache, it can cause database errors on the site, and you may be unable to clear the cache via the dashboard. To resolve the issue, [flush your Redis cache from the command line](#clear-cache).

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -402,10 +402,13 @@ activerehashing yes
 ```
 
 ### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
-Yes. There is a `redis.log` file that is available on the Redis container for each environment. You can see where the log files and configuration reside:
+Yes. There is a `redis.log` file that is available on the Redis container for each environment. To access the Redis container, copy the SFTP command line string from the **Connection Info** button, and replace `appserver` with `cacheserver`. You can see where the log files and configuration reside:
 
 ```nohighlight
-$ sftp -o Port=2222 live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg@cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in Connected to cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in.
+$ sftp -o Port=2222 live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg@cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in
+Connected to cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in.
+sftp> ls
+certs          chef.stamp     data           lock           logs           metadata.json  redis.conf     tmp
 sftp> ls -la logs/
 -rw-r--r-- 1 11455 11455 40674752 Mar 10 19:46 redis.log
 sftp>

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -401,5 +401,15 @@ set-max-intset-entries 512
 activerehashing yes
 ```
 
+### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
+Yes. There is a `redis.log` file that is available on the Redis container for each environment. You can see where the log files and configuration reside:
+
+```nohighlight
+$ sftp -o Port=2222 live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg@cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in Connected to cacheserver.live.81fd3bea-d11b-401a-85e0-07ca0f4ce7cg.drush.in.
+sftp> ls -la logs/
+-rw-r--r-- 1 11455 11455 40674752 Mar 10 19:46 redis.log
+sftp>
+```
+
 ### Why won't my site work after importing a database backup?
 When you replace the database with one that doesn't match the Redis cache, it can cause database errors on the site, and you may be unable to clear the cache via the dashboard. To resolve the issue, [flush your Redis cache from the command line](#clear-cache).


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Removes section in Redis FAQ about retrieving `redis.log` via SFTP. SFTP access is not available to Redis servers.

(Similar to this PR on the original Drupal-specific Redis doc: https://github.com/pantheon-systems/documentation/issues/3208)

## Remaining Work
- none
