### PR TITLE
PHP mcrypt and PHP version 7.1 and above

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -13,7 +13,9 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 
 ## Install SimpleSAMLphp
 
-1. Download [SimpleSAMLphp version 1.14.x](https://simplesamlphp.org/) and add it to your git repository as `/private/simplesamlphp-1.14.x`.
+Note: PHP mcrypt is still used in SimpleSAMLphp 1.14.x, but removed as a dependency in SimpleSAML 1.15.x version. PHP mcrypt has been depcreated in PHP 7.1 version, and removed from core PHP 7.2 version. Consider using the appropriate lower versions if issues are encountered.
+
+1. Download [SimpleSAMLphp version 1.15.x](https://simplesamlphp.org/) and add it to your git repository as `/private/simplesamlphp-1.15.x`.
 
         wget https://simplesamlphp.org/download\?latest -O simplesamlphp-latest.tar.gz
         mkdir private
@@ -21,14 +23,14 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
         git add private
         git commit -am "Adding SimpleSAML"
 
-2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.14.x/www`:
+2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.15.x/www`:
 
 
         ln -s ./private/simplesamlphp-1.14.x/www ./simplesaml
         git add simplesaml
         git commit -am "Adding SimpleSAML symlink"
 
-3. [Generate or install certs](https://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to the repository in `/private/simplesamlphp-1.14.x/cert`.
+3. [Generate or install certs](https://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to the repository in `/private/simplesamlphp-1.15.x/cert`.
 
 ## Configure SimpleSAMLphp
 
@@ -81,7 +83,7 @@ Set up your SimpleSAMLphp `config.php` as follows:
 4. With configuration completed, commit the changes to your SimpleSAMLphp files:
 
 
-        git add private/simplesamlphp-1.14.x
+        git add private/simplesamlphp-1.15.x
         git commit -am "Adding SimpleSaml config files."
 
 
@@ -94,13 +96,13 @@ Add the following lines to `settings.php` so that the Drupal module can locate S
 For Drupal 7 sites:
 ```php
 # Provide universal absolute path to the installation.
-$conf['simplesamlphp_auth_installdir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.14.x';
+$conf['simplesamlphp_auth_installdir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.15.x';
 ```
 
 For Drupal 8 sites:
 ```php
 # Provide universal absolute path to the installation.
-$settings['simplesamlphp_dir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.14.x';
+$settings['simplesamlphp_dir'] = $_ENV['HOME'] .'/code/private/simplesamlphp-1.15.x';
 ```
 
 You can now enable and configure the module. If SAML authentication fails because of a configuration error, look at the watchdog log to see why.

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -4,7 +4,7 @@ description: Using SimpleSAMLphp to configure a single sign-on system for your D
 tags: [siteintegrations, security]
 categories: [automate]
 ---
-Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.14/simplesamlphp-sp). This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
+Start by following the SimpleSAMLphp's [service provider quickstart instructions](https://simplesamlphp.org/docs/1.15/simplesamlphp-sp){.external}. This documentation contains only the necessary extra steps to get it working on Pantheon with Drupal or WordPress.
 
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
@@ -13,24 +13,35 @@ Start by following the SimpleSAMLphp's [service provider quickstart instructions
 
 ## Install SimpleSAMLphp
 
-Note: PHP mcrypt is still used in SimpleSAMLphp 1.14.x, but removed as a dependency in SimpleSAML 1.15.x version. PHP mcrypt has been depcreated in PHP 7.1 version, and removed from core PHP 7.2 version. Consider using the appropriate lower versions if issues are encountered.
+<div class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">[PHP mcrypt](http://php.net/manual/en/book.mcrypt.php){.external} is still used in SimpleSAMLphp 1.14.x, but removed as a dependency in SimpleSAML 1.15.x. PHP mcrypt has been depcreated in PHP 7.1, and removed from core PHP 7.2. Consider using the appropriate lower versions if you encounter issues.
+</p></div>
 
-1. Download [SimpleSAMLphp version 1.15.x](https://simplesamlphp.org/) and add it to your git repository as `/private/simplesamlphp-1.15.x`.
+<div class="alert alert-export" role="alert">
+<h4 class="info">Version Number</h4>
+<p markdown="1">In the code examples below, replace `15.x` with the downloaded version of SimpleSAMLphp.
+</p>
+</div>
 
-        wget https://simplesamlphp.org/download\?latest -O simplesamlphp-latest.tar.gz
-        mkdir private
-        tar -zxvf simplesamlphp-latest.tar.gz -C private
-        git add private
-        git commit -am "Adding SimpleSAML"
+1. Download [SimpleSAMLphp version 1.15.x](https://simplesamlphp.org/){.external} and add it to your git repository as `/private/simplesamlphp-1.15.x`.
+
+    ```bash
+    wget https://simplesamlphp.org/download?latest -O simplesamlphp-latest.tar.gz
+    mkdir private
+    tar -zxvf simplesamlphp-latest.tar.gz -C private
+    git add private
+    git commit -am "Adding SimpleSAML"
+    ```
 
 2. Add a symlink to your repository from `/simplesaml` to `/private/simplesamlphp-1.15.x/www`:
 
 
-        ln -s ./private/simplesamlphp-1.14.x/www ./simplesaml
+        ln -s ./private/simplesamlphp-1.15.x/www ./simplesaml
         git add simplesaml
         git commit -am "Adding SimpleSAML symlink"
 
-3. [Generate or install certs](https://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1) as needed and add them to the repository in `/private/simplesamlphp-1.15.x/cert`.
+3. [Generate or install certs](https://simplesamlphp.org/docs/1.9/simplesamlphp-sp#section_1_1){.external} as needed and add them to the repository in `/private/simplesamlphp-1.15.x/cert`.
 
 ## Configure SimpleSAMLphp
 
@@ -109,7 +120,7 @@ You can now enable and configure the module. If SAML authentication fails becaus
 
 ## WordPress Configuration
 
-To use SimpleSAMLphp with WordPress, first install and activate the [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) plugin.
+To use SimpleSAMLphp with WordPress, first install and activate the [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/){.external} plugin.
 
 Then, to configure the WP SAML Auth plugin to work with SimpleSAMLphp, add the following filter to your theme's `functions.php` file:
 
@@ -117,15 +128,15 @@ Then, to configure the WP SAML Auth plugin to work with SimpleSAMLphp, add the f
 add_filter( 'wp_saml_auth_option', function( $value, $option ){
   if ( 'simplesamlphp_autoload' === $option ) {
     // Note: Your path may differ, if you've installed a later SimpleSAMLphp version
-    $value = ABSPATH . '/private/simplesamlphp-1.14.11/lib/_autoload.php';
+    $value = ABSPATH . '/private/simplesamlphp-1.15.x/lib/_autoload.php';
   }
   return $value;
 }, 10, 2 );
 ```
 
-For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md).
+For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md){.external}.
 
 ## Troubleshooting
 ### Varnish Not Working/Cookie Being Set for Anonymous Users
 
-The current version of the SimpleSAMLphp Authentication module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. There are two patches; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.
+The current version of the SimpleSAMLphp Authentication module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009){.external} in the official issue queue. There are two patches; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537){.external} looks to be the best solution until the fix is accepted into an official project release.


### PR DESCRIPTION
Closes #3995 

## Effect
PR includes the following changes:
- Highlight SimpleSAML version 1.15.x 
- Highlight PHP mcrypt deprecation

## Remaining Work
- [x] Markup for a Warning or Notes section
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
