### PR TITLE
S3 Command Paths

### DIFF
--- a/source/_docs/drupal-s3.md
+++ b/source/_docs/drupal-s3.md
@@ -116,9 +116,9 @@ terminus drush <site>.<env> -- en libraries s3fs -y
 Get the [AWS SDK Library 2.x](https://github.com/aws/aws-sdk-php/releases){.external}:
 
 ```nohighlight
-terminus drush <site>.<env> -- make --no-core code/sites/all/modules/s3fs/s3fs.make code/
+terminus drush <site>.<env> -- make --no-core sites/all/modules/s3fs/s3fs.make code/
   //or if you have a contrib subfolder for modules use:
-  //terminus drush <site>.<env> -- make --no-core code/sites/all/modules/contrib/s3fs/s3fs.make code/
+  //terminus drush <site>.<env> -- make --no-core sites/all/modules/contrib/s3fs/s3fs.make code/
 ```
 
 The above command will add the AWS SDK version 2.x library into the `sites/all/libraries/awssdk2` directory.


### PR DESCRIPTION
Closes #3624 

## Effect
PR includes the following changes:
- Removes `code/` from the Terminus example commands, per @eabquina 

## Remaining Work
- [x] Review from @eabquina (optional)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
