### PR TITLE
Update site-plan.md

### DIFF
--- a/source/_docs/site-plan.md
+++ b/source/_docs/site-plan.md
@@ -10,7 +10,7 @@ tags: [billing]
  Otherwise, click the **current plan**:
  ![Change current plan for paid sites](/source/docs/assets/images/dashboard/change-plan.png)
 
-Plan changes take immediate effect. The associated card will be charged or credited a prorated amount upon upgrade or downgrade.
+Plan changes take immediate effect. The associated card will be charged or credited a prorated amount upon upgrade or downgrade even if the site has not launched.
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>


### PR DESCRIPTION
Changed: The associated card will be charged or credited a prorated amount upon upgrade or downgrade.

To: The associated card will be charged or credited a prorated amount upon upgrade or downgrade even if the site has not launched.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
