### PR TITLE
ImageMagick path

### DIFF
--- a/source/_docs/external-libraries.md
+++ b/source/_docs/external-libraries.md
@@ -103,13 +103,15 @@ There are no known plugins in the WordPress.org repository that will enable the 
 
 [ImageMagick](https://www.imagemagick.org/script/index.php) is a software suite to create, edit, compose, or convert bitmap images. It can read and write images in a variety of  [formats](https://www.imagemagick.org/script/formats.php) (over 100) including  [DPX](https://www.imagemagick.org/script/motion-picture.php),  [EXR](https://www.imagemagick.org/script/high-dynamic-range.php), GIF, JPEG, JPEG-2000, PDF, PNG, Postscript, SVG, and TIFF. Use ImageMagick to resize, flip, mirror, rotate, distort, shear and transform images, adjust image colors, apply various special effects, or draw text, lines, polygons, ellipses and Bézier curves. 
 
-Pantheon runs the latest stable packaged version in Fedora, which is currently ImageMagick 6.8.8-10 Q16 x86_64 2015-03-10.
+Pantheon runs the latest stable packaged version in Fedora, which is currently ImageMagick 6.8.8-10 Q16 x86_64 2015-03-10. 
 
 ### Drupal ImageMagick Configuration
 
 Once you have downloaded and enabled the Imagemagick module, you'll need to configure the image toolkit settings. Go to the image toolkit settings page at: `admin/config/media/image-toolkit` to select ImageMagick.
 
 When creating a new preset, if the "Division by Zero" warning appears, add the [`image_allow_insecure_derivatives`](https://www.drupal.org/project/image_allow_insecure_derivatives) conf variable to your settings.php file.
+
+Some modules use ImageMagick but require to provide the explicit path for the library (i.e, [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize) etc.) The path to use should be `/usr/bin/convert`
 
 ## Troubleshooting and FAQs
 #### What if I need a library not listed here?


### PR DESCRIPTION
Added in the section for ImageMagick path

Closes #3437

## Effect
PR includes the following changes:
- Instructions for ImageMagick path
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
