### PR TITLE
reference and link troubleshooting section

### DIFF
--- a/source/_docs/core-updates.md
+++ b/source/_docs/core-updates.md
@@ -218,8 +218,6 @@ Squashing and rewriting history may cause one-click updates to break, meaning up
 
 If you are in a situation where you've altered the commit history in such a way that the dashboard is no longer able to determine if your site is up to date with the upstream, the simplest course of corrective action is to use `git reset --hard` to reset the site repository to the last known good commit before the squash/rebase/revert was applied. This *will* result in losing *all* changes that have happened since this commit. You will need to re-apply all custom/contributed code updates that occurred in the interim, so make sure to take stock of these changes first and develop a plan to reapply them with the fixed Git history.
 
-**Note:** This
-
 ### One-Click Update Not Appearing for Sites Using a Custom Upstream
 Core updates for Custom Upstreams are initiated by the repository maintainer, not Pantheon. Please report issues directly to the project maintainer for expected updates.
 


### PR DESCRIPTION
Closes #3549 

## Effect
PR includes the following changes:
- In the section on using `-Xtheirs` to resolve conflicts, links to the troubleshooting section on `git reset` in case of failure.

## Remaining Work
- [x] Review from @sarahg 
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [x] Update Status Report
- [x] Archive from **Done** in Waffle
