### PR TITLE
Update external Git repo info in the FAQ

### DIFF
--- a/source/_docs/faq.md
+++ b/source/_docs/faq.md
@@ -60,7 +60,7 @@ Yes. Pantheon sites run on a highly available clustered infrastructure.
 
 ### Can I use my own Git repository (e.g GitHub)?
 
-Not at the moment, but we're looking for a way to support it that allows us to maintain tight integration with our workflow visualization and tools.
+Yes. While your Pantheon site will only run from code in your Pantheon Git repository, this can be mirrored from an external repository by setting up a [custom upstream](/docs/custom-upstream/), [continuous integration workflow](/docs/guides/build-tools/), or by syncing your code to [multiple remotes](/docs/guides/collaborative-development).
 
 ### Does Pantheon support Drupal Multisite?
 


### PR DESCRIPTION
Closes #3734

## Effect
PR includes the following changes:
- Adds a few options for how to use an external repo for your Pantheon site (custom upstreams, build tools/CI, syncing repos).

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
