### PR TITLE
Further clarify what the clone operation does

### DIFF
--- a/source/_docs/guides/quickstart/06-clone-live-to-dev.md
+++ b/source/_docs/guides/quickstart/06-clone-live-to-dev.md
@@ -69,6 +69,8 @@ In this lesson, we’ll explore your Live site and add an article or post to sim
     <div class="alert alert-danger" role="alert">
       <h4 class="info">Warning</h4>
       <p>As intended, this action will overwrite your Dev database and files. If you skipped the backup task you will be unable to recover this data hereafter.</p>
+      <p>The Clone operation only involves the FILES folder (wp-content/uploads or sites/default/files) which do not include core, theme, plugins or modules. You will still need to manually copy over your CODE from one environment to another via SFTP of Git.</p>
+      
     </div>
 
 7. Click **Clone the Database & files from Live into the Development Environment**.


### PR DESCRIPTION
Closes #4286

## Effect
PR includes the following changes:
- Clarify that the cloning operation only involves FILES folder (wp-content/uploads or sites/default/files) which do not include core, theme, plugins or modules.


## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
