### PR TITLE
traffic clarification

### DIFF
--- a/source/_docs/metrics.md
+++ b/source/_docs/metrics.md
@@ -42,6 +42,9 @@ All non-Basic plans come with free overage protection. Where there is a pattern 
 ### What about bots?
 Pantheon-identified bots are excluded from the Visits and Pages Served Metrics.
 
+### What about redirects?
+Only requests with a 2xx status as pages, so 301 redirects will not be included in metrics
+
 ### Can I see metrics for other environments?
 Yes! Metrics are now available for the entire site or by environment via the Terminus `alpha:metrics` command, when [installed via Git](https://github.com/pantheon-systems/terminus#installing-with-git).
 

--- a/source/_docs/metrics.md
+++ b/source/_docs/metrics.md
@@ -43,7 +43,7 @@ All non-Basic plans come with free overage protection. Where there is a pattern 
 Pantheon-identified bots are excluded from the Visits and Pages Served Metrics.
 
 ### What about redirects?
-Only requests with a 2xx status as pages, so 301 redirects will not be included in metrics
+Only requests with a 2xx status count as pages served, so 301 redirects will not be included in metrics.
 
 ### Can I see metrics for other environments?
 Yes! Metrics are now available for the entire site or by environment via the Terminus `alpha:metrics` command, when [installed via Git](https://github.com/pantheon-systems/terminus#installing-with-git).


### PR DESCRIPTION
301 redirects are not included in pages served count

Closes #4123

## Effect
PR includes the following changes:
 note in FAQ about 301 redirects

## Remaining Work
- [ ] review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
