### PR TITLE
Custom Certificate Access Clarification

### DIFF
--- a/source/_docs/custom-certificates.md
+++ b/source/_docs/custom-certificates.md
@@ -7,7 +7,7 @@ earlynote: This documentation covers features and options not available across t
 
 ## Access
 
-A white glove concierge service is now available and **currently limited to existing Legacy SSL contract customers**, including Enterprise, EDU+, Pantheon One, Elite, and Resellers.
+A limited white glove concierge service is now available to contract customers only (Enterprise, EDU+, Pantheon One, Elite, and Resellers) for sites that **currently have a Legacy SSL certificate installed**. All others can either take advantage of our [platform included automated HTTPS powered by Let's Encrypt](/docs/https/) or [terminate HTTPS through a 3rd-party CDN service provider](https://pantheon.io/docs/https/?action=#can-i-bring-my-own-certificate). 
 
 ## Upgrade to the Global CDN
 


### PR DESCRIPTION
The wording is still not clear to customers. Want to make it clear to customer what qualifies and if a site doesn't qualify what a customer can do next. 

## Effect
PR includes the following changes:
- Clarifies even further who qualifies


## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
