### PR TITLE
Put limit in the large file recommended plugins in wp

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -110,6 +110,12 @@ It is also possible to deliver smaller media files from Pantheon using [progress
 
 Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through WordPress or Drupal, and must be added by [SFTP or rsync](/docs/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.
 
+| File Size       | Platform Compatibility            | Notes                               |
+|:--------------- | --------------------------------- |------------------------------------ |
+| ≥ 100MB         | <span style=color:green>✔</span>  | Can be uploaded via any means       |
+| < 100MB - 256MB | <span style=color:orange>✔</span> | Must be uploaded over SFTP or rsync |
+| < 256MB         | <span style=color:red>❌</span>   | Must be hosted via 3rd party CDN    |
+
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
  - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}.

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -108,14 +108,14 @@ It is also possible to deliver smaller media files from Pantheon using [progress
 
 ## Large Files
 
-Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through a CMS upload system, and must be added by [SFTP or rsync](/docs/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.
+Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through WordPress or Drupal, and must be added by [SFTP or rsync](/docs/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
  - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}.
  - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external}.
 
-Be aware, even when using an external CDN to host files, you cannot upload files over 100MB through the CMS. Upload these files directly to the CDN (here's Amazon's documentation for [upoading to an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/upload-objects.html){.external}).
+Be aware, even when using an external CDN to host files, you cannot upload files over 100MB through the CMS. Upload these files directly to the CDN (here's Amazon's documentation for [uploading to an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/upload-objects.html){.external}).
 
 See our documentation for [Drupal](/docs/drupal-s3) and [WordPress](/docs/wordpress-s3/) for more information about integrating S3 with your Pantheon site.
 

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -112,8 +112,8 @@ Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's 
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
- - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}
- - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external}
+ - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}.
+ - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external} for files that is not more than 100mb.
 
 See our documentation for [Drupal](/docs/drupal-s3) and [WordPress](/docs/wordpress-s3/) for more information about integrating S3 with your Pantheon site.
 

--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -108,12 +108,14 @@ It is also possible to deliver smaller media files from Pantheon using [progress
 
 ## Large Files
 
-Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 256MB will fail no matter how they are uploaded, even if using SFTP or rsync. Transfers with files over 50MB will experience noticeable degradation in performance.
+Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through a CMS upload system, and must be added by [SFTP or rsync](/docs/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 
  - Drupal sites can use a module such as [S3 File System](https://www.drupal.org/project/s3fs){.external}.
- - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external} for files that is not more than 100mb.
+ - WordPress sites can use plugins such as [S3 Uploads](https://github.com/humanmade/S3-Uploads){.external} or [WP Offload Media](https://deliciousbrains.com/wp-offload-media/){.external}.
+
+Be aware, even when using an external CDN to host files, you cannot upload files over 100MB through the CMS. Upload these files directly to the CDN (here's Amazon's documentation for [upoading to an S3 bucket](https://docs.aws.amazon.com/AmazonS3/latest/user-guide/upload-objects.html){.external}).
 
 See our documentation for [Drupal](/docs/drupal-s3) and [WordPress](/docs/wordpress-s3/) for more information about integrating S3 with your Pantheon site.
 


### PR DESCRIPTION
Closes #4217

## Effect
PR includes the following changes:
- Wp recommended plugins will still respect the max file upload limit of 100mb

## Remaining Work
- [ ] Technical Review
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
