### PR TITLE
Clarify annual billing savings and preferred pricing

### DIFF
--- a/source/_docs/annual-billing.md
+++ b/source/_docs/annual-billing.md
@@ -10,8 +10,14 @@ For standard billing information, see [Billing in the Site Dashboard](/docs/site
 
 ## Annual Billing Savings
 
-The table below shows how much sites can save by switching to annual billing. Performance plans receive savings equal to at least month of free service. On a basic plan, the savings equate to two months of free service.
+The table below shows how much sites can save by switching to annual billing. Performance plans receive savings equivalent to at least one month of free service. On a basic plan, the savings are equivalent to two months of free service.
 
+<dl>
+  <dt>List Price</dt>
+    <dd>Set price for new sites created after September that aren’t purchased via a qualified agency partner.</dd>
+  <dt>Preferred Price</dt>
+    <dd>Introductory price available to the general public until late October, after which it will be exclusively available via qualified agency partners.</dd>
+</dl>
 
 <!-- Nav tabs -->
 <ul class="nav nav-tabs" role="tablist">

--- a/source/_docs/annual-billing.md
+++ b/source/_docs/annual-billing.md
@@ -14,7 +14,7 @@ The table below shows how much sites can save by switching to annual billing. Pe
 
 <dl>
   <dt>List Price</dt>
-    <dd>Set price for new sites created after September that aren’t purchased via a qualified agency partner.</dd>
+    <dd>Set price for new sites created after late October that aren’t purchased via a qualified agency partner.</dd>
   <dt>Preferred Price</dt>
     <dd>Introductory price available to the general public until late October, after which it will be exclusively available via qualified agency partners.</dd>
 </dl>

--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -12,7 +12,7 @@ For more information on the announcement of new plans, see [this related blog po
 ## List and Preferred Pricing
 <dl>
   <dt>List Price</dt>
-    <dd>Set price for new sites created after September that aren’t purchased via a qualified agency partner.</dd>
+    <dd>Set price for new sites created after late October that aren’t purchased via a qualified agency partner.</dd>
   <dt>Preferred Price</dt>
     <dd>Introductory price available to the general public until late October, after which it will be exclusively available via qualified agency partners.</dd>
 </dl>
@@ -63,8 +63,8 @@ All existing sites will have preferred pricing locked in for the plan they migra
 ### Are legacy plans still available?
 No new sites can be created on legacy plans outside of existing contracted agreements. The legacy plans are no longer available for purchase online.
 
-### Will I be able to keep preferred pricing after September?
-All existing sites as of September (legacy & new) will lock in preferred pricing, regardless of whether they are associated with a qualified agency partner.
+### Will I be able to keep preferred pricing after October?
+All existing sites as of early October (legacy & new) will lock in preferred pricing, regardless of whether they are associated with a qualified agency partner.
 
 In late October all new online site plan purchases will be at list price unless purchased through a qualified agency.
 

--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -26,51 +26,15 @@ For more information on the announcement of new plans, see [this related blog po
 | Performance (XL)     | $750            | $1,000      |
 
 ### Annual Billing
+Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.
 
-Pantheon offers [annual billing plans at lower rates](/docs/annual-billing/), giving up to two month's worth of savings.
-
-<dl>
-  <dt>List Price</dt>
-    <dd>Set price for new sites created after September that aren’t purchased via a qualified agency partner.</dd>
-  <dt>Preferred Price</dt>
-    <dd>Introductory price available to the general public until late October, after which it will be exclusively available via qualified agency partners.</dd>
-</dl>
-
-<!-- Nav tabs -->
-<ul class="nav nav-tabs" role="tablist">
-  <!-- Active tab -->
-  <li id="tab-1-id" role="presentation" class="active"><a href="#tab-1-anchor" aria-controls="tab-1-anchor" role="tab" data-toggle="tab">List Price</a></li>
-
-  <!-- 2nd Tab Nav -->
-  <li id="tab-2-id" role="presentation"><a href="#tab-2-anchor" aria-controls="tab-2-anchor" role="tab" data-toggle="tab">Preferred Price</a></li>
-
-</ul>
-
-<!-- Tab panes -->
-<div class="tab-content">
-<!-- Active pane content -->
-<div role="tabpanel" class="tab-pane active" id="tab-1-anchor" markdown="1">
-|                    | Basic         | Performance Small | Performance Medium | Performance Large | Performance XL       |
-|:------------------ |:------------- |:----------------- |:------------------ |:----------------- |:-------------------- |
-| Monthly Price      | $50           | $175              | $300               | $600              | $1,000               |
-| Annual Price       | $500          | $1,925            | $3,300             | $6,600            | $11,000              |
-| **Annual Savings** | **$100**      | **$175**          | **$300**           | **$600**          | **$1,000**           |
-
-**Note:** List price will not go into effect until the introduction of the Partner Program.
-</div>
-
-<!-- 2nd pane content -->
-<div role="tabpanel" class="tab-pane" id="tab-2-anchor" markdown="1">
-
-|                    | Basic   | Performance Small | Performance Medium | Performance Large | Performance XL  |
-|:------------------ |:------- |:----------------- |:------------------ |:----------------- |:--------------- |
-| Monthly Price      | $35     | $125              | $225               | $450              | $750            |
-| Annual Price       | $350    | $1,375            | $2,475             | $4,950            | $8,250          |
-| **Annual Savings** | **$70** | **$125**          | **$225**           | **$450**          | **$750**        |
-
-</div>
-
-</div>
+| Plan                 | Preferred Annual Price | Annual Savings  |
+| -------------------- | ---------------------- | --------------- |
+| Basic                | $350                   | $70             |
+| Performance (Small)  | $1375                  | $125            |
+| Performance (Medium) | $2475                  | $225            |
+| Performance (Large)  | $4950                  | $450            |
+| Performance (XL)     | $8250                  | $750            |
 
 ## Frequently Asked Questions
 

--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -28,13 +28,13 @@ For more information on the announcement of new plans, see [this related blog po
 ### Annual Billing
 Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.
 
-| Plan                 | Annual Price | Annual Savings  |
-| -------------------- | ------------ | --------------- |
-| Basic                | $350             | $70         |
-| Performance (Small)  | $1375            | $125        |
-| Performance (Medium) | $2475            | $225        |
-| Performance (Large)  | $4950            | $450        |
-| Performance (XL)     | $8250            | $750        |
+| Plan                 | Preferred Annual Price | Annual Savings  |
+| -------------------- | ---------------------- | --------------- |
+| Basic                | $350                   | $70             |
+| Performance (Small)  | $1375                  | $125            |
+| Performance (Medium) | $2475                  | $225            |
+| Performance (Large)  | $4950                  | $450            |
+| Performance (XL)     | $8250                  | $750            |
 
 ## Frequently Asked Questions
 

--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -26,7 +26,7 @@ For more information on the announcement of new plans, see [this related blog po
 | Performance (XL)     | $750            | $1,000      |
 
 ### Annual Billing
-Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.
+Pantheon offers [annual billing plans at lower rates](/docs/annual-billing/), giving up to two month's worth of savings.
 
 | Plan                 | Preferred Annual Price | Annual Savings  |
 | -------------------- | ---------------------- | --------------- |

--- a/source/_docs/new-plans-faq.md
+++ b/source/_docs/new-plans-faq.md
@@ -26,15 +26,51 @@ For more information on the announcement of new plans, see [this related blog po
 | Performance (XL)     | $750            | $1,000      |
 
 ### Annual Billing
-Pantheon offers annual billing plans at lower rates, giving up to two month's worth of savings.
 
-| Plan                 | Preferred Annual Price | Annual Savings  |
-| -------------------- | ---------------------- | --------------- |
-| Basic                | $350                   | $70             |
-| Performance (Small)  | $1375                  | $125            |
-| Performance (Medium) | $2475                  | $225            |
-| Performance (Large)  | $4950                  | $450            |
-| Performance (XL)     | $8250                  | $750            |
+Pantheon offers [annual billing plans at lower rates](/docs/annual-billing/), giving up to two month's worth of savings.
+
+<dl>
+  <dt>List Price</dt>
+    <dd>Set price for new sites created after September that aren’t purchased via a qualified agency partner.</dd>
+  <dt>Preferred Price</dt>
+    <dd>Introductory price available to the general public until late October, after which it will be exclusively available via qualified agency partners.</dd>
+</dl>
+
+<!-- Nav tabs -->
+<ul class="nav nav-tabs" role="tablist">
+  <!-- Active tab -->
+  <li id="tab-1-id" role="presentation" class="active"><a href="#tab-1-anchor" aria-controls="tab-1-anchor" role="tab" data-toggle="tab">List Price</a></li>
+
+  <!-- 2nd Tab Nav -->
+  <li id="tab-2-id" role="presentation"><a href="#tab-2-anchor" aria-controls="tab-2-anchor" role="tab" data-toggle="tab">Preferred Price</a></li>
+
+</ul>
+
+<!-- Tab panes -->
+<div class="tab-content">
+<!-- Active pane content -->
+<div role="tabpanel" class="tab-pane active" id="tab-1-anchor" markdown="1">
+|                    | Basic         | Performance Small | Performance Medium | Performance Large | Performance XL       |
+|:------------------ |:------------- |:----------------- |:------------------ |:----------------- |:-------------------- |
+| Monthly Price      | $50           | $175              | $300               | $600              | $1,000               |
+| Annual Price       | $500          | $1,925            | $3,300             | $6,600            | $11,000              |
+| **Annual Savings** | **$100**      | **$175**          | **$300**           | **$600**          | **$1,000**           |
+
+**Note:** List price will not go into effect until the introduction of the Partner Program.
+</div>
+
+<!-- 2nd pane content -->
+<div role="tabpanel" class="tab-pane" id="tab-2-anchor" markdown="1">
+
+|                    | Basic   | Performance Small | Performance Medium | Performance Large | Performance XL  |
+|:------------------ |:------- |:----------------- |:------------------ |:----------------- |:--------------- |
+| Monthly Price      | $35     | $125              | $225               | $450              | $750            |
+| Annual Price       | $350    | $1,375            | $2,475             | $4,950            | $8,250          |
+| **Annual Savings** | **$70** | **$125**          | **$225**           | **$450**          | **$750**        |
+
+</div>
+
+</div>
 
 ## Frequently Asked Questions
 


### PR DESCRIPTION
Closes #4111 
Closes #4112 

## Effect
PR includes the following changes:
- Adds a table to `new-plans-faq` to clarify annual billing
- Clarifies definition of List/Preferred pricing in `annual-billing`

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
