### PR TITLE
Add keyword to help documentation discoverability.

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -153,7 +153,7 @@ For details, see [Configure Redirects](/docs/redirects/#php-vs-htaccess).
 
 ### Drupal False Positive
 
-Drupal 7 and 8 checks for arbitratry code execution prevention by looking for a specific string in the `.htaccess` file. Since Pantheon uses NGINX as described above, this message can be safely ignored. For more details, see [this Drupal.org issue](https://www.drupal.org/project/drupal/issues/2150399){.external} on SA-CORE-2013-003.
+Drupal 7 and 8 checks for arbitratry code execution prevention by looking for a specific string in the `.htaccess` file. Since Pantheon uses NGINX as described above, this message can be safely ignored. For more details, see [this Drupal.org issue](https://www.drupal.org/project/drupal/issues/2150399){.external} on `SA-CORE-2013-003`.
 
 ## nginx.conf
 

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -153,7 +153,7 @@ For details, see [Configure Redirects](/docs/redirects/#php-vs-htaccess).
 
 ### Drupal False Positive
 
-Drupal 7 and 8 checks for arbitratry code execution prevention by looking for a specific string in the `.htaccess` file. Since Pantheon uses NGINX as described above, this message can be safely ignored. For more details, see [this Drupal.org issue](https://www.drupal.org/project/drupal/issues/2150399){.external}.
+Drupal 7 and 8 checks for arbitratry code execution prevention by looking for a specific string in the `.htaccess` file. Since Pantheon uses NGINX as described above, this message can be safely ignored. For more details, see [this Drupal.org issue](https://www.drupal.org/project/drupal/issues/2150399){.external} on SA-CORE-2013-003.
 
 ## nginx.conf
 


### PR DESCRIPTION
I had a customer with questions about the SA-CORE-2013-003 alert and only found this documentation via a Google search that pointed me to https://github.com/pantheon-systems/documentation/issues/3838. I thought I'd take a stab at improving findability.

Closes # n/a

Related to #3838 and #3896 

## Effect
PR includes the following changes:
- Adds keyword (Drupal security update number) to Drupal False Positive documentation

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
