### PR TITLE
Add Composer install directions for SimpleSAMLphp

### DIFF
--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -136,47 +136,46 @@ add_filter( 'wp_saml_auth_option', function( $value, $option ){
 
 For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md){.external}.
 
-## Install SimpleSAMLphp with Composer
 When using Composer to manage the SimpleSAMLphp library, you'll need to store your config files outside of the vendor directory in order to prevent those from being overwritten when you apply updates. We can use a symlink to allow SimpleSAMLphp to utilize the config files stored in the non-standard location.
 
 Commands below require a [nested docroot](/docs/nested-docroot/) structure and should all be run from the site root (not the nested docroot `web` directory).
 
-1. Add the SimpleSAMLphp library.
+1. Add the SimpleSAMLphp library:
 
-```bash
-composer require simplesamlphp/simplesamlphp
-```
+ ```bash
+ composer require simplesamlphp/simplesamlphp
+ ```
 
-2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`.
+2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`:
 
-```bash
-ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml
-```
+ ```bash
+ ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml
+ ```
 
-3. Create your site-specific config file.
+3. Create your site-specific config file:
 
-```bash
-mkdir private
-cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php
-```
+ ```bash
+ mkdir private
+ cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php
+ ```
 
-4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`).
+4. Follow the directions above to [set up your config file](#configure-simplesamlphp) (`private/simplesaml-config.php`).
 
-5. Add a symlink from SimpleSAMLphp's default config file over to your customized config, stored outside the vendor directory.
+5. Add a symlink from SimpleSAMLphp's default config file over to your customized config, stored outside the vendor directory:
 
-```bash
-ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php
-```
+ ```bash
+ ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php
+ ```
 
-6. Add this symlink as a post-update script to composer.json. This allows the symlink to be recreated if we update or re-install SimpleSAMLphp using Composer.
+6. Add this symlink as a post-update script to `composer.json`. This allows the symlink to be recreated if we update or re-install SimpleSAMLphp using Composer:
 
-```json
-    "scripts": {
-        "post-install-cmd": [
-            "ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php"
-        ]
-    },
-```
+ ```json
+     "scripts": {
+         "post-install-cmd": [
+             "ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php"
+         ]
+     },
+ ```
 
 7. Commit and push these changes back to your Pantheon dev or multidev environment, where you should now be able to access the SimpleSAMLphp installation page at `dev-yoursite.pantheonsite.io/simplesaml`.
 

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -139,7 +139,7 @@ For more details, including additional plugin configuration options, [please see
 ## Install SimpleSAMLphp with Composer
 When using Composer to manage the SimpleSAMLphp library, you'll need to store your config files outside of the vendor directory in order to prevent those from being overwritten when you apply updates. We can use a symlink to allow SimpleSAMLphp to utilize the config files stored in the non-standard location.
 
-Commands below assume a [nested docroot](/docs/nested-docroot/) structure and should all be run from the site root.
+Commands below require a [nested docroot](/docs/nested-docroot/) structure and should all be run from the site root (not the nested docroot `web` directory).
 
 1. Add the SimpleSAMLphp library.
 
@@ -162,7 +162,7 @@ cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simple
 
 4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`).
 
-5. Add a symlink from SimpleSAMLphp's default config file over to our customized config, stored outside the vendor directory.
+5. Add a symlink from SimpleSAMLphp's default config file over to your customized config, stored outside the vendor directory.
 
 ```bash
 ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -137,28 +137,36 @@ add_filter( 'wp_saml_auth_option', function( $value, $option ){
 For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md){.external}.
 
 ## Install SimpleSAMLphp with Composer
-On a Composer-managed site, you may prefer to install SimpleSAMLphp with Composer as well. When using Composer to manage the SimpleSAMLphp library, you'll need to store your config files outside of the vendor directory in order to prevent those from being overwritten when you apply updates. We can use a symlink to allow SimpleSAMLphp to utilize the config files stored in the non-standard location.
+When using Composer to manage the SimpleSAMLphp library, you'll need to store your config files outside of the vendor directory in order to prevent those from being overwritten when you apply updates. We can use a symlink to allow SimpleSAMLphp to utilize the config files stored in the non-standard location.
 
 Commands below assume a [nested docroot](/docs/nested-docroot/) structure and should all be run from the site root.
 
 1. Add the SimpleSAMLphp library.
 
-`composer require simplesamlphp/simplesamlphp`
+```bash
+composer require simplesamlphp/simplesamlphp
+```
 
 2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`. 
 
-`ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml`
+```bash
+ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml
+```
 
 3. Create your site-specific config file.
 
-`mkdir private` 
-`cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php`
+```bash
+mkdir private
+cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php
+```
 
 4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`). 
 
-5. Add a symlink from SimpleSAMLphp's default config file over to our customized one, stored outside the vendor directory.
- 
-`ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php`
+5. Add a symlink from SimpleSAMLphp's default config file over to our customized config, stored outside the vendor directory.
+
+```bash 
+ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php
+```
 
 6. Add this symlink as a post-update script to composer.json. This allows the symlink to be recreated if we update or re-install SimpleSAMLphp using Composer.
 

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -147,7 +147,7 @@ Commands below assume a [nested docroot](/docs/nested-docroot/) structure and sh
 composer require simplesamlphp/simplesamlphp
 ```
 
-2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`. 
+2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`.
 
 ```bash
 ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml
@@ -160,11 +160,11 @@ mkdir private
 cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php
 ```
 
-4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`). 
+4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`).
 
 5. Add a symlink from SimpleSAMLphp's default config file over to our customized config, stored outside the vendor directory.
 
-```bash 
+```bash
 ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php
 ```
 
@@ -172,7 +172,7 @@ ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesam
 
 ```json
     "scripts": {
-        "post-update-cmd": [
+        "post-install-cmd": [
             "ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php"
         ]
     },

--- a/source/_docs/shibboleth-sso.md
+++ b/source/_docs/shibboleth-sso.md
@@ -136,6 +136,42 @@ add_filter( 'wp_saml_auth_option', function( $value, $option ){
 
 For more details, including additional plugin configuration options, [please see the README](https://github.com/pantheon-systems/wp-saml-auth/blob/master/README.md){.external}.
 
+## Install SimpleSAMLphp with Composer
+On a Composer-managed site, you may prefer to install SimpleSAMLphp with Composer as well. When using Composer to manage the SimpleSAMLphp library, you'll need to store your config files outside of the vendor directory in order to prevent those from being overwritten when you apply updates. We can use a symlink to allow SimpleSAMLphp to utilize the config files stored in the non-standard location.
+
+Commands below assume a [nested docroot](/docs/nested-docroot/) structure and should all be run from the site root.
+
+1. Add the SimpleSAMLphp library.
+
+`composer require simplesamlphp/simplesamlphp`
+
+2. Add a symlink from `web/simplesaml` to `vendor/simplesamlphp/simplesamlphp/www`. 
+
+`ln -s ../vendor/simplesamlphp/simplesamlphp/www ./web/simplesaml`
+
+3. Create your site-specific config file.
+
+`mkdir private` 
+`cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesaml-config.php`
+
+4. Follow the directions [above](#configure-simplesamlphp) to set up your config file (`private/simplesaml-config.php`). 
+
+5. Add a symlink from SimpleSAMLphp's default config file over to our customized one, stored outside the vendor directory.
+ 
+`ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php`
+
+6. Add this symlink as a post-update script to composer.json. This allows the symlink to be recreated if we update or re-install SimpleSAMLphp using Composer.
+
+```json
+    "scripts": {
+        "post-update-cmd": [
+            "ln -s ../../../../private/simplesaml-config.php ./vendor/simplesamlphp/simplesamlphp/config/config.php"
+        ]
+    },
+```
+
+7. Commit and push these changes back to your Pantheon dev or multidev environment, where you should now be able to access the SimpleSAMLphp installation page at `dev-yoursite.pantheonsite.io/simplesaml`.
+
 ## Troubleshooting
 ### Varnish Not Working/Cookie Being Set for Anonymous Users
 


### PR DESCRIPTION
Closes #3696 

## Effect
PR includes the following changes:
- Adds Composer install directions for SimpleSAMLphp

## Remaining Work
- [x] fix "File exists" error when running a `composer update` (maybe the post-update script should be PHP instead of a shell command)
- [x] technical review
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
