### PR TITLE
Exclude double quotes from TOC anchors

### DIFF
--- a/source/docs/assets/js/jquery.tocify.js
+++ b/source/docs/assets/js/jquery.tocify.js
@@ -376,7 +376,7 @@
 
             }
 
-            hashValue = this._generateHashValue(arr, self, index).replace(/\?/g, "").replace(/\(/g, "").replace(/\)/g, "").replace(/\'/g, "").replace(/\,/g, "").replace(/\//g, "").replace(/\./g, "").replace(/\&/g, "and");
+            hashValue = this._generateHashValue(arr, self, index).replace(/\?/g, "").replace(/\(/g, "").replace(/\)/g, "").replace(/\'/g, "").replace(/\,/g, "").replace(/\//g, "").replace(/\./g, "").replace(/\&/g, "and").replace(/\"/g, "");
 
             // Appends a list item HTML element to the last unordered list HTML element found within the HTML element calling the plugin
             item = $("<li/>", {


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Fixes TOC anchors for headers that include double quote character by striping the character via JS

For example: `/docs/settings-php/#error-"the-provided-host-name-is-not-valid-for-this-server"` => `/docs/settings-php#error-the-provided-host-name-is-not-valid-for-this-server`

Note: Affected TOC links require the data-proofer-ignore HTML attribute when linked from another doc page. Otherwise, htmlproofer will report the link as broken due to the nature of the test (server side vs client side)