### PR TITLE
Add example how to empty folders using rsync

### DIFF
--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -142,16 +142,17 @@ $: export ENV=dev
 $: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
 $: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
 ```
-### Empty a folder recursively using rsync
-Since rm -rf command is not available and via ftp command line, an alternative way to recursively empty a folder is using the rsync --delete flag. This example shows how to empty the remote folder `files/remote_folder_to_empty`.
+### Empty a Folder Recursively Using Rsync
+Since the `rm -r` command is not available over SFTP on Pantheon, an alternative way to recursively empty a folder is to use the rsync `--delete` flag. This example shows how to empty the remote folder `files/remote_folder_to_empty` (change this to match the remote directory you want to empty).
 
-In your local machine, you must first create an empty folder by using `mkdir empty_folder`.
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -a --delete -e 'ssh -p 2222' empty_folder/ --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/remote_folder_to_empty 
+In your local machine, you must first create an empty folder with `mkdir empty_folder`.
+
+```bash
+export ENV=dev
+export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
+rsync -rLvz --size-only --ipv4 --progress -a --delete -e 'ssh -p 2222' empty_folder/ --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/remote_folder_to_empty
 ```
-Note: Don't forget to change `files/remote_folder_to_empty` to the remote folder you wish to empty out.
+Now you can use `rmdir` over SFTP to remove the empty directory itself.
 
 ## Known Issues
 

--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -142,6 +142,17 @@ $: export ENV=dev
 $: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
 $: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
 ```
+### Empty a folder recursively using rsync
+Since rm -rf command is not available and via ftp command line, an alternative way to recursively empty a folder is using the rsync --delete flag. This example shows how to empty the remote folder `files/remote_folder_to_empty`.
+
+In your local machine, you must first create an empty folder by using `mkdir empty_folder`.
+```nohighlight
+$: export ENV=dev
+$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
+$: rsync -rLvz --size-only --ipv4 --progress -a --delete -e 'ssh -p 2222' empty_folder/ --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/remote_folder_to_empty 
+```
+Note: Don't forget to change `files/remote_folder_to_empty` to the remote folder you wish to empty out.
+
 ## Known Issues
 
 If you're uploading many files, and your Live environment has [multiple application containers](/docs/application-containers/#multiple-application-containers), upload to an environment other than Live (e.g. Dev), then use the clone operation in the Dashboard or [Terminus](/docs/terminus) to move the files to Live. Uploading a large amount of files into a multi-container Live environment may fail silently.

--- a/source/_docs/rsync-and-sftp.md
+++ b/source/_docs/rsync-and-sftp.md
@@ -82,44 +82,42 @@ Rsync is highly customizable. See the [man page](https://linux.die.net/man/1/rsy
 
 ## Examples
 
-Before you begin, make sure you have the following information:
-
-**Site URL:** https://dashboard.pantheon.io/sites/3ef6264e-51d9-43b9-a60b-6cc22c3129308as83<br />
-**Environment (ENV):** dev<br />
-**Site (SITE):** 3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
+<div class="alert alert-export" role="alert">
+<h4 class="info">Exports</h4>
+<p markdown="1">The examples below use the variables `$ENV` and `$SITE`. You can replace these variables with your site UUID and environment, or set them before you begin:
+<pre>
+<code class="bash">export ENV=dev
+export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
+</code></pre>
+</p>
+<p markdown="1"> Replace the example values above with the environment you're working with and your site UUID. You can find the UUID in your Site Dashboard URL:</p><br>
+<p markdown="1">https://dashboard.pantheon.io/sites/**3ef6264e-51d9-43b9-a60b-6cc22c3129308as83**</p>
+</div>
 
 ### Download a Drupal Directory from Pantheon
 Download the contents of the `sites/default/files` directory into a folder on your local environment in the `files` home folder:
 
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/default/files/ ~/files
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/default/files/ ~/files
 ```
 ### Download a WordPress Directory from Pantheon
 Download the contents of the `wp-content/uploads` directory into a folder on your local environment in the `files` home folder:
 
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/wp-content/uploads ~/files
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/wp-content/uploads ~/files
 ```
 
 ### Download a Drupal File from Pantheon
 Download the `sites/default/settings.php` file into a Drupal installation called _Foo_ on your local environment in a  `sites/default/files` folder:
 
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/default/settings.php ~/Foo/sites/default
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/default/settings.php ~/Foo/sites/default
 ```
 ### Download a WordPress File from Pantheon
 Download the `index.php` file into a WordPress installation called _Foo_ on your local environment in a `wp-content/uploads` folder:
 
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/wp-content/uploads/index.php ~/Foo/sites/wp-content/uploads
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/wp-content/uploads/index.php ~/Foo/sites/wp-content/uploads
 ```
 
 ### Upload a Directory to Pantheon
@@ -129,27 +127,21 @@ If you need to upload the files directory from a local installation called Foo i
 <h4 class="info">Warning</h4>
 <p>Always use the <code>temp-dir flag</code> when using rsync for uploads. Removing the flag will result in broken files after cloning from one environment to another.</p></div>
 
-```nohighlight
-$: export ENV=test
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/files/. --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/files/. --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
 ```
 ### Upload a Single File to Pantheon
 This example shows how to upload the logo.png file into a Pantheon site's theme folder.
 
-```nohighlight
-$: export ENV=dev
-$: export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
-$: rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
+```bash
+rsync -rLvz --size-only --ipv4 --progress -e 'ssh -p 2222' ~/Foo/sites/all/themes/foo/logo.png --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:code/sites/all/themes/foo
 ```
-### Empty a Folder Recursively Using Rsync
+### Empty a Folder Recursively Using rsync
 Since the `rm -r` command is not available over SFTP on Pantheon, an alternative way to recursively empty a folder is to use the rsync `--delete` flag. This example shows how to empty the remote folder `files/remote_folder_to_empty` (change this to match the remote directory you want to empty).
 
 In your local machine, you must first create an empty folder with `mkdir empty_folder`.
 
 ```bash
-export ENV=dev
-export SITE=3ef6264e-51d9-43b9-a60b-6cc22c3129308as83
 rsync -rLvz --size-only --ipv4 --progress -a --delete -e 'ssh -p 2222' empty_folder/ --temp-dir=~/tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/remote_folder_to_empty
 ```
 Now you can use `rmdir` over SFTP to remove the empty directory itself.


### PR DESCRIPTION
Closes # https://github.com/pantheon-systems/documentation/issues/3926

## Effect
PR includes the following changes:
- Add an example in docs on how to empty folders using rsync

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
