### PR TITLE
Fixed a typo in drupal-cron.md

### DIFF
--- a/source/_docs/drupal-cron.md
+++ b/source/_docs/drupal-cron.md
@@ -101,7 +101,7 @@ You can also use [Terminus](/docs/terminus/) to see when cron was last run with 
 terminus drush <site>.<env> -- wd-show --type='cron'
 ```
 
-### Can I add taks to cron through Drupal?
+### Can I add tasks to cron through Drupal?
 
 No. You can create a custom module that uses the [`hook_cron`](https://api.drupal.org/api/drupal/core%21core.api.php/function/hook_cron/8.6.x){.external} function, or schedule a drush command to be run via [Terminus](/source/docs/terminus/) from your local cron, or an external service like [cron-job.org](https://cron-job.org/){.external}.
 


### PR DESCRIPTION
fixed a typo in "Can I add tasks (taks) to cron through Drupal"

Closes #

## Effect
PR includes the following changes:
- Changed a line in the Cron documentation


## Remaining Work
- None

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
