### PR TITLE
Added suggestions for custom certs

### DIFF
--- a/source/_docs/custom-certificates.md
+++ b/source/_docs/custom-certificates.md
@@ -118,7 +118,7 @@ Please allow two business days to get a CSR and load the certificate.
 
 ### What about new Enterprise sites or sites purchased online?
 
-Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know while we are still gathering interest](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}. If bringing your own certificate is an immediate requirement, please see the suggestions [here](/docs/https/#can-i-bring-my-own-certificate).
+Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know while we are still gathering interest](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}. If bringing your own certificate is an immediate requirement, please see the suggestions <a href="/docs/https/#can-i-bring-my-own-certificate" data-proofer-ignore>here</a>.
 
 ### Will custom certificates be self-serve?
 

--- a/source/_docs/custom-certificates.md
+++ b/source/_docs/custom-certificates.md
@@ -118,7 +118,7 @@ Please allow two business days to get a CSR and load the certificate.
 
 ### What about new Enterprise sites or sites purchased online?
 
-Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}.
+Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know while we are still gathering interest](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}. If bringing your own certificate is an immediate requirement, please see the suggestions [here](https://pantheon.io/docs/https/#can-i-bring-my-own-certificate).
 
 ### Will custom certificates be self-serve?
 

--- a/source/_docs/custom-certificates.md
+++ b/source/_docs/custom-certificates.md
@@ -118,7 +118,7 @@ Please allow two business days to get a CSR and load the certificate.
 
 ### What about new Enterprise sites or sites purchased online?
 
-Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know while we are still gathering interest](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}. If bringing your own certificate is an immediate requirement, please see the suggestions [here](https://pantheon.io/docs/https/#can-i-bring-my-own-certificate).
+Custom certificates are currently available to customers with a Pantheon contract using Legacy SSL. We have no current plans to offer it to new sites or Basic or Performance sites. If you are interested in using a custom certificate, however, please [let us know while we are still gathering interest](https://learn.pantheon.io/201806-Custom-Cert-Reg.html){.external}. If bringing your own certificate is an immediate requirement, please see the suggestions [here](/docs/https/#can-i-bring-my-own-certificate).
 
 ### Will custom certificates be self-serve?
 


### PR DESCRIPTION
As suggested by @thomas-thackery in the internal Slack: https://pantheon.slack.com/archives/C03SU7UCJ/p1533671916000116

Closes #4027

## Effect
Add suggestions on what customers should do if they do not qualify for Custom SSL certs. Please feel free to modify @thomas-thackery @alexfornuto on what would best for customers to be guided in having their custom ssl sorted out.

## Remaining Work

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
