### PR TITLE
Update number of sandbox sites allowed for individuals.

### DIFF
--- a/source/_docs/create-sites.md
+++ b/source/_docs/create-sites.md
@@ -24,7 +24,7 @@ The Pantheon Dashboard provides a quick "click to install" method of creating ne
 
 ## Sandbox Sites
 
-Sandbox sites are useful for trying out the Pantheon platform, creating sandboxes for development, or for starting a new client project. We allocate two Sandbox sites for all user accounts. If you have reached your limit of Sandbox sites, delete an unused site or take a site live. If you're building sites for third parties, sign up for [Pantheon for Agencies](https://pantheon.io/agencies/pantheon-for-agencies). If you're at an educational institution, sign up for [Pantheon for EDU](https://pantheon.io/pantheon-top-edu).
+Sandbox sites are useful for trying out the Pantheon platform, creating sandboxes for development, or for starting a new client project. We allocate three Sandbox sites for all user accounts. If you have reached your limit of Sandbox sites, delete an unused site or take a site live. If you're building sites for third parties, sign up for [Pantheon for Agencies](https://pantheon.io/agencies/pantheon-for-agencies). If you're at an educational institution, sign up for [Pantheon for EDU](https://pantheon.io/pantheon-top-edu).
 
 ## Your Pantheon Account
 Your account is your own individual account, and every account can manage multiple projects or sites at a time. Pantheon doesn't recommend sharing your account with other people. If you're collaborating on a project or handing over ownership to a client, use our [team management](/docs/team-management) and [ownership transfer](/docs/site-owner-faq/#billing-tasks) tools.


### PR DESCRIPTION
Per a recent discussion in Slack, I believe the correct number of sandboxes is three, not two--but probably worth verifying with an expert.

## Effect
PR includes the following changes:
- Changes number of sandboxes from two to three.

## Remaining Work
- Verify actual number of sandboxes allocated.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
