### PR TITLE
Clarify Quicksilver plugin name

### DIFF
--- a/source/_docs/terminus/plugins/directory.md
+++ b/source/_docs/terminus/plugins/directory.md
@@ -109,14 +109,14 @@ The following plugins are just a few of the most popular available for Terminus 
   <div class="flex-panel-item">
     <div class="flex-panel-body">
       <div class="flex-panel-title">
-        <h3 class="plugin-title">Terminus Quicksilver Plugin</h3>
+        <h3 class="plugin-title">Quicksilver</h3>
         <div class="pantheon-official">
         <img alt="Official Pantheon Plugin" src="/source/docs/assets/images/official-plugin.svg" class="main-topic-info__plugin-image" >
           <p class="pantheon-official">Pantheon Official</p>
         </div>
       </div>
       <p class="topic-info__description">Author: <a href="https://github.com/greg-1-anderson">Greg Anderson</a></p>
-      <p class="topic-info__description">Install Quicksilver webhooks from the <a href="https://github.com/pantheon-systems/quicksilver-examples">Quicksilver examples</a>, or a personal collection.</p>
+      <p class="topic-info__description">Install <a href="/docs/quicksilver">Quicksilver</a> webhooks from the <a href="https://github.com/pantheon-systems/quicksilver-examples">Quicksilver examples</a>, or a personal collection.</p>
       <a href="https://github.com/pantheon-systems/terminus-quicksilver-plugin" class="btn-primary btn get-plugin">Get Plugin</a>
     </div>
   </div>

--- a/source/_docs/terminus/plugins/directory.md
+++ b/source/_docs/terminus/plugins/directory.md
@@ -109,7 +109,7 @@ The following plugins are just a few of the most popular available for Terminus 
   <div class="flex-panel-item">
     <div class="flex-panel-body">
       <div class="flex-panel-title">
-        <h3 class="plugin-title">Quicksilver</h3>
+        <h3 class="plugin-title">Terminus Quicksilver Plugin</h3>
         <div class="pantheon-official">
         <img alt="Official Pantheon Plugin" src="/source/docs/assets/images/official-plugin.svg" class="main-topic-info__plugin-image" >
           <p class="pantheon-official">Pantheon Official</p>


### PR DESCRIPTION
Closes #3050 

## Effect
PR includes the following changes:
- Updates the Terminus Plugin Directory entry with a link in the description to the Quicksilver doc, to help alleviate confusion between the plugin and the product.

## Remaining Work
- [x] Review from @greg-1-anderson, @davidneedham, @rachelwhitton 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
