### PR TITLE
update rsync in deployment scripts

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -82,17 +82,15 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
   curl -v -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/pantheon-systems/terminus/releases > ~/documentation/output_prod/docs/assets/terminus/releases.json
   # rsync output_prod/* to Valhalla
   
-  while [ 1 ]
+  while true
   do
-	  rsync --size-only --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
-  	if [ "$?" -eq "0" ] ; then
-    		echo "Success: Deployed to $url".
-		exit
-  	else
-    		echo "Error: Deploy failed, retrying..."
-		sleep 5
-	fi
-
+    if ! rsync --size-only --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/; then
+      echo "Failed, retrying..."
+      sleep 5
+    else
+      print "Success: Deployed to $url".
+      break
+    fi
   done
   
 

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -88,7 +88,7 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
       echo "Failed, retrying..."
       sleep 5
     else
-      print "Success: Deployed to $url".
+      echo "Success: Deployed to $url"
       break
     fi
   done

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -84,7 +84,7 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
   
   while true
   do
-    if ! rsync --size-only --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/; then
+    if ! rsync --size-only --delete-after -rtlvzi --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/; then
       echo "Failed, retrying..."
       sleep 5
     else

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -85,7 +85,7 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
   while [ 1 ]
   do
 	  rsync --size-only --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
-  	if [ "$?" -eq "0" ] then
+  	if [ "$?" -eq "0" ] ; then
     		echo "Success: Deployed to $url".
 		exit
   	else

--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -81,7 +81,7 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
   ~/documentation/vendor/pantheon-systems/terminus/bin/terminus list --format=json > ~/documentation/output_prod/docs/assets/terminus/commands.json
   curl -v -H "Authorization: token $GITHUB_TOKEN" https://api.github.com/repos/pantheon-systems/terminus/releases > ~/documentation/output_prod/docs/assets/terminus/releases.json
   # rsync output_prod/* to Valhalla
-  rsync --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
+  rsync --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/
   if [ "$?" -eq "0" ]
   then
     echo "Success: Deployed to $url"

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -45,7 +45,7 @@ else
   done
 
   # Push HTML to the multidev
-  rsync --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:files/docs/
+  rsync --size-only --delete-after -rtlvzi --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:files/docs/
   if [ "$?" -eq "0" ]
   then
       echo "Success: Deployed to http://"$ENV"-$SITE_NAME.pantheonsite.io/docs"

--- a/scripts/manual-deploy.sh
+++ b/scripts/manual-deploy.sh
@@ -13,7 +13,7 @@ read SITE_NAME
 
 # Checks to ensure that we don't manually deploy to live
 if [[ $ENV == "live" && $SITE_UUID == "72e163bd-0054-4332-8bf8-219c50b78581" ]]; then
-  echo Deploys to the live site should only be done by an internal team member via CircleCI upon committing to master. For questions, ping @rachelwhitton
+  echo Deploys to the live site should only be done by an internal team member via CircleCI upon committing to master. For questions, ping @alexfornuto
 else
   echo Deploying to the $ENV environment on the $SITE_NAME site...
   # remove any existing generated output files
@@ -45,7 +45,7 @@ else
   done
 
   # Push HTML to the multidev
-  rsync --size-only --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:files/docs/
+  rsync --checksum --delete-after -rtlvz --ipv4 --progress -e 'ssh -p 2222' output_prod/docs/* --temp-dir=../../tmp/ $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:files/docs/
   if [ "$?" -eq "0" ]
   then
       echo "Success: Deployed to http://"$ENV"-$SITE_NAME.pantheonsite.io/docs"

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -8,7 +8,7 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p>This is only for advanced users working on integrating a Shibboleth single sign-on system with their Drupal site using the <a href="https://www.drupal.org/project/simplesamlphp_auth">SimpleSAMLphp Authentication</a> module from Drupal.org, or with their WordPress site using the <a href="https://wordpress.org/plugins/wp-saml-auth/">WP SAML Auth</a> plugin from WordPress.org.</p>
+  <p markdown="1">This is only for advanced users working on integrating a Shibboleth single sign-on system with their Drupal site using the [SimpleSAMLphp Authentication](https://www.drupal.org/project/simplesamlphp_auth){.external} module from Drupal.org, or with their WordPress site using the [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/){.external} plugin from WordPress.org.</p>
 </div>
 
 ## Install SimpleSAMLphp

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -12,7 +12,8 @@ WordPress configuration is set in wp-config.php, located within your WordPress s
 Pantheon uses environment variables to automatically supply configuration settings (e.g. Database credentials) dynamically to wp-config.php - no editing required. However, you are welcome to customize wp-config.php with any customizations you may need for plugins, themes, and caching.
 
 <div class="alert alert-danger" role="alert"><h4 class="info">Warning</h4>
-<p>You should NEVER put the database connection information for a Pantheon database within your <code>wp-config.php</code>. These credentials will change. If you are having connection errors, please ensure you are running the latest version of WordPress core and have the correct <code>wp-config.php</code> file for Pantheon.</p></div>
+<p markdown="1">You should NEVER put the database connection information for a Pantheon database within your `wp-config.php`. These credentials will change. If you are having connection errors, please ensure you are running the latest version of WordPress core and have the correct `wp-config.php` file for Pantheon.</p>
+</div>
 
 ## Local Database Configuration for Development
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Hopefully by removing --size-only rsync will properly use --checksum and only copy updated files to the multidev

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
