### PR TITLE
Add FileZilla Quickconnect troubleshooting

### DIFF
--- a/source/_docs/filezilla.md
+++ b/source/_docs/filezilla.md
@@ -64,7 +64,7 @@ Your file uploads (Drupal's `sites/default/files` and WordPress's `wp-content/up
 ## Troubleshooting
 
 ### Uploading to the Files Directory
-Filezilla does not correctly upload files when the target directory on Pantheon is `files`. We recommend setting the target directory to `code/sites/default/files`, which is a symlink to `files` on Pantheon. If you experience issues using FileZilla, try the task using an alternate program such as [Transmit](https://panic.com/transmit/) (Mac OS) or [WinSCP](/docs/winscp) (Windows).
+FileZilla does not correctly upload files when the target directory on Pantheon is `files`. We recommend setting the target directory to `code/sites/default/files`, which is a symlink to `files` on Pantheon. If you experience issues using FileZilla, try the task using an alternate program such as [Transmit](https://panic.com/transmit/) (Mac OS) or [WinSCP](/docs/winscp) (Windows).
 
 ### nodename nor servname provided, or not known
 The following error is caused by an invalid hostname, most often the result of a typo:
@@ -77,6 +77,17 @@ Error:            Could not connect to server
 Double check settings and resolve typos to fix this issue.
 
 ### Site Manager
-Features offered in the Filezilla Site Manager (like [Synchronized Browsing](https://wiki.filezilla-project.org/Using#Synchronized_Browsing){.external}) are not supported because the Pantheon platform sometimes migrates sites across appservers without warning and the non-static binding string will change. This means that while you can set up your site in the Site Manager, you will need to reconfigure the login information and file paths whenever the dev environment site binding changes.
+Features offered in the FileZilla Site Manager (like [Synchronized Browsing](https://wiki.filezilla-project.org/Using#Synchronized_Browsing){.external}) are not supported because the Pantheon platform sometimes migrates sites across appservers without warning and the non-static binding string will change. This means that while you can set up your site in the Site Manager, you will need to reconfigure the login information and file paths whenever the dev environment site binding changes.
 
 The value for **Default remote directory** in the Site Manager can be copied from the **Remote site** field in the main window, and you can append `code` to the path to synchronize with your local codebase. Rememebr that the site binding is subject to change. 
+
+### Quickconnect is refusing to connect
+
+The following error is always thrown when using Quickconnect option in FileZilla:
+
+```bash
+Error:        	Cannot establish FTP connection to an SFTP server. Please select proper protocol.
+Error:        	Critical error: Could not connect to server
+```
+
+Quickconnect do not give options for protocol selection. Please see how to properly [Configure FileZilla](docs/filezilla/#configure-filezilla).

--- a/source/_docs/filezilla.md
+++ b/source/_docs/filezilla.md
@@ -83,11 +83,12 @@ The value for **Default remote directory** in the Site Manager can be copied fro
 
 ### Quickconnect is refusing to connect
 
-The following error is always thrown when using Quickconnect option in FileZilla:
+The following error is always thrown when using the Quickconnect option in FileZilla:
+
 
 ```bash
 Error:        	Cannot establish FTP connection to an SFTP server. Please select proper protocol.
 Error:        	Critical error: Could not connect to server
 ```
 
-Quickconnect do not give options for protocol selection. Please see how to properly [Configure FileZilla](docs/filezilla/#configure-filezilla).
+Quickconnect does not give options for protocol selection. You need to manually add the protocol (`sftp://`) in the **Host** field.


### PR DESCRIPTION
Closes #4119

## Effect
PR includes the following changes:
- FileZilla Quickconnect by default uses FTP and there is no option to select a different protocol and note it in the troubleshooting section
- Spelled FileZilla name correctly

## Remaining Work

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
