### PR TITLE
Fix broken SendGrid link in email.md

### DIFF
--- a/source/_docs/email.md
+++ b/source/_docs/email.md
@@ -61,7 +61,7 @@ Pantheon strongly encourages using ports other than `25`, `465` or `587` to send
     <tbody>
       <tr>
         <td>SendGrid</td>
-        <td><a href="https://sendgrid.com/docs/Classroom/Basics/Email_Infrastructure/smtp_ports.html" target="blank">2525</a></td>
+        <td><a href="https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html" target="blank">2525</a></td>
       </tr>
       <tr>
         <td>Mandrill</td>


### PR DESCRIPTION
The existing [Sendgrid SMTP link](https://sendgrid.com/docs/Classroom/Basics/Email_Infrastructure/smtp_ports.html) is broken and I'm suggesting we replace with:

- https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html

Sendgrid has a bunch of somewhat-relevant SMTP articles on both their blog and docs.

For example:

- [How to Send an SMTP Email](https://sendgrid.com/docs/for-developers/sending-email/getting-started-smtp/) is really more of a developer doc showing how to programmatically connect and relies heavily on Telnet for testing/illustration. I think this is too complicated for first link from Pantheon.
- [What is an SMTP Server?](https://sendgrid.com/blog/what-is-an-smtp-server/) is the most basic article and it's from their blog (not docs) but it's written in plain English and shows hostname and ports, and answers several basic SMTP questions.
- [Integrating With the SMTP API](https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html) is the briefest and most straightforward - providing data without much fluff.

Closes #

## Effect
PR includes the following changes:
- Fix broken link

## Remaining Work
- Verify that the link I'm suggesting is the best solution for Pantheon.


