### PR TITLE
Add note from recent Visual Composer tests

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -400,7 +400,8 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 <hr>
 
 ### [Visual Composer: Page Builder](https://vc.wpbakery.com/){.external}
-**Issue**: This plugin requires write access to the site's codebase for editing files, which is not granted on Test and Live environments by design.
+**Issue**: This plugin requires write access to the site's codebase for editing files, which is not granted on Test and Live environments by design. Note: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as it uses [wp_filesystem()](#wp_filesystem->get_contents).
+
 <hr>
 
 ### [Weather Station](https://wordpress.org/plugins/live-weather-station/){.external}

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -399,8 +399,12 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 
 <hr>
 
-### [Visual Composer: Page Builder](https://vc.wpbakery.com/){.external}
-**Issue**: This plugin requires write access to the site's codebase for editing files, which is not granted on Test and Live environments by design. Note: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as it uses [wp_filesystem()](#wp_filesystem->get_contents).
+### [Visual Composer: Website Builder](https://visualcomposer.io/){.external}
+**Issue**: This plugin fails to download additional assets during the internal plugin activation procedure on Test and Live environemtns.
+
+**Resolution**: If this plugin is installed and activated on a new site _before_ the Test and Live environment are created, it will properly transfer all assets and database settings to the additional environments.
+
+**Note**: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as of August 2018.
 
 <hr>
 


### PR DESCRIPTION
To assist CSEs when answering VC questions, I added a note referencing the VC release notes that claim this works on Pantheon.

Closes #3975 

Relates to https://github.com/pantheon-systems/documentation/pull/3805 

## Effect
PR includes the following changes:
- Explains that VC still doesn't work on Pantheon with a link to the function that causes problems.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
