### PR TITLE
Fix Terminus Manual TOC

### DIFF
--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -23,6 +23,9 @@
           if(/\/commands.*/.test(aaObj[i].href)>=1) {
             $('#docs-terminus').removeClass('active-trail');
           }
+          if(/\/scripting.*/.test(aaObj[i].href)>=1) {
+            $('#docs-terminus').removeClass('active-trail');
+          }
           if(/\/releases.*/.test(aaObj[i].href)>=1) {
             $('#docs-terminus').removeClass('active-trail');
           }


### PR DESCRIPTION

## Effect
PR includes the following changes:
- Remove active class in TOC for get started on scripting page

Before:
 
![screen shot 2018-11-19 at 3 40 02 pm](https://user-images.githubusercontent.com/10119525/48736696-900a6680-ec11-11e8-8d71-786849d677a3.png)

After: 

![screen shot 2018-11-19 at 3 50 35 pm](https://user-images.githubusercontent.com/10119525/48737148-e62bd980-ec12-11e8-9ca3-5777a1228aeb.png)



## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
