### PR TITLE
add note about scope of support

### DIFF
--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -142,14 +142,13 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
 
 9. [Authorize CircleCI on GitHub](https://github.com/login/oauth/authorize?client_id=78a2ba87f071c28e65bb){.external}.
 
-    <div class="alert alert-info" markdown="1">
-    #### Note {.info}
     If you are redirected to the CircleCI homepage, you have already authorized the service for your GitHub account. Nice! Way to be ahead of the game.
-    </div>
 
 <div class="alert alert-info" markdown="1">
 #### Note {.info}
-Pantheon's [support team](/docs/support/) cannot troubleshoot issues with third-party services like GitHub or CircleCI. If you need help configuring external systems, consider joining the [Pantheon Power Users](/docs/power-users/) community on Slack.
+Pantheon's [support team](/docs/support/) cannot troubleshoot issues with third-party services like GitHub or CircleCI.
+
+If you need help configuring external systems, consider joining the [Pantheon Power Users](/docs/power-users/) community on Slack.
 </div>
 
 

--- a/source/_docs/guides/build-tools/01-introduction.md
+++ b/source/_docs/guides/build-tools/01-introduction.md
@@ -142,10 +142,16 @@ Composer is used to fetch dependencies declared by the project as part of a Circ
 
 9. [Authorize CircleCI on GitHub](https://github.com/login/oauth/authorize?client_id=78a2ba87f071c28e65bb){.external}.
 
-    <div class="alert alert-info">
-    <h4 class="info">Note</h4>
-    <p markdown="1">If you are redirected to the CircleCI homepage, you have already authorized the service for your GitHub account. Nice! Way to be ahead of the game.</p>
+    <div class="alert alert-info" markdown="1">
+    #### Note {.info}
+    If you are redirected to the CircleCI homepage, you have already authorized the service for your GitHub account. Nice! Way to be ahead of the game.
     </div>
+
+<div class="alert alert-info" markdown="1">
+#### Note {.info}
+Pantheon's [support team](/docs/support/) cannot troubleshoot issues with third-party services like GitHub or CircleCI. If you need help configuring external systems, consider joining the [Pantheon Power Users](/docs/power-users/) community on Slack.
+</div>
+
 
 ### Access Tokens (Optional)
 


### PR DESCRIPTION
Closes #4316 

## Effect
PR includes the following changes:
- Adds a note about the scope of Pantheon Support, and link to Power Users

## Remaining Work
- [x] Review from @xq42 or others in @pantheon-systems/cse 
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
