### PR TITLE
WooCommerce PHP Sessions warning

### DIFF
--- a/source/_docs/wordpress-sessions.md
+++ b/source/_docs/wordpress-sessions.md
@@ -6,7 +6,7 @@ categories: [wordpress]
 ---
 WordPress Core [does not use sessions](https://wordpress.org/support/topic/how-does-wordpress-handle-sessions-and-session-variables/?replies=7). All "user state" is managed via cookies. This is a Core design decision.
 
-However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin.
+However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin. **[WooCommerce](https://woocommerce.com/) uses PHP Sessions and must have the WordPress Native PHP Sessions plugin installed and activated to work properly on Pantheon.**
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>

--- a/source/_docs/wordpress-sessions.md
+++ b/source/_docs/wordpress-sessions.md
@@ -6,7 +6,9 @@ categories: [wordpress]
 ---
 WordPress Core [does not use sessions](https://wordpress.org/support/topic/how-does-wordpress-handle-sessions-and-session-variables/?replies=7). All "user state" is managed via cookies. This is a Core design decision.
 
-However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin. **[WooCommerce](https://woocommerce.com/) uses PHP Sessions and must have the WordPress Native PHP Sessions plugin installed and activated to work properly on Pantheon.**
+However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin.
+
+[WooCommerce](https://woocommerce.com/){.external}, for example, uses PHP Sessions and must have the WordPress Native PHP Sessions plugin installed and activated to work properly on Pantheon.
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>


### PR DESCRIPTION
Addresses feedback to the doc requesting an example.

## Effect
PR includes the following changes:
- Add a warning about WooCommerce's need for the PHP session plugin to function on Pantheon.

## Docs Team Work
- [x] Technical Review
- [x] Copy Review

## Post Launch
~~- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)~~
~~- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)~~
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
