### PR TITLE
PEG qualifying blurb

### DIFF
--- a/source/_docs/outgoing-ips.md
+++ b/source/_docs/outgoing-ips.md
@@ -12,7 +12,7 @@ Outgoing requests sent by Drupal and WordPress applications facilitate tasks bet
 </div>
 
 ## Pantheon Enterprise Gateway
-If your site relies on a static IP address for outgoing requests, the recommended solution is the [Pantheon Enterprise Gateway](/docs/pantheon-enterprise-gateway/). This is the only way to guarantee compatibility with extensions or services that require a known outgoing IP. Otherwise, you will need to find an alternative service to accomplish the request.
+If your site relies on a static IP address for outgoing requests, and your site is within an Enterprise or EDU+ organizations, then the recommended solution is the [Pantheon Enterprise Gateway](/docs/pantheon-enterprise-gateway/). This is the only way to guarantee compatibility with extensions or services that require a known outgoing IP. Otherwise, you will need to find an alternative service to accomplish the request.
 
 ## IP Address Based Security Schemes
 Each application container worker uses a distinct application server, each with a different hostname (which will not resolve externally) and datacenter assigned IP. Application servers are regularly seamlessly reconfigured, which may change both the hostname and IP.


### PR DESCRIPTION
=## Effect
PR includes the following changes:
- Mentions on the outgoing IP page that the PEG is only available for sites within Enterprise or EDU+ orgs. Keeps from having to click through for more info. 

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
