### PR TITLE
Add info on what scopes the GitHub token needs

### DIFF
--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -144,7 +144,7 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
 
 ### Access Tokens (Optional)
 
-The Build Tools plugin will prompt you to create access tokens for both [GitHub](https://github.com/settings/tokens){.external} and [CircleCI](https://circleci.com/account/api){.external}, which are stored as environment variables. You many optionally generate these tokens ahead of time and manually export them to the local variables `GITHUB_TOKEN` and `CIRCLE_TOKEN`, respectively:
+The Build Tools plugin will prompt you to create access tokens for both [GitHub](https://github.com/settings/tokens){.external} and [CircleCI](https://circleci.com/account/api){.external}, which are stored as environment variables. The GitHub token will need the 'repo' (required) and 'delete-repo' (optional) scopes. You many optionally generate these tokens ahead of time and manually export them to the local variables `GITHUB_TOKEN` and `CIRCLE_TOKEN`, respectively:
 
 ```bash
 export GITHUB_TOKEN=yourGitHubToken


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Had to find out what scopes after running the `terminus build:project:create` command

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
