### PR TITLE
Update new-plans-faq.md

### DIFF
--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -26,7 +26,7 @@ For more information on the announcement of new plans, see [this related blog po
 | Performance (XL)     | $750            | $1,000      |
 
 ### Annual Billing
-Coming soon, Pantheon will offer annual billing plans at lower rates, giving up to two month's worth of savings.
+Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.
 
 | Plan                 | Annual Price | Annual Savings  |
 | -------------------- | ------------ | --------------- |


### PR DESCRIPTION
Closes: NA

## Effect
PR includes the following changes:
- Changed this: Coming soon, Pantheon will offer annual billing plans at lower rates, giving up to two month's worth of savings.
To this: Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.


## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
