### PR TITLE
Add Launch Check opt-out example for D8.

### DIFF
--- a/source/_docs/drupal-launch-check.md
+++ b/source/_docs/drupal-launch-check.md
@@ -36,14 +36,14 @@ To generate the reports, Pantheon uses [Site Audit](https://drupal.org/project/
 
 ## Frequently Asked Questions
 
-#### Trusted Host Setting for Drupal 8
+### Trusted Host Setting for Drupal 8
 A warning within `/admin/reports/status` will appear when the `trusted_host_patterns` setting is not configured. This setting protects sites from HTTP Host header attacks. However, sites running on Pantheon are not vulnerable to this specific attack and the warning can be safely ignored. For more details, see [Configuring settings.php](/docs/settings-php/#trusted-host-setting).
 
-#### Why does site audit have more reports than what's shown in the Dashboard?
+### Why does site audit have more reports than what's shown in the Dashboard?
 
 The Dashboard integration is intended to provide developers with the most actionable items; some reports are purely informational and have been omitted. Additionally, some reports are more system intensive, so it makes more sense to allow them to be run on-demand, rather than automatically.
 
-#### How can I manually run site audit on my site?
+### How can I manually run site audit on my site?
 
 You can get a list of all available site audit reports using [Terminus](/docs/terminus/):
 ```nohighlight
@@ -55,14 +55,14 @@ You can also execute a full report in HTML format.
 terminus remote:drush <site>.<env> -- aa --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
 ```
 
-#### Are there plans to support Drupal 6 sites?
+### Are there plans to support Drupal 6 sites?
 At this time, there are no plans to support Drupal 6 with this tool.
 
-#### Can I opt-out of a specific recommendation?
+### Can I opt-out of a specific recommendation?
 
 If you want to permanently opt-out of a check, you can set configuration options in `settings.php`. Individual check names can be specified with a combination of the report name and check name. Note that the configuration array is `$conf` in Drupal 7 and `$config` in Drupal 8.
 
-##### Examples
+#### Examples
 Drupal 7 — permanently opt-out of the PageCompression check in the Cache report:
 
 ```php
@@ -75,17 +75,17 @@ Drupal 8 — permanently out-out of the check for Development modules:
 $config['site_audit']['opt_out']['ExtensionsDev'] = TRUE;
 ```
 
-The specific key you'll use in the `$conf` or `$config` array is a combination of the report and the check. You can find a list of checks for the report here: [Site Audit Checks D7](http://cgit.drupalcode.org/site_audit/tree/Check?h=7.x-1.x) | [Site Audit Checks D8](http://cgit.drupalcode.org/site_audit/tree/Check?h=8.x-2.x).
+The specific key you'll use in the `$conf` or `$config` array is a combination of the report and the check. You can find a list of checks for the report here: [Site Audit Checks D7](http://cgit.drupalcode.org/site_audit/tree/Check?h=7.x-1.x){.external} | [Site Audit Checks D8](http://cgit.drupalcode.org/site_audit/tree/Check?h=8.x-2.x){.external}.
 
 Keep in mind that the site audit is executed via Drush so it's best to use the [`$_ENV` superglobal](/docs/read-environment-config/) for doing things like limiting the exclusions to one environment.
 
-#### I want to contribute/I found a mistake. How should I proceed?
+### I want to contribute/I found a mistake. How should I proceed?
 
 Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) to add and request features, or to report inaccuracies.
 
 ## Troubleshooting
 
-#### Site Audit isn't running on my site.
+### Site Audit isn't running on my site.
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/docs/terminus/) command to execute Site Audit directly on your Pantheon site:
 ```bash

--- a/source/_docs/drupal-launch-check.md
+++ b/source/_docs/drupal-launch-check.md
@@ -60,11 +60,22 @@ At this time, there are no plans to support Drupal 6 with this tool.
 
 #### Can I opt-out of a specific recommendation?
 
-If you want to permanently opt-out of a check, you can use the [$conf array in settings.php](https://drupal.org/node/1525472). Individual check names can be specified with a combination of the report name and check name. For example, to permanently opt-out of the PageCompression check in the Cache report:
+If you want to permanently opt-out of a check, you can set configuration options in `settings.php`. Individual check names can be specified with a combination of the report name and check name. Note that the configuration array is `$conf` in Drupal 7 and `$config` in Drupal 8.
+
+##### Examples
+Drupal 7 — permanently opt-out of the PageCompression check in the Cache report:
+
 ```php
 $conf['site_audit']['opt_out']['CachePageCompression'] = TRUE;
 ```
-The specific key you'll use in the `$conf` array is a combination of the report and the check. You can find a list of checks for the report here: [Site Audit Checks](http://cgit.drupalcode.org/site_audit/tree/Check).
+
+Drupal 8 — permanently out-out of the check for Development modules:
+
+```php
+$config['site_audit']['opt_out']['ExtensionsDev'] = TRUE;
+```
+
+The specific key you'll use in the `$conf` or `$config` array is a combination of the report and the check. You can find a list of checks for the report here: [Site Audit Checks D7](http://cgit.drupalcode.org/site_audit/tree/Check?h=7.x-1.x) | [Site Audit Checks D8](http://cgit.drupalcode.org/site_audit/tree/Check?h=8.x-2.x).
 
 Keep in mind that the site audit is executed via Drush so it's best to use the [`$_ENV` superglobal](/docs/read-environment-config/) for doing things like limiting the exclusions to one environment.
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Add a Launch Check opt-out example for Drupal 8.

## Remaining Work
- [ ] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
