### PR TITLE
Update PR and Issue Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,5 +1,8 @@
 
 Re: <Doc title and/or link>
+
+Priority (Low Med High): 
+
 ## Issue Description
 
 ## Suggested Resolution

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,7 +1,7 @@
 
-Re: <Doc title and/or link>
+Re: <Add Doc title and/or link>
 
-Priority (Low Med High): 
+Priority (Low‚ Medium‚ High): 
 
 ## Issue Description
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,7 +14,7 @@ PR includes the following changes:
 - [ ] Technical Review
 - [ ] Copy Review
 
-## Post Launch
+### Post Launch
 - [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
 - [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
 - [ ] Update Status Report

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,11 +10,8 @@ PR includes the following changes:
 - [ ] List any outstanding todos
 - [ ] If needed
 
-## Docs Team Work
-- [ ] Technical Review
-- [ ] Copy Review
-
-### Post Launch
+## Post Launch
+To be completed by the docs team upon merge: 
 - [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
 - [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
 - [ ] Update Status Report


### PR DESCRIPTION
## Effect
- Instruct user to add doc link when opening issue via GitHub directly in issue template
- Include priorities when opening issue via GitHub directly in issue template
- Consolidate **Docs Team Work** and **Post Launch** todos and note intended usage by docs team only in PR template
