### PR TITLE
add debug.log location override in wpconfig

### DIFF
--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -207,17 +207,20 @@ if (defined('PANTHEON_ENVIRONMENT')) {
     if (!defined( 'WP_DEBUG' )) {
     define( 'WP_DEBUG', true );
     }
-    define( 'WP_DEBUG_LOG', true ); // Stored in wp-content/debug.log
+    ini_set('log_errors','On');
+    ini_set('display_errors','On');
+    ini_set('error_reporting', E_ALL );
+    define( 'WP_DEBUG_LOG', true ); // Stored in wp-content/debug.log by default.
+    ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' ); // Optionally overrides the debug.log location to a writable path.
     define( 'WP_DEBUG_DISPLAY', true );
   }
   // Wordpress debug settings in test and live environments.
   else {
     // Debugging disabled.
-    ini_set('log_errors','On');
+    ini_set('log_errors','Off');
     ini_set('display_errors','Off');
-    ini_set('error_reporting', E_ALL );
     define('WP_DEBUG', false);
-    define('WP_DEBUG_LOG', true);
+    define('WP_DEBUG_LOG', false);
     define('WP_DEBUG_DISPLAY', false);
   }
 }

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -198,7 +198,7 @@ No, Varnish logs are not available for download.
 ### How do I enable error logging for WordPress?
 Enable the [WP_DEBUG and WP_DEBUG_LOG](https://codex.wordpress.org/Debugging_in_WordPress) constants on Development environments (Dev and Multidevs) to write errors to `wp-content/debug.log` and show all PHP errors, notices, and warnings on the page. We suggest setting the WordPress debugging constants per environment:
 <script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/wordpress/wp-debug-expanded.wp-config.php?footer=minimal"></script>
-By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments but can be overridden to the [`/wp-content/uploads/` folder](/docs/wp-config-php/#how-do-i-change-the-default-debug-log-location).
+By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments. This can be overridden to the [`/wp-content/uploads/` folder](/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location).
 
 ### How can I access the Drupal event log?
 

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -223,7 +223,13 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 }
 ```
 
-By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments. This can be overridden to the [`/wp-content/uploads/` folder](/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location).
+By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments. This can be overridden to the <a href="/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location" data-proofer-ignore>`/wp-content/uploads/` folder</a>.
+
+
+<div class="alert alert-danger" role="alert" markdown="1">
+#### Warning {.info}
+Enabling debug logging is not recommended for production environments due to the increased resource overhead. If you need to enable debug logging on the live environment to resolve a problem, remember to disable it when you are done.
+</div>
 
 ### How can I access the Drupal event log?
 

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -231,7 +231,7 @@ By default, the WordPress debug log path is set to `/wp-content/` and not writab
 
 <div class="alert alert-danger" role="alert" markdown="1">
 #### Warning {.info}
-Enabling debug logging is not recommended for production environments due to the increased resource overhead. If you need to enable debug logging on the live environment to resolve a problem, remember to disable it when you are done.
+Enabling debug logging is not recommended for production environments due to the increased resource overhead and security risk. If you need to enable debug logging on the live environment to resolve a problem, remember to disable it when you are done.
 </div>
 
 ### How can I access the Drupal event log?

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -198,7 +198,7 @@ No, Varnish logs are not available for download.
 ### How do I enable error logging for WordPress?
 Enable the [WP_DEBUG and WP_DEBUG_LOG](https://codex.wordpress.org/Debugging_in_WordPress) constants on Development environments (Dev and Multidevs) to write errors to `wp-content/debug.log` and show all PHP errors, notices, and warnings on the page. We suggest setting the WordPress debugging constants per environment:
 <script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/wordpress/wp-debug-expanded.wp-config.php?footer=minimal"></script>
-Writing to `wp-content/debug.log` is not supported on Test or Live environments.
+By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments but can be overridden to the [`/wp-content/uploads/` folder](/docs/wp-config-php/#how-do-i-change-the-default-debug-log-location).
 
 ### How can I access the Drupal event log?
 

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -196,6 +196,14 @@ No, access to Apache Solr logs is not available. For more information on debuggi
 No, Varnish logs are not available for download.
 
 ### How do I enable error logging for WordPress?
+
+<div class="alert alert-danger" role="alert" markdown="1">
+#### Warning {.info}
+The steps in this section enable debug logging. Debug logging increases resource overhead and presents a security risk. It is not recommended for production environments.
+
+To minimize risk exposure, especially in a Live environment, disable debug logging when you are done.
+</div>
+
 Enable the [WP_DEBUG and WP_DEBUG_LOG](https://codex.wordpress.org/Debugging_in_WordPress) constants on Development environments (Dev and Multidevs) to write errors to `wp-content/debug.log` and show all PHP errors, notices, and warnings on the page. We suggest setting the WordPress debugging constants per environment in `wp-config.php`:
 
 ```php
@@ -226,13 +234,7 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 }
 ```
 
-By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments. This can be overridden to the <a href="/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location" data-proofer-ignore>`/wp-content/uploads/` folder</a>.
-
-
-<div class="alert alert-danger" role="alert" markdown="1">
-#### Warning {.info}
-Enabling debug logging is not recommended for production environments due to the increased resource overhead and security risk. If you need to enable debug logging on the live environment to resolve a problem, remember to disable it when you are done.
-</div>
+By default, the WordPress debug log path is set to `/wp-content/` and is not writable on Test or Live environments. This can be overridden to the <a href="/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location" data-proofer-ignore>`/wp-content/uploads/` folder</a>.
 
 ### How can I access the Drupal event log?
 

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -196,8 +196,33 @@ No, access to Apache Solr logs is not available. For more information on debuggi
 No, Varnish logs are not available for download.
 
 ### How do I enable error logging for WordPress?
-Enable the [WP_DEBUG and WP_DEBUG_LOG](https://codex.wordpress.org/Debugging_in_WordPress) constants on Development environments (Dev and Multidevs) to write errors to `wp-content/debug.log` and show all PHP errors, notices, and warnings on the page. We suggest setting the WordPress debugging constants per environment:
-<script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/wordpress/wp-debug-expanded.wp-config.php?footer=minimal"></script>
+Enable the [WP_DEBUG and WP_DEBUG_LOG](https://codex.wordpress.org/Debugging_in_WordPress) constants on Development environments (Dev and Multidevs) to write errors to `wp-content/debug.log` and show all PHP errors, notices, and warnings on the page. We suggest setting the WordPress debugging constants per environment in `wp-config.php`:
+
+```php
+// All Pantheon Environments.
+if (defined('PANTHEON_ENVIRONMENT')) {
+  //Wordpress debug settings in development environments.
+  if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+    // Debugging enabled.
+    if (!defined( 'WP_DEBUG' )) {
+    define( 'WP_DEBUG', true );
+    }
+    define( 'WP_DEBUG_LOG', true ); // Stored in wp-content/debug.log
+    define( 'WP_DEBUG_DISPLAY', true );
+  }
+  // Wordpress debug settings in test and live environments.
+  else {
+    // Debugging disabled.
+    ini_set('log_errors','On');
+    ini_set('display_errors','Off');
+    ini_set('error_reporting', E_ALL );
+    define('WP_DEBUG', false);
+    define('WP_DEBUG_LOG', true);
+    define('WP_DEBUG_DISPLAY', false);
+  }
+}
+```
+
 By default, the WordPress debug log path is set to `/wp-content/` and not writable on Test or Live environments. This can be overridden to the [`/wp-content/uploads/` folder](/docs/wp-config-php/#how-do-i-change-the-default-debuglog-location).
 
 ### How can I access the Drupal event log?

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -105,7 +105,7 @@ See [Configure Redirects](/docs/redirects/).
 
 ### How do I change the default debug.log location?
 
-WordPress has an option to write logging information to a [file](/docs/logs/#how-do-i-enable-error-logging-for-wordpress) when enabled. By default, the file is located in the `/wp-content` folder, which is not writable on all environments in Pantheon. You can change the location of this file to the uploads folder by adding the following to `wp-config.php`:
+WordPress has an option to write logging information to a <a href="/docs/logs/#how-do-i-enable-error-logging-for-wordpress" data-proofer-ignore>file</a> when enabled. By default, the file is located in the `/wp-content` folder, which is not writable on all environments in Pantheon. You can change the location of this file to the uploads folder by adding the following to `wp-config.php`:
 
 ```php
 ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -120,9 +120,6 @@ You don't have to! Pantheon automatically injects database credentials into the
 - [Pantheon WordPress](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php){.external}
 - [WordPress Core](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php){.external}
 
-### Where can I find examples of Pantheon's wp-config.php?
-You can view examples at the [pantheon-settings-examples repo](https://github.com/pantheon-systems/pantheon-settings-examples/tree/master/wordpress){.external}.
-
 ## Troubleshooting
 ### Request to a Remote API Does Not Return Expected Response
 

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -52,9 +52,11 @@ See [Configure Redirects](/docs/redirects/).
 
 ### How do I change the default debug.log location?
 
-WordPress has an option to write logging information to a [file](/docs/logs/#how-do-i-enable-error-logging-for-wordpress) when enabled. By default, the location of the debug file is located in the /wp-content folder which is not writable on all environments in Pantheon. You can change the location of that file to the uploads folder by adding this in the wp-confi.php:
+WordPress has an option to write logging information to a [file](/docs/logs/#how-do-i-enable-error-logging-for-wordpress) when enabled. By default, the file is located in the `/wp-content` folder, which is not writable on all environments in Pantheon. You can change the location of this file to the uploads folder by adding the following to `wp-config.php`:
 
-```ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );```
+```php
+ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );
+```
 
 ### Where do I specify database credentials?
 

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -50,6 +50,12 @@ See [Reading the Pantheon Environment Configuration](/docs/read-environment-conf
 
 See [Configure Redirects](/docs/redirects/).
 
+### How do I change the default debug.log location?
+
+WordPress has an option to write logging information to a [file](/docs/logs/#how-do-i-enable-error-logging-for-wordpress) when enabled. By default, the location of the debug file is located in the /wp-content folder which is not writable on all environments in Pantheon. You can change the location of that file to the uploads folder by adding this in the wp-confi.php:
+
+```ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );```
+
 ### Where do I specify database credentials?
 
 You don't have to! Pantheon automatically injects database credentials into the site environment; if you hard code database credentials, you will break the Pantheon workflow.

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -21,9 +21,22 @@ If you are also developing locally and need to configure WordPress for your desk
 
 ## Pantheon's WordPress Config
 
+<div class="panel panel-drop panel-guide" id="accordion">
+<div class="panel-heading panel-drop-heading">
+<a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#unique-anchor">
+<h3 class="info panel-title panel-drop-title" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-wrench"></span>View Pantheon's WordPress Configuration</h3>
+</a>
+</div>
+<div id="unique-anchor" class="collapse" markdown="1" style="padding:10px;">
+
 <script src="//gist-it.appspot.com/https://github.com/pantheon-systems/wordpress/blob/master/wp-config.php?footer=minimal"></script>
+</div>
+</div>
+
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4><p><code>$_SERVER['SERVER_NAME']</code> should <strong>not</strong> be used to set <code>WP_HOME</code> and/or <code>WP_SITEURL</code>. For more information, see <a href="/docs/server_name-and-server_port/">SERVER_NAME and SERVER_PORT on Pantheon</a>.</p></div>
+
+
 
 ##Frequently Asked Questions
 
@@ -33,15 +46,55 @@ Depending on your use case, there are two possibilities.
 
 For web only actions, like [redirects](/docs/domains/#primary-domain), check for the existence of `$_ENV['PANTHEON_ENVIRONMENT']`. If it exists, it will contain a string with the current environment (Dev, Test, or Live).
 
-<script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/%24_SERVER-environment?footer=minimal"></script>
+```php
+// Pantheon - web only.
+if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
+  // Only on dev web environment.
+  if ($_SERVER['PANTHEON_ENVIRONMENT'] == 'dev') {
+    // Custom code.
+  }
+}
+```
 
-For actions that should take place on both web requests _and_ wp-cli commands (e,g, Redis cache configuration), use the constant ​`PANTHEON_ENVIRONMENT`. Again, it will contain Dev, Test, or Live.
+For actions that should take place on both web requests _and_ wp-cli commands (e,g, Redis cache configuration), use the constant `PANTHEON_ENVIRONMENT`. Again, it will contain Dev, Test, or Live.
 
-<script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/web-cli-environment?footer=minimal"></script>
+```php
+// Pantheon - all (web and CLI) operations.
+if (defined('PANTHEON_ENVIRONMENT')) {
+  // Only on dev environment.
+  if (PANTHEON_ENVIRONMENT == 'dev') {
+    // Custom code.
+  }
+}
+```
 
-As an example, here's how you can hard-code your WordPress debug configuration based on the environment. To learn more, see [Defining variables in a wp-config.php](https://codex.wordpress.org/Editing_wp-config.php).
+As an example, here's how you can hard-code your WordPress debug configuration based on the environment. To learn more, see [Defining variables in a wp-config.php](https://codex.wordpress.org/Editing_wp-config.php){.external}.
 
-<script src="//gist-it.appspot.com/https://github.com/pantheon-systems/pantheon-settings-examples/blob/master/wordpress/wp-debug-expanded.wp-config.php?footer=minimal"></script>
+```php
+// All Pantheon Environments.
+if (defined('PANTHEON_ENVIRONMENT')) {
+  //Wordpress debug settings in development environments.
+  if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+    // Debugging enabled.
+    if (!defined( 'WP_DEBUG' )) {
+    define( 'WP_DEBUG', true );
+    }
+    define( 'WP_DEBUG_LOG', true ); // Stored in wp-content/debug.log
+    define( 'WP_DEBUG_DISPLAY', true );
+  }
+  // Wordpress debug settings in test and live environments.
+  else {
+    // Debugging disabled.
+    ini_set('log_errors','On');
+    ini_set('display_errors','Off');
+    ini_set('error_reporting', E_ALL );
+    define('WP_DEBUG', false);
+    define('WP_DEBUG_LOG', true);
+    define('WP_DEBUG_DISPLAY', false);
+  }
+}
+```
+
 ### How can I read the Pantheon environmental configuration, like database credentials?
 
 See [Reading the Pantheon Environment Configuration](/docs/read-environment-config/).
@@ -64,11 +117,11 @@ You don't have to! Pantheon automatically injects database credentials into the
 
 ### Where can I get a copy of a default wp-config.php for Pantheon?
 
-- Pantheon WordPress -  [https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php)
-- WordPress Core -   [https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php)
+- Pantheon WordPress -  [https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php){.external}
+- WordPress Core -   [https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php){.external}
 
 ### Where can I find examples of Pantheon wp-config.php?
-You can view examples at the [pantheon-settings-examples repo](https://github.com/pantheon-systems/pantheon-settings-examples/tree/master/wordpress).
+You can view examples at the [pantheon-settings-examples repo](https://github.com/pantheon-systems/pantheon-settings-examples/tree/master/wordpress){.external}.
 
 ## Troubleshooting
 ### Request to a Remote API Does Not Return Expected Response

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -23,11 +23,11 @@ If you are also developing locally and need to configure WordPress for your desk
 
 <div class="panel panel-drop panel-guide" id="accordion">
 <div class="panel-heading panel-drop-heading">
-<a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#unique-anchor">
+<a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#pantheon-wp-config-php">
 <h3 class="info panel-title panel-drop-title" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-wrench"></span>View Pantheon's WordPress Configuration</h3>
 </a>
 </div>
-<div id="unique-anchor" class="collapse" markdown="1" style="padding:10px;">
+<div id="pantheon-wp-config-php" class="collapse" markdown="1" style="padding:10px;">
 
 <script src="//gist-it.appspot.com/https://github.com/pantheon-systems/wordpress/blob/master/wp-config.php?footer=minimal"></script>
 </div>
@@ -42,33 +42,33 @@ If you are also developing locally and need to configure WordPress for your desk
 
 ### How can I write logic based on the Pantheon server environment?
 
-Depending on your use case, there are two possibilities.
+Depending on your use case, there are two possibilities:
 
-For web only actions, like [redirects](/docs/domains/#primary-domain), check for the existence of `$_ENV['PANTHEON_ENVIRONMENT']`. If it exists, it will contain a string with the current environment (Dev, Test, or Live).
+1. For web only actions, like [redirects](/docs/domains/#primary-domain), check if `$_ENV['PANTHEON_ENVIRONMENT']` exists. If it does, it will contain a string with the current environment (Dev, Test, or Live):
 
-```php
-// Pantheon - web only.
-if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
-  // Only on dev web environment.
-  if ($_SERVER['PANTHEON_ENVIRONMENT'] == 'dev') {
-    // Custom code.
-  }
-}
-```
+ ```php
+ // Pantheon - web only.
+ if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
+      // Only on dev web environment.
+      if ($_SERVER['PANTHEON_ENVIRONMENT'] == 'dev') {
+       // Custom code.
+      }
+ }
+ ```
 
-For actions that should take place on both web requests _and_ wp-cli commands (e,g, Redis cache configuration), use the constant `PANTHEON_ENVIRONMENT`. Again, it will contain Dev, Test, or Live.
+2. For actions that should take place on both web requests _and_ wp-cli commands (e.g. Redis cache configuration), use the constant `PANTHEON_ENVIRONMENT`. Again, it will contain Dev, Test, or Live:
 
-```php
-// Pantheon - all (web and CLI) operations.
-if (defined('PANTHEON_ENVIRONMENT')) {
-  // Only on dev environment.
-  if (PANTHEON_ENVIRONMENT == 'dev') {
-    // Custom code.
-  }
-}
-```
+ ```php
+ // Pantheon - all (web and CLI) operations.
+ if (defined('PANTHEON_ENVIRONMENT')) {
+      // Only on dev environment.
+      if (PANTHEON_ENVIRONMENT == 'dev') {
+        // Custom code.
+      }
+ }
+ ```
 
-As an example, here's how you can hard-code your WordPress debug configuration based on the environment. To learn more, see [Defining variables in a wp-config.php](https://codex.wordpress.org/Editing_wp-config.php){.external}.
+The following example shows how to hard-code your WordPress debug configuration based on the environment. To learn more, see [Defining variables in a wp-config.php](https://codex.wordpress.org/Editing_wp-config.php){.external}:
 
 ```php
 // All Pantheon Environments.
@@ -105,7 +105,7 @@ See [Configure Redirects](/docs/redirects/).
 
 ### How do I change the default debug.log location?
 
-WordPress has an option to write logging information to a <a href="/docs/logs/#how-do-i-enable-error-logging-for-wordpress" data-proofer-ignore>file</a> when enabled. By default, the file is located in the `/wp-content` folder, which is not writable on all environments in Pantheon. You can change the location of this file to the uploads folder by adding the following to `wp-config.php`:
+WordPress has an option to <a href="/docs/logs/#how-do-i-enable-error-logging-for-wordpress" data-proofer-ignore>write logging information to a file</a>. When enabled, the file is located in the `/wp-content` folder, which is not writable on all environments in Pantheon. You can change the location of this file to the uploads folder by adding the following to `wp-config.php`:
 
 ```php
 ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );
@@ -117,10 +117,10 @@ You don't have to! Pantheon automatically injects database credentials into the
 
 ### Where can I get a copy of a default wp-config.php for Pantheon?
 
-- Pantheon WordPress -  [https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php){.external}
-- WordPress Core -   [https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php){.external}
+- [Pantheon WordPress](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php){.external}
+- [WordPress Core](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php){.external}
 
-### Where can I find examples of Pantheon wp-config.php?
+### Where can I find examples of Pantheon's wp-config.php?
 You can view examples at the [pantheon-settings-examples repo](https://github.com/pantheon-systems/pantheon-settings-examples/tree/master/wordpress){.external}.
 
 ## Troubleshooting


### PR DESCRIPTION
Closes #4069

## Effect
PR includes the following changes:
- Add relevant information in docs on how to enable it and how to make it work in the platform across all environments

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
