### PR TITLE
Reference Drush and WP-CLI under script execution time

### DIFF
--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -21,7 +21,7 @@ Rules are for the good of the group, and timeouts are no exception. We've config
   <tr>
     <td><a href="https://secure.php.net/manual/en/info.configuration.php#ini.max-execution-time">PHP max_execution_time</a></td>
     <td>120 seconds</td>
-    <td>Maximum time a script can run before being terminated by the parser. Helps prevent poorly written scripts from tying up your application container's PHP workers.
+    <td>Maximum time a script can run before being terminated by the parser. This included Drush & WP-CLI commands. Helps prevent poorly written scripts from tying up your application container's PHP workers.
     <br/><br/>
      You can reduce this timeout to be less than 120 seconds via <code>settings.php</code> or <code>wp-config.php</code>, but you cannot increase it beyond 120 seconds.</td>
   </tr>

--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -21,9 +21,9 @@ Rules are for the good of the group, and timeouts are no exception. We've config
   <tr>
     <td><a href="https://secure.php.net/manual/en/info.configuration.php#ini.max-execution-time">PHP max_execution_time</a></td>
     <td>120 seconds</td>
-    <td>Maximum time a script can run before being terminated by the parser. This included Drush & WP-CLI commands. Helps prevent poorly written scripts from tying up your application container's PHP workers.
+    <td>Maximum time a script can run before being terminated by the parser. This includes Drush & WP-CLI commands. Helps prevent poorly written scripts from tying up your application container's PHP workers.
     <br/><br/>
-     You can reduce this timeout to be less than 120 seconds via <code>settings.php</code> or <code>wp-config.php</code>, but you cannot increase it beyond 120 seconds.</td>
+     You can edit this timeout via <code>settings.php</code> or <code>wp-config.php</code>. Scripts executed through the GlobalCDN will still be restricted by the 59 second connection timeout.</td>
   </tr>
   <tr>
     <td>Solr</td>


### PR DESCRIPTION
Closes #4243 

## Effect
PR includes the following changes:
- Explicitly states that Drush and WP-CLI will hit the max script execution limit.

## Remaining Work
- [x] Review from @ruthiehallarsis to make sure that resolves her concerns.
- [x] Technical review (@alexdicianu)
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
