### PR TITLE
update WP site network availability

### DIFF
--- a/source/_docs/agency-tips.md
+++ b/source/_docs/agency-tips.md
@@ -43,7 +43,7 @@ The following tools are specifically for WordPress.
 In order to use PHP Sessions with a WordPress site you will need to install the [WordPress Native PHP Sessions plugin](https://wordpress.org/plugins/wp-native-php-sessions/). For details, see [WordPress and PHP Sessions](/docs/wordpress-sessions/).
 
 ### WordPress Multisite
-Running a WordPress Site Network requires a special configuration that is only available on Elite plans. These sites can only be created by Pantheon employees. For details, see [WordPress Site Networks](/docs/guides/multisite/).
+Running a WordPress Site Network requires a special configuration that is only available to contract customers. These sites can only be created by Pantheon employees. For details, see [WordPress Site Networks](/docs/guides/multisite/).
 
 ### Migration
 The guided migration process for WordPress is baked into the Pantheon User Dashboard - simply click **Migrate Existing Site** and select WordPress to get started. For details, see [Migrate Sites to Pantheon](/docs/migrate/).

--- a/source/_docs/guides/multisite/01-introduction.md
+++ b/source/_docs/guides/multisite/01-introduction.md
@@ -40,6 +40,6 @@ We do not support uses of WordPress Site Networks that run functionally-differen
 - WordPress Multi-Network installations
 
 ## Request a WordPress Site Network
-Running a WordPress Site Network requires a special configuration that is only available on Elite plans. Only Pantheon employees have the ability to create the sites and add you to the team. Existing WordPress sites cannot be converted to a network, however they can be [migrated](/docs/migrate-wordpress-site-networks/).
+Running a WordPress Site Network requires a special configuration that is only available to contract customers. Only Pantheon employees have the ability to create the sites and add you to the team. Existing WordPress sites cannot be converted to a network, however they can be [migrated](/docs/migrate-wordpress-site-networks/).
 
-[Complete this form](https://pantheon.io/pantheon-elite-plans){.external} or reach out to your existing account manager to request a new WordPress Site Network be created for you. Once an employee of Pantheon has created the network, you will receive an email informing you that you've been added to the site.
+Reach out to your existing account manager to request a new WordPress Site Network be created for you. Once an employee of Pantheon has created the network, you will receive an email informing you that you've been added to the site.

--- a/source/_docs/migrate-wordpress-site-networks.md
+++ b/source/_docs/migrate-wordpress-site-networks.md
@@ -7,7 +7,7 @@ categories: [wordpress]
 
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p markdown="1">Before you can migrate a WordPress Site Network, you must be on an [Elite plan](https://pantheon.io/pantheon-elite-plans){.external} and a Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.</p>
+  <p markdown="1">Before you can migrate a WordPress Site Network, you must be a contract customer, and a Pantheon employee must create a [WordPress Site Network](/docs/guides/multisite/) for you.</p>
 </div>
 
 ## Requirements

--- a/source/_partials/content/notes/multisite.html
+++ b/source/_partials/content/notes/multisite.html
@@ -1,4 +1,4 @@
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
-<p>Running a WordPress Site Network requires a special configuration that is only available on Elite plans, and only Pantheon employees have the ability to create the sites and add you to the team.</p>
+<p>Running a WordPress Site Network requires a special configuration that is only available to contract customers, and only Pantheon employees have the ability to create the sites and add you to the team.</p>
 </div>


### PR DESCRIPTION

## Effect
PR includes the following changes:
- Defines WP Site Networks as being available to contract customers, versus elite site plans. 

## Remaining Work
- [x] Review from @allenfear 


## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
