### PR TITLE
Make the load testing steps CMS-agnostic

### DIFF
--- a/source/_docs/load-and-performance-testing.md
+++ b/source/_docs/load-and-performance-testing.md
@@ -57,9 +57,9 @@ Note the start time for the test. As the test executes, it's a good idea to keep
 
 Once the test is running, execute common tasks done by editors and administrators and note the time. Example tasks may include:
 
-* Clear the drupal cache
+* Clear the cache
 * Clear the edge cache (if this is a load test, performance tests should not be cached)
-* Run Drupal cron
+* Run cron
 * Run any scripts that could be triggered while users are on the site.
 
 ##Assess Results


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Remove the references to Drupal when suggesting load testers run cron and clear caches — these would apply to WP, too.

## Remaining Work
- n/a

## Docs Team Work
- [ ] Review
