### PR TITLE
Add setup for outgoing email

### DIFF
--- a/source/_docs/guides/launch/07-next-steps.md
+++ b/source/_docs/guides/launch/07-next-steps.md
@@ -31,7 +31,7 @@ When you're ready to launch another site, use this best-practice checklist to es
 <span class="checklist-icons glyphicon-unchecked"></span> [Redirect to a Primary Domain](/docs/guides/launch/redirects/)<br>
 <span class="checklist-icons glyphicon-unchecked"></span> [Setup Availability Monitoring](/docs/new-relic/#configure-ping-monitors-for-availability)<br>
 <span class="checklist-icons glyphicon-unchecked"></span> [Enable and Schedule Weekly Backups](/docs/guides/launch/launch-check/)<br>
-<span class="checklist-icons glyphicon-unchecked"></span> [Setup Outgoing Email](/docs/email/)<br>
+<span class="checklist-icons glyphicon-unchecked"></span> [Set Up Outgoing Email](/docs/email/)<br>
 <span class="checklist-icons glyphicon-unchecked"></span> [WordPress Launch Check](/docs/wordpress-launch-check/) / [Drupal Launch Check](/docs/drupal-launch-check)<br>
 <span class="checklist-icons glyphicon-unchecked"></span> [Review Status Reports](/docs/guides/launch/launch-check/)<br>
 <span class="checklist-icons glyphicon-unchecked"></span> [Enable Redis](/docs/redis/#enable-redis)<br>


### PR DESCRIPTION
Closes #4268

## Effect
PR includes the following changes:
- Add in the checklist the outgoing email setup https://pantheon.io/docs/email/

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
