### PR TITLE
Fixes initial failure on Write a New Test example

### DIFF
--- a/source/_docs/guides/build-tools/06-tests.md
+++ b/source/_docs/guides/build-tools/06-tests.md
@@ -60,7 +60,7 @@ The following is an example of how to increase test coverage for your project by
         Given I am logged in as a user with the "administrator" role
         And I am on "/node/add/page"
         And I enter "Test Page" for "Title"
-        And I press "Save and publish"
+        And I press "Save"
         Then I should see "Basic page Test Page has been created."
     ```
     By following this pattern, you can add similar tests to confirm that the most important features of your site remain functional. To save time on test runs, remove the example tests that cover basic Drupal features, and only run tests on your core functionality.


### PR DESCRIPTION
In the Build Tools documentation, when following the docs for “Write a New Test”, the example test fails on first run. The content UI changed and the [form button now reads only “Save” as of Drupal 8.4.0](https://www.drupal.org/node/2847274).

## Effect
PR includes the following changes:
- updates the button text value of example test

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
