### PR TITLE
Fix Perf Small resource specs

### DIFF
--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -86,7 +86,7 @@ No action is required. Existing sites will automatically switch to the equivalen
   | ---------------------- | --------------------- | ------------------------ |
   | Application Containers |          1            |            1             |
   | PHP Workers            |          8            |            8             |
-  | PHP Memory Limit       |         256MB         |          512MB           |
+  | PHP Memory Limit       |         256MB         |          256MB           |
   | Storage                |         20GB          |          30GB            |
   | Custom Domain Limit (per site) <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-content="For details, see <a href='/docs/domains/#custom-domains'>Domains and Redirects</a>."><em class="fa fa-info-circle"></em></a>|            25         |           5              |
   | Free and managed HTTPS <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-content="For details, see <a href='/docs/https/'>HTTPS on Pantheon's Global CDN</a>."><em class="fa fa-info-circle"></em></a> |          ✓             |            ✓             |


### PR DESCRIPTION
Base on this bug ticket, Performance Small gets same configuration with Professional plan so 256MB is the correct PHP Memory Limit 

Ref: BUGS-2037

Closes #

## Effect
PR includes the following changes:
- Change PHP memory Limit of Performance Small