### PR TITLE
Uploading files over 256MB is not possible

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -90,7 +90,7 @@ It is also possible to deliver smaller media files from Pantheon using [progress
 
 Pantheon's file serving infrastructure is not optimized to store and deliver very large files. The bigger the file, the slower the transfer. Files over 50MB will experience a noticeable performance degradation due to our caching infrastructure configuration.
 
-Pantheon cannot be used to host files over 256MB, no matter how the file is uploaded.
+Pantheon cannot be used to host files over 256MB, no matter how the file is uploaded. Attempting to upload a file using SFTP or rsync will fail if the file size is over 256MB.
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 


### PR DESCRIPTION
The doc states "Pantheon cannot be used to host files over 256MB, no matter how the file is uploaded." which seems to imply that it _is_ possible to use SFTP or some other method to upload files over 256MB. 

This change is to clarify that the transfer will fail due to the large file size.
