### PR TITLE
Removed outdated/broken Drupal LDAP help links.

### DIFF
--- a/source/_docs/ldap-and-ldaps.md
+++ b/source/_docs/ldap-and-ldaps.md
@@ -12,7 +12,7 @@ categories: []
 <h4 class="info">Note</h4>
 <p>We do not recommend using LDAP for single sign-on authentication as it is not secure.  The recommended approach for sites and the Dashboard is to use SAML. For details, see <a href="/docs/guides/two-factor-authentication/"> Secure Your Site with Two-Factor Authentication</a>.
 </p></div>
-LDAP provides access and maintenance of a distributed directory storing organized sets of records. Using LDAP as a consumer of services is supported on the platform and will work at all plan levels, assuming correct configuration. The implementation and configuration details are up to the user as not all instances are supported. For general information about implementing LDAPS, see [https://drupal.org/node/1404368](https://drupal.org/node/1404368) and [https://drupal.org/node/1302032](https://drupal.org/node/1302032).
+LDAP provides access and maintenance of a distributed directory storing organized sets of records. Using LDAP as a consumer of services is supported on the platform and will work at all plan levels, assuming correct configuration. The implementation and configuration details are up to the user as not all instances are supported.
 
 PHP on Pantheon includes LDAP using OpenLDAP, so no changes to the platform are necessary in order to enable LDAP on your Pantheon site.
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Removes two links to Drupal.org for LDAP info. One is outdated and one goes to a 404.

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
