### PR TITLE
Fix Drush "aa" command example

### DIFF
--- a/source/_docs/drupal-launch-check.md
+++ b/source/_docs/drupal-launch-check.md
@@ -78,7 +78,7 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/docs/terminus/) command to execute Site Audit directly on your Pantheon site:
 ```bash
-terminus drush <site>.<env> -- -vd @pantheon.SITENAME.ENV aa --skip=insights --detail --vendor=pantheon --strict=0
+terminus drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon --strict=0
 ```
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Removes unneeded alias declaration from the Drush "aa" command example. Running it as shown in the current example yields "Could not find the alias" errors.

## Remaining Work
- [ ] technical review