### PR TITLE
remove windows from Terminus manual

### DIFF
--- a/source/_docs/terminus.md
+++ b/source/_docs/terminus.md
@@ -14,7 +14,7 @@ searchboost: 200
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-<a href="/docs/terminus/install">Install Terminus</a> on Mac OS X or Linux, or on Windows using [Git BASH on Git for Windows](https://git-for-windows.github.io/). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/docs/terminus/get-started/legacy).
+[Install Terminus](/docs/terminus/install) on Mac OS X or Linux. For details on legacy versions of Terminus, see [Legacy Terminus Versions](/docs/terminus/get-started/legacy).
 
 <div class="enablement">
   <h4 class="info" markdown="1">[Command Line Training](https://pantheon.io/agencies/learn-pantheon?docs){.external}</h4>
@@ -23,7 +23,7 @@ Our command line interface, Terminus, provides advanced interaction with Pantheo
 
 ## Usage
 
-Use Terminus to perform these and other operations:  
+Use Terminus to perform these and other operations:
 
 - Create a new site
 - Create and delete Multidev environments

--- a/source/_docs/terminus/install.md
+++ b/source/_docs/terminus/install.md
@@ -11,16 +11,16 @@ previousurl: terminus/
 image: terminus-thumbLarge
 searchboost: 100
 ---
-Terminus is available for Mac OS X, Linux, and Windows 7 and 10.
+Terminus is available for Mac OS X and Linux
+
+Some Windows users have installed Terminus using [Git BASH on Git for Windows](https://git-for-windows.github.io/){.external}, or the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){.external}, but this is unsupported.
+
 ## Requirements
 
 * PHP Version 5.5.9 or later (must include the [php-xml extension](https://secure.php.net/manual/en/dom.setup.php)). You can check your PHP version by running `php -v` from a terminal application.
 * [PHP-CLI](http://www.php-cli.com/)
 * [PHP-CURL](https://secure.php.net/manual/en/curl.setup.php)
 * [Composer](https://getcomposer.org/download/)
-* Windows Only: Terminus requires a \*nix-like environment. If you don't already have a bash emulator, we recommend [Git for Windows](https://git-for-windows.github.io/).
-
-  If you already have it configured and are regularly using it, we have seen some users find success with [Bash on Ubuntu on Windows](https://msdn.microsoft.com/en-us/commandline/wsl/install_guide) (Windows 10 only).
 
 ## Install
 <p class="instruction">Install the most recent release of Terminus with the following command within a directory where you have permission to write files. If in doubt, you can create a <code>terminus</code> directory in your <code>$HOME</code> and install there:</p>


### PR DESCRIPTION
Closes AL-1397

## Effect
PR includes the following changes:
- Removes Windows as supported Operating System for Terminus

## Remaining Work
- [x] Review from @pantheon-systems/alchemy 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
