### PR TITLE
remove reference to upstream link

### DIFF
--- a/source/_docs/sites.md
+++ b/source/_docs/sites.md
@@ -31,7 +31,7 @@ If you no longer need your site, you can remove it here.
 This tab shows general information about your site, such as the framework, upstream, date it was created, and your current plan.
 
 #### View your Site's Upstream
-To find a link to your site's upstream, click **Settings**, then **About Site**.
+To find your site's upstream, click **Settings**, then **About Site**.
 
 ![Upstream link](/docs/assets/images/dashboard/upstream-link.png)
 


### PR DESCRIPTION
Closes `AL-1617`

## Effect
PR includes the following changes:
- remove reference to upstream link
- This link only appears under certain conditions, and is not the general view

## Remaining Work
- [x] Copy review (do we really need it tho?)

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report (debatable)
- [ ] Archive from **Done** in Waffle