### PR TITLE
Update d7-composer-init.html

### DIFF
--- a/source/_partials/content/d7-composer-init.html
+++ b/source/_partials/content/d7-composer-init.html
@@ -29,6 +29,9 @@
     "post-update-cmd": [
       "@remove-git-submodules"
     ]
+  },
+  "config": {
+    "vendor-dir": "sites/all/vendor"
   }
 }</code></pre>
 </li>

--- a/source/_partials/content/d7-composer-init.html
+++ b/source/_partials/content/d7-composer-init.html
@@ -6,6 +6,10 @@
    <h4 class="info">Note</h4>
    <p>Since Pantheon does not support Git submodules <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-title="Git submodules" data-content="Some Composer packages are added as Git submodules, which place a Git repository within a subdirectory of your site’s repository."><em class="fa fa-info-circle"></em></a>, we recommend using the provided script <code>remove-git-submodules</code> to remove any <code>.git</code> directories upon install and update.</p>
  </div>
+ <div class="alert alert-danger" role="alert">
+  <h4 class="info">Warning</h4>
+  <p markdown="1">The example below specifies <code>vendor-dir</code> to <code>sites/all/vendors</code> for compatibility with the <a href="https://www.drupal.org/project/composer_vendor" class="external">Composer Vendor</a> module, but this directory is not a protected path. Be sure to set a protected path in the <a href="/docs/pantheon-yml/#protected-web-paths">Pantheon YAML Configuration File</a> before proceeding.</p>
+</div>
  <pre><code class="json">{
   "repositories": [
     {


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Modify the suggested composer.json and to include 'sites/all/vendor' as `vendor-dir`.

By default, composer downloads packages to `vendor` directory but `Composer Vendor` module only autoloads the content of `sites/all/vendor`.  Specify vendor-dir to `sites/all/vendor` will fix the issue.

Test site: http://sendgrid-jts.pantheonsite.io/