### PR TITLE
Remove erroneous wording for team management

### DIFF
--- a/source/_docs/team-management.md
+++ b/source/_docs/team-management.md
@@ -70,7 +70,7 @@ Within the Team modal of the Site Dashboard, the site owner can click **Make Own
 ![Make Owner](/source/docs/assets/images/dashboard/sandbox-make-owner.png)
 
 #### Paid Sites
-To change the owner of a paid site (e.g. Basic, or Performance), you'll need to update the billing information by clicking **Invite a business owner to pay for this site** within in the Settings page of the Site Dashboard. Enter the email address for the new site owner and select the applicable plan for the site. Once the new owner receives the invitation they will be directed to provide payment information, at which point they will assume ownership of the site.
+To change the owner of a paid site (e.g. Basic, or Performance), you'll need to update the billing information by clicking **Invite a business owner to pay for this site** within in the Settings page of the Site Dashboard. Enter the email address for the new site owner. Once the new owner receives the invitation they will be directed to provide payment information, at which point they will assume ownership of the site.
 
 ![Invite a business owner to pay for this site](/source/docs/assets/images/dashboard/payment-form-invite.png)<br />
 Enterprise Organizations can use the same process to assume ownership of a site;  however, Agency Partners do not have the ability to own sites directly.


### PR DESCRIPTION
Suggesting to remove "and select the applicable plan for the site" from the end of the description in the second sentence under Paid Sites, as that is not the screen encountered by myself or a client when I follow these instructions. The option to select the applicable plan for the site is absent.

Closes #

## Effect
PR includes the following changes:
- removal of "and select the applicable plan for the site" from the end of the description in the second sentence under Paid Sites.

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [x] Update Status Report
- [x] Archive from **Done** in Waffle
