### PR TITLE
Update link to Anatomy of a Command docs.

### DIFF
--- a/source/_docs/wp-cli.md
+++ b/source/_docs/wp-cli.md
@@ -57,7 +57,7 @@ terminus wp <site>.<env> -- db query "SELECT * FROM wp_users WHERE ID=1"
 
 ## Extending WP-CLI With Subcommands
 
-WP-CLI has a framework for users to write their own commands. Learn about the [anatomy of a subcommand](https://github.com/wp-cli/wp-cli/wiki/Commands-Cookbook#anatomy){.external} to solve your thorny problems with WP-CLI.
+WP-CLI has a framework for users to write their own commands. Learn about the [anatomy of a subcommand](https://make.wordpress.org/cli/handbook/commands-cookbook/#anatomy-of-a-command){.external} to solve your thorny problems with WP-CLI.
 
 
 ## Troubleshooting


### PR DESCRIPTION
The previous link went to a page that has been deprecated.

Closes # n/a

## Effect
PR includes the following changes:
- Updates deprecated link.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
