### PR TITLE
Update Cookie Prefixes

### DIFF
--- a/source/_docs/caching-advanced-topics.md
+++ b/source/_docs/caching-advanced-topics.md
@@ -159,21 +159,4 @@ If you're using the [Security tool](/docs/security/) within the Pantheon Site D
 
 ## Cookie Handling
 
-The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (.vcl) file for your reference. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache.
-
-```nohighlight
-NO_CACHE
-S+ESS[a-z0-9]+
-fbs[a-z0-9_]+
-SimpleSAML[A-Za-z]+
-PHPSESSID
-wordpress[A-Za-z0-9_]*
-wp-[A-Za-z0-9_]+
-comment_author_[a-z0-9_]+
-duo_wordpress_auth_cookie
-duo_secure_wordpress_auth_cookie
-bp_completed_create_steps # BuddyPress cookie used when creating groups
-bp_new_group_id # BuddyPress cookie used when creating groups
-wp-resetpass-[A-Za-z0-9_]+
-(wp_)?woocommerce[A-Za-z0-9_-]+
-```
+{% include("content/cache-busting.html")%}

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -5,9 +5,6 @@ tags: [cacheedge]
 categories: []
 ---
 
-## Cookie Naming Requirements
-For cookies to function on cached pages they must match the pattern: `STYXKEY[a-zA-Z0-9_-]`. Note that on WordPress sites, if you want session cookies to be excluded from caching, they must be named with `wp-` as their prefix.
-
 ## Disable Caching for Specific Pages
 You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response.
 
@@ -57,8 +54,12 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
 
 As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.
 
+## Cache-busting Cookies
+
+{% include("content/cache-busting.html")%}
+
 ## Cache-varying Cookies
-Respond to a request with cached content depending on the presence and value of a particular cookie. It's important to note that in order for the response to be cached by Pantheon's edge, the cookie name must match `STYXKEY[a-zA-Z0-9_-]`.
+Respond to a request with cached content depending on the presence and value of a particular cookie. It's important to note that in order for the response to be cached by Pantheon's edge, the cookie name must match `STYXKEY[a-zA-Z0-9_-]+`.
 
 First, check to see if the cookie is set within the incoming request. If the cookie is set, store the value and use it to generate varied content as appropriate for your use case and implementation.
 

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -54,11 +54,11 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
 
 As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.
 
-## Cache-busting Cookies
+## Cache-Busting Cookies
 
 {% include("content/cache-busting.html")%}
 
-## Cache-varying Cookies
+## Cache-Varying Cookies
 Respond to a request with cached content depending on the presence and value of a particular cookie. It's important to note that in order for the response to be cached by Pantheon's edge, the cookie name must match `STYXKEY[a-zA-Z0-9_-]+`.
 
 First, check to see if the cookie is set within the incoming request. If the cookie is set, store the value and use it to generate varied content as appropriate for your use case and implementation.

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -33,7 +33,7 @@ if (preg_match('#^' . $friendly_path . '#', $_SERVER['REQUEST_URI'])) {
 **Be sure the `friendly_path` variable is properly set to restrict the cookie to the specific directory.**
 
 
-As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.
+As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control` header](/docs/cache-control) to bypass cache on Pantheon.
 
 ## Disable Caching On The Dev Environment
 
@@ -49,8 +49,6 @@ if (isset($_SERVER['PANTHEON_ENVIRONMENT'])) {
   }
 }
 ```
-
-As an alternative to setting a `NO_CACHE` cookie within the response, you can [modify the `Cache-Control:` header](/docs/cache-control) to bypass cache on Pantheon.
 
 ## Cache-Busting Cookies
 

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -19,11 +19,9 @@ For example, this block sets `NO_CACHE` for all pages in the `/news/` directory.
  * yourself per your specific use case before the following conditional.
  *
  * Example: anything in the /news/ directory
- *
- * $friendly_path = '/news/';
  */
 
-$friendly_path = '/some-directory-here/';
+$friendly_path = '/news/';
 
 if (preg_match('#^' . $friendly_path . '#', $_SERVER['REQUEST_URI'])) {
   $domain =  $_SERVER['HTTP_HOST'];

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -37,7 +37,7 @@ As an alternative to setting a `NO_CACHE` cookie within the response, you can [m
 
 ## Disable Caching On The Dev Environment
 
-You may decide to disable caching on the Dev environment as you make changes to cachable contents like css, js or images so that you don't need to clear the cache to see these changes.
+You may decide to disable caching on the Dev environment as you make changes to cachable files like CSS, JavaScript or images so that you don't need to clear the cache to see these changes.
 
 To bypass caching on the Dev environment, add the following to `settings.php` for Drupal and `wp-config.php` for WordPress:
 

--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -6,7 +6,7 @@ categories: []
 ---
 
 ## Cookie Naming Requirements
-For cookies to function on cached pages they must match the pattern: `STYXKEY[a-zA-Z0-9_-]`.
+For cookies to function on cached pages they must match the pattern: `STYXKEY[a-zA-Z0-9_-]`. Note that on WordPress sites, if you want session cookies to be excluded from caching, they must be named with `wp-` as their prefix.
 
 ## Disable Caching for Specific Pages
 You can use regular expression(s) to determine if the current request (`$_SERVER['REQUEST_URI']`) should be excluded from cache. If the request matches, bypass cache by setting the `NO_CACHE` cookie in the response.

--- a/source/_docs/mobile-redirection.md
+++ b/source/_docs/mobile-redirection.md
@@ -21,7 +21,7 @@ Be sure that you have:
 </div>
 
 ### Considerations
-We recommend handling mobile detection using Responsive Web Design (RWD) techniques to avoid compromising potential scalability. Creating separate mobile URLs greatly increases the amount of work required to maintain and update your site and introduces possible technical problems. For details, see [Caching: Advanced Topics](/docs/caching-advanced-topics#device-detection).
+We recommend handling mobile detection using Responsive Web Design (RWD) techniques to avoid compromising potential scalability. Creating separate mobile URLs greatly increases the amount of work required to maintain and update your site and introduces possible technical problems. For details, see [Caching: Advanced Topics](/docs/caching-advanced-topics/#device-detection).
 
 ## Add the Mobile Domain to Live
 1. Go to the Live environment on your Site Dashboard, and select **Domains/HTTPS**.

--- a/source/_partials/content/cache-busting.html
+++ b/source/_partials/content/cache-busting.html
@@ -1,4 +1,4 @@
-The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (.vcl) file for your reference. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache.
+The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (`.vcl`) file for your reference. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache:
 
 <pre><code class="nohighlight">
 NO_CACHE

--- a/source/_partials/content/cache-busting.html
+++ b/source/_partials/content/cache-busting.html
@@ -1,0 +1,17 @@
+The following is the "Cache-Busting Cookie Patterns" section from Pantheon's Varnish configuration (.vcl) file for your reference. Advanced Drupal and WordPress developers should reference this if they have any questions regarding what cookie patterns the Global CDN will not cache.
+
+<pre><code class="nohighlight">
+NO_CACHE
+S+ESS[a-z0-9]+
+fbs[a-z0-9_]+
+SimpleSAML[A-Za-z]+
+PHPSESSID
+wordpress[A-Za-z0-9_]*
+wp-[A-Za-z0-9_]+
+comment_author_[a-z0-9_]+
+duo_wordpress_auth_cookie
+duo_secure_wordpress_auth_cookie
+bp_completed_create_steps # BuddyPress cookie used when creating groups
+bp_new_group_id # BuddyPress cookie used when creating groups
+wp-resetpass-[A-Za-z0-9_]+
+(wp_)?woocommerce[A-Za-z0-9_-]+</code></pre>


### PR DESCRIPTION
Continues #4214 

## Effect
PR includes the following changes:
- moves the cache-busting cookies information from Caching Advanced Topics into a partial to be included in Cookies.
- Adds a `+` to the patterns for cache-varying cookies.
-

## Remaining Work
- [x] Technical review from @sarahg / @greg-1-anderson 
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
