### PR TITLE
Password reset for previous owner address

### DIFF
--- a/source/_docs/site-access.md
+++ b/source/_docs/site-access.md
@@ -11,8 +11,7 @@ This article will help you gain access to an account if a site owner has left th
 
 
 ###The Email Address is Known
-
-1. Go to the [Dashboard](https://dashboard.pantheon.io) and select the [Forgot your password](https://dashboard.pantheon.io/reset-password) link.
+1. Go to the [Password Reset](https://dashboard.pantheon.io/reset-password) page.
 2. Enter the previous owner's email address, and click **Request reset link**.
 3. Work with your email administrator so you can use the reset link to gain access.
 4. After you sign in, update the email address to an existing employee.


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Removes link to Dashboard
- Leaves just the link to the Password Reset page

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
