### PR TITLE
Incorrect robots.txt output in WordPress

### DIFF
--- a/source/_docs/bots-and-indexing.md
+++ b/source/_docs/bots-and-indexing.md
@@ -107,20 +107,20 @@ if (($_SERVER['REQUEST_URI'] == '/sitemap.xml') &&
 
 For more examples of redirecting via PHP, see [Configure Redirects](/docs/redirects/).
 
-### Incorrect robots.txt output in WordPress
+### Incorrect robots.txt Output in WordPress
 
 In WordPress, do not enable **Discourage search engines from indexing this site** on Dev or Test environments. This option is set in **Settings** > **Reading** > **Search Engine Visibility** in the WordPress Admin Dashboard.
 
 This setting creates a built-in `robots.txt` file that disallows or blocks crawlers. While the file applied by the platform normally overrides it, it doesn't when there's a trailing slash on the URL pointing to `robots.txt`.
 
-As a workaround, you can override the output by creating your custom filter for `robots_txt`. You can add this as a custom plugin, or an entry in your themes `functions.php` file:
+As a workaround, you can override the output by creating your custom filter for `robots_txt`. You can add this as a custom plugin, or an entry in your theme's `functions.php` file:
 
 
 ```php
 add_filter('robots_txt', 'custom_robots_txt', 10,  2);
 
 function custom_robots_txt($output, $public) {
-    
+
     $robots_txt =  "User Agent: * \n";
     $robots_txt .=  "Sitemap: https://www.example.com/sitemap_index.xml \n";
     $robots_txt .=  "Disallow: /secure/ ";
@@ -129,4 +129,3 @@ function custom_robots_txt($output, $public) {
     return $robots_txt;
 }
 ```
-

--- a/source/_docs/bots-and-indexing.md
+++ b/source/_docs/bots-and-indexing.md
@@ -109,13 +109,15 @@ For more examples of redirecting via PHP, see [Configure Redirects](/docs/redire
 
 ### Incorrect robots.txt output in WordPress
 
-In WordPress, make sure not to enable **Discourage search engines from indexing this site** option under Settings > Reading > Search Engine Visibility in the WordPress Admin Dashboard. This will output a built-in robots.txt version that disallows or blocks crawlers.
+In WordPress, do not enable **Discourage search engines from indexing this site** on Dev or Test environments. This option is set in **Settings** > **Reading** > **Search Engine Visibility** in the WordPress Admin Dashboard.
 
-Crawlers always look for the correct file path of robots.txt and shouldn't be using any other path. In WordPress, the built-in robots_txt filter applies if you add a trailing slash to file path (i.e. www.example.com/robots.txt/ instead of just www.example.com/robots.txt). This can happen even if you have a custom robots.txt file in your site.
+This setting creates a built-in `robots.txt` file that disallows or blocks crawlers. While the file applied by the platform normally overrides it, it doesn't when there's a trailing slash on the URL pointing to `robots.txt`.
 
-As a workaround, you can override the output by creating your custom filter for robots_txt. You can add this as a custom plugin, or an entry in your themes functions.php file. See example below:
+As a workaround, you can override the output by creating your custom filter for `robots_txt`. You can add this as a custom plugin, or an entry in your themes `functions.php` file:
 
-```add_filter('robots_txt', 'custom_robots_txt', 10,  2);
+
+```php
+add_filter('robots_txt', 'custom_robots_txt', 10,  2);
 
 function custom_robots_txt($output, $public) {
     
@@ -127,3 +129,4 @@ function custom_robots_txt($output, $public) {
     return $robots_txt;
 }
 ```
+

--- a/source/_docs/bots-and-indexing.md
+++ b/source/_docs/bots-and-indexing.md
@@ -106,3 +106,24 @@ if (($_SERVER['REQUEST_URI'] == '/sitemap.xml') &&
 ```
 
 For more examples of redirecting via PHP, see [Configure Redirects](/docs/redirects/).
+
+### Incorrect robots.txt output in WordPress
+
+In WordPress, make sure not to enable **Discourage search engines from indexing this site** option under Settings > Reading > Search Engine Visibility in the WordPress Admin Dashboard. This will output a built-in robots.txt version that disallows or blocks crawlers.
+
+Crawlers always look for the correct file path of robots.txt and shouldn't be using any other path. In WordPress, the built-in robots_txt filter applies if you add a trailing slash to file path (i.e. www.example.com/robots.txt/ instead of just www.example.com/robots.txt). This can happen even if you have a custom robots.txt file in your site.
+
+As a workaround, you can override the output by creating your custom filter for robots_txt. You can add this as a custom plugin, or an entry in your themes functions.php file. See example below:
+
+```add_filter('robots_txt', 'custom_robots_txt', 10,  2);
+
+function custom_robots_txt($output, $public) {
+    
+    $robots_txt =  "User Agent: * \n";
+    $robots_txt .=  "Sitemap: https://www.example.com/sitemap_index.xml \n";
+    $robots_txt .=  "Disallow: /secure/ ";
+    // add more $robots_txt .= for each line
+
+    return $robots_txt;
+}
+```


### PR DESCRIPTION
New known error for troubleshooting

Closes #4215 

## Effect
PR includes the following changes:
- Add extra troubleshooting section
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
