### PR TITLE
Crosslink hotfix changes to pantheon note

### DIFF
--- a/source/_docs/pantheon-yml.md
+++ b/source/_docs/pantheon-yml.md
@@ -135,7 +135,7 @@ remote:
 ```
 
 ### Deploying Hotfixes
-Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/docs/hotfixes/). As a workaround, make some modification to `pantheon.yml` file in a development environment and deploy up to production using the standard Pantheon workflow.
+Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/docs/hotfixes/). As a workaround, make a modification to your `pantheon.yml` file in a development environment (e.g, add a code comment), then deploy up to production using the standard Pantheon workflow.
 
 ## See Also
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/docs/quicksilver/)

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -78,6 +78,11 @@ remote: >   8.0 is not one of [5.3, 5.5, 5.6, 7.0]
 
 Modify `pantheon.yml` until valid and commit the fix before attempting to push again.
 
+<div markdown="1" class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">As of this writing, deploying to the test or live environments with `git tag` will not trigger the PHP upgrade because the pantheon.yml changes are not detected using this method. Instead you must use the Pantheon's workflow and dashboard to promote and trigger the changes from DEV to TEST to LIVE.</p>
+</div>
+
 #### SFTP Mode
 
 When you upload a new or modified `pantheon.yml` file in SFTP mode, your site dashboard will detect the changes:

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -80,7 +80,7 @@ Modify `pantheon.yml` until valid and commit the fix before attempting to push a
 
 <div markdown="1" class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
-<p markdown="1">As of this writing, deploying to the test or live environments with `git tag` will not trigger the PHP upgrade because the pantheon.yml changes are not detected using this method. Instead you must use the Pantheon's workflow and dashboard to promote and trigger the changes from DEV to TEST to LIVE.</p>
+<p markdown="1">Changes to `pantheon.yml` [deployed as hotfixes](/docs/pantheon-yml#deploying-hotfixes) are not detected.</p>
 </div>
 
 #### SFTP Mode


### PR DESCRIPTION
Amends #4024 

## Effect
PR includes the following changes:
- Notes in the PHP versions doc that changes to pantheon.yml in hotfixes aren't detected.
- Links to existing note in the Pantheon.yml doc created in #3698

## Remaining Work
- [ ] Review from @wturnerharris
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
