### PR TITLE
add SmartCrawl Pro to plugin with issues

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -475,7 +475,6 @@ define('FS_METHOD', 'direct');
 
 Alternative plugins that have an xml sitemap feature that works well in the platform are [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/){.external} or [Yoast](https://wordpress.org/plugins/wordpress-seo/){.external}. 
 
-[Upgrade your site's PHP version](/docs/php-versions) to 5.5, 5.6, or 7.0.
 <hr>
 
 ### [Timthumb](https://code.google.com/p/timthumb/){.external}

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -465,7 +465,7 @@ This workaround may potentially break again with the next plugin update, and you
 <hr>
 
 ### [SmartCrawl Pro](https://premium.wpmudev.org/project/smartcrawl-wordpress-seo/){.external}
-**Issue:** The sitemap url linked by the plugin produces a `500 Internal Server Error` on Test and Live environments, which results to a PHP error: `class not found WP_Filesystem_Direct`. See more [details about the issue](https://premium.wpmudev.org/forums/topic/smartcrawl-pro-class-wp_filesystem_direct-not-found){.external}.
+**Issue:** The sitemap URL linked by the plugin produces a `500 Internal Server Error` on Test and Live environments. This results in a PHP error: `class not found WP_Filesystem_Direct`. See more [details about the issue](https://premium.wpmudev.org/forums/topic/smartcrawl-pro-class-wp_filesystem_direct-not-found){.external}.
 
 **Solution:** The plugin fails to implement a direct `FS_METHOD` in Test and Live environments. Add the following to `wp-config.php`, before the line `/* That's all, stop editing! Happy Pressing. */`:
 
@@ -473,7 +473,10 @@ This workaround may potentially break again with the next plugin update, and you
 define('FS_METHOD', 'direct');
 ```
 
-Alternative plugins that have an xml sitemap feature that works well in the platform are [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/){.external} or [Yoast](https://wordpress.org/plugins/wordpress-seo/){.external}. 
+Alternative plugins that have an XML sitemap feature that works well on the platform are:
+
+* [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/){.external}
+* [Yoast](https://wordpress.org/plugins/wordpress-seo/){.external}
 
 <hr>
 

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -464,6 +464,16 @@ This workaround may potentially break again with the next plugin update, and you
 
 <hr>
 
+### [SmartCrawl Pro](https://premium.wpmudev.org/project/smartcrawl-wordpress-seo/){.external}
+**Issue**: The sitemap url link by the plugin produces a `500 Internal Server Error` on Test and Live environments which results to a PHP error: `class not found WP_Filesystem_Direct`. See more [details about the issue](https://premium.wpmudev.org/forums/topic/smartcrawl-pro-class-wp_filesystem_direct-not-found){.external}.
+
+**Solution**: The plugin is failing to implement a direct `FS_METHOD` in Test and Live environments resulting to that error. Adding `define('FS_METHOD', 'direct');` in the `wp-config.php` before the `/* That's all, stop editing! Happy Pressing. */` would fix the issue.
+
+Alternative plugins that have an xml sitemap feature that works well in the platform are [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/){.external} or [Yoast](https://wordpress.org/plugins/wordpress-seo/){.external}. 
+
+[Upgrade your site's PHP version](/docs/php-versions) to 5.5, 5.6, or 7.0.
+<hr>
+
 ### [Timthumb](https://code.google.com/p/timthumb/){.external}
 **Issue**: TimThumb is no longer supported or maintained.
 <hr>

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -465,9 +465,13 @@ This workaround may potentially break again with the next plugin update, and you
 <hr>
 
 ### [SmartCrawl Pro](https://premium.wpmudev.org/project/smartcrawl-wordpress-seo/){.external}
-**Issue**: The sitemap url link by the plugin produces a `500 Internal Server Error` on Test and Live environments which results to a PHP error: `class not found WP_Filesystem_Direct`. See more [details about the issue](https://premium.wpmudev.org/forums/topic/smartcrawl-pro-class-wp_filesystem_direct-not-found){.external}.
+**Issue:** The sitemap url linked by the plugin produces a `500 Internal Server Error` on Test and Live environments, which results to a PHP error: `class not found WP_Filesystem_Direct`. See more [details about the issue](https://premium.wpmudev.org/forums/topic/smartcrawl-pro-class-wp_filesystem_direct-not-found){.external}.
 
-**Solution**: The plugin is failing to implement a direct `FS_METHOD` in Test and Live environments resulting to that error. Adding `define('FS_METHOD', 'direct');` in the `wp-config.php` before the `/* That's all, stop editing! Happy Pressing. */` would fix the issue.
+**Solution:** The plugin fails to implement a direct `FS_METHOD` in Test and Live environments. Add the following to `wp-config.php`, before the line `/* That's all, stop editing! Happy Pressing. */`:
+
+```php
+define('FS_METHOD', 'direct');
+```
 
 Alternative plugins that have an xml sitemap feature that works well in the platform are [Google Sitemap Generator](https://wordpress.org/plugins/google-sitemap-generator/){.external} or [Yoast](https://wordpress.org/plugins/wordpress-seo/){.external}. 
 


### PR DESCRIPTION
Closes #4179

## Effect
PR includes the following changes:
- Add solution to put define('FS_METHOD', 'direct') in wp-config

## Remaining Work

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
