### PR TITLE
Remove request to notify support in advance of tests.

### DIFF
--- a/source/_docs/traffic-limits.md
+++ b/source/_docs/traffic-limits.md
@@ -61,7 +61,7 @@ Having high performance responses to crawlers is _beneficial_ to SEO, which is o
 ### What about load tests or penetration tests?
 Our onboarding team performs load tests prior to every Elite site launch, and we encourage customers to load test prior to releasing a big update. We also fully support customers who want to penetration test their site, which can result in significant spikes in traffic.
 
-However, if you are load or pen testing in extreme excess of your plan limits, or do so on a regular and repeated basis, we reserve the right to charge for a plan that is appropriate to the load placed on the platform. This is one of the reasons we ask customers to [notify support](/docs/support/) of such tests as a courtesy.
+However, if you are load or pen testing in extreme excess of your plan limits, or do so on a regular and repeated basis, we reserve the right to charge for a plan that is appropriate to the load placed on the platform. 
 
 ### What about legitimate traffic spikes?
 We understand that the internet can make any website famous overnight and that this isn't under your control. Pantheon's platform is specifically designed to shine under this circumstance, and it's one of the main reasons people choose us to run their sites.


### PR DESCRIPTION
We recently stopped asking customers to notify us in advance of pen testing, and I suspect this is also true of load testing. I removed the relevant line from the documentation, but it would probably be best to have @newtoid or @shakhossain review to ensure this is correct.

Closes # n/a

## Effect
PR includes the following changes:
- Removes request for customers to let support know in advance of load testing

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
