### PR TITLE
Added the snippet location in the wp-config

### DIFF
--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -9,7 +9,7 @@
 <!-- Tab panes -->
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="wp">
-<p markdown="1">Add the following to <code>wp-config.php</code> (Ideally placed above <code>/* That's all, stop editing! Happy blogging. */</code> and don't forget to replace <code>www.example.com</code>):</p>
+<p markdown="1">Add the following to <code>wp-config.php</code>, usually placed above <code>/* That's all, stop editing! Happy blogging. */</code>. Don't forget to replace <code>www.example.com</code>:</p>
 <pre id="git-pull-wp"><code class="php hljs" data-lang="hljs">if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
   // Redirect to https://$primary_domain in the Live environment
   if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live') {

--- a/source/_partials/redirects.twig
+++ b/source/_partials/redirects.twig
@@ -9,7 +9,7 @@
 <!-- Tab panes -->
 <div class="tab-content">
 <div role="tabpanel" class="tab-pane active" id="wp">
-<p markdown="1">Add the following to <code>wp-config.php</code> (replace <code>www.example.com</code>):</p>
+<p markdown="1">Add the following to <code>wp-config.php</code> (Ideally placed above <code>/* That's all, stop editing! Happy blogging. */</code> and don't forget to replace <code>www.example.com</code>):</p>
 <pre id="git-pull-wp"><code class="php hljs" data-lang="hljs">if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
   // Redirect to https://$primary_domain in the Live environment
   if ($_ENV['PANTHEON_ENVIRONMENT'] === 'live') {


### PR DESCRIPTION
Closes https://github.com/pantheon-systems/documentation/issues/3939

## Effect
PR includes the following changes:
- Add a recommended location where to put the wp-config snippet, ideally above /* That's all, stop editing! Happy blogging. */

## Remaining Work
- [x] Technical Review (@slashzero)
- [x] Copy Review (@alexfornuto)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
