### PR TITLE
Update D8+Composer-CI

### DIFF
--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -85,6 +85,16 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
    * Remove the `find tests/scripts/ -type f | xargs chmod 755` line from the `post-update-cmd` section of `scripts`.
        * You may need to remove a trailing comma from the end of the last item in the `post-update-cmd` section, otherwise the JSON will be invalid.
 
+3. Remove the following section from `pantheon.yml`:
+
+   ```yml
+     sync_code:
+       after:
+         - type: webphp
+           description: Push changes back to GitHub if needed
+           script: private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php
+   ```
+
 ## Managing Drupal with Composer
 
 <div class="alert alert-info" role="alert">


### PR DESCRIPTION
Closes #4263 

## Effect
PR includes the following changes:
- Per @daggerhart's suggestion and @greg-1-anderson's revision
- Creates a new step in the process of removing CI processess
- Removes `sync_code` from `pantheon.yml`

## Remaining Work
- [x] Technical Review
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
