### PR TITLE
Fix CircleCI caching.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,4 @@
 version: 2
-dependencies:
-  cache_directories:
-    - ~/.composer/cache
-    - ~/build/vendor
-    - ~/build/node_modules
 jobs:
   build:
     docker:
@@ -11,6 +6,10 @@ jobs:
     working_directory: ~/build
     steps:
       - checkout
+      - restore_cache:
+          keys:
+            - npm-v1-{{ checksum "package-lock.json" }}
+            - composer-v1-{{ checksum "composer.lock" }}
       - run:
           name: Prep Environment
           command: |
@@ -58,6 +57,14 @@ jobs:
             # Run sitespeed.io performance testing.
             mkdir ~/build/artifacts
             bash scripts/run-sitespeed-test.sh
+      - save_cache:
+          key: npm-v1-{{ checksum "package-lock.json" }}
+          paths:
+            - ~/build/node_modules
+      - save_cache:
+          key: composer-v1-{{ checksum "composer.lock" }}
+          paths:
+            - ~/.composer/cache
       - store_artifacts:
           path: ~/build/sitespeed-result
 
@@ -68,6 +75,7 @@ jobs:
             fi
 
 
+# Below is CircleCI 1.0 Config Syntax that is still supported on CircleCI 2.0
 experimental:
   notify:
     branches:


### PR DESCRIPTION
This PR fixes caching for the CircleCI build.

The current config is using CircleCI 1.0 caching syntax which no longer works on 2.0.

The Node and Composer caches each get cached in their own step. A checksum of each of their lock files is used as the cache key. This means, as long as the lock file doesn't change, all the dependencies are the same and we can restore the cache.

The third directory seems to be an erroneous one and was removed.

Also added a comment at the end for some FYI info that might be useful sometime in the future.