### PR TITLE
Darken Image Border

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 11.3
+assets_version: 11.4
 
 #######################################################################################################
 # The contributors. Include your info here, under the "contributors" key, using the following template:

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -5576,7 +5576,7 @@ td{
   color: #000 !important;
 }
 #doc img, .changelog-wrapper img {
-  border: 1px solid #ddd;
+  border: 1px solid #b0b0b0;
   border-radius: 4px;
   padding: 10px;
 }


### PR DESCRIPTION
Follows #3620 

## Effect
PR includes the following changes:
- Darkens the recently added image border from #dddddd to #b0b0b0

Example:
![image](https://user-images.githubusercontent.com/2349184/39388508-73b701ba-4a4e-11e8-8c99-535c7eb4275d.png)


## Docs Team Work
- [ ] Technical Review
- [ ] Copy Review

## Post Launch
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
