### PR TITLE
[WIP, NOMERGE] Remove SSH config recommendation directing users to old ciphers

### DIFF
--- a/source/_docs/sftp.md
+++ b/source/_docs/sftp.md
@@ -126,12 +126,6 @@ Uncommitted SFTP changes may not be recognized by the Dev environment when the S
 ### How do I find my site's Binding path?
 You should not manually set the "Remote Path" in your SFTP client's settings. Instead, leave the Remote Path blank and you will automatically be redirected to the proper directory when logging in.
 
-### My SFTP client takes a long time to connect.
-Your SSH connection may be using a slow encryption protocol. Configuring your SSH client to use the `diffie-hellman-group1-sha1` protocol will result in the fastest connections. For OSX/Linux, add the following to your ssh config (~/.ssh/config):
-
-    Host *.drush.in
-        KexAlgorithms diffie-hellman-group1-sha1
-
 ### I am receiving errors connecting to my server with an SFTP client.
 This is caused by using the SFTP application's default connection settings. We recommend you set the connection limit to **1** and then connect to your site.
 


### PR DESCRIPTION
*please don't merge this yet, we are still in the process of rolling out the new SSH to the platform. We should merge this after the rollout is 100% complete*

A new SSH server has been rolled out to the platform which supports a more modern set of ciphers and no longer exhibits the ~5sec connection delay of the previous SSH server.

## Effect
PR includes the following changes:
- Removes an outdated SFTP FAQ directing users to use an old set of ciphers to work around issue in an older version of Pantheon-SSH server.


## Remaining Work
- [ ] rollout new SSH to the remainder of the platform before merging

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
