### PR TITLE
Start Upgrade button location details

### DIFF
--- a/source/_docs/global-cdn.md
+++ b/source/_docs/global-cdn.md
@@ -76,7 +76,7 @@ If you don't see action required in your Domains / HTTPS tool, please [contact s
 
 ### Upgrade Your Site
 
-1. Click the **Start Upgrade** button from the Site Dashboard.
+1. From the Site Dashboard, click the **Start Upgrade** button on the Domains section of the Live tab.
 2. It can take up to an hour for the new certificate to deploy across the entire CDN. If you want to avoid any possible hiccoughs you can wait 60 minutes before updating DNS.
 
   If you want to proceed without waiting, we strongly recommend testing locally before making the final DNS change:

--- a/source/_docs/global-cdn.md
+++ b/source/_docs/global-cdn.md
@@ -76,7 +76,7 @@ If you don't see action required in your Domains / HTTPS tool, please [contact s
 
 ### Upgrade Your Site
 
-1. From the Site Dashboard, click the **Start Upgrade** button on the Domains section of the Live tab.
+1. From the Site Dashboard, click the **Start Upgrade** button in the <span class="glyphicons glyphicons-global"></span> Domains / HTTPS section of the <span class="glyphicons glyphicons-cardio"></span> Live tab.
 2. It can take up to an hour for the new certificate to deploy across the entire CDN. If you want to avoid any possible hiccoughs you can wait 60 minutes before updating DNS.
 
   If you want to proceed without waiting, we strongly recommend testing locally before making the final DNS change:


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Added exact location of "Start Upgrade" button for upgrading CDN

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
