### PR TITLE
Update 01-introduction.md

### DIFF
--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -134,6 +134,11 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
       <button class="btn btn-default btn-clippy" data-clipboard-target="#build-tools-plugin">Copy</button>
       <figure><pre id="build-tools-plugin"><code class="command bash" data-lang="bash">composer create-project -n -d $HOME/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:~1</code></pre></figure>
     </div>
+    
+    <div class="alert alert-info">
+    <h4 class="info">Note</h4>
+    <p markdow="1">The Terminus Build Tools Plugin does not support private repositories.</p>
+    </div>
 
 9. [Authorize CircleCI on Github](https://github.com/login/oauth/authorize?client_id=78a2ba87f071c28e65bb){.external}.
 

--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -137,14 +137,14 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
     
     <div class="alert alert-info">
     <h4 class="info">Note</h4>
-    <p markdow="1">The Terminus Build Tools Plugin does not support private repositories.</p>
+    <p markdown="1">The Terminus Build Tools Plugin does not support private repositories.</p>
     </div>
 
 9. [Authorize CircleCI on Github](https://github.com/login/oauth/authorize?client_id=78a2ba87f071c28e65bb){.external}.
 
     <div class="alert alert-info">
     <h4 class="info">Note</h4>
-    <p markdow="1">If you are redirected to the CircleCI homepage, you have already authorized the service for your GitHub account. Nice! Way to be ahead of the game.</p>
+    <p markdown="1">If you are redirected to the CircleCI homepage, you have already authorized the service for your GitHub account. Nice! Way to be ahead of the game.</p>
     </div>
 
 ### Access Tokens (Optional)


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Added info alert to communicate the fact that The Terminus Build Tools Plugin does not support private repositories (out of the box).

## Remaining Work
- [x] Technical Review
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
