### PR TITLE
Clarify Unprivileged User Access to Multidev

### DIFF
--- a/source/_docs/multidev.md
+++ b/source/_docs/multidev.md
@@ -165,7 +165,7 @@ This will create a new branch with the commit history intact. From the Multidev 
 
 ### How can I get Multidev and how much does it cost?
 
-Multidev is available to all Enterprise organizations, EDU organizations, Pantheon Partners, and Direct Online customers with Gold support. Unprivileged members of organizations can access, but not create Multidev environments. Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
+Multidev is available to all Enterprise organizations, EDU organizations, Pantheon Partners, and Direct Online customers with Gold support. Unprivileged members of organizations can access and commit to, but not create Multidev environments. Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
 
 ### If I use SFTP mode on a branch environment, do all environments have to be in SFTP mode?
 


### PR DESCRIPTION
Closes #4289 

## Effect
PR includes the following changes:
- Clarifies that unprivileged user access to multidev environments includes commit access.

## Remaining Work
- [ ] Review from @rachelwhitton 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
