### PR TITLE
Drush versions: Note that Drush 8 works for Drupal 6-8.

### DIFF
--- a/source/_docs/drush-versions.md
+++ b/source/_docs/drush-versions.md
@@ -4,7 +4,7 @@ description: Learn about Pantheon's default Drush version and how to implement s
 tags: [devdrush, services, pantheonyml]
 categories: [drupal]
 ---
-By default, Pantheon runs Drush 8 on newly created Drupal sites.
+By default, Pantheon runs Drush 8 on newly created Drupal sites. Drush 8 is compatible with Drupal 6, 7, and 8.
 
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>


### PR DESCRIPTION
## Effect

There has been some confusion around whether or not Drush 8 works with Drupal versions released prior to Drupal 8. 

This PR adds a note to [Drush Versions](https://pantheon.io/docs/drush-versions) that Drush 8 works with Drupal 6-8, per the Drush docs: http://docs.drush.org/en/master/install/

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
