### PR TITLE
Edit description for redirect scenario

### DIFF
--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -29,7 +29,7 @@ The following configuration will redirect HTTP to HTTPS _and_ enforce use of a p
 ## Additional Redirects (Optional)
 Implement scenario specific redirects as required by the site. Depending on the needs of the site, you may only need one, some, or none of the following.
 ### Redirect to HTTPS
-The following configuration will redirect HTTP requests to HTTPS, such as `http://env-site-name.pantheonsite.io` to `https://env-site-name.pantheonsite.io` or `http://example.com` to `https://example.com`:
+The following configuration will redirect HTTP requests to HTTPS, such as `http://env-site-name.pantheonsite.io` to `https://env-site-name.pantheonsite.io`:
 
 ```php
 // Require HTTPS across all Pantheon environments


### PR DESCRIPTION

## Effect
PR includes the following changes:
- Remove part of the description for the Redirect to HTTPS scenario to reduce confusion around the behavior of the snippet. Providing an example with a custom domain reads as if the snippet enforces a standard domain when it simply enforces HTTPS 

@alexfornuto feel free to reject this PR and/or gather additional input from CSE