### PR TITLE
CVE-2017-18258

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,7 +16,7 @@ GEM
       yell (~> 2.0)
     mercenary (0.3.5)
     mini_portile2 (2.3.0)
-    nokogiri (1.8.1)
+    nokogiri (1.8.2)
       mini_portile2 (~> 2.3.0)
     parallel (1.6.1)
     rake (10.4.2)


### PR DESCRIPTION
fix suggested by github vuln service

Closes #

## Effect
PR includes the following changes:
- Change to Gemlock file Nokogiri 1.8.1 to 1.8.2 as suggested by Github


## Remaining Work
none

## Post Launch
To be completed by the docs team upon merge: 
none