### PR TITLE
Update documentation with pantheon.yml caveat

### DIFF
--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -78,6 +78,11 @@ remote: >   8.0 is not one of [5.3, 5.5, 5.6, 7.0]
 
 Modify `pantheon.yml` until valid and commit the fix before attempting to push again.
 
+<div markdown="1" class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">As of this writing, deploying to the test or live environments with `git tag` will not trigger the PHP upgrade because the pantheon.yml changes are not detected using this method. Instead you must use the Pantheon's workflow and dashboard to promote and trigger the changes from DEV to TEST to LIVE.</p>
+</div>
+
 #### SFTP Mode
 
 When you upload a new or modified `pantheon.yml` file in SFTP mode, your site dashboard will detect the changes:


### PR DESCRIPTION
For reference, we had a conversation with support and uncovered this caveat.

https://dashboard.pantheon.io/organizations/ed90aecf-6a42-4111-93d5-1f751257c502#support/ticket/105012

## Effect
PR includes the following changes:
- Update documentation with pantheon.yml + git tag deploy caveat

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
