### PR TITLE
Clean up Redis Install Inctructions.

### DIFF
--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -201,7 +201,6 @@ All plans except for a Basic plan can use Redis. Redis is available to Sandbox s
 
       }
       ```
-  7. Enable the module via `admin/build/modules`. This is necessary for cache clearing to work in all cases.
   8. Verify Redis is enabled by going to the Dashboard and clicking **Connection Info**. If you see the Redis cache connection string, Redis is enabled.
   9. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
   </div>

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -40,10 +40,11 @@ All plans except for a Basic plan can use Redis. Redis is available to Sandbox s
 
 <!-- Tab panes -->
 <div class="tab-content">
-  <!-- Active pane content -->
-  <div role="tabpanel" class="tab-pane active" id="tab-1-anchor" markdown="1">
-  1. Enable Redis from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
-  2. Install the [WP Redis](https://wordpress.org/plugins/wp-redis/){.external} plugin via SFTP or Git. To install via [Terminus](/docs/terminus), [set the connection mode to SFTP](/docs/sftp) then run:
+<!-- Active pane content -->
+<div role="tabpanel" class="tab-pane active" id="tab-1-anchor" markdown="1">
+1. Enable Redis from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
+
+2. Install the [WP Redis](https://wordpress.org/plugins/wp-redis/){.external} plugin via SFTP or Git. To install via [Terminus](/docs/terminus), [set the connection mode to SFTP](/docs/sftp) then run:
 
     ```
     terminus wp <site>.<env> -- plugin install wp-redis
@@ -54,7 +55,7 @@ All plans except for a Basic plan can use Redis. Redis is available to Sandbox s
     ```
     terminus wp <site>.<env> -- plugin install wp-redis --url=<url>
     ```
-  3. Create a new file named `wp-content/object-cache.php` that contains the following:
+3. Create a new file named `wp-content/object-cache.php` that contains the following:
 
     ```php
     <?php
@@ -63,147 +64,154 @@ All plans except for a Basic plan can use Redis. Redis is available to Sandbox s
     ```
 
     This file is a symlink to the `/plugins/wp-redis/object-cache.php` file. Using SFTP or Git, commit the new file to the Dev environment.
-  4. In the Dev environment's WordPress Dashboard, verify installation by selecting **Drop-ins** from the Plugins section:
+
+4. In the Dev environment's WordPress Dashboard, verify installation by selecting **Drop-ins** from the Plugins section:
 
     ![The object-cache Drop-In Plugin](/docs/assets/images/redis-dropin-plugin.png "The object-cache plugin, visible in the Drop-ins section of Plugins.")
 
     When a new version of the WP Redis plugin is released, you can upgrade by the normal Plugin update mechanism in WordPress or via Terminus:
 
-    ```
+    ```bash
     terminus wp <site>.<env> -- plugin update wp-redis
     ```
-  <div class="alert alert-info">
-  <h4 class="info">Note</h4>
-  <p markdown="1">[WP Redis](https://wordpress.org/plugins/wp-redis/){.external} is loaded via a drop-in file, so there's no need to activate it on your WordPress sites.</p></div>
 
-  <div class="panel panel-drop panel-guide" id="accordion">
-    <div class="panel-heading panel-drop-heading">
-       <a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#advance-installs"><h3 class="panel-title panel-drop-title info" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-lightbulb"></span> Explore Advanced Install Methods (Optional)</h3></a>
-     </div>
-     <div id="advance-installs" class="collapse">
-       <div class="panel-inner" markdown="1">
-        #### Install via Composer {.info}
-        1. Set the Dev environment's connection mode to Git from within the Site Dashboard or via Terminus:
+<div class="alert alert-info">
+<h4 class="info">Note</h4>
+<p markdown="1">[WP Redis](https://wordpress.org/plugins/wp-redis/){.external} is loaded via a drop-in file, so there's no need to activate it on your WordPress sites.</p></div>
 
-            ```
-            terminus connection:set <site>.<env> git
-            ```
-        2. [Clone the site's codebase](/docs/git/#clone-your-site-codebase) if you have not done so already.
-        3. Use the following within `composer.json` to install the WP Redis plugin as a drop-in via Composer using [koodimonni/composer-dropin-installer](https://github.com/Koodimonni/Composer-Dropin-Installer){.external}:
+<div class="panel panel-drop panel-guide" id="accordion">
+<div class="panel-heading panel-drop-heading">
+<a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#advance-installs"><h3 class="panel-title panel-drop-title info" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-lightbulb"></span> Explore Advanced Install Methods (Optional)</h3></a>
+</div>
+<div id="advance-installs" class="collapse">
+<div class="panel-inner" markdown="1">
+#### Install via Composer {.info}
+1. Set the Dev environment's connection mode to Git from within the Site Dashboard or via Terminus:
 
-            ```json
-            "repositories": {
-              "wpackagist": {
-                "type": "composer",
-                "url": "https://wpackagist.org"
-              }
-            },
-            "require": {
-              "composer/installers": "^1.0.21",
-              "koodimonni/composer-dropin-installer": "*",
-              "wpackagist-plugin/wp-redis": "0.6.0"
-              },
-              "extra": {
-                "installer-paths": {
-                  "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
-                  },
-                "dropin-paths": {
-                   "wp-content": [
-                   "package:wpackagist-plugin/wp-redis:object-cache.php"
-                 ]
-               }
-             }
-            ```
-        4. Run `composer install` to install WP Redis into the `wp-content` directory.
-        5. Use git status to verify your local state, then commit and push your code to Pantheon:
+    ```bash
+    terminus connection:set <site>.<env> git
+    ```
+2. [Clone the site's codebase](/docs/git/#clone-your-site-codebase) if you have not done so already.
+3. Use the following within `composer.json` to install the WP Redis plugin as a drop-in via Composer using [koodimonni/composer-dropin-installer](https://github.com/Koodimonni/Composer-Dropin-Installer){.external}:
 
-            ```bash
-            git status
-            git commit --all -m "Initiate composer, require custom code"
-            git push origin master
-            ```
-        </div>
-      </div>
-    </div>
-  </div>
-
-  <!-- 2nd pane content -->
-  <div role="tabpanel" class="tab-pane" id="tab-2-anchor" markdown="1">
-  1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
-  2. Install and activate the [Redis](https://www.drupal.org/project/redis){.external} module from Drupal.org.
-
-      <div class="alert alert-info">
-      <h4 class="info">Note</h4><p markdown="1">You **must** activate the module before proceeding.
-      </p></div>
-
-      You can install and enable the module from the command line using [Terminus](/docs/terminus):
-
-          terminus remote:drush <site>.<env> -- en redis -y
-  3. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site.
-
-      ```php
-      // Configure Redis
-
-      if (defined('PANTHEON_ENVIRONMENT')) {
-        // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
-        $settings['container_yamls'][] = 'modules/redis/example.services.yml';
-
-        //phpredis is built into the Pantheon application container.
-        $settings['redis.connection']['interface'] = 'PhpRedis';
-        // These are dynamic variables handled by Pantheon.
-        $settings['redis.connection']['host']      = $_ENV['CACHE_HOST'];
-        $settings['redis.connection']['port']      = $_ENV['CACHE_PORT'];
-        $settings['redis.connection']['password']  = $_ENV['CACHE_PASSWORD'];
-
-        $settings['cache']['default'] = 'cache.backend.redis'; // Use Redis as the default cache.
-        $settings['cache_prefix']['default'] = 'pantheon-redis';
-
-        // Set Redis to not get the cache_form (no performance difference).
-        $settings['cache']['bins']['form']      = 'cache.backend.database';
+    ```json
+    "repositories": {
+      "wpackagist": {
+        "type": "composer",
+        "url": "https://wpackagist.org"
       }
-      ```
-  4. On your dev site, navigate to `/admin/reports/status` and confirm that the **REDIS** line says "Connected, using the PhpRedis client."
-  </div>
+    },
+    "require": {
+      "composer/installers": "^1.0.21",
+      "koodimonni/composer-dropin-installer": "*",
+      "wpackagist-plugin/wp-redis": "0.6.0"
+      },
+      "extra": {
+        "installer-paths": {
+          "wp-content/plugins/{$name}/": ["type:wordpress-plugin"]
+          },
+        "dropin-paths": {
+           "wp-content": [
+           "package:wpackagist-plugin/wp-redis:object-cache.php"
+         ]
+       }
+     }
+    ```
+4. Run `composer install` to install WP Redis into the `wp-content` directory.
+5. Use git status to verify your local state, then commit and push your code to Pantheon:
 
-  <!-- 3rd pane content -->
-  <div role="tabpanel" class="tab-pane" id="tab-3-anchor" markdown="1">
-  1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
-  2. Add the [Redis](https://www.drupal.org/project/redis){.external} module from Drupal.org. You can install and enable the module from the command line using [Terminus](/docs/terminus):
+    ```bash
+    git status
+    git commit --all -m "Initiate composer, require custom code"
+    git push origin master
+    ```
+</div>
+</div>
+</div>
+</div>
 
-          terminus remote:drush <site>.<env> -- en redis -y
-  3. Ignore the directions bundled with the Redis module. Pantheon automatically manages the following `settings.php`/`$conf`/`variable_get` items for you:
-      - `redis_client_host`
-      - `redis_client_port`
-      - `redis_client_password`
-  4. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site.
+<!-- 2nd pane content -->
+<div role="tabpanel" class="tab-pane" id="tab-2-anchor" markdown="1">
+1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
+2. Install and activate the [Redis](https://www.drupal.org/project/redis){.external} module from Drupal.org.
 
-      ```php
-      // All Pantheon Environments.
-      if (defined('PANTHEON_ENVIRONMENT')) {
-        // Use Redis for caching.
-        $conf['redis_client_interface'] = 'PhpRedis';
+    <div class="alert alert-info">
+    <h4 class="info">Note</h4><p markdown="1">You **must** activate the module before proceeding.
+    </p></div>
 
-        // Point Drupal to the location of the Redis plugin.
-        $conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
-        // If you've installed your plugin in a contrib directory, use this line instead:
-        // $conf['cache_backends'][] = 'sites/all/modules/contrib/redis/redis.autoload.inc';
+    You can install and enable the module from the command line using [Terminus](/docs/terminus):
 
-        $conf['cache_default_class'] = 'Redis_Cache';
-        $conf['cache_prefix'] = array('default' => 'pantheon-redis');
+        terminus remote:drush <site>.<env> -- en redis -y
+3. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site.
 
-        // Do not use Redis for cache_form (no performance difference).
-        $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+    ```php
+    // Configure Redis
 
-        // Use Redis for Drupal locks (semaphore).
-        $conf['lock_inc'] = 'sites/all/modules/redis/redis.lock.inc';
-        // Or if you've installed the redis module in a contrib subdirectory, use:
-        // $conf['lock_inc'] = 'sites/all/modules/contrib/redis/redis.lock.inc';
+    if (defined('PANTHEON_ENVIRONMENT')) {
+      // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
+      $settings['container_yamls'][] = 'modules/redis/example.services.yml';
 
-      }
-      ```
-  8. Verify Redis is enabled by going to the Dashboard and clicking **Connection Info**. If you see the Redis cache connection string, Redis is enabled.
-  9. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
-  </div>
+      //phpredis is built into the Pantheon application container.
+      $settings['redis.connection']['interface'] = 'PhpRedis';
+      // These are dynamic variables handled by Pantheon.
+      $settings['redis.connection']['host']      = $_ENV['CACHE_HOST'];
+      $settings['redis.connection']['port']      = $_ENV['CACHE_PORT'];
+      $settings['redis.connection']['password']  = $_ENV['CACHE_PASSWORD'];
+
+      $settings['cache']['default'] = 'cache.backend.redis'; // Use Redis as the default cache.
+      $settings['cache_prefix']['default'] = 'pantheon-redis';
+
+      // Set Redis to not get the cache_form (no performance difference).
+      $settings['cache']['bins']['form']      = 'cache.backend.database';
+    }
+    ```
+4. On your dev site, navigate to `/admin/reports/status` and confirm that the **REDIS** line says "Connected, using the PhpRedis client."
+</div>
+
+<!-- 3rd pane content -->
+<div role="tabpanel" class="tab-pane" id="tab-3-anchor" markdown="1">
+1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
+2. Add the [Redis](https://www.drupal.org/project/redis){.external} module from Drupal.org. You can install and enable the module from the command line using [Terminus](/docs/terminus):
+
+    ```bash
+    terminus remote:drush <site>.<env> -- en redis -y
+    ```
+
+3. Ignore the directions bundled with the Redis module. Pantheon automatically manages the following `settings.php`/`$conf`/`variable_get` items for you:
+    - `redis_client_host`
+    - `redis_client_port`
+    - `redis_client_password`
+4. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site.
+
+    ```php
+    // All Pantheon Environments.
+    if (defined('PANTHEON_ENVIRONMENT')) {
+      // Use Redis for caching.
+      $conf['redis_client_interface'] = 'PhpRedis';
+
+      // Point Drupal to the location of the Redis plugin.
+      $conf['cache_backends'][] = 'sites/all/modules/redis/redis.autoload.inc';
+      // If you've installed your plugin in a contrib directory, use this line instead:
+      // $conf['cache_backends'][] = 'sites/all/modules/contrib/redis/redis.autoload.inc';
+
+      $conf['cache_default_class'] = 'Redis_Cache';
+      $conf['cache_prefix'] = array('default' => 'pantheon-redis');
+
+      // Do not use Redis for cache_form (no performance difference).
+      $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
+
+      // Use Redis for Drupal locks (semaphore).
+      $conf['lock_inc'] = 'sites/all/modules/redis/redis.lock.inc';
+      // Or if you've installed the redis module in a contrib subdirectory, use:
+      // $conf['lock_inc'] = 'sites/all/modules/contrib/redis/redis.lock.inc';
+
+    }
+    ```
+5. Enable the module via from `/admin/modules` if you haven't already done so with Terminus.
+
+6. Verify Redis is enabled by going to the Dashboard and clicking **Connection Info**. If you see the Redis cache connection string, Redis is enabled.
+7. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
+</div>
 </div>
 
 ## Use the Redis Command-Line Client


### PR DESCRIPTION
Closes #3924
Continues #3925, which was branched from an external fork.

## Effect
PR includes the following changes:

From #3925:
- Removed Step 5 in Enable Redis Drupal 7 tab - "Enable the module via `admin/build/modules`. This is necessary for cache clearing to work in all cases. in [enabling Redis in Drupal 7](https://pantheon.io/docs/redis/#enable-redis)" page

Additionally
- Recreated the line but specified that it's required if you didn't use Terminus to download/enable the module.
- Fixed the admin path.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
