### PR TITLE
Sort Feedback by Last Tag

### DIFF
--- a/source/_views/doc.html
+++ b/source/_views/doc.html
@@ -80,7 +80,7 @@
 <div class="container-fluid">
  <div class="row">
    <div class="survey-pio-outter col-md-12">
-     <iframe style="width:100%;min-height:300px;" frameborder="0" src="https://www.getfeedback.com/r/12z1fMzn?page={{page.url}}&topic={{page.categories|last}}"></iframe>
+     <iframe style="width:100%;min-height:300px;" frameborder="0" src="https://www.getfeedback.com/r/12z1fMzn?page={{page.url}}&topic={{page.tags|last}}"></iframe>
    </div>
  </div>
 </div>

--- a/source/_views/video.html
+++ b/source/_views/video.html
@@ -52,7 +52,7 @@
 <div class="container-fluid">
  <div class="row">
    <div class="survey-pio-outter col-md-12">
-     <iframe style="width:100%;min-height:300px;" frameborder="0" src="https://www.getfeedback.com/r/12z1fMzn?page={{page.url}}&topic={{page.categories|last}}"></iframe>
+     <iframe style="width:100%;min-height:300px;" frameborder="0" src="https://www.getfeedback.com/r/12z1fMzn?page={{page.url}}&topic={{page.tags|last}}"></iframe>
    </div>
  </div>
 </div>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Replace `categories` with `tags` to populate **[TOPIC]** in GetFeedback survey results 

<img width="631" alt="screen shot 2018-05-07 at 10 04 02 am" src="https://user-images.githubusercontent.com/10119525/39714196-2421668a-51de-11e8-8265-0f80658503df.png">

Additional things to consider: Is the last tag (`{{page.tags|last}}`) most appropriate? Should we sort by first tag? As we find pages that are incorrectly sorted, we should update the tag used to sort the doc (e.g., move the more relevant tag to the last position) rather than trying to update all of them and sort them again in an audit. 
