### PR TITLE
Removed Visual Composer: Page Builder

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -384,10 +384,6 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 
 <hr>
 
-### [Visual Composer: Page Builder](https://vc.wpbakery.com/){.external}
-**Issue**: This plugin requires write access to the site's codebase for editing files, which is not granted on Test and Live environments by design.
-<hr>
-
 ### [Weather Station](https://wordpress.org/plugins/live-weather-station/){.external}
 **Issue**: This module uses [`php-intl`]( https://secure.php.net/manual/en/intro.intl.php), which is not currently supported by Pantheon.
 


### PR DESCRIPTION
Closes #3975 

## Effect
PR includes the following changes:
- Removed Wordpress plugin Visual Composer: PageBuilder. The latest version of the plugin works on Test and Live environments. 

- Assets directory path was changed. Access to this directory is granted on Test and Live environments.

- The release with the issue fix: 2.2 / 22 March 2018
Visual Composer Website Builder latest release: 2.6.1 / 22 May 2018

P.S. Incorrect product name. The correct product name is Visual Composer Website Builder.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
