### PR TITLE
clarify multidev access on site level

### DIFF
--- a/source/_docs/change-management.md
+++ b/source/_docs/change-management.md
@@ -22,8 +22,8 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 |:---------------------------------------- |:-------------------------------- |:-------------------------------- |:-------------------------------- |:-------------------------------- |
 | Create sites within an org               | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
 | Access the org Dashboard                 | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  |
-| Work in Dev/Multidev environments        | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
-| Create Multidev environments             | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  |
+| Work in Dev environments                 | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
+| Access to Multidev environments          | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  |
 | Deploy to Test and Live                  | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  |
 | Invite new team members                  | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  |
 | Manage user roles                        | <span style=color:green>✔</span> | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  |

--- a/source/_docs/change-management.md
+++ b/source/_docs/change-management.md
@@ -36,7 +36,7 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 | Permissions                              | User in Charge / Owner <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Owner" data-content="Partner organizations only"><em class="fa fa-info-circle"></em></a> | Team Member | Developer <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Enterprise organizations only"><em class="fa fa-info-circle"></em></a> |
 |:---------------------------------------- |:-------------------------------- |:-------------------------------- |:-------------------------------- |
 | Access the site Dashboard                | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
-| Work in Dev/Multidev environments        | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
+| Work in Dev environments                 | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:green>✔</span> |
 | Deploy to Test and Live                  | <span style=color:green>✔</span> | <span style=color:green>✔</span> | <span style=color:red>❌</span>  |
 | Manage user roles                        | <span style=color:green>✔</span> | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  |
 | Delete sites or remove users from a site | <span style=color:green>✔</span> | <span style=color:red>❌</span>  | <span style=color:red>❌</span>  |

--- a/source/_docs/multidev.md
+++ b/source/_docs/multidev.md
@@ -165,7 +165,19 @@ This will create a new branch with the commit history intact. From the Multidev 
 
 ### How can I get Multidev?
 
-Multidev is available to all Enterprise organizations, EDU organizations, Pantheon Partners, and Direct Online customers with [Gold support](/docs/support/#support-features-and-response-times). Unprivileged members of organizations can access and commit to, but not create Multidev environments. Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
+Multidev is available to:
+
+ - Enterprise organizations
+ - EDU organizations
+ - Pantheon Partner Program agencies (at the level of Pantheon Partner and above)
+ - Direct Online customers with [Gold support](/docs/support/#support-features-and-response-times) and above.
+
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+Unprivileged members of organizations cannot access Multidev environments. See [Change Management](/docs/change-management/) for more information.
+</div>
+
+Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
 
 ### If I use SFTP mode on a branch environment, do all environments have to be in SFTP mode?
 

--- a/source/_docs/multidev.md
+++ b/source/_docs/multidev.md
@@ -163,9 +163,9 @@ This will create a new branch with the commit history intact. From the Multidev 
 
 ## Frequently Asked Questions (FAQs)
 
-### How can I get Multidev and how much does it cost?
+### How can I get Multidev?
 
-Multidev is available to all Enterprise organizations, EDU organizations, Pantheon Partners, and Direct Online customers with Gold support. Unprivileged members of organizations can access and commit to, but not create Multidev environments. Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
+Multidev is available to all Enterprise organizations, EDU organizations, Pantheon Partners, and Direct Online customers with [Gold support](/docs/support/#support-features-and-response-times). Unprivileged members of organizations can access and commit to, but not create Multidev environments. Visit the [Partner Program Page](https://pantheon.io/agencies/partner-program){.external} to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us){.external}.
 
 ### If I use SFTP mode on a branch environment, do all environments have to be in SFTP mode?
 


### PR DESCRIPTION
Closes #4305 

## Effect
PR includes the following changes:
- New line in the Site-Team permissions table
- This line clarifies the existing line regarding working in Dev/Multidev environments, by specifically stating you can create or delete them.

## Preview
![image](https://user-images.githubusercontent.com/2349184/49617056-9f5f1300-f978-11e8-9f5e-aa0613f3d411.png)

## Remaining Work
- [ ] Confirmation from @pantheon-systems/product-management that the description of behavior is correct. (~provided by @slivermon~ Updated, needs re-review)
- [x] @NeoMeteor does this clarify the confusion raised in your issue?
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
