### PR TITLE
Use email instead of user ID in the password reset example

### DIFF
--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -41,7 +41,7 @@ You will receive an email that contains a link you can use one time to reset you
 Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/) via [Terminus](/docs/terminus):
 
 ```nohighlight
-$ terminus wp <site>.<env> -- user update 1234 --user_pass=NEWPASSWORD
+$ terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWORD
 ```
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adjust the example WP-CLI password reset command to use an email instead of a user ID. This also works and folks are more likely to know their email than their WP user ID.

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
