### PR TITLE
Clarify that WordPress and WooCommerce core do not use PHP Sessions

### DIFF
--- a/source/_docs/guides/woocommerce/03-configure.md
+++ b/source/_docs/guides/woocommerce/03-configure.md
@@ -20,9 +20,9 @@ image: guides/woocommerce/WooCommerce-logo-400-200
 ---
 We've configured a few things for our WooCommerce site. But there are a few additional things to configure.
 
-The first is [adding PHP sessions to WordPress](/docs/wordpress-sessions/). WordPress doesn't include any state tracking which makes it challenging for any plugin to remember which user did what - and for ecommerce that means who added what to their cart.
+The first is [adding PHP sessions to WordPress](/docs/wordpress-sessions/). WordPress and WooCommerce core do not use PHP Sessions but other plugins and extensions may.
 
-To solve this, _you must_ install [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/){.external}. It's a free plugin you can download from WordPress.org or install through your WordPress dashboard.
+To enable PHP Sessions on Pantheon, _you must_ install [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/){.external}. It's a free plugin you can download from WordPress.org or install through your WordPress dashboard.
 
 ![Install WordPress native PHP sessions plugin](/source/docs/assets/images/guides/woocommerce/10-install-WordPress-native-PHP-sessions-plugin.png)
 

--- a/source/_docs/guides/woocommerce/03-configure.md
+++ b/source/_docs/guides/woocommerce/03-configure.md
@@ -20,9 +20,9 @@ image: guides/woocommerce/WooCommerce-logo-400-200
 ---
 We've configured a few things for our WooCommerce site. But there are a few additional things to configure.
 
-The first is [adding PHP sessions to WordPress](/docs/wordpress-sessions/). WordPress and WooCommerce core do not use PHP Sessions but other plugins and extensions may.
+The first is [adding PHP sessions to WordPress](/docs/wordpress-sessions/). WordPress and WooCommerce core do not use PHP Sessions, but other plugins and extensions may.
 
-To enable PHP Sessions on Pantheon, _you must_ install [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/){.external}. It's a free plugin you can download from WordPress.org or install through your WordPress dashboard.
+To enable PHP Sessions on Pantheon, install [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/){.external}. It's a free plugin you can download from WordPress.org or install through your WordPress dashboard.
 
 ![Install WordPress native PHP sessions plugin](/source/docs/assets/images/guides/woocommerce/10-install-WordPress-native-PHP-sessions-plugin.png)
 

--- a/source/_docs/wordpress-sessions.md
+++ b/source/_docs/wordpress-sessions.md
@@ -8,8 +8,6 @@ WordPress Core [does not use sessions](https://wordpress.org/support/topic/how-d
 
 However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin.
 
-[WooCommerce](https://woocommerce.com/){.external}, for example, uses PHP Sessions and must have the WordPress Native PHP Sessions plugin installed and activated to work properly on Pantheon.
-
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>
 <p markdown="1">Given the variety of implementations, this plugin will not solve all `$_SESSION` based issues and errors. If you use this plugin and still have issues, modify the code within your theme or plugin that calls `$_SESSION` to remove this functionality or use an alternative.</p>


### PR DESCRIPTION
* Update to the configuration section of the WooCommerce guide to clarify that WordPress and WooCommerce core do not use PHP Sessions. The previous wording suggested that WooCommerce core uses PHP Sessions, which it does not.

* Remove the incorrect statement that WooCommerce uses PHP Sessions from the WordPress and PHP Sessions doc

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
