### PR TITLE
Add Cygwin as an option for Windows users.

### DIFF
--- a/source/_docs/terminus/install.md
+++ b/source/_docs/terminus/install.md
@@ -14,7 +14,7 @@ searchboost: 100
 ---
 Terminus is available for Mac OS X and Linux
 
-Some Windows users have installed Terminus using [Git BASH on Git for Windows](https://git-for-windows.github.io/){.external}, or the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){.external}, but this is unsupported.
+Some Windows users have installed Terminus using [Git BASH on Git for Windows](https://git-for-windows.github.io/){.external}, or the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10){.external}, but this is unsupported. You can also use [Cygwin on Windows](/docs/cygwin-windows/).
 
 Because some Terminus command use SSH authentication, consider [generating and adding SSH keys](/docs/ssh-keys/) to your account before you continue.
 


### PR DESCRIPTION
We document Cygwin as a way to install Terminus on Windows, but it wasn't previously linked here.

Closes # n/a

## Effect
PR includes the following changes:
- Adds Cygwin as an option, with a link to our documentation.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
