### PR TITLE
Update Drupal module recommendation for S3.

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -94,7 +94,7 @@ Pantheon cannot be used to host files over 256MB, no matter how the file is upl
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
- - Drupal sites can use a module such as [Amazon S3 CORS Upload](https://drupal.org/project/amazons3_cors){.external}
+ - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}
  - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload S3](https://deliciousbrains.com/wp-offload-s3/){.external}
 
 See our documentation for [Drupal](/docs/drupal-s3) and [WordPress](/docs/wordpress-s3/) for more information about integrating S3 with your Pantheon site.


### PR DESCRIPTION
Closes #3843

## Effect
PR includes the following changes:
- Updates Drupal module recommendation for S3. The updated recommendation matches up with our S3 doc here: https://pantheon.io/docs/drupal-s3/

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
