### PR TITLE
Define issue with wp_filesystem->get_contents

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -526,6 +526,18 @@ The list of [WordPress roles and capabilities](https://codex.wordpress.org/Roles
 * `edit_plugins`
 * `edit_themes`
 
+### [wp_filesystem->get_contents()](https://developer.wordpress.org/reference/classes/wp_filesystem_base/get_contents/){.external}
+
+**Issue**: The function `wp_filesystem->get_contents()` can fail when an environment is in Git mode (as Test and Live always are) because it is aware of filesystem-level permissions which are restricted in this mode.
+
+**Solution**: As described in [this StackExchange answer](https://wordpress.stackexchange.com/questions/166161/why-cant-the-wp-filesystem-api-read-googlefonts-json/166172#166172){.external}, for cases where file ownership doesn't matter this function could be replaced with `file_get_contents()`. This is true of most cases where the file in question is only being read, not written to.
+
+If the function cannot be replaced, you can create a workaround by adding to your `wp-config.php` file:
+
+```php
+define('FS_METHOD', 'direct');
+```
+
 ## PHP Libraries
 Due to the cloud-based infrastructure of the Pantheon platform, certain PHP libraries are not available on the platform.
 


### PR DESCRIPTION
Closes #3674 

## Effect
PR includes the following changes:
- Defines the issue with `wp_filesystem->get_contents` in git mode
- Explains why it shouldn't be used
- Provides a workaround 

## Remaining Work
- [ ] Technical Review from someone who knows WP better than I. 
- [ ] Copy Review (maybe)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
