### PR TITLE
Indicate vcl file not editable and not provided

### DIFF
--- a/source/_docs/caching-advanced-topics.md
+++ b/source/_docs/caching-advanced-topics.md
@@ -159,7 +159,7 @@ If you're using the [Security tool](/docs/security/) within the Pantheon Site D
 
 ## Cookie Handling
 
-The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (.vcl) file for your reference. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache.
+The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (.vcl) file for your reference. Varnish Configuration is not user editable and we do not provide the complete .vcl file details. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache.
 
 ```nohighlight
 NO_CACHE


### PR DESCRIPTION
Closes #4157

## Effect
PR includes the following changes:
- Add indication in our doc that Varnish configuration (VCL) is not user editable and we don't provide the complete copy of that file.

## Remaining Work

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
