### PR TITLE
Make numbers consistent re: large file backups

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -183,7 +183,7 @@ $urls[] = array( 'https://www.example.com', 'http://www.example.com', 'https://e
 
 ## Large (>100GB) File Backups
 
-Large backups take longer, use more resources, and have a higher likelihood of failing.  Additionally, a 100GB tarball is in itself not particularly convenient for anyone.  For this reason, scheduled backups do not backup files for sites with footprints over 200GB (although code and database are backed-up as normal).  Despite the lack of backups, file content is highly durable and stored on multiple servers.
+Large backups take longer, use more resources, and have a higher likelihood of failing.  Additionally, a 100GB compressed tarball is in itself not particularly convenient for anyone.  For this reason, scheduled backups do not backup files for sites with footprints over 200GB (although code and database are backed-up as normal).  Despite the lack of backups, file content is highly durable and stored on multiple servers.
 
 ## CSS Preprocessors
 


### PR DESCRIPTION
Based on workflow logs and the original version of this doc, I believe 200GB is the cut-off, not 100GB. The use of both 100 & 200 in that paragraph confused the customer in chat, so I wanted to clarify here.

Closes # n/a

## Effect
PR includes the following changes:
- Clarifies file backup size limits

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
