### PR TITLE
explain why CNAME records are preferred

### DIFF
--- a/source/_docs/dns.md
+++ b/source/_docs/dns.md
@@ -173,6 +173,8 @@ Address: 2620:12a:8000::1
 
 In the example above, we can create an `A` record for `www` set to `23.185.0.1` to substitute the `CNAME` record.
 
+{% include("content/cname-advantage.html")%}
+
 ## See Also
 
  - [Launch Essentials](/docs/guides/launch/)

--- a/source/_docs/domains.md
+++ b/source/_docs/domains.md
@@ -89,6 +89,10 @@ Pantheon Partners, Strategic Partners, Enterprise accounts, Resellers, and OEM P
 
 For details, see [Vanity Domains](/docs/vanity-domains/).
 
+## Frequently Asked Questions
+
+{% include("content/cname-advantage.html")%}
+
 ## Troubleshooting
 ### Failed cache clears, search and replace, or Drush and WP-CLI operations
 All redirect logic should include the `php_sapi_name() != "cli"` conditional statement to see if WordPress or Drupal is running via the command line. Drush and WP-CLI are used by the platform for operations like cache clearing and search and replace, so it is important to only redirect web requests, otherwise the redirect will kill the PHP process before Drush or WP-CLI is executed, resulting in a silent failure:

--- a/source/_docs/guides/launch/04-configure-dns.md
+++ b/source/_docs/guides/launch/04-configure-dns.md
@@ -49,3 +49,5 @@ For more detailed instructions pertaining to your specific DNS host, click below
 {% include("content/enable-https.html")%}
 
 {% include("content/https-requirements.html")%}
+
+{% include("content/cname-advantage.html")%}

--- a/source/_partials/content/cname-advantage.html
+++ b/source/_partials/content/cname-advantage.html
@@ -1,0 +1,4 @@
+<h3> Why does Pantheon recommend CNAME records?</h3>
+
+<p><code>CNAME</code> records point domains at other domains, instead of IP addresses. Using <code>CNAME</code> records means your DNS configuration is more stable in the event of a hardware change that updates IP addresses on the platform. Pantheon manages our own DNS records, and will update the <code>A</code> record for the platform domain your <code>CNAME</code> record is pointed to immediately.</p>
+


### PR DESCRIPTION
Closes #3798 

## Effect
PR includes the following changes:
- Creates a partial file explaining why CNAME records are preferred.
- Adds the partial to several docs covering DNS records.


## Remaining Work
- [ ] Technical Review
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
