### PR TITLE
Reset password clarification

### DIFF
--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -1,6 +1,6 @@
 ---
 title: Resetting Passwords
-description: Learn how to reset your Pantheon Website Management Platform dashboard passwords.
+description: Learn how to reset your Pantheon Dashboard password or your site user login password.
 tags: [debugdb]
 categories: []
 ---

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -1,9 +1,10 @@
 ---
 title: Resetting Passwords
-description: Learn how to reset your Pantheon Dashboard password or your site user login password.
+description: Learn how to reset passwords for WordPress, Drupal, and the Pantheon Dashboard. 
 tags: [debugdb]
 categories: []
 ---
+## Pantheon Dashboard Login
 If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password) and follow the instructions.
 
 


### PR DESCRIPTION
Original subtitle doesn't include language about resetting site user login passwords

## Effect
PR includes the following changes:
- Change subheading to include language about retting site user login passwords as well

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
