### PR TITLE
ProfServices: Change PEG to Pantheon Enterprise Gateway

### DIFF
--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -33,7 +33,7 @@ If you need advice on architecting a solution, planning for the future, preparin
         <td>Yes (1/Qtr)</td>
         </tr>
       <tr>
-        <td>PEG, annual (Elite sites Only); recurring</td>
+        <td>Pantheon Enterprise Gateway, annual (Elite sites Only); recurring</td>
         <td></td>
         </tr>
       <tr>


### PR DESCRIPTION
Closes #

## Effect
- Professional Services: Change PEG to Pantheon Enterprise Gateway

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
