### PR TITLE
Note the error shown when WP upload error occurs

### DIFF
--- a/source/_docs/wordpress-known-issues.md
+++ b/source/_docs/wordpress-known-issues.md
@@ -41,4 +41,4 @@ It's especially ill-advised to use Multisite to set up many distinct/separate si
 See [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues) for a list of WordPress plugins that are not supported and/or require workarounds.
 
 ## Image uploads
-Since WordPress 4.5, a bug exists affecting the upload of large dimension images regardless of file size. See this [core issue](https://core.trac.wordpress.org/ticket/36534) for more information.
+Since WordPress 4.5, a bug exists affecting the upload of large dimension images regardless of file size. This generally presents itself as an "HTTP error" when uploading. See this [core issue](https://core.trac.wordpress.org/ticket/36534) for more information.

--- a/source/_docs/wordpress-known-issues.md
+++ b/source/_docs/wordpress-known-issues.md
@@ -41,4 +41,4 @@ It's especially ill-advised to use Multisite to set up many distinct/separate si
 See [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues) for a list of WordPress plugins that are not supported and/or require workarounds.
 
 ## Image uploads
-Since WordPress 4.5, a bug exists affecting the upload of large dimension images regardless of file size. This generally presents itself as an "HTTP error" when uploading. See this [core issue](https://core.trac.wordpress.org/ticket/36534) for more information.
+Since WordPress 4.5, a bug exists affecting the upload of large dimension images regardless of file size. This generally presents itself as an "HTTP error" when uploading. See this [core issue](https://core.trac.wordpress.org/ticket/36534){.external} for more information.


### PR DESCRIPTION
https://pantheon.io/docs/wordpress-known-issues/#image-uploads

## Effect
PR includes the following changes:
- Adds the error message shown when the [WP image upload bug](https://pantheon.io/docs/wordpress-known-issues/#image-uploads) comes up.

internal ref: #108859

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
