### PR TITLE
Add documentation for 'filemount' in pantheon.yml

### DIFF
--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -47,6 +47,20 @@ The name of the nested directory is not configurable.
 
 For more information, see [Serving Sites from the Web Subdirectory](/docs/nested-docroot/).
 
+### Filemount Path
+Pantheon provides a [cloud-based filesystem](https://pantheon.io/docs/files/) to store user-generated content and other website files. By default, a symlink to this filesystem will be created at `sites/default/files` (Drupal) or `wp-content/uploads` (WordPress), but this location may be changed.
+
+```yaml
+filemount: /files
+```
+
+#### Considerations
+* Specify the exact path; only a limited selection of paths are valid:
+  * /files
+  * /sites/default/files
+  * /wp-content/uploads
+* The path specified by `filemount` **must** be listed in the site's .gitignore file
+* The parent directory for the specified path (e.g. `/sites/default` or `/wp-content`) must exist in the site's git repository
 
 ### PHP Version
 Override the upstreams default PHP version with the `php_version` property. PHP version is managed in version control and deployed along with the rest of your site's code to encourages a good best practice of testing before making a change on your Live site.

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -55,10 +55,15 @@ filemount: /files
 ```
 
 #### Considerations
+* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, it is best done only in the upstream repository for new sites.
 * Specify the exact path; only a limited selection of paths are valid:
   * /files
   * /sites/default/files
   * /wp-content/uploads
+* The path to the files directory must be configured in your framework to match what is selected in pantheon.yml
+  * [Drupal 8](https://www.drupal.org/upgrade/file_public_path)
+  * [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after)
+  * [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder)
 * The path specified by `filemount` **must** be listed in the site's .gitignore file
 * The parent directory for the specified path (e.g. `/sites/default` or `/wp-content`) must exist in the site's git repository
 

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -62,7 +62,7 @@ Complete the following before deploying `filemount` (required):
 
 #### Considerations
 * Recommended usage limited to [Custom Upstream Configurations](#custom-upstream-configurations) in `pantheon.upstream.yml`
-* Path must be inside the site's docroot
+* Path must be relative to the site's docroot
 * Specify the exact path; limited selection of valid paths:
   * `/files`
   * `/sites/default/files`

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -48,24 +48,24 @@ The name of the nested directory is not configurable.
 For more information, see [Serving Sites from the Web Subdirectory](/docs/nested-docroot/).
 
 ### Filemount Path
-Pantheon provides a [cloud-based filesystem](https://pantheon.io/docs/files/) to store user-generated content and other website files. By default, a symlink to this filesystem will be created at `sites/default/files` (Drupal) or `wp-content/uploads` (WordPress), but this location may be changed.
+Pantheon provides a [cloud-based filesystem](/docs/files/) to store user-generated content and other website files. By default, we create a symlink to this filesystem at `/sites/default/files` (Drupal) or `/wp-content/uploads` (WordPress), but you can change the location with the `filemount` variable:
 
-```yaml
+```
 filemount: /files
 ```
 
 #### Considerations
-* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, it is best done only in the upstream repository for new sites.
+* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, we suggest making this changes only in a [Custom Upstream](/docs/custom-upstream).
 * Specify the exact path; only a limited selection of paths are valid:
-  * /files
-  * /sites/default/files
-  * /wp-content/uploads
-* The path to the files directory must be configured in your framework to match what is selected in pantheon.yml
-  * [Drupal 8](https://www.drupal.org/upgrade/file_public_path)
-  * [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after)
-  * [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder)
-* The path specified by `filemount` **must** be listed in the site's .gitignore file
-* The path <filemount>/private (where <filemount> is the selected filemount path) should be added to the protected file paths, as described above.
+  * `/files`
+  * `/sites/default/files`
+  * `/wp-content/uploads`
+* The path to the files directory must be configured in your CMS to match what is selected in `pantheon.yml`, according to these instructions:
+  * [Drupal 8](https://www.drupal.org/upgrade/file_public_path){.external}
+  * [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after){.external}
+  * [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder){.external}
+* The path specified by `filemount` *must* be listed in the site's `.gitignore` file
+* The path `filemount/private` (where `filemount` is the selected filemount path) should be added to the protected file paths, as [described above](#protected-web-paths)
 * The parent directory for the specified path (e.g. `/sites/default` or `/wp-content`) must exist in the site's git repository
 
 ### PHP Version
@@ -136,5 +136,5 @@ remote:
 Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/docs/hotfixes/). As a workaround, make some modification to `pantheon.yml` file in a development environment and deploy up to production using the standard Pantheon workflow.
 
 ## See Also
-- [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver/)  
+- [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver/)
 - [Upgrade PHP Versions](/docs/php-versions/)

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -54,6 +54,12 @@ Pantheon provides a [cloud-based filesystem](/docs/files/) to store user-generat
 filemount: /files
 ```
 
+Complete the following before deploying `filemount` (required):
+
+1. Reconfigure [Drupal 8](https://www.drupal.org/upgrade/file_public_path){.external}, [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after){.external}, or [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder){.external} to use the new path
+2. Add path to the `.gitignore` file
+3. Configure a `private` subdirectory of the new path within [`protected_web_paths`](#protected-web-paths)
+
 #### Considerations
 * Recommended usage limited to [Custom Upstream Configurations](#custom-upstream-configurations) in `pantheon.upstream.yml`
 * Path must be inside the site's docroot
@@ -61,12 +67,6 @@ filemount: /files
   * `/files`
   * `/sites/default/files`
   * `/wp-content/uploads`
-
-Complete the following before deploying `filemount` (required):
-
-1. Reconfigure [Drupal 8](https://www.drupal.org/upgrade/file_public_path){.external}, [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after){.external}, or [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder){.external} to use the new path
-2. Add path to the `.gitignore` file
-3. Configure a `private` subdirectory of the new path within [`protected_web_paths`](#protected-web-paths)
 
 ### PHP Version
 Override the upstreams default PHP version with the `php_version` property. PHP version is managed in version control and deployed along with the rest of your site's code to encourages a good best practice of testing before making a change on your Live site.

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -65,6 +65,7 @@ filemount: /files
   * [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after)
   * [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder)
 * The path specified by `filemount` **must** be listed in the site's .gitignore file
+* The path <filemount>/private (where <filemount> is the selected filemount path) should be added to the protected file paths, as described above.
 * The parent directory for the specified path (e.g. `/sites/default` or `/wp-content`) must exist in the site's git repository
 
 ### PHP Version

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -55,18 +55,18 @@ filemount: /files
 ```
 
 #### Considerations
-* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, we suggest making these changes only in a [Custom Upstream](/docs/custom-upstream).
-* Specify the exact path; only a limited selection of paths are valid:
+* Recommended usage limited to [Custom Upstream Configurations](#custom-upsream-configurations) in `pantheon.upstream.yml`
+* Path must be inside the site's docroot
+* Specify the exact path; limited selection of valid paths:
   * `/files`
   * `/sites/default/files`
   * `/wp-content/uploads`
-* The path to the files directory must be configured in your CMS to match what is selected in `pantheon.yml`, according to these instructions:
-  * [Drupal 8](https://www.drupal.org/upgrade/file_public_path){.external}
-  * [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after){.external}
-  * [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder){.external}
-* The path specified by `filemount` *must* be listed in the site's `.gitignore` file
-* The path `filemount/private` (where `filemount` is the selected filemount path) should be added to the protected file paths, as [described above](#protected-web-paths)
-* The parent directory for the specified path (e.g. `/sites/default` or `/wp-content`) must exist in the site's git repository
+
+Complete the following before deploying `filemount` (required):
+
+1. Reconfigure [Drupal 8](https://www.drupal.org/upgrade/file_public_path){.external}, [Drupal 7](https://www.drupal.org/docs/7/distributions/drupal-commons/installing-drupal-commons/configuring-file-system-settings-after){.external}, or [WordPress](https://codex.wordpress.org/Editing_wp-config.php#Moving_uploads_folder){.external} to use the new path
+2. Add path to the `.gitignore` file
+3. Configure a `private` subdirectory of the new path within [`protected_web_paths`](#protected-web-paths)
 
 ### PHP Version
 Override the upstreams default PHP version with the `php_version` property. PHP version is managed in version control and deployed along with the rest of your site's code to encourages a good best practice of testing before making a change on your Live site.

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -55,7 +55,7 @@ filemount: /files
 ```
 
 #### Considerations
-* Recommended usage limited to [Custom Upstream Configurations](#custom-upsream-configurations) in `pantheon.upstream.yml`
+* Recommended usage limited to [Custom Upstream Configurations](#custom-upstream-configurations) in `pantheon.upstream.yml`
 * Path must be inside the site's docroot
 * Specify the exact path; limited selection of valid paths:
   * `/files`

--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -55,7 +55,7 @@ filemount: /files
 ```
 
 #### Considerations
-* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, we suggest making this changes only in a [Custom Upstream](/docs/custom-upstream).
+* Since relocating the filemount path involves multiple steps which must be done correctly and in unison, we suggest making these changes only in a [Custom Upstream](/docs/custom-upstream).
 * Specify the exact path; only a limited selection of paths are valid:
   * `/files`
   * `/sites/default/files`


### PR DESCRIPTION
Closes #n/a

## Effect
PR includes the following changes:
- Documentation for `filemount` directive

This feature has been "dark deployed" to the platform. This PR brings it to light.

## Remaining Work
- [x] Docs review
- [x] Approval to publish from product (e.g. @ari-gold)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
