### PR TITLE
wp-offload-s3 has been renamed wp-offload-media

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -95,7 +95,7 @@ Pantheon cannot be used to host files over 256MB, no matter how the file is upl
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
  - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}
- - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload S3](https://deliciousbrains.com/wp-offload-s3/){.external}
+ - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external}
 
 See our documentation for [Drupal](/docs/drupal-s3) and [WordPress](/docs/wordpress-s3/) for more information about integrating S3 with your Pantheon site.
 

--- a/source/_docs/wordpress-s3.md
+++ b/source/_docs/wordpress-s3.md
@@ -48,9 +48,9 @@ If you do not have an existing bucket for your site, create one:
 7. Review your settings, and then click **Create bucket**.
 
 ## Integrate S3 with WordPress
-You will need to install a plugin such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload S3](https://deliciousbrains.com/wp-offload-s3/){.external}.
+You will need to install a plugin such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external}.
 
-WP Offload S3 requires a paid license but is configurable in the WordPress admin UI and offers a number of options and features, including multisite support. S3 Uploads is open-source but does not include an admin UI and requires [Terminus](/docs/terminus) and [WP-CLI](/docs/wp-cli) for setup and migration.
+WP Offload Media requires a paid license but is configurable in the WordPress admin UI and offers a number of options and features, including multisite support. S3 Uploads is open-source but does not include an admin UI and requires [Terminus](/docs/terminus) and [WP-CLI](/docs/wp-cli) for setup and migration.
 
 ### Install and Deploy S3 Uploads
 
@@ -61,7 +61,7 @@ WP Offload S3 requires a paid license but is configurable in the WordPress admin
 
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
-<p markdown="1">This plugin has known [multisite issues](https://github.com/humanmade/S3-Uploads/pull/214){.external}. If you need an alternative plugin with premium support and a multisite version, consider [WP Offload s3](#install-and-deploy-wp-offload-s3).</p>
+<p markdown="1">This plugin has known [multisite issues](https://github.com/humanmade/S3-Uploads/pull/214){.external}. If you need an alternative plugin with premium support and a multisite version, consider [WP Offload Media](#install-and-deploy-wp-offload-media).</p>
 </div>
 
 1. Download the latest plugin release from [Github](https://github.com/humanmade/S3-Uploads/releases){.external} and extract it to `wp-content/plugins/`. Note that our documentation has been tested for version 2.0.0.
@@ -116,5 +116,5 @@ Upon succesful migration, this command will also provide a search/replace comman
 #### Further configuration
 Check out the plugin's [README file](https://github.com/humanmade/S3-Uploads/blob/master/README.md){.external} for information on advanced configuration, such as cache control, URL rewriting and offline development.
 
-### Install and Deploy WP Offload S3
-Follow documentation from [DeliciousBrains](https://deliciousbrains.com/wp-offload-s3/doc/quick-start-guide){.external}. No specialized configuration is required for this plugin to run on Pantheon.
+### Install and Deploy WP Offload Media
+Follow documentation from [DeliciousBrains](https://deliciousbrains.com/wp-offload-media/doc/quick-start-guide){.external}. No specialized configuration is required for this plugin to run on Pantheon.


### PR DESCRIPTION
More info: https://deliciousbrains.com/wp-offload-s3-is-now-wp-offload-media-and-adds-support-for-digitalocean-spaces

Closes #

## Effect
PR includes the following changes:
- Renames all text, headers, and links from `WP Offload S3` to `WP Offload Media`.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
