### PR TITLE
Contain Images within Content Wells

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 11.2
+assets_version: 11.3
 
 #######################################################################################################
 # The contributors. Include your info here, under the "contributors" key, using the following template:

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -5250,6 +5250,8 @@ div.navsearch-container {
   margin: 0px !important;
   border-radius:4px;
   max-height: 70px;
+  border: none !important;
+  padding: unset !important;
 }
 .pantheon-official {
   color: #78868e;
@@ -5573,6 +5575,8 @@ td{
 #navbar .create-account a:hover {
   color: #000 !important;
 }
-.img{
-    border: 1px solid #44515e;
+#doc img, .changelog-wrapper img {
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  padding: 10px;
 }

--- a/wraith.yaml
+++ b/wraith.yaml
@@ -12,13 +12,14 @@ domains:
 # They should exist for all of the domains you've specified above.
 paths:
   home: /
-  article-index: /articles
-  single-article: /articles/going-live
-  subdir-index: /articles/local
   guide-index: /guides
-  single-guide: /guides/visual-diff-with-wraith
+  topic-page: /get-started
   changelog-index: /changelog
-  single-changelog: /changelog/2015-10-October
+  changelog: /changelog/2018/01
+  terminus-manual: /terminus/updates
+  doc: /metrics
+  guide: /guides/build-tools
+
 
 # amount of fuzz ImageMagick will use when comparing images. A higher fuzz makes the comparison less strict.
 fuzz: '20%'
@@ -29,11 +30,8 @@ threshold: 5
 
 # screen widths (and optional height) to resize the browser to before taking the screenshot
 screen_widths:
-  - 320
-  - 600x768
-  - 768
-  - 1024
   - 1280
+  - 1366
 
 # the engine to run Wraith with. Examples: 'phantomjs', 'casperjs', 'slimerjs'
 browser: "casperjs"


### PR DESCRIPTION
Re: 9652158

ping @alexfornuto & @kimby77 for review :) 

## Effect
PR includes the following changes:
- Bust browser cache by bumping asset ver
- Capture one of each content type in `wraith.yml`
- Contain images within content wells of all content types, but not on "index" pages. For example: 
    <img width="1432" alt="screen_shot_2018-04-26_at_12_05_10_pm" src="https://user-images.githubusercontent.com/10119525/39320695-90d201e6-494a-11e8-8cdd-9f372caae815.png">

## Regression Test Results
 - Paths reporting 0% diff include `/docs/`, `/docs/get-started/`, `/docs/guides/`, and `/docs/terminus/updates` as expected, for example: 
   <img width="1204" alt="screen shot 2018-04-26 at 11 40 41 am" src="https://user-images.githubusercontent.com/10119525/39319652-4f1766a4-4947-11e8-8b52-2cbf8e6ceb99.png">
- Paths reporting appropriate diff include `/docs/changelog/`, `/docs/changelog/2018/01/`, `/docs/metrics/`, and `/docs/guides/build-tools/` as expected, for example: 
  <img width="992" alt="screen shot 2018-04-26 at 11 48 58 am" src="https://user-images.githubusercontent.com/10119525/39319821-dd2492fa-4947-11e8-9598-0b3d984ff9eb.png">

