### PR TITLE
Cancellation: No partial refund

### DIFF
--- a/source/_docs/site-plan.md
+++ b/source/_docs/site-plan.md
@@ -153,7 +153,12 @@ The Site Owner will receive an email confirmation of this change, a new invoice 
 Invoices and transaction history related to this change can be found in **<span class="glyphicons glyphicons-cogwheel"></span> Account** > **Billing**.
 
 ## Cancel Current Plan
-Review the [previous section](#sandbox) on feature availability before downgrading to Sandbox.
+Review the [previous section](#sandbox) on feature availability before downgrading to Sandbox. 
+
+<div class="alert alert-info">
+<h4 class="info">Note</h4>
+<p markdown="1">While all site plans downgrades will be effective immediately, no partial refunds will be issued.</p></div>
+
 
 1. Go to the Site Dashboard.
 2. Select the current plan:


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Mention of no partial refund for unused service. Language comes from similar mention on annual plan. 


## Remaining Work
- [ ] Our TOS §11.1 Fees fleshes this out, but there is no direct anchor to this section, https://pantheon.io/terms-of-service. 
- [ ] Consider leaving the mention at the section head of Cancellation and possibly also at the Downgrade section as this will be where CSE will send customers to make the change. Were the mention lower in the doc, it runs the risk of being missed entirely. 
- [] Reach out to Product to get this information on the Downgrade screen itself. 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
