### PR TITLE
Update to new-plans-faq.md to correct a typo

### DIFF
--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -44,7 +44,7 @@ All existing sites will have preferred pricing locked in for the plan they migra
 
 
 ### Are legacy plans still available?
-No new sites can be created on legacy plans outside of existng contracted agreements. The legacy plans are no longer available for purchase online.
+No new sites can be created on legacy plans outside of existing contracted agreements. The legacy plans are no longer available for purchase online.
 
 ### Will I be able to keep preferred pricing after August 1st?
 All existing sites as of August 1st (legacy & new) will lock in preferred pricing as long as they are on that plan, regargless of whether they are associated with a qualified agency partner.


### PR DESCRIPTION
Typo correction under the heading "Are legacy plans still available?" for the word "existing" in the first sentence. It had been missing an "i".

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
