### PR TITLE
Document setting custom upstream on existing site.

### DIFF
--- a/source/_docs/create-custom-upstream.md
+++ b/source/_docs/create-custom-upstream.md
@@ -241,6 +241,11 @@ Once all sites have been updated to track the new Custom Upstream, you can safel
 
 ## Switch an Existing Site to a Custom Upstream
 
+<div class="alert alert-danger" role="alert">
+<h4 class="info">Warning</h4>
+<p markdown="1">Switching the upstream of an existing site is risky. Consider creating a new site from your custom upstream, and migrating the contents, using the [Terminus Site Clone](https://github.com/pantheon-systems/terminus-site-clone-plugin){.external} plugin. If you must switch upstreams, [back up](/docs/backups/) your site first, and consider our documentation on [upstream merge conflicts](/docs/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts).</p>
+</div>
+
 Only a Site Owner can change an existing site to use a new custom upstream. Site owners can [contact support](/docs/support/), or use [Terminus](/docs/terminus/):
 
 ```bash

--- a/source/_docs/create-custom-upstream.md
+++ b/source/_docs/create-custom-upstream.md
@@ -239,6 +239,16 @@ Once all sites have been updated to track the new Custom Upstream, you can safel
 2. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
 3. Click **Settings** next to the existing upstream, then click **Delete**.
 
+## Switch an Existing Site to a Custom Upstream
+
+Only a Site Owner can change an existing site to use a new custom upstream. Site owners can [contact support](/docs/support/), or use [Terminus](/docs/terminus/):
+
+```bash
+terminus site:upstream:set $site $upstream_id
+```
+
+In the example above, set or replace the variables `$site` and `$upstream_id` with your site name and upstream machine name, respectively. You can find your custom upstream's machine name using `terminus org:upstream:list $org`, where `$org` is your organization name.
+
 ## Next Steps
 - [Best Practices for Maintaining Custom Upstreams](/docs/maintain-custom-upstream)
 - [Switching an Existing site to a Custom Upstream with Terminus](/docs/terminus/examples/#switch-upstreams)

--- a/source/_docs/create-custom-upstream.md
+++ b/source/_docs/create-custom-upstream.md
@@ -243,7 +243,7 @@ Once all sites have been updated to track the new Custom Upstream, you can safel
 
 <div class="alert alert-danger" role="alert">
 <h4 class="info">Warning</h4>
-<p markdown="1">Switching the upstream of an existing site is risky. Consider creating a new site from your custom upstream, and migrating the contents, using the [Terminus Site Clone](https://github.com/pantheon-systems/terminus-site-clone-plugin){.external} plugin. If you must switch upstreams, [back up](/docs/backups/) your site first, and consider our documentation on [upstream merge conflicts](/docs/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts).</p>
+<p markdown="1">Switching the upstream of an existing site is risky. Consider creating a new site from your custom upstream and migrating the contents. If you must switch upstreams, [back up](/docs/backups/) your site first, and consider our documentation on [upstream merge conflicts](/docs/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts).</p>
 </div>
 
 Only a Site Owner can change an existing site to use a new custom upstream. Site owners can [contact support](/docs/support/), or use [Terminus](/docs/terminus/):


### PR DESCRIPTION
Closes #3443 

## Effect
PR includes the following changes:
- Documents how to set an existing site to use a custom upstream.

## Remaining Work
- [x] ~~Review from @cityofoaksdesign, who suggested this addition~~ [done](https://github.com/pantheon-systems/documentation/issues/3443#issuecomment-412165197)
- [x] Review from @allenfear on warning
- [ ] Technical review
- [ ] Copy Reivew

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
