### PR TITLE
Multidev names may contain a dash '-'

### DIFF
--- a/source/_docs/multidev.md
+++ b/source/_docs/multidev.md
@@ -51,7 +51,7 @@ There are a number of terms used throughout the Multidev workflow:
 
     <div class="alert alert-danger" role="alert">
     <h4 class="info">Warning</h4>
-    <p>Multidev branch names must be all lowercase and less than 11 characters. Environments cannot be created with the following reserved names: master, settings, team, support, multidev, debug, files, tags, and billing.</p>
+    <p>Multidev branch names must be all lowercase, be less than 11 characters, but may contain a dash `-`. Environments cannot be created with the following reserved names: master, settings, team, support, multidev, debug, files, tags, and billing.</p>
     </div>
 
 4. Click **Create Environment**.


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Multidev branches my contain a dash `-` 

This is more concise than mentioning all non-alphanumeric characters that _can't_ be used. 
Names can't _start_ with a dash, but might be overkill to state that as the Dashboard/Terminus will grouse anyway. 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
