### PR TITLE
Can't pre-provision from WPEngine

### DIFF
--- a/source/_docs/guides/launch/03-domains.md
+++ b/source/_docs/guides/launch/03-domains.md
@@ -77,4 +77,4 @@ When a certificate is ready you can switch DNS destinations from your existing s
   </div>
 </div>
 ### Maintenance Window
-If you are unable to prove domain ownership, you will not be able to pre-provision HTTPS to prevent service interruption. In these cases, we recommend completing the next section ([Configure DNS](/docs/guides/launch/configure-dns/)) during a planned maintenance window lasting up to one hour. HTTPS will be available for the domain within an hour of pointing DNS to Pantheon.
+If you are unable to prove domain ownership (e.g. WPEngine blocks serving the required challenge file) you will not be able to pre-provision HTTPS to prevent service interruption. In these cases, we recommend completing the next section ([Configure DNS](/docs/guides/launch/configure-dns/)) during a planned maintenance window lasting up to one hour. HTTPS will be available for the domain within an hour of pointing DNS to Pantheon.

--- a/source/_docs/guides/launch/03-domains.md
+++ b/source/_docs/guides/launch/03-domains.md
@@ -77,4 +77,4 @@ When a certificate is ready you can switch DNS destinations from your existing s
   </div>
 </div>
 ### Maintenance Window
-If you are unable to prove domain ownership (e.g. WPEngine blocks serving the required challenge file) you will not be able to pre-provision HTTPS to prevent service interruption. In these cases, we recommend completing the next section ([Configure DNS](/docs/guides/launch/configure-dns/)) during a planned maintenance window lasting up to one hour. HTTPS will be available for the domain within an hour of pointing DNS to Pantheon.
+If you are unable to prove domain ownership (e.g. WP Engine blocks serving the required challenge file) you will not be able to pre-provision HTTPS to prevent service interruption. In these cases, we recommend completing the next section ([Configure DNS](/docs/guides/launch/configure-dns/)) during a planned maintenance window lasting up to one hour. HTTPS will be available for the domain within an hour of pointing DNS to Pantheon.

--- a/source/_docs/migrate.md
+++ b/source/_docs/migrate.md
@@ -341,7 +341,7 @@ If multiple SQL files are present the import will fail. Only provide one `.sql` 
 If multiple `settings.php` files are present the import will fail. Pantheon does not need the `settings.php` file to import the site. To prevent import problems, it's best to remove `settings.php`.
 
 ### How can I migrate from WP Engine?
-Follow the [standard procedure for migrating WordPress sites to Pantheon](#migrate-existing-sites) as described above. If your migration fails, you can try the following workaround:
+Follow the [standard procedure for migrating WordPress sites to Pantheon](#migrate-existing-sites) as described above. Note that WP Engine blocks the Let's Encrypt challenge file, so you should schedule a [maintenance window](/docs/guides/launch/domains/#maintenance-window) for HTTPS. If your migration fails, you can try the following workaround:
 
 1. Create and download a backup point from WP Engine.
 2. Unzip your site's backup point on your local machine.


### PR DESCRIPTION
Closes #3441

We have work in the product backlog to allow serving the challenge via DNS


## Remaining Work
- [x] Link to this section form https://pantheon.io/docs/migrate/#how-can-i-migrate-from-wp-engine ?

## Post Launch
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
