### PR TITLE
Update D8 no Composer guide to add a missing step

### DIFF
--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -79,6 +79,8 @@ Next, you will need to modify `composer.json`.
 * Remove all dependencies in the `require-dev` section.
 * Update the `scripts` section to remove the `lint`, `code-sniff`, and `unit-test` lines.
 * Remove the `"find .circleci/scripts/pantheon/ -type f | xargs chmod 755",` line from the `post-update-cmd` section of `scripts`.
+* Remove the `"find tests/scripts/ -type f | xargs chmod 755"` line from the `post-update-cmd` section of `scripts`.
+    * You will may need to remove a trailing comma from the end of the last item in the `post-update-cmd` section, otherwise the JSON will be invalid.
 
 ## Managing Drupal with Composer
 

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -80,7 +80,7 @@ Next, you will need to modify `composer.json`.
 * Update the `scripts` section to remove the `lint`, `code-sniff`, and `unit-test` lines.
 * Remove the `"find .circleci/scripts/pantheon/ -type f | xargs chmod 755",` line from the `post-update-cmd` section of `scripts`.
 * Remove the `"find tests/scripts/ -type f | xargs chmod 755"` line from the `post-update-cmd` section of `scripts`.
-    * You will may need to remove a trailing comma from the end of the last item in the `post-update-cmd` section, otherwise the JSON will be invalid.
+    * You may need to remove a trailing comma from the end of the last item in the `post-update-cmd` section, otherwise the JSON will be invalid.
 
 ## Managing Drupal with Composer
 


### PR DESCRIPTION
Closes #4007

## Effect
PR includes the following changes:
- Add a step to remove an additional line from `composer.json`

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
