### PR TITLE
Clarify that site networks require Elite plan.

### DIFF
--- a/source/_docs/guides/multisite/01-introduction.md
+++ b/source/_docs/guides/multisite/01-introduction.md
@@ -41,6 +41,6 @@ We do not support uses of WordPress Site Networks that run functionally-differen
 - WordPress Multi-Network installations
 
 ## Request a WordPress Site Network
-Running a WordPress Site Network requires a special configuration that is only available to contract customers. Only Pantheon employees have the ability to create the sites and add you to the team. Existing WordPress sites cannot be converted to a network, however they can be [migrated](/docs/migrate-wordpress-site-networks/).
+Running a WordPress Site Network requires a special configuration that is only available to Elite customers. Only Pantheon employees have the ability to create the sites and add you to the team. Existing WordPress sites cannot be converted to a network, however they can be [migrated](/docs/migrate-wordpress-site-networks/).
 
 Reach out to your existing account manager to request a new WordPress Site Network be created for you. Once an employee of Pantheon has created the network, you will receive an email informing you that you've been added to the site. If you don't have an account manager, you can [contact sales](https://pantheon.io/contact-us){.external}.


### PR DESCRIPTION
Changed the word "contract" to Elite.  

Per conversations with David Newton & Cory...since not all contract clients are elite, but all Site Networks must be Elite sites, it seems less confusing to specify Elite.
 https://pantheon.slack.com/archives/C03SRV7HB/p1542404326525500

Closes #

## Effect
PR includes the following changes:
- Changes the definition of who can have a site network.

## Remaining Work
- n/a

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
