### PR TITLE
Put the Elite plan prerequisite on top of the list

### DIFF
--- a/source/_docs/migrate-wordpress-site-networks.md
+++ b/source/_docs/migrate-wordpress-site-networks.md
@@ -5,9 +5,13 @@ tags: [migratemanual]
 categories: [wordpress]
 ---
 
+<div class="alert alert-info" role="alert">
+  <h4 class="info">Note</h4>
+  <p markdown="1">Before you can migrate a WordPress Site Network, you must be on an [Elite plan](https://pantheon.io/pantheon-elite-plans){.external} and a Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.</p>
+</div>
+
 ## Requirements
 
-* An [Elite plan](https://pantheon.io/pantheon-elite-plans) and a Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.
 * [Download](https://git-scm.com/downloads) and install [Git](/docs/git/)
 * [Rsync or SFTP Client](/docs/rsync-and-sftp/)
 * [MySQL Client](/docs/mysql-access/)

--- a/source/_docs/migrate-wordpress-site-networks.md
+++ b/source/_docs/migrate-wordpress-site-networks.md
@@ -7,10 +7,10 @@ categories: [wordpress]
 
 ## Requirements
 
+* An [Elite plan](https://pantheon.io/pantheon-elite-plans) and a Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.
 * [Download](https://git-scm.com/downloads) and install [Git](/docs/git/)
 * [Rsync or SFTP Client](/docs/rsync-and-sftp/)
 * [MySQL Client](/docs/mysql-access/)
-* A Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.
 
 ## Import the Codebase
 


### PR DESCRIPTION
Closes https://github.com/pantheon-systems/documentation/issues/3934

## Effect
PR includes the following changes:
- Put the Elite plan prerequisite on top of the list

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
