### PR TITLE
Visual Composer and WPBakery Page Builder

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -412,11 +412,16 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 <hr>
 
 ### [Visual Composer: Website Builder](https://visualcomposer.io/){.external}
-**Issue**: This plugin fails to download additional assets during the internal plugin activation procedure on Test and Live environemtns.
+**Issue**: This plugin fails to download additional assets during the internal plugin activation procedure on Test and Live environments.
 
 **Resolution**: If this plugin is installed and activated on a new site _before_ the Test and Live environment are created, it will properly transfer all assets and database settings to the additional environments.
 
-**Note**: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as of August 2018.
+**Note**: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as of August 2018. There is an extra step required as a workaround to make the plugin work. In `wp-config.php`, place this block of code:
+```
+if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    define('FS_METHOD', 'direct');
+}
+```
 
 <hr>
 
@@ -468,6 +473,18 @@ if (defined( "PANTHEON_BINDING" )) {
 **Please note:** You will need to make this change every timethat the plugin is updated.
 
 **Issue #2**: This plugin creates a session on every page, which can prevent [page level caching](https://wordpress.org/support/topic/cannot-cache-pages-due-to-sessions-on-every-page-with-wsl-plugin/){.external}.
+
+<hr>
+
+### [WPBakery: Page Builder](https://wpbakery.com/){.external}
+**Issue**: Custom CSS and Design Options pages of the plugin `(?page=vc-custom_css, ?page=vc-color)` tries to create new files when saved. Due to problems related to incorrect `FS_METHOD`, files are not created or saved in its expected folder `wp-content/uploads/js_composer`
+
+**Solution**: In `wp-config.php`, place this block of code:
+```
+if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    define('FS_METHOD', 'direct');
+}
+```
 
 <hr>
 

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -414,9 +414,9 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 ### [Visual Composer: Website Builder](https://visualcomposer.io/){.external}
 **Issue**: This plugin fails to download additional assets during the internal plugin activation procedure on Test and Live environments.
 
-**Resolution**: If this plugin is installed and activated on a new site _before_ the Test and Live environment are created, it will properly transfer all assets and database settings to the additional environments.
+**Solution 1**: If this plugin is installed and activated on a new site _before_ the Test and Live environment are created, it will properly transfer all assets and database settings to the additional environments.
 
-**Note**: Despite [release notes](https://visualcomposer.io/docs/release-notes/){.external} indicating the plugin now works on Pantheon, we find the plugin still has issues on our platform as of August 2018. There is an extra step required as a workaround to make the plugin work. In `wp-config.php`, place this block of code:
+**Solution 2**: To activate the plugin on existing Test and Live environments, add the following code block to `wp-config.php`:
 ```
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
     define('FS_METHOD', 'direct');
@@ -477,9 +477,10 @@ if (defined( "PANTHEON_BINDING" )) {
 <hr>
 
 ### [WPBakery: Page Builder](https://wpbakery.com/){.external}
-**Issue**: Custom CSS and Design Options pages of the plugin `(?page=vc-custom_css, ?page=vc-color)` tries to create new files when saved. Due to problems related to incorrect `FS_METHOD`, files are not created or saved in its expected folder `wp-content/uploads/js_composer`
+**Issue**: The Custom CSS and Design Options pages of the plugin (`?page=vc-custom_css, ?page=vc-color`) try to create new files when saved. Due to problems related to incorrect `FS_METHOD`, files are not created or saved in the expected folder `wp-content/uploads/js_composer`
 
 **Solution**: In `wp-config.php`, place this block of code:
+
 ```
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
     define('FS_METHOD', 'direct');

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -414,9 +414,9 @@ For an alternative 2FA plugin, see [Secure Your Site with Two-Factor Authenticat
 ### [Visual Composer: Website Builder](https://visualcomposer.io/){.external}
 **Issue**: This plugin fails to download additional assets during the internal plugin activation procedure on Test and Live environments.
 
-**Solution 1**: If this plugin is installed and activated on a new site _before_ the Test and Live environment are created, it will properly transfer all assets and database settings to the additional environments.
+**Solution 1: New sites, without existing Test and Live environments**: If this plugin is installed and activated on a new site _before_ the Test and Live environments are created, it will properly transfer all assets and database settings to the additional environments.
 
-**Solution 2**: To activate the plugin on existing Test and Live environments, add the following code block to `wp-config.php`:
+**Solution 2: Sites with existing Test and Live environments**: To activate the plugin on sites with existing Test and Live environments, add the following code block to `wp-config.php`:
 ```
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
     define('FS_METHOD', 'direct');
@@ -477,7 +477,7 @@ if (defined( "PANTHEON_BINDING" )) {
 <hr>
 
 ### [WPBakery: Page Builder](https://wpbakery.com/){.external}
-**Issue**: The Custom CSS and Design Options pages of the plugin (`?page=vc-custom_css, ?page=vc-color`) try to create new files when saved. Due to problems related to incorrect `FS_METHOD`, files are not created or saved in the expected folder `wp-content/uploads/js_composer`
+**Issue**: The Custom CSS and Design Options pages of the plugin (`?page=vc-custom_css`, `?page=vc-color`) try to create new files when saved. Due to problems related to incorrect `FS_METHOD`, files are not created or saved in the expected folder, `wp-content/uploads/js_composer`.
 
 **Solution**: In `wp-config.php`, place this block of code:
 


### PR DESCRIPTION
Added section for WPBakery Page Builder and Visual Composer about setting the workaround to make the plugin work

Closes #3805 
Closes #3975 

## Effect
PR includes the following changes:
- New Workaround for Visual Composer
- Added the WPBakery Page Builder plugin (original version)

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
