### PR TITLE
bump minimum PHP version for Terminus

### DIFF
--- a/source/_docs/terminus/install.md
+++ b/source/_docs/terminus/install.md
@@ -17,7 +17,7 @@ Some Windows users have installed Terminus using [Git BASH on Git for Windows](h
 
 ## Requirements
 
-* PHP Version 5.5.9 or later (must include the [php-xml extension](https://secure.php.net/manual/en/dom.setup.php)). You can check your PHP version by running `php -v` from a terminal application.
+* PHP Version 5.5.38 or later (must include the [php-xml extension](https://secure.php.net/manual/en/dom.setup.php)). You can check your PHP version by running `php -v` from a terminal application.
 * [PHP-CLI](http://www.php-cli.com/)
 * [PHP-CURL](https://secure.php.net/manual/en/curl.setup.php)
 * [Composer](https://getcomposer.org/download/)


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Bumps minimum PHP version to 5.5.38


## Remaining Work
- [x] Technical Review (@greg-1-anderson or @sehamilton)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
