### PR TITLE
Composer Gotchas

### DIFF
--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -111,7 +111,7 @@ Since we modified `composer.json` we will need to update Composer. This will als
 
 ```bash
 composer update
-```bash
+```
 
 This may take a while as all of Drupal core and its dependencies will be downloaded. Subsequent updates should take less time.
 

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -83,7 +83,7 @@ Next, you will need to modify `composer.json`.
 
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p markdown="1">When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the [Pantheon platform is not compatible with git submodules](/docs/git-faq/#does-pantheon-support-git-submodules). If you use packages that come as submodules and remove the `.git` directory to compensate, you will need to remove the `vendor` directory before running additional `composer` commands.</p>
+  <p markdown="1">When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the [Pantheon platform is not compatible with git submodules](/docs/git-faq/#does-pantheon-support-git-submodules). If you remove the `.git` directories, be sure to put them back again after you push your commit up to Pantheon (see instructions below). To do this, remove the vendor directory and run `composer install`.</p>
 </div>
 
 ### Downloading Drupal Dependencies with Composer

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -83,7 +83,7 @@ Next, you will need to modify `composer.json`.
 
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p markdown="1">When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the [Pantheon platform is not compatible with git submodules](/docs/git-faq/#does-pantheon-support-git-submodules). If you remove the `.git` directories, be sure to put them back again after you push your commit up to Pantheon (see instructions below). To do this, remove the vendor directory and run `composer install`.</p>
+  <p markdown="1">When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the <a href="/docs/git-faq/#does-pantheon-support-git-submodules" data-proofer-ignore> Pantheon platform is not compatible with git submodules</a>. If you remove the `.git` directories, be sure to put them back again after you push your commit up to Pantheon (see instructions below). To do this, remove the vendor directory and run `composer install`.</p>
 </div>
 
 ### Downloading Drupal Dependencies with Composer

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -103,6 +103,11 @@ Next, you will need to modify `composer.json`.
 
 ## Managing Drupal with Composer
 
+<div class="alert alert-info" role="alert">
+  <h4 class="info">Note</h4>
+  <p markdown="1">When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the [Pantheon platform is not compatible with git submodules](/docs/git-faq/#does-pantheon-support-git-submodules). If you use packages that come as submodules and remove the `.git` directory to compensate, you will need to remove the `vendor` directory before running additional `composer` commands.</p>
+</div>
+
 ### Downloading Drupal Dependencies with Composer
 
 Normally the next step would be going through the standard Drupal installation. But since we’re using Composer, none of the core files exist yet. Let’s use Composer to download Drupal core.

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -77,29 +77,7 @@ Start by deleting the following directories:
 Next, you will need to modify `composer.json`.
 
 * Remove all dependencies in the `require-dev` section
-* Update the `scripts` section to the following:
-
-```json
-    "scripts": {
-        "build-assets": [
-            "@prepare-for-pantheon",
-            "composer install --optimize-autoloader --no-dev"
-        ],
-        "drupal-scaffold": "DrupalComposer\\DrupalScaffold\\Plugin::scaffold",
-        "prepare-for-pantheon": "DrupalProject\\composer\\ScriptHandler::prepareForPantheon",
-        "post-install-cmd": [
-            "@drupal-scaffold",
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
-        ],
-        "post-update-cmd": [
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
-        ],
-        "post-create-project-cmd": [
-            "@drupal-scaffold",
-            "DrupalProject\\composer\\ScriptHandler::createRequiredFiles"
-        ]
-    },
-```
+* Update the `scripts` section to remove the `lint` `code-sniff`, and `unit-test` lines.
 
 ## Managing Drupal with Composer
 


### PR DESCRIPTION
Closes #3857 

## Effect
PR includes the following changes:
- Warns about submodules and removing `.git` directories
- Removed part of a `composer.json` file that could be updated elsewhere, 
- Instead reference what parts of `composer.json` need to be modified.

## Remaining Work
- [x] Review from @greg-1-anderson 
- [ ] Copy review would be swell.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
