### PR TITLE
Update Drush path on timeouts and add CKFinder 3 issue and solution

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -69,6 +69,27 @@ If you have already enabled the Apache Solr Multilingual module and found that y
 $baseUrl = '/ckfinder/userfiles/';
 ```
 
+**Issue (CKFinder 3)**: CKFinder's working folder cache is located inside the module's folder hitting this error `Fatal error: Uncaught CKSource\CKFinder\Exception\AccessDeniedException: Couldn't create resource type directory. Please check permissions.`
+
+**Solution (CKFinder 3)**: Manually edit the `ckfinder/config.php` file and edit the following lines to point to the standard writeable path. Please note that you will need to create the folder `ckfinder-cache` under `sites/default/files` for this to work:
+
+```
+$config['privateDir'] = array(
+    ...
+    ...
+    'cache'  => '.sites/default/files/ckfinder-cache',
+    ...
+);
+
+$config['backends'][] = array(
+    ...
+    ...
+    'baseUrl'      => '/sites/default/files',
+    ...
+);
+
+```
+
 <hr>
 ### [Composer Manager](https://www.drupal.org/project/composer_manager){.external}
 This module has been deprecated by its authors. The suggestions made below are not guaranteed to be successful in all use cases.

--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -119,7 +119,7 @@ Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/termi
 
 As [strongly recommended by the Migrate module](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). You can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
 ```
-$conf['migrate_drush_path'] = $_ENV['HOME'] . '/drush';
+$conf['migrate_drush_path'] = '/usr/local/bin/drush';
 ```
 
 #### Can Pantheon change the non-configurable timeouts for my site?


### PR DESCRIPTION
Closes #4195 

## Effect
PR includes the following changes:
- Adds an issue and solution for CKFinder 3 here on our Modules Known Issues page - https://pantheon.io/docs/modules-plugins-known-issues/#ckfinder
- Updates the drush path to the correct value in the timeouts page here - https://pantheon.io/docs/timeouts/#frequently-asked-questions

## Remaining Work
- n/a

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
