### PR TITLE
Clarify https requirements and provisioning

### DIFF
--- a/source/_docs/guides/launch/04-configure-dns.md
+++ b/source/_docs/guides/launch/04-configure-dns.md
@@ -24,7 +24,7 @@ In this lesson we'll configure DNS and provision [free, automated HTTPS](/docs/h
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
-<p markdown="1">If your site is already live and is serving HTTPS traffic and will require HTTPS on Pantheon, return to [Connect a Domain Name](/docs/guides/launch/domains/) and complete the steps to pre-provision HTTPS before updating DNS to avoid downtime.</p>
+<p markdown="1">If your site is already live and serving HTTPS traffic, and will require HTTPS on Pantheon, return to [Connect a Domain Name](/docs/guides/launch/domains/) and complete the steps to pre-provision HTTPS before updating DNS to avoid downtime.</p>
 </div>
 
 {% include("content/configure-dns.html")%}

--- a/source/_docs/guides/launch/04-configure-dns.md
+++ b/source/_docs/guides/launch/04-configure-dns.md
@@ -24,7 +24,7 @@ In this lesson we'll configure DNS and provision [free, automated HTTPS](/docs/h
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
-<p markdown="1">If your site is already live and requires HTTPS, return to [Connect a Domain Name](/docs/guides/launch/domains/) and complete the steps to pre-provision HTTPS before updating DNS to avoid downtime.</p>
+<p markdown="1">If your site is already live and is serving HTTPS traffic and will require HTTPS on Pantheon, return to [Connect a Domain Name](/docs/guides/launch/domains/) and complete the steps to pre-provision HTTPS before updating DNS to avoid downtime.</p>
 </div>
 
 {% include("content/configure-dns.html")%}

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,6 +1,6 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All A/AAAA/CNAME/DNAME DNS records must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
+  <li>All A/AAAA/CNAME/DNAME DNS records for any Pantheon-hosted domains ("example.com") and/or subdomains ("www.example.com" or "blog.example.com") must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
   <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>

--- a/source/_partials/content/https-requirements.html
+++ b/source/_partials/content/https-requirements.html
@@ -1,6 +1,6 @@
 <h3>Requirements for Automated Certificate Renewal</h3>
 <ul>
-  <li>All A/AAAA/CNAME/DNAME DNS records for any Pantheon-hosted domains ("example.com") and/or subdomains ("www.example.com" or "blog.example.com") must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
+  <li>All A/AAAA/CNAME/DNAME DNS records for any Pantheon-hosted domains (<code>example.com</code>) and/or subdomains (<code>www.example.com</code> or <code>blog.example.com</code>) must point to Pantheon's servers so Let's Encrypt can verify domain ownership.</li>
   <li>AAAA records are not required, but if set must exclusively point to Pantheon.</li>
   <li>Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.</li>
   <li>CAA records must either 1) not exist for the domain and its parent domains or 2) authorize Let's Encrypt.</li>


### PR DESCRIPTION

## Effect
PR includes the following changes:
- Resolves customer confusion that not ALL DNS entries for their site need to be pointed over. (They were unsure if they could keep hr.domain.com, clients.domain.com and other 3rd-party hosted domains)
- Clarify that pre-provisioning is only available for sites already serving HTTPS before moving to Pantheon.


## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
