### PR TITLE
Account for the submodules issue

### DIFF
--- a/source/_docs/guides/partial-composer.md
+++ b/source/_docs/guides/partial-composer.md
@@ -62,6 +62,15 @@ Use the `init` command to create a `composer.json` file that includes the approp
               "wp-content/plugins/{$name}/": ["type:wordpress-plugin"],
               "wp-content/themes/{$name}/": ["type:wordpress-theme"]
             }
+          },
+          "scripts": {
+            "remove-git-submodules": "find . -mindepth 2 -type d -name .git | xargs rm -rf",
+            "post-install-cmd": [
+              "@remove-git-submodules"
+             ],
+            "post-update-cmd": [
+              "@remove-git-submodules"
+            ]
           }
       }
       ```


### PR DESCRIPTION
Dependencies that get pulled in as submodules are compatible with Pantheon. Use this code created by @sarahg 

## Effect
PR includes the following changes:
- Add code to help Composer deal with submodules

## Post Launch
To be completed by the docs team upon merge: 
- [x] Technical review
- [x] Copy review
