### PR TITLE
Note that mcrypt is not included with PHP 7.2

### DIFF
--- a/source/_docs/application-containers.md
+++ b/source/_docs/application-containers.md
@@ -24,7 +24,7 @@ Attempts to remotely access services, such as MySQL or SFTP connections, will fa
 
 - All containers are created equally; free accounts are not underpowered.
 - All environments contain a highly tuned PHP-FPM worker and a modern version of PHP. For a comprehensive list of what's installed, see [Securely Working with phpinfo](/docs/phpinfo).
-  - Packages: LDAP, SOAP, GD, Mcrypt, MySQL, Imagick (ImageMagick), PDO, mbstring, XML, IMAP
+  - Packages: LDAP, SOAP, GD, Mcrypt (when running PHP versions under 7.2), MySQL, Imagick (ImageMagick), PDO, mbstring, XML, IMAP
   - Extensions: APC, New Relic PHP agent, OAuth, Redis
   - [short\_open\_tag](https://secure.php.net/manual/en/ini.core.php#ini.short-open-tag) is off (Pantheon does not support `<? ?>` syntax; use `<?php ?>` instead)
   - Maximum PHP execution time and other timeouts can be configured as noted in [Timeouts on Pantheon](/docs/timeouts/).


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Note that mcrypt is not installed with PHP 7.2 — mycrypt was deprecated in 7.1 and excluded from PHP core in 7.2.

internal ref: BUGS-2168 / #121738

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
