### PR TITLE
Updating #POPs Fastly Supports

### DIFF
--- a/source/_docs/global-cdn.md
+++ b/source/_docs/global-cdn.md
@@ -5,7 +5,7 @@ earlynote: The documentation on this page discusses features and options that ar
 searchboost: 200
 ---
 
-Pantheon's new [Global CDN](https://pantheon.io/global-cdn){.external} is a core platform offering, with improved performance and security for customer sites. Content is served from 40+ global POPs (points of presence) where site pages and assets are cached, plus [free managed HTTPS](/docs/https) using [Let's Encrypt](https://letsencrypt.org){.external}.
+Pantheon's new [Global CDN](https://pantheon.io/global-cdn){.external} is a core platform offering, with improved performance and security for customer sites. Content is served from 60+ global POPs (points of presence) where site pages and assets are cached, plus [free managed HTTPS](/docs/https) using [Let's Encrypt](https://letsencrypt.org){.external}.
 
 <div class="enablement">
   <h4 class="info" markdown="1">[Agency DevOps Training](https://pantheon.io/agencies/learn-pantheon?docs){.external}</h4>


### PR DESCRIPTION
Updates to #POPs per https://www.fastly.com/network-map

Closes #

## Effect
PR includes the following changes:
- updating #POPs fastly supports per https://www.fastly.com/network-map

## Remaining Work
- Are there other references to the 40+ number?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
