### PR TITLE
Correct spelling to "CircleCI"

### DIFF
--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -69,7 +69,7 @@ This guide describes how to use build tools such as GitHub and CircleCI with Com
 </div>
 
 ## Artifact Deployment
-Only files unique to the project are tracked as part of the project's main "source" repository on GitHub, which requires an abstraction layer to compile dependencies and deploy an entire "artifact" to the site repository on Pantheon. The abstraction layer is facilitated by CirlceCI in the Pantheon maintained examples, but the principles are the same for other continuous integration service providers.
+Only files unique to the project are tracked as part of the project's main "source" repository on GitHub, which requires an abstraction layer to compile dependencies and deploy an entire "artifact" to the site repository on Pantheon. The abstraction layer is facilitated by CircleCI in the Pantheon maintained examples, but the principles are the same for other continuous integration service providers.
 
 Composer is used to fetch dependencies declared by the project as part of a CircleCI build step. This ensures that the final composed build results are installed on Pantheon:
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Corrects spelling from "CirlceCI"

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
