### PR TITLE
Correcting greater than/less than signs.

### DIFF
--- a/source/_docs/platform-considerations.md
+++ b/source/_docs/platform-considerations.md
@@ -112,9 +112,9 @@ Due to the configuration of the [Pantheon Filesystem](/docs/files/), Pantheon's 
 
 | File Size       | Platform Compatibility            | Notes                               |
 |:--------------- | --------------------------------- |------------------------------------ |
-| ≥ 100MB         | <span style=color:green>✔</span>  | Can be uploaded via any means       |
-| < 100MB - 256MB | <span style=color:orange>✔</span> | Must be uploaded over SFTP or rsync |
-| < 256MB         | <span style=color:red>❌</span>   | Must be hosted via 3rd party CDN    |
+| ≤ 100MB         | <span style=color:green>✔</span>  | Can be uploaded via any means       |
+|   100MB - 256MB | <span style=color:orange>✔</span> | Must be uploaded over SFTP or rsync |
+| > 256MB         | <span style=color:red>❌</span>   | Must be hosted via 3rd party CDN    |
 
 If you are distributing large binaries or hosting big media files, we recommend using a CDN like Amazon S3 as a cost-effective file serving solution that allows uploads directly to S3 from your site without using Pantheon as an intermediary.
 


### PR DESCRIPTION
I believe the greater than/less than signs were used in the wrong order (e.g. it read 'greater than or equal to 100MB', 'greater than 100mb-256mb' and 'less than 256mb' in the chart. I swapped the direction of the 1st and 3rd, and removed the middle one since it's really between them. I'd normally just merge but want to make sure I'm not doing this incorrectly.

Closes n/a

## Effect
PR includes the following changes:
- Swaps the greater than/less than signs
- Removes one greater than sign 

## Remaining Work
- [ ] none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
