### PR TITLE
Link to "no CI" guide as an option for D8 solr.

### DIFF
--- a/source/_docs/solr-drupal-8.md
+++ b/source/_docs/solr-drupal-8.md
@@ -17,7 +17,7 @@ Be sure that you:
 
 * Enable Solr in the Pantheon Site Dashboard: **Settings** > **Add Ons** > **Apache Solr Index Server: Add**.
 * Install [Composer](https://getcomposer.org/){.external}
-* Create a Composer managed site on Pantheon following the [Build Tools](/docs/guides/build-tools/) guide
+* Create a Composer managed site on Pantheon following the [Build Tools](/docs/guides/build-tools/) guide or the [Composer without CI](/docs/guides/drupal-8-composer-no-ci/) guide. 
 
 <div class="alert alert-danger">
 <h4 class="info">Warning</h4>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Updates Solr pre-reqs to include a link to the No CI-style Composer guide.

## Remaining Work
none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
