### PR TITLE
Add hyphen to "On-Server" in title for consistency

### DIFF
--- a/source/_docs/guides/quickstart/08-onserver-dev-part1.md
+++ b/source/_docs/guides/quickstart/08-onserver-dev-part1.md
@@ -1,6 +1,6 @@
 ---
 title: Quick Start
-subtitle: On Server Dev, Part 1
+subtitle: On-Server Dev, Part 1
 quickstart: true
 anchorid: onserver-dev-part1
 generator: pagination


### PR DESCRIPTION
Part 2 of this doc uses "On-Server" in the title; Part 1 didn't use the hyphen.

Seemed like a good first task to learn doc process.

Closes # - n/a

## Effect
PR includes the following changes:
- Adds hyphen to "On-Server" in page title.

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
