### PR TITLE
Added section for CNAME workaround Link

### DIFF
--- a/source/_docs/https.md
+++ b/source/_docs/https.md
@@ -135,6 +135,10 @@ If you encounter rate limits, we recommend the following approaches:
 - Request that your apex domain (e.g., `example.edu`) be added to the public suffix list by submitting a [pull request](https://github.com/publicsuffix/list/wiki/Guidelines){.external}, which will cause Let's Encrypt to treat every subdomain of the main domain as independent for limit purposes. Also, browsers and malware scanners will treat the subdomains as independent.
 - Consider using another certificate service for sites that are not on Pantheon. For example, educational institutions may want to consider using the [Incommon Certificate Service](https://www.incommon.org/certificates/){.external} as a workaround.
 
+### CNAME is not allowed for DNS Manager
+If your domain's DNS configuration relies on an existing MX or TXT record that intentionally disallows CNAME records, we can follow the CNAME Record Workaround as described in [this link](https://pantheon.io/docs/domains/#cname-record-workaround){.external}.
+
+
 ## Glossary
 ### HTTPS
 HTTPS encrypts and decrypts requests. For more information, see [this Google resource](https://support.google.com/webmasters/answer/6073543?hl=en).


### PR DESCRIPTION
Closes #3776 

## Effect
PR includes the following changes:
- New Section for CNAME workaround Link
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
