### PR TITLE
Add link to Drupal 8 .gitignore file.

### DIFF
--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -6,6 +6,7 @@ categories: []
 ---
 Files are user uploads, usually images or documents. They are excluded from version control via Pantheon's .gitignore files:
 
+- [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/master/.gitignore)
 - [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore)
 - [WordPress](https://github.com/pantheon-systems/WordPress/blob/master/.gitignore)
 

--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -6,9 +6,9 @@ categories: []
 ---
 Files are user uploads, usually images or documents. They are excluded from version control via Pantheon's .gitignore files:
 
-- [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/master/.gitignore)
-- [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore)
-- [WordPress](https://github.com/pantheon-systems/WordPress/blob/master/.gitignore)
+- [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/master/.gitignore){.external}
+- [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore){.external}
+- [WordPress](https://github.com/pantheon-systems/WordPress/blob/master/.gitignore){.external}
 
 The Pantheon architecture is comprised of highly available [application containers](/docs/application-containers/) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Adds link to d8 .gitignore
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
