### PR TITLE
Add EWWW Image Optimizer in WP plugins that has known issues

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -361,6 +361,13 @@ For more details, see [SERVER_NAME and SERVER_PORT on Pantheon](/docs/server_nam
 **Solution**: Remove .gitignore files from the `constant-contact-forms` and `constant-contact-forms/vendor/psr/log` directories.
 <hr>
 
+### [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/){.external}
+**Issue**: The plugin says I’m missing something: `EWWW Image Optimizer uses jpegtran, optipng, pngout, pngquant, gifsicle, and cwebp. You are missing: jpegtran, optipng, gifsicle. Please install via the Settings Page or the Installation Instructions.`. The plugin also installs executable binary files which is not allowed to be executed in the platform. The solution outlined in [here](https://docs.ewww.io/article/6-the-plugin-says-i-m-missing-something){.external} will also not work. 
+
+**Solution**: Use an alternative plugin instead like the [EWWW Image Optimizer Cloud](https://wordpress.org/plugins/ewww-image-optimizer-cloud/){.external} which is a cloud version of the plugin that executes the compression from an external service instead of the server. Another alternative that works well with the default configuration is [Smush Image Compression and Optimization](https://wordpress.org/plugins/wp-smushit/){.external}.
+
+<hr>
+
 ### [Force Login](https://wordpress.org/plugins/wp-force-login/){.external}
 **Issue**: This plugin appends a port number using `$_SERVER['SERVER_PORT']` at the end of the URL when the user logs in to the site.
 


### PR DESCRIPTION
Closes #4145

## Effect
PR includes the following changes:
-Add EWWW Image Optimizer in WP plugins that has known issues and alternative solutions

## Remaining Work

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
