### PR TITLE
Fix migrate_drush_path

### DIFF
--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -128,3 +128,4 @@ No, these settings apply to every site on Pantheon. One of the ways Pantheon sca
 ### How do I change the Solr timeout on Drupal?
 
 Edit the `pantheon_apachesolr` module within your Drupal site installation and enjoy your voided warranty (we can't support user modifications). Seriously, this treats a symptom and not the problem; you should reduce the batch size instead and avoid indexing large binary files.
+

--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -116,8 +116,9 @@ Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/termi
 ### What if I run into a timeout when using the Drupal Migrate UI?
 
 As [strongly recommended by the Migrate module](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). You can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
+
 ```
-$conf['migrate_drush_path'] = $_ENV['HOME'] . '/drush';
+$conf['migrate_drush_path'] = $_ENV['HOME'] . '/bin/drush';
 ```
 
 ### Can Pantheon change the non-configurable timeouts for my site?


### PR DESCRIPTION
Continues part of  #4222 

## Effect
PR includes the following changes:
- Fixes the path to configure for `migrate_drush_path`, as discussed in #4222 

## Remaining Work
- [x] Technical Review
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
