### PR TITLE
Git Rebase -> Git Merge for Custom Upstream Updates

### DIFF
--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -4,7 +4,7 @@ description: Detailed information on how to maintain Custom Upstreams and distri
 tags: [tools, workflow]
 categories: []
 ---
-Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core.
+Maintainers of [Custom Upstreams](/docs/custom-upstream/) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core.
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
@@ -12,13 +12,13 @@ Maintainers of [Custom Upstreams](/docs/custom-upstream) bear the responsibility
 </div>
 
 ## Before You Begin
-Follow the procedure to [create a custom upstream](/docs/create-custom-upstream) so that you have:
+Follow the procedure to [create a custom upstream](/docs/create-custom-upstream/) so that you have:
 
 - A repository for your Custom Upstream hosted with your preferred provider (GitLab, Bitbucket, etc)
 - A local clone of that repository, which tracks Pantheon's upstream as a remote
 - Pantheon's core code merged into your Custom Upstream repository
 - Your Custom Upstream repository connected to Pantheon
-- [Terminus](/docs/terminus)
+- [Terminus](/docs/terminus/)
 
 ## Create a Test Site on Pantheon
 This test site will be used later for evaluating the Custom Upstream changes we will make in the next section.
@@ -55,7 +55,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
     </div>
     </div><br>
 
-2. We will also add the test site you created above as a remote to your Custom Upstream. To do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus). Replace `<site>` with your site name:
+2. We will also add the test site you created above as a remote to your Custom Upstream. To do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus/). Replace `<site>` with your site name:
 
     ```command
     terminus connection:info <site>.dev --field=git_url
@@ -121,7 +121,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
     This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
-Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [WordPress and Drupal Core Updates](/docs/core-updates).
+Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus/) and the [Mass Update](/docs/terminus/examples/#mass-update/) plugin. For more details, see [WordPress and Drupal Core Updates](/docs/core-updates/).
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>
@@ -131,10 +131,10 @@ Updates will become available to sites downstream as one-click updates within an
 
 ## Tips and Tricks
 ### Use the Pantheon Workflow
-To fully test core updates, create content on your test site and use the standard [Pantheon workflow](/docs/pantheon-workflow) to push up to your Test and Live environments. Checkout <a href="/docs/guides/drupal8-commandline#managing-content-configuration-and-code-across-environments" data-proofer-ignore>our guide</a> for an example of generating content from the command line.
+To fully test core updates, create content on your test site and use the standard [Pantheon workflow](/docs/pantheon-workflow/) to push up to your Test and Live environments. Checkout <a href="/docs/guides/drupal8-commandline#managing-content-configuration-and-code-across-environments" data-proofer-ignore>our guide</a> for an example of generating content from the command line.
 
 ### Sample a Few Sites
-For agencies that manage large portfolios, we suggest picking a few sample sites with varying functionality and design to test updates on a [Multidev](/docs/multidev) environment. Once things look good, release the update to all.
+For agencies that manage large portfolios, we suggest picking a few sample sites with varying functionality and design to test updates on a [Multidev](/docs/multidev/) environment. Once things look good, release the update to all.
 
 ### Upstream Configuration File
 Use the `pantheon.upstream.yml` file when working with Custom Upstreams to set default values for advanced site configurations to be used downstream. For details, see [Pantheon YAML Configuration Files](/docs/pantheon-yml/).

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -133,7 +133,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
     This assumes you are using the default remote destination (`origin`) for your Custom Upstream repository that's hosted with your preferred provider.
 
-Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus/) and the [Mass Update](/docs/terminus/examples/#mass-update/) plugin. For more details, see [WordPress and Drupal Core Updates](/docs/core-updates/).
+Updates will become available to sites downstream as one-click updates within an hour of being pushed to the remote repository on sites running the Custom Upstream within your Organization. You can apply the updates on each site individually within the Site Dashboard, or you can apply updates in bulk using [Terminus](/docs/terminus/) and the [Mass Update](/docs/terminus/examples/#mass-update) plugin. For more details, see [WordPress and Drupal Core Updates](/docs/core-updates/).
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -89,15 +89,15 @@ This test site will be used later for evaluating the Custom Upstream changes we 
      <div class="tab-content">
      <div role="tabpanel" class="tab-pane active" id="wp">
      <pre><code class="command hljs">git fetch pantheon-wordpress
-    git rebase pantheon-wordpress/master</code></pre>
+    git merge pantheon-wordpress/master</code></pre>
      </div>
      <div role="tabpanel" class="tab-pane" id="d8">
      <pre><code class="command hljs">git fetch pantheon-drops-8
-    git rebase pantheon-drops-8/master</code></pre>
+    git merge pantheon-drops-8/master</code></pre>
      </div>
      <div role="tabpanel" class="tab-pane" id="d7">
      <pre><code class="command hljs">git fetch pantheon-drops-7
-    git rebase pantheon-drops-7/master</code></pre>
+    git merge pantheon-drops-7/master</code></pre>
      </div>
      </div><br>
 
@@ -180,15 +180,15 @@ If you receive the error that you have conflicts while updating core, the fastes
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane active" id="wp-xtheirs">
       <pre><code class="command hljs" data-lang="">git fetch pantheon-wordpress
-    git rebase pantheon-wordpress/master -Xtheirs</code></pre>
+    git merge pantheon-wordpress/master -Xtheirs</code></pre>
       </div>
       <div role="tabpanel" class="tab-pane" id="d8-xtheirs">
       <pre><code class="command hljs" data-lang="">git fetch pantheon-drops-8
-    git rebase pantheon-drops-8/master -Xtheirs</code></pre>
+    git merge pantheon-drops-8/master -Xtheirs</code></pre>
       </div>
       <div role="tabpanel" class="tab-pane" id="d7-xtheirs">
       <pre><code class="command hljs" data-lang="">git fetch pantheon-drops-7
-    git rebase pantheon-drops-7/master -Xtheirs</code></pre>
+    git merge pantheon-drops-7/master -Xtheirs</code></pre>
       </div>
     </div><br>
 
@@ -234,22 +234,22 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
      <div class="tab-content">
      <div role="tabpanel" class="tab-pane active" id="wp-2conflict">
      <pre><code class="command hljs">git fetch pantheon-wordpress
-    git rebase pantheon-wordpress/master</code></pre>
+    git merge pantheon-wordpress/master</code></pre>
      </div>
      <div role="tabpanel" class="tab-pane" id="d8-2conflict">
      <pre><code class="command hljs">git fetch pantheon-drops-8
-    git rebase pantheon-drops-8/master</code></pre>
+    git merge pantheon-drops-8/master</code></pre>
      </div>
      <div role="tabpanel" class="tab-pane" id="d7-2conflict">
      <pre><code class="command hljs">git fetch pantheon-drops-7
-    git rebase pantheon-drops-7/master</code></pre>
+    git merge pantheon-drops-7/master</code></pre>
      </div>
      </div><br>
 
 3. If a conflict is introduced, the output provides all the details we need in order to resolve. For example:
 
   ```bash
-  $ git rebase pantheon-wordpress/master
+  $ git merge pantheon-wordpress/master
   First, rewinding head to replay your work on top of it...
   Applying: Adjust rendering of version release notes
   Using index info to reconstruct a base tree...
@@ -259,11 +259,11 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
   CONFLICT (content): Merge conflict in wp-admin/about.php
   error: Failed to merge in the changes.
   Patch failed at 0001 Adjust rendering of version release notes
-  The copy of the patch that failed is found in: .git/rebase-apply/patch
+  The copy of the patch that failed is found in: .git/merge-apply/patch
 
-  When you have resolved this problem, run "git rebase --continue".
-  If you prefer to skip this patch, run "git rebase --skip" instead.
-  To check out the original branch and stop rebasing, run "git rebase --abort".
+  When you have resolved this problem, run "git merge --continue".
+  If you prefer to skip this patch, run "git merge --skip" instead.
+  To check out the original branch and stop rebasing, run "git merge --abort".
   ```
 
   In this example, you would open `wp-admin/about.php` in your preferred text editor.
@@ -276,5 +276,5 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
 
   ```command
   git add .
-  git rebase --continue
+  git merge --continue
   ```

--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -44,33 +44,39 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
     <!-- Tab panes -->
     <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="wp1">
-    <pre id="git-pull-wp"><code class="command hljs" data-lang="">git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git</code></pre>
+    <div role="tabpanel" class="tab-pane active" id="wp1" markdown="1">
+    ```git
+    git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d81">
-    <pre id="git-pull-drops-8"><code class="command hljs" data-lang="">git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d81" markdown="1">
+    ```git
+    git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d71">
-    <pre id="git-pull-drops-7"><code class="command hljs" data-lang="">git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d71" markdown="1">
+    ```git
+    git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git
+    ```
     </div>
     </div><br>
 
 2. We will also add the test site you created above as a remote to your Custom Upstream. To do that, we first need to grab the test site's repository URL on Pantheon using [Terminus](/docs/terminus/). Replace `<site>` with your site name:
 
-    ```command
+    ```bash
     terminus connection:info <site>.dev --field=git_url
     ```
 
 3. Replace `<git_url>` in the following command to add your new test site as a [remote](https://git-scm.com/docs/git-remote){.external}:
 
-    ```command
+    ```git
     git remote add pantheon-test <git_url>
     ```
 
 
 4. Checkout a new branch:
 
-    ```command
+    ```git
     git checkout -b core-update
     ```
 
@@ -87,23 +93,29 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
      <!-- Tab panes -->
      <div class="tab-content">
-     <div role="tabpanel" class="tab-pane active" id="wp">
-     <pre><code class="command hljs">git fetch pantheon-wordpress
-    git merge pantheon-wordpress/master</code></pre>
+     <div role="tabpanel" class="tab-pane active" id="wp" markdown="1">
+     ```git
+     git fetch pantheon-wordpress
+     git merge pantheon-wordpress/master
+     ```
      </div>
-     <div role="tabpanel" class="tab-pane" id="d8">
-     <pre><code class="command hljs">git fetch pantheon-drops-8
-    git merge pantheon-drops-8/master</code></pre>
+     <div role="tabpanel" class="tab-pane" id="d8" markdown="1">
+     ```git
+     git fetch pantheon-drops-8
+     git merge pantheon-drops-8/master
+     ```
      </div>
-     <div role="tabpanel" class="tab-pane" id="d7">
-     <pre><code class="command hljs">git fetch pantheon-drops-7
-    git merge pantheon-drops-7/master</code></pre>
+     <div role="tabpanel" class="tab-pane" id="d7" markdown="1">
+     ```git
+     git fetch pantheon-drops-7
+     git merge pantheon-drops-7/master
+     ```
      </div>
      </div><br>
 
 6. Push to your new test site on Pantheon:
 
-  ```command
+  ```git
   git push pantheon-test core-update
   ```
 
@@ -113,7 +125,7 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
 9. Use this new Multidev environment to evaluate your `core-update` branch. When you're ready to release, merge the branch into master and push to your remote repository on GitHub or Bitbucket:
 
-    ```command
+    ```git
     git checkout master
     git merge --no-ff core-update
     git push origin master
@@ -131,7 +143,7 @@ Updates will become available to sites downstream as one-click updates within an
 
 ## Tips and Tricks
 ### Use the Pantheon Workflow
-To fully test core updates, create content on your test site and use the standard [Pantheon workflow](/docs/pantheon-workflow/) to push up to your Test and Live environments. Checkout <a href="/docs/guides/drupal8-commandline#managing-content-configuration-and-code-across-environments" data-proofer-ignore>our guide</a> for an example of generating content from the command line.
+To fully test core updates, create content on your test site and use the standard [Pantheon workflow](/docs/pantheon-workflow/) to push up to your Test and Live environments. Checkout <a href="/docs/guides/drupal8-commandline/#managing-content-configuration-and-code-across-environments" data-proofer-ignore>our guide</a> for an example of generating content from the command line.
 
 ### Sample a Few Sites
 For agencies that manage large portfolios, we suggest picking a few sample sites with varying functionality and design to test updates on a [Multidev](/docs/multidev/) environment. Once things look good, release the update to all.
@@ -156,14 +168,20 @@ If you receive the error that you have conflicts while updating core, the fastes
 
     <!-- Tab panes -->
     <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="wp-1xtheirs">
-    <pre id="git-pull-wp"><code class="command hljs" data-lang="">git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git</code></pre>
+    <div role="tabpanel" class="tab-pane active" id="wp-1xtheirs" markdown="1">
+    ```git
+    git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d8-1xtheirs">
-    <pre id="git-pull-drops-8"><code class="command hljs" data-lang="">git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d8-1xtheirs" markdown="1">
+    ```git
+    git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d7-1xtheirs">
-    <pre id="git-pull-drops-7"><code class="command hljs" data-lang="">git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d7-1xtheirs" markdown="1">
+    ```git
+    git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git
+    ```
     </div>
     </div><br>
 
@@ -178,17 +196,23 @@ If you receive the error that you have conflicts while updating core, the fastes
 
     <!-- Tab panes -->
     <div class="tab-content">
-      <div role="tabpanel" class="tab-pane active" id="wp-xtheirs">
-      <pre><code class="command hljs" data-lang="">git fetch pantheon-wordpress
-    git merge pantheon-wordpress/master -Xtheirs</code></pre>
+      <div role="tabpanel" class="tab-pane active" id="wp-xtheirs" markdown="1">
+      ```git
+      git fetch pantheon-wordpress
+      git merge pantheon-wordpress/master -Xtheirs
+      ```
       </div>
-      <div role="tabpanel" class="tab-pane" id="d8-xtheirs">
-      <pre><code class="command hljs" data-lang="">git fetch pantheon-drops-8
-    git merge pantheon-drops-8/master -Xtheirs</code></pre>
+      <div role="tabpanel" class="tab-pane" id="d8-xtheirs" markdown="1">
+      ```git
+      git fetch pantheon-drops-8
+      git merge pantheon-drops-8/master -Xtheirs
+      ```
       </div>
-      <div role="tabpanel" class="tab-pane" id="d7-xtheirs">
-      <pre><code class="command hljs" data-lang="">git fetch pantheon-drops-7
-    git merge pantheon-drops-7/master -Xtheirs</code></pre>
+      <div role="tabpanel" class="tab-pane" id="d7-xtheirs" markdown="1">
+      ```git
+      git fetch pantheon-drops-7
+      git merge pantheon-drops-7/master -Xtheirs
+      ```
       </div>
     </div><br>
 
@@ -210,14 +234,20 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
 
     <!-- Tab panes -->
     <div class="tab-content">
-    <div role="tabpanel" class="tab-pane active" id="wp-1conflict">
-    <pre id="git-pull-wp"><code class="command hljs" data-lang="">git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git</code></pre>
+    <div role="tabpanel" class="tab-pane active" id="wp-1conflict" markdown="1">
+    ```git
+    git remote add pantheon-wordpress git://github.com/pantheon-systems/WordPress.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d8-1conflict">
-    <pre id="git-pull-drops-8"><code class="command hljs" data-lang="">git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d8-1conflict" markdown="1">
+    ```git
+    git remote add pantheon-drops-8 git://github.com/pantheon-systems/drops-8.git
+    ```
     </div>
-    <div role="tabpanel" class="tab-pane" id="d7-1conflict">
-    <pre id="git-pull-drops-7"><code class="command hljs" data-lang="">git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git</code></pre>
+    <div role="tabpanel" class="tab-pane" id="d7-1conflict" markdown="1">
+    ```git
+    git remote add pantheon-drops-7 git://github.com/pantheon-systems/drops-7.git
+    ```
     </div>
     </div><br>
 
@@ -232,17 +262,23 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
 
      <!-- Tab panes -->
      <div class="tab-content">
-     <div role="tabpanel" class="tab-pane active" id="wp-2conflict">
-     <pre><code class="command hljs">git fetch pantheon-wordpress
-    git merge pantheon-wordpress/master</code></pre>
+     <div role="tabpanel" class="tab-pane active" id="wp-2conflict" markdown="1">
+     ```git
+     git fetch pantheon-wordpress
+     git merge pantheon-wordpress/master
+     ```
      </div>
-     <div role="tabpanel" class="tab-pane" id="d8-2conflict">
-     <pre><code class="command hljs">git fetch pantheon-drops-8
-    git merge pantheon-drops-8/master</code></pre>
+     <div role="tabpanel" class="tab-pane" id="d8-2conflict" markdown="1">
+     ```git
+     git fetch pantheon-drops-8
+     git merge pantheon-drops-8/master
+     ```
      </div>
-     <div role="tabpanel" class="tab-pane" id="d7-2conflict">
-     <pre><code class="command hljs">git fetch pantheon-drops-7
-    git merge pantheon-drops-7/master</code></pre>
+     <div role="tabpanel" class="tab-pane" id="d7-2conflict" markdown="1">
+     ```git
+     git fetch pantheon-drops-7
+     git merge pantheon-drops-7/master
+     ```
      </div>
      </div><br>
 
@@ -274,7 +310,7 @@ If attempts to automatically resolve conflicts fail or if you want your changes 
 
 4. Run `git status` to see conflicting files in the current index again. Once all conflicts have been addressed, you can add them to your index and continue pulling in updates:
 
-  ```command
+  ```git
   git add .
   git merge --continue
   ```


### PR DESCRIPTION
This is a change in how we advice folks to update custom upstream code. Previously we used rebase but it could cause conflicts. Merge is a lot cleaner. Reference: https://www.atlassian.com/git/tutorials/merging-vs-rebasing

I updated the doc to use merge instead and believe the syntax should be the same as per https://git-scm.com/docs/git-merge.

Closes #3881

## Remaining Work
 - [x] Apply style updates throughout doc, to conform to current standards.

## Post Launch
To be completed by the docs team upon merge: 

- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
