### PR TITLE
Note that hotfixes don't reload pantheon.yml.

### DIFF
--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -112,6 +112,9 @@ remote:
 remote:
 ```
 
+### Deploying a Hotfix
+Changes made to `pantheon.yml` file on a branch **are not** detected when deploying a [hotfix](/docs/hotfixes/). As a workaround, make some modification to `pantheon.yml` file and deploy that forward using the standard process.
+
 ## See Also
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver/)  
 - [Upgrade PHP Versions](/docs/php-versions/)

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -112,8 +112,8 @@ remote:
 remote:
 ```
 
-### Deploying a Hotfix
-Changes made to `pantheon.yml` file on a branch **are not** detected when deploying a [hotfix](/docs/hotfixes/). As a workaround, make some modification to `pantheon.yml` file and deploy that forward using the standard process.
+### Deploying Hotfixes
+Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/docs/hotfixes/). As a workaround, make some modification to `pantheon.yml` file in a development environment and deploy up to production using the standard Pantheon workflow.
 
 ## See Also
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver/)  


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Note that hotfix-style deploys will not re-read pantheon.yml, so changes to that deployed via a hotfix (e.g changing PHP version) will not take effect.

Internal ref: BUGS-1997

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
