### PR TITLE
Updating Drupal 8 Solr information

### DIFF
--- a/source/_docs/solr-drupal-8.md
+++ b/source/_docs/solr-drupal-8.md
@@ -90,7 +90,7 @@ To actually search your index you will need a module like [Search API Pages](htt
 
 
 ## Solr Versions and Schemas
-The version of Solr on Pantheon is Apache Solr v3.6. To accommodate this older version of Solr, use the 8.x-1.x branch of [Search API Solr](https://www.drupal.org/project/search_api_solr) and its Solr 4 schema file.
+The version of Solr on Pantheon is Apache Solr v3.6. To accommodate this older version of Solr, use the `8.x-1.x` branch of [Search API Solr](https://www.drupal.org/project/search_api_solr){.external} and its Solr 4 schema file.
 
 {% include("content/solr-commit-changes.html") %}
 

--- a/source/_docs/solr-drupal-8.md
+++ b/source/_docs/solr-drupal-8.md
@@ -90,14 +90,12 @@ To actually search your index you will need a module like [Search API Pages](htt
 
 
 ## Solr Versions and Schemas
-Currently, the version of Solr on Pantheon is Apache Solr v3.6. Officially, the lowest supported version of Solr in Search API Solr is Solr 4. [Pantheon will soon offer a higher version of Solr](https://www.drupal.org/node/2775595). Until then, you can use the schema for Solr 4 that Search API Pantheon provides.
+The version of Solr on Pantheon is Apache Solr v3.6. To accommodate this older version of Solr, use the 8.x-1.x branch of [Search API Solr](https://www.drupal.org/project/search_api_solr) and its Solr 4 schema file.
 
 {% include("content/solr-commit-changes.html") %}
 
 ## Force Reposting of Schema File on Pantheon Environments
-Each Pantheon environment (Dev, Test, Live, and Multidevs) has its own Solr server. So indexing and searching in one environment does not impact any other environment. Currently, the schema file must be reposted to each environment's Solr server. To do so, re-save the search server (e.g. `/admin/config/search/search-api/server/pantheon/edit`).
-
-Before this module is released as a Beta, reposting the schema file will be done automatically. For details, see [https://www.drupal.org/node/2775549](https://www.drupal.org/node/2775549).
+Each Pantheon environment (Dev, Test, Live, and Multidevs) has its own Solr server. So indexing and searching in one environment does not impact any other environment.
 
 ## Safely Remove Solr
 The following code changes are required before Solr can be safely uninstalled and disabled:


### PR DESCRIPTION
## Effect

This PR updates two sections:

1. It clarifies which version of Search API Solr to use with Search API Pantheon. When this doc was first written there was only one version.
2. It removes guidance on reposting schema files now that https://www.drupal.org/node/2775549 is merged.

The sections updated by this PR had been copied from the README of Search API Pantheon and I've made the same updates there: https://github.com/pantheon-systems/search_api_pantheon/pull/72

## Remaining Work
- [ ] Review from Docs team

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
