### PR TITLE
Note how to include archived log files when downloading logs

### DIFF
--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -281,7 +281,8 @@ sftp -o Port=2222 live.$SITE_UUID@$app_server << !
 !
 done
 ```
-Adjust to `appserver.test.$SITE_UUID.drush.in` to pull logs from Test.
+- Adjust to `appserver.test.$SITE_UUID.drush.in` to pull logs from Test.
+- Adjust to `mget *` to include archived log files.
 
 ## See Also
 - [MySQL Slow Log](/docs/mysql-slow-log/)


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Note how to include archived log files when downloading logs

Occasionally customers are surprised to not get *all* logs when using the log retrieval script.

## Remaining Work
- [x] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
