### PR TITLE
CNAME to A record vanity domains

### DIFF
--- a/source/_docs/vanity-domains.md
+++ b/source/_docs/vanity-domains.md
@@ -23,7 +23,7 @@ From your Organization Dashboard, go to Dashboard and [submit a support request]
 </div>
 
 ## Create Wildcard DNS Records
-At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows. Replace `X` with a `1`, `2`, `3`, or `4`:
+At your DNS provider, create a wildcard A/AAAA record pointing to our edge. Using the example domain `sites.example.com`, the record would need to be created as follows. Replace `X` with a `1`, `2`, `3`, or `4`:
 
 > `*.sites.example.com` **A** `23.185.0.X`
 

--- a/source/_docs/vanity-domains.md
+++ b/source/_docs/vanity-domains.md
@@ -22,8 +22,8 @@ From your Organization Dashboard, go to Dashboard and [submit a support request]
 </p>
 </div>
 
-## Create a Wildcard CNAME Record
-At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows:
+## Create Wildcard DNS Records
+At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows. Replace `X` with a `1`, `2`, `3`, or `4`:
 
 > `*.sites.example.com` **A** `23.185.0.X`
 
@@ -31,7 +31,7 @@ At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If y
 
 > `*.sites.example.com` **AAAA** `2620:12a:8001::X`
 
-Remember to replace the `X` in this example with the offset assigned to your site, as found in **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS** in your site's Dashboard. See <a href="/docs/dns/#what-are-aaaa-records-and-do-i-need-them" data-proofer-ignore>Introduction to Domain Name Services</a> for more information about AAAA records.
+See <a href="/docs/dns/#what-are-aaaa-records-and-do-i-need-them" data-proofer-ignore>Introduction to Domain Name Services</a> for more information about AAAA records.
 
 <div class="alert-info alert" markdown="1">
 #### Note {.info}

--- a/source/_docs/vanity-domains.md
+++ b/source/_docs/vanity-domains.md
@@ -24,13 +24,15 @@ From your Organization Dashboard, go to Dashboard and [submit a support request]
 
 ## Create a Wildcard CNAME Record
 
-At your DNS provider, create a wildcard CNAME record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows:
+At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows:
 
-`*.sites.example.com` **CNAME** `edge.live.getpantheon.com`
+> `*.sites.example.com` **A** `23.185.0.X`
+
+See [Introduction to Domain Name Services](/docs/dns/#what-are-aaaa-records-and-do-i-need-them) for more information about AAAA records.
 
 <div class="alert-info alert" markdown="1">
 #### Note {.info}
-If the domain in question is already in use, be sure to configure your vanity domain at Pantheon _before_ changing DNS records to avoid any downtime. 
+If the domain in question is already in use, be sure to configure your vanity domain at Pantheon _before_ changing DNS records to avoid any downtime.
 </div>
 
 ## Effects and Considerations
@@ -67,11 +69,11 @@ If you run sites on subdomains of your primary site (e.g. `sites.awesomeagency.c
 
 ## Robots.txt with Custom Vanity Domains
 
-For SEO and to prevent duplicate content, the robots.txt file attached to the custom Vanity domain will contain the following by default:
+For SEO and to prevent duplicate content, the `robots.txt` file attached to the custom Vanity domain will contain the following by default:
 
 ```
 # https://live-sitename.agencyname.com/robots.txt
 User-agent: *
 Disallow: /
 ```
-To present an alternate robots.txt file from within the source code, a custom domain needs to be <a href="/docs/guides/launch/domains/" data-proofer-ignore>added to the site's Dashboard</a> and the appropriate DNS record created.
+To present an alternate `robots.txt` file from within the source code, a custom domain needs to be <a href="/docs/guides/launch/domains/" data-proofer-ignore>added to the site's Dashboard</a> and the appropriate DNS record created.

--- a/source/_docs/vanity-domains.md
+++ b/source/_docs/vanity-domains.md
@@ -23,12 +23,15 @@ From your Organization Dashboard, go to Dashboard and [submit a support request]
 </div>
 
 ## Create a Wildcard CNAME Record
-
 At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If you go with `sites.example.com`, the record would need to be created as follows:
 
 > `*.sites.example.com` **A** `23.185.0.X`
 
-See <a href="/docs/dns/#what-are-aaaa-records-and-do-i-need-them" data-proofer-ignore>Introduction to Domain Name Services</a> for more information about AAAA records.
+> `*.sites.example.com` **AAAA** `2620:12a:8000::X`
+
+> `*.sites.example.com` **AAAA** `2620:12a:8001::X`
+
+Remember to replace the `X` in this example with the offset assigned to your site, as found in **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS** in your site's Dashboard. See <a href="/docs/dns/#what-are-aaaa-records-and-do-i-need-them" data-proofer-ignore>Introduction to Domain Name Services</a> for more information about AAAA records.
 
 <div class="alert-info alert" markdown="1">
 #### Note {.info}

--- a/source/_docs/vanity-domains.md
+++ b/source/_docs/vanity-domains.md
@@ -28,7 +28,7 @@ At your DNS provider, create a wildcard A/AAAA record pointing to our edge. If y
 
 > `*.sites.example.com` **A** `23.185.0.X`
 
-See [Introduction to Domain Name Services](/docs/dns/#what-are-aaaa-records-and-do-i-need-them) for more information about AAAA records.
+See <a href="/docs/dns/#what-are-aaaa-records-and-do-i-need-them" data-proofer-ignore>Introduction to Domain Name Services</a> for more information about AAAA records.
 
 <div class="alert-info alert" markdown="1">
 #### Note {.info}


### PR DESCRIPTION
Closes #4114 

## Effect
PR includes the following changes:
- suggests using A record over CNAME
- uses info from and links back to [What are AAAA records, and do I need them?](https://pantheon.io/docs/custom-certificates/#what-are-the-global-cdn-ip-addresses)

## Remaining Work
- [x] Confirm tech w/ @ari-gold 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
