### PR TITLE
add clarifying language

### DIFF
--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -4,7 +4,7 @@ description: Detailed information on how to maintain Custom Upstreams and distri
 tags: [tools, workflow]
 categories: []
 ---
-Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core. 
+Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core.
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
@@ -32,7 +32,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
 ## Test and Release Pantheon Core Updates
 
-1. Within your local clone of your Custom Upstream repository, add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} if you haven't done so already:
+1. From your local clone of your Custom Upstream repository, add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} if you haven't done so already:
 
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
@@ -54,7 +54,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
     </div>
     </div><br>
 
-2. We will also add the test site you created above as a remote to your Custom Upstream. Do do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus). Replace `<site>` with your site name:
+2. We will also add the test site you created above as a remote to your Custom Upstream. To do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus). Replace `<site>` with your site name:
 
     ```command
     terminus connection:info <site>.dev --field=git_url

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -4,7 +4,7 @@ description: Detailed information on how to maintain Custom Upstreams and distri
 tags: [tools, workflow]
 categories: []
 ---
-Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon.
+Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core. 
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
@@ -20,6 +20,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 - Your Custom Upstream repository connected to Pantheon
 
 ## Create a Test Site on Pantheon
+This test site will be used later for evaluating the Custom Upstream changes we will make in the next section.
 
 1. From your User Dashboard, click **Create New Site**.
 2. Name your site.
@@ -31,7 +32,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
 
 ## Test and Release Pantheon Core Updates
 
-1. Add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} within a local clone of your Custom Upstream repository if you haven't done so already:
+1. Within your local clone of your Custom Upstream repository, add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} if you haven't done so already:
 
     <!-- Nav tabs -->
     <ul class="nav nav-tabs" role="tablist">
@@ -53,7 +54,7 @@ Follow the procedure to [create a custom upstream](/docs/create-custom-upstream)
     </div>
     </div><br>
 
-2. We'll need to do the same for your new test site on Pantheon. Let's grab the site's repository URL on Pantheon using [Terminus](/docs/terminus). Replace `<site>` with your site name:
+2. We will also add the test site you created above as a remote to your Custom Upstream. Do do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus). Replace `<site>` with your site name:
 
     ```command
     terminus connection:info <site>.dev --field=git_url


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Added clarifying language to distinguish between 


## Docs Team Work
- [x] Technical Review
- [x] Copy Review

## Post Launch
- [ ] ~~Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)~~
- [ ] ~~Include/exclude pages ^ respectively within docs search service provider (if applicable)~~
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
