### PR TITLE
Explicitly defining code style for the code blocks

### DIFF
--- a/source/_docs/guides/wordpress-commandline.md
+++ b/source/_docs/guides/wordpress-commandline.md
@@ -88,7 +88,11 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 4. Use the [WP-CLI `core install`](https://developer.wordpress.org/cli/commands/core/install/) command to install WordPress on the Dev environment:
 
   ```command
-  terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
+  terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io \
+    --title="Terminus Demo Site" \
+    --admin_user=admin \
+    --admin_password=changemelater \
+    --admin_email=name@yoursite.com
   ```
 
   As a reminder, WP-CLI is the command line utility for WordPress itself.	Terminus is simply passing through the WP-CLI commands to the site on Pantheon. To get a full list of WP-CLI commands run:

--- a/source/_docs/guides/wordpress-commandline.md
+++ b/source/_docs/guides/wordpress-commandline.md
@@ -30,7 +30,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Install Terminus within the `$HOME/terminus` directory:
 
-  ```bash
+  ```command
   mkdir $HOME/terminus
   cd $HOME/terminus
   curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
@@ -38,7 +38,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. [Generate a Machine Token](https://dashboard.pantheon.io/login?destination=%2Fuser#account/tokens/create/terminus/) from within **User Dashboard** > **Account** > **Machine Tokens**. Then use it to authenticate Terminus:
 
-  ```bash
+  ```command
   terminus auth:login --machine-token=‹machine-token›
   ```
 
@@ -46,7 +46,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Once installed, verify your session:
 
-  ```bash
+  ```command
   terminus site:list
   ```
 
@@ -63,7 +63,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Create a new WordPress site on Pantheon:
 
-  ```bash
+  ```command
   terminus site:create tessa-site-wp "Terminus Demo Site" WordPress
   ```
 
@@ -71,7 +71,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. Open your new Site Dashboard in a browser:
 
- ```bash
+ ```command
  terminus dashboard:view tessa-site-wp
  ```
 
@@ -79,7 +79,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Get the platform domain for the Dev environment:
 
-  ```bash
+  ```command
   terminus env:info tessa-site-wp.dev --field=domain
   ```
 
@@ -87,13 +87,13 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Use the [WP-CLI `core install`](https://developer.wordpress.org/cli/commands/core/install/) command to install WordPress on the Dev environment:
 
-  ```bash
+  ```command
   terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
   ```
 
   As a reminder, WP-CLI is the command line utility for WordPress itself.	Terminus is simply passing through the WP-CLI commands to the site on Pantheon. To get a full list of WP-CLI commands run:
 
-  ```bash
+  ```command
   terminus wp tessa-site-wp.dev -- help
   ```
 
@@ -101,20 +101,20 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Create the Test environment:
 
-  ```bash
+  ```command
   terminus env:deploy tessa-site-wp.test --updatedb --note="Initialize the Test environment"
   ```
 
 5. Create the Live environment:
 
-    ```bash
+    ```command
     terminus env:deploy tessa-site-wp.live  --updatedb --note="Initialize the Live environment"
     ```
 
 ### Export the Site Name as a Variable
 1. Instead of having to type the site name out, let's export our site name to a variable so we can copy/paste the remainder of our commands:
 
-  ```bash
+  ```command
   export TERMINUS_SITE=tessa-site-wp
   ```
 
@@ -122,7 +122,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. We can test this by echoing our variable:
 
-  ```bash
+  ```command
   echo $TERMINUS_SITE
   ```
 
@@ -130,7 +130,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Let's see our new variable in action. Get the connection information for the Dev environment:
 
-  ```bash
+  ```command
   terminus connection:info $TERMINUS_SITE.dev
   ```
 
@@ -139,7 +139,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 1. Install and activate the [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) plugin:
 
-  ```bash
+  ```command
   terminus wp $TERMINUS_SITE.dev -- plugin install contact-form-7 --activate
   ```
 
@@ -150,13 +150,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 2. Review the file changes:
 
-  ```bash
+  ```command
   terminus env:diffstat $TERMINUS_SITE.dev
   ```
 
 3. Commit your changes to the Dev environment:
 
-  ```bash
+  ```command
   terminus env:commit $TERMINUS_SITE.dev --message="Install CF7"
   ```
 
@@ -165,7 +165,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 4. Deploy the code to Test and pull content down from Live:
 
-  ```bash
+  ```command
   terminus env:deploy $TERMINUS_SITE.test --sync-content  --updatedb --cc --note="Deploy C7 plugin"
   ```
 
@@ -177,13 +177,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 5. Activate the Contact Form 7 plugin on the Test environment by making a manual configuration change:
 
-  ```bash
+  ```command
   terminus wp $TERMINUS_SITE.test -- plugin activate contact-form-7
   ```
 
 6. Once you've experimented in the Test environment and verified that your new plugin is working, and everything else is still in working order, deploy to Live:
 
-  ```bash
+  ```command
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy after CF7 Install"
   ```
 
@@ -196,7 +196,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 7. Activate the Contact Form 7 plugin on the Live environment by making a manual configuration change:
 
-  ```bash
+  ```command
   terminus wp $TERMINUS_SITE.live -- plugin activate contact-form-7
   ```
 
@@ -208,25 +208,25 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 1. Install and activate the [Shapely](https://wordpress.org/themes/shapely/) theme:
 
-  ```bash
+  ```command
   terminus wp $TERMINUS_SITE.dev -- theme install shapely --activate
   ```
 
 2. Check out the Dev environment's site URL to see the new theme in action. The `terminus env:info` command from earlier gives us the URL. Here it is again with our environment variable:
 
-   ```bash
+   ```command
    terminus env:info $TERMINUS_SITE.dev --field=domain
    ```
 
 3. Commit your changes to the Dev environment:
 
-  ```bash
+  ```command
   terminus env:commit $TERMINUS_SITE.dev --message="Install shapely theme"
   ```
 
 4. No WordPress site is ready for development without a [child theme](https://codex.wordpress.org/Child_Themes). Let's create one! Run [the `scaffold child-theme` WP-CLI command](https://developer.wordpress.org/cli/commands/scaffold/child-theme/) (replace `Tessa-child-theme` and `shapely`):
 
-  ```bash
+  ```command
   terminus wp $TERMINUS_SITE.dev -- scaffold child-theme Tessa-child-theme --parent_theme=shapely
   ```
 
@@ -240,13 +240,13 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 5. Commit your changes to the Dev environment:
 
-  ```bash
+  ```command
   terminus env:commit $TERMINUS_SITE.dev --message="Create Child of Shapely Theme"
   ```
 
 6. Deploy the themes to Test and pull content down from Live:
 
-  ```bash
+  ```command
   terminus env:deploy $TERMINUS_SITE.test --sync-content --updatedb --cc --note="Deploy Themes"
   ```
 
@@ -254,7 +254,7 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 7. Deploy code to Live, then apply configuration changes:
 
-  ```bash
+  ```command
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy Themes"
   ```
 

--- a/source/_docs/guides/wordpress-commandline.md
+++ b/source/_docs/guides/wordpress-commandline.md
@@ -10,6 +10,7 @@ contributors:
   - calevans
   - stevector
   - tessak22
+  - davidneedham
 date: 3/7/2017
 ---
 Many developers feel more at home using the command line than they do using a GUI. Edit a text file, issue a command, and bang—you've completed your task. There's just something about doing it all from the command line that makes it a little more exciting. Until recently, WordPress didn't have a great answer for developers who are most at home on the CLI.
@@ -29,7 +30,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Install Terminus within the `$HOME/terminus` directory:
 
-  ```
+  ```bash
   mkdir $HOME/terminus
   cd $HOME/terminus
   curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
@@ -37,7 +38,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. [Generate a Machine Token](https://dashboard.pantheon.io/login?destination=%2Fuser#account/tokens/create/terminus/) from within **User Dashboard** > **Account** > **Machine Tokens**. Then use it to authenticate Terminus:
 
-  ```
+  ```bash
   terminus auth:login --machine-token=‹machine-token›
   ```
 
@@ -45,7 +46,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Once installed, verify your session:
 
-  ```
+  ```bash
   terminus site:list
   ```
 
@@ -62,7 +63,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Create a new WordPress site on Pantheon:
 
-  ```
+  ```bash
   terminus site:create tessa-site-wp "Terminus Demo Site" WordPress
   ```
 
@@ -70,7 +71,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. Open your new Site Dashboard in a browser:
 
- ```
+ ```bash
  terminus dashboard:view tessa-site-wp
  ```
 
@@ -78,7 +79,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Get the platform domain for the Dev environment:
 
-  ```
+  ```bash
   terminus env:info tessa-site-wp.dev --field=domain
   ```
 
@@ -86,13 +87,13 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Use the [WP-CLI `core install`](https://developer.wordpress.org/cli/commands/core/install/) command to install WordPress on the Dev environment:
 
-  ```
+  ```bash
   terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
   ```
 
   As a reminder, WP-CLI is the command line utility for WordPress itself.	Terminus is simply passing through the WP-CLI commands to the site on Pantheon. To get a full list of WP-CLI commands run:
 
-  ```
+  ```bash
   terminus wp tessa-site-wp.dev -- help
   ```
 
@@ -100,20 +101,20 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Create the Test environment:
 
-  ```
+  ```bash
   terminus env:deploy tessa-site-wp.test --updatedb --note="Initialize the Test environment"
   ```
 
 5. Create the Live environment:
 
-    ```
+    ```bash
     terminus env:deploy tessa-site-wp.live  --updatedb --note="Initialize the Live environment"
     ```
 
 ### Export the Site Name as a Variable
 1. Instead of having to type the site name out, let's export our site name to a variable so we can copy/paste the remainder of our commands:
 
-  ```
+  ```bash
   export TERMINUS_SITE=tessa-site-wp
   ```
 
@@ -121,7 +122,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. We can test this by echoing our variable:
 
-  ```
+  ```bash
   echo $TERMINUS_SITE
   ```
 
@@ -129,7 +130,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Let's see our new variable in action. Get the connection information for the Dev environment:
 
-  ```
+  ```bash
   terminus connection:info $TERMINUS_SITE.dev
   ```
 
@@ -138,7 +139,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 1. Install and activate the [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) plugin:
 
-  ```
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- plugin install contact-form-7 --activate
   ```
 
@@ -149,13 +150,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 2. Review the file changes:
 
-  ```
+  ```bash
   terminus env:diffstat $TERMINUS_SITE.dev
   ```
 
 3. Commit your changes to the Dev environment:
 
-  ```
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Install CF7"
   ```
 
@@ -164,7 +165,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 4. Deploy the code to Test and pull content down from Live:
 
-  ```
+  ```bash
   terminus env:deploy $TERMINUS_SITE.test --sync-content  --updatedb --cc --note="Deploy C7 plugin"
   ```
 
@@ -176,13 +177,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 5. Activate the Contact Form 7 plugin on the Test environment by making a manual configuration change:
 
-  ```
+  ```bash
   terminus wp $TERMINUS_SITE.test -- plugin activate contact-form-7
   ```
 
 6. Once you've experimented in the Test environment and verified that your new plugin is working, and everything else is still in working order, deploy to Live:
 
-  ```
+  ```bash
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy after CF7 Install"
   ```
 
@@ -195,7 +196,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 7. Activate the Contact Form 7 plugin on the Live environment by making a manual configuration change:
 
-  ```
+  ```bash
   terminus wp $TERMINUS_SITE.live -- plugin activate contact-form-7
   ```
 
@@ -207,25 +208,25 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 1. Install and activate the [Shapely](https://wordpress.org/themes/shapely/) theme:
 
-  ```
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- theme install shapely --activate
   ```
 
 2. Check out the Dev environment's site URL to see the new theme in action. The `terminus env:info` command from earlier gives us the URL. Here it is again with our environment variable:
 
-   ```
+   ```bash
    terminus env:info $TERMINUS_SITE.dev --field=domain
    ```
 
 3. Commit your changes to the Dev environment:
 
-  ```
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Install shapely theme"
   ```
 
 4. No WordPress site is ready for development without a [child theme](https://codex.wordpress.org/Child_Themes). Let's create one! Run [the `scaffold child-theme` WP-CLI command](https://developer.wordpress.org/cli/commands/scaffold/child-theme/) (replace `Tessa-child-theme` and `shapely`):
 
-  ```
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- scaffold child-theme Tessa-child-theme --parent_theme=shapely
   ```
 
@@ -239,13 +240,13 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 5. Commit your changes to the Dev environment:
 
-  ```
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Create Child of Shapely Theme"
   ```
 
 6. Deploy the themes to Test and pull content down from Live:
 
-  ```
+  ```bash
   terminus env:deploy $TERMINUS_SITE.test --sync-content --updatedb --cc --note="Deploy Themes"
   ```
 
@@ -253,7 +254,7 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 7. Deploy code to Live, then apply configuration changes:
 
-  ```
+  ```bash
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy Themes"
   ```
 

--- a/source/_docs/guides/wordpress-commandline.md
+++ b/source/_docs/guides/wordpress-commandline.md
@@ -30,7 +30,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Install Terminus within the `$HOME/terminus` directory:
 
-  ```command
+  ```bash
   mkdir $HOME/terminus
   cd $HOME/terminus
   curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
@@ -38,7 +38,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. [Generate a Machine Token](https://dashboard.pantheon.io/login?destination=%2Fuser#account/tokens/create/terminus/) from within **User Dashboard** > **Account** > **Machine Tokens**. Then use it to authenticate Terminus:
 
-  ```command
+  ```bash
   terminus auth:login --machine-token=‹machine-token›
   ```
 
@@ -46,7 +46,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Once installed, verify your session:
 
-  ```command
+  ```bash
   terminus site:list
   ```
 
@@ -63,7 +63,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 1. Create a new WordPress site on Pantheon:
 
-  ```command
+  ```bash
   terminus site:create tessa-site-wp "Terminus Demo Site" WordPress
   ```
 
@@ -71,7 +71,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. Open your new Site Dashboard in a browser:
 
- ```command
+ ```bash
  terminus dashboard:view tessa-site-wp
  ```
 
@@ -79,7 +79,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Get the platform domain for the Dev environment:
 
-  ```command
+  ```bash
   terminus env:info tessa-site-wp.dev --field=domain
   ```
 
@@ -87,17 +87,13 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Use the [WP-CLI `core install`](https://developer.wordpress.org/cli/commands/core/install/) command to install WordPress on the Dev environment:
 
-  ```command
-  terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io \
-    --title="Terminus Demo Site" \
-    --admin_user=admin \
-    --admin_password=changemelater \
-    --admin_email=name@yoursite.com
+  ```bash
+  terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
   ```
 
   As a reminder, WP-CLI is the command line utility for WordPress itself.	Terminus is simply passing through the WP-CLI commands to the site on Pantheon. To get a full list of WP-CLI commands run:
 
-  ```command
+  ```bash
   terminus wp tessa-site-wp.dev -- help
   ```
 
@@ -105,20 +101,20 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 4. Create the Test environment:
 
-  ```command
+  ```bash
   terminus env:deploy tessa-site-wp.test --updatedb --note="Initialize the Test environment"
   ```
 
 5. Create the Live environment:
 
-    ```command
+    ```bash
     terminus env:deploy tessa-site-wp.live  --updatedb --note="Initialize the Live environment"
     ```
 
 ### Export the Site Name as a Variable
 1. Instead of having to type the site name out, let's export our site name to a variable so we can copy/paste the remainder of our commands:
 
-  ```command
+  ```bash
   export TERMINUS_SITE=tessa-site-wp
   ```
 
@@ -126,7 +122,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 2. We can test this by echoing our variable:
 
-  ```command
+  ```bash
   echo $TERMINUS_SITE
   ```
 
@@ -134,7 +130,7 @@ Terminus provides advanced interaction with the platform and allows us to run WP
 
 3. Let's see our new variable in action. Get the connection information for the Dev environment:
 
-  ```command
+  ```bash
   terminus connection:info $TERMINUS_SITE.dev
   ```
 
@@ -143,7 +139,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 1. Install and activate the [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) plugin:
 
-  ```command
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- plugin install contact-form-7 --activate
   ```
 
@@ -154,13 +150,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 2. Review the file changes:
 
-  ```command
+  ```bash
   terminus env:diffstat $TERMINUS_SITE.dev
   ```
 
 3. Commit your changes to the Dev environment:
 
-  ```command
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Install CF7"
   ```
 
@@ -169,7 +165,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 4. Deploy the code to Test and pull content down from Live:
 
-  ```command
+  ```bash
   terminus env:deploy $TERMINUS_SITE.test --sync-content  --updatedb --cc --note="Deploy C7 plugin"
   ```
 
@@ -181,13 +177,13 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 5. Activate the Contact Form 7 plugin on the Test environment by making a manual configuration change:
 
-  ```command
+  ```bash
   terminus wp $TERMINUS_SITE.test -- plugin activate contact-form-7
   ```
 
 6. Once you've experimented in the Test environment and verified that your new plugin is working, and everything else is still in working order, deploy to Live:
 
-  ```command
+  ```bash
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy after CF7 Install"
   ```
 
@@ -200,7 +196,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 
 7. Activate the Contact Form 7 plugin on the Live environment by making a manual configuration change:
 
-  ```command
+  ```bash
   terminus wp $TERMINUS_SITE.live -- plugin activate contact-form-7
   ```
 
@@ -212,25 +208,25 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 1. Install and activate the [Shapely](https://wordpress.org/themes/shapely/) theme:
 
-  ```command
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- theme install shapely --activate
   ```
 
 2. Check out the Dev environment's site URL to see the new theme in action. The `terminus env:info` command from earlier gives us the URL. Here it is again with our environment variable:
 
-   ```command
+   ```bash
    terminus env:info $TERMINUS_SITE.dev --field=domain
    ```
 
 3. Commit your changes to the Dev environment:
 
-  ```command
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Install shapely theme"
   ```
 
 4. No WordPress site is ready for development without a [child theme](https://codex.wordpress.org/Child_Themes). Let's create one! Run [the `scaffold child-theme` WP-CLI command](https://developer.wordpress.org/cli/commands/scaffold/child-theme/) (replace `Tessa-child-theme` and `shapely`):
 
-  ```command
+  ```bash
   terminus wp $TERMINUS_SITE.dev -- scaffold child-theme Tessa-child-theme --parent_theme=shapely
   ```
 
@@ -244,13 +240,13 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 5. Commit your changes to the Dev environment:
 
-  ```command
+  ```bash
   terminus env:commit $TERMINUS_SITE.dev --message="Create Child of Shapely Theme"
   ```
 
 6. Deploy the themes to Test and pull content down from Live:
 
-  ```command
+  ```bash
   terminus env:deploy $TERMINUS_SITE.test --sync-content --updatedb --cc --note="Deploy Themes"
   ```
 
@@ -258,7 +254,7 @@ Now that you have WordPress installed, let's make it look a little better by add
 
 7. Deploy code to Live, then apply configuration changes:
 
-  ```command
+  ```bash
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploy Themes"
   ```
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- The formatting / coloring of code blocks used for the various `terminus` commands was inconsistent. This manually defines that the format should be bash for every terminus code block.
- An experiment to test breaking long lines of code with `\`

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
