### PR TITLE
FAQ table on HTTPS specs

### DIFF
--- a/source/_docs/https.md
+++ b/source/_docs/https.md
@@ -91,6 +91,20 @@ Refer to [Cloudflare Domain Configuration](/docs/cloudflare/).
 ### For how long are Let's Encrypt certificates valid and what happens when they expire?
 Let's Encrypt certificates are valid for 90 days and are automatically updated on the platform before they expire.
 
+### What are the technical specifications for Pantheon's HTTPS?
+
+|                                                                       |                                 |
+|:--------------------------------------------------------------------- |:------------------------------- |
+| **Certificate Type**                                                  | Shared, issued by Let's Encrypt |
+| **Renewal**                                                           | Automatic                       |
+| **Inbound IP**                                                        | Static (shared)                 |
+| **Client Support**                                                    | 95.55% of Browsers <br>Some very old browsers not supported <sup><a href="https://caniuse.com/#search=TLS%201.2">1 <a href="https://caniuse.com/#search=SNI">2</a></sup> |
+| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/){.external}    | A+ [with HSTS](/docs/hsts/)     |
+| **Protocol**                                                          | TLS 1.2 with SNI                |
+| **Ciphers**                                                           | No 3DES cipher                  |
+| **Delivery**                                                          | [Global CDN](/docs/global-cdn)  |
+| **Encryption Endpoint**                                               | Application Container           |
+
 
 ## Known Issues
 ### HTTPS doesn't provision with incorrect AAAA configurations
@@ -118,7 +132,7 @@ If you encounter rate limits, we recommend the following approaches:
 
 - [Ask Let's Encrypt to increase your rate limit](https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform){.external}.
 - Request that your apex domain (e.g., `example.edu`) be added to the public suffix list by submitting a [pull request](https://github.com/publicsuffix/list/wiki/Guidelines){.external}, which will cause Let's Encrypt to treat every subdomain of the main domain as independent for limit purposes. Also, browsers and malware scanners will treat the subdomains as independent.
-- Consider using another certificate service for sites that are not on Pantheon. For example, educational institutions may want to consider using the [Incommon Certificate Service](https://www.incommon.org/certificates/){.external} as a workaround. 
+- Consider using another certificate service for sites that are not on Pantheon. For example, educational institutions may want to consider using the [Incommon Certificate Service](https://www.incommon.org/certificates/){.external} as a workaround.
 
 ## Glossary
 ### HTTPS

--- a/source/_docs/https.md
+++ b/source/_docs/https.md
@@ -93,17 +93,18 @@ Let's Encrypt certificates are valid for 90 days and are automatically updated o
 
 ### What are the technical specifications for Pantheon's HTTPS?
 
-|                                                                       |                                 |
-|:--------------------------------------------------------------------- |:------------------------------- |
-| **Certificate Type**                                                  | Shared, issued by Let's Encrypt |
-| **Renewal**                                                           | Automatic                       |
-| **Inbound IP**                                                        | Static (shared)                 |
-| **Client Support**                                                    | 95.55% of Browsers <br>Some very old browsers not supported <sup><a href="https://caniuse.com/#search=TLS%201.2">1 <a href="https://caniuse.com/#search=SNI">2</a></sup> |
-| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/){.external}    | A+ [with HSTS](/docs/hsts/)     |
-| **Protocol**                                                          | TLS 1.2 with SNI                |
-| **Ciphers**                                                           | No 3DES cipher                  |
-| **Delivery**                                                          | [Global CDN](/docs/global-cdn)  |
-| **Encryption Endpoint**                                               | Application Container           |
+|                                                                       | Legacy                    | Global CDN with Let's Encrypt   |
+|:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |
+| **Price**                                                             | $60/month per environment | Free                            |
+| **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt |
+| **Renewal**                                                           | Self-managed (up to you)  | Automatic                       |
+| **Inbound IP**                                                        | Static (unique)           | Static (shared)                 |
+| **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br>Some very old browsers not supported <sup><a href="https://caniuse.com/#search=TLS%201.2">1 <a href="https://caniuse.com/#search=SNI">2</a></sup> |
+| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/){.external}    | A                         | A+ [with HSTS](/docs/hsts/)     |
+| **Protocol**                                                          | TLS 1.1 & 1.2             | TLS 1.2 with SNI                |
+| **Ciphers**                                                           | Weak 3DES Cipher          | No Weak 3DES cipher             |
+| **Delivery**                                                          | US Datacenter             | [Global CDN](/docs/global-cdn)  |
+| **Encryption Endpoint**                                               | Load Balancer             | Application Container           |
 
 
 ## Known Issues

--- a/source/_docs/https.md
+++ b/source/_docs/https.md
@@ -39,6 +39,21 @@ Pantheon's new [Global CDN](/docs/global-cdn) provides [free, automated HTTPS](h
 
 {% include("content/https-requirements.html")%}
 
+## Technical Specifications
+
+|                                                                       | Legacy                    | Global CDN with Let's Encrypt   |
+|:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |
+| **Price**                                                             | $60/month per environment | Free                            |
+| **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt |
+| **Renewal**                                                           | Self-managed (up to you)  | Automatic                       |
+| **Inbound IP**                                                        | Static (unique)           | Static (shared)                 |
+| **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br>Some very old browsers not supported <sup><a href="https://caniuse.com/#search=TLS%201.2">1 <a href="https://caniuse.com/#search=SNI">2</a></sup> |
+| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/){.external}    | A                         | A+ [with HSTS](/docs/hsts/)     |
+| **Protocol**                                                          | TLS 1.1 & 1.2             | TLS 1.2 with SNI                |
+| **Ciphers**                                                           | Weak 3DES Cipher          | No Weak 3DES cipher             |
+| **Delivery**                                                          | US Datacenter             | [Global CDN](/docs/global-cdn)  |
+| **Encryption Endpoint**                                               | Load Balancer             | Application Container           |
+
 ## Frequently Asked Questions
 
 ### How do I switch my site over to HTTPS from HTTP?
@@ -91,23 +106,8 @@ Refer to [Cloudflare Domain Configuration](/docs/cloudflare/).
 ### For how long are Let's Encrypt certificates valid and what happens when they expire?
 Let's Encrypt certificates are valid for 90 days and are automatically updated on the platform before they expire.
 
-### What are the technical specifications for Pantheon's HTTPS?
-
-|                                                                       | Legacy                    | Global CDN with Let's Encrypt   |
-|:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |
-| **Price**                                                             | $60/month per environment | Free                            |
-| **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt |
-| **Renewal**                                                           | Self-managed (up to you)  | Automatic                       |
-| **Inbound IP**                                                        | Static (unique)           | Static (shared)                 |
-| **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br>Some very old browsers not supported <sup><a href="https://caniuse.com/#search=TLS%201.2">1 <a href="https://caniuse.com/#search=SNI">2</a></sup> |
-| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/){.external}    | A                         | A+ [with HSTS](/docs/hsts/)     |
-| **Protocol**                                                          | TLS 1.1 & 1.2             | TLS 1.2 with SNI                |
-| **Ciphers**                                                           | Weak 3DES Cipher          | No Weak 3DES cipher             |
-| **Delivery**                                                          | US Datacenter             | [Global CDN](/docs/global-cdn)  |
-| **Encryption Endpoint**                                               | Load Balancer             | Application Container           |
-
-
 ## Known Issues
+
 ### HTTPS doesn't provision with incorrect AAAA configurations
 Pantheon cannot not begin provisioning HTTPS if the Site Dashboard detects incorrect values set on AAAA records. Once you update the records using the recommended values, HTTPS will start to provision automatically. The values for AAAA records look similar, but they are distinct.
 


### PR DESCRIPTION
Closes #3588 

## Effect
PR includes the following changes:
- Adds an FAQ section with a table breaking down the technical specs of our HTTPS offering.
- Mostly stolen from [this old version](https://github.com/pantheon-systems/documentation/blob/6e6d5279d02b227746074b392628b8afa2fb8345/source/_docs/free-https.md) of the doc, but I updated the **Client Support** percentage based on the number currently provided by the first reference link.
- Selected only specs that I thought relevant, excluding those more pertinent to the original table, which was comparing to our Legacy SSL offering.

## Remaining Work
- [x] Request clarification from @ari-gold on the **Ciphers** section; it looks like we only listed a cipher we _don't_ use.
- [x] Identify any data excluded from the original table that should be included, or any new data to add.

## Post Launch
- NA
