### PR TITLE
Fix Solr schema post path for D7.

### DIFF
--- a/source/_docs/solr-drupal-7.md
+++ b/source/_docs/solr-drupal-7.md
@@ -178,9 +178,9 @@ It needs to be done for Dev, Test, and Live individually. You can do this at `ad
 
 #### Re-Index Content
 
-ApacheSolr module: You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
+**ApacheSolr module:** You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
 
-Search API Solr module: Navigate to your Search Index list page at `admin/config/search/search_api` and click the index you need to rebuild. On the index view page, you can either queue all items for reindexing or clear your existing index and re-index in batches.
+**Search API Solr module:** Navigate to your Search Index list page at `admin/config/search/search_api` and click the index you need to rebuild. On the index view page, you can either queue all items for reindexing or clear your existing index and re-index in batches.
 
 ## Safely Remove Solr
 The following code changes are required before Solr can be safely uninstalled and disabled:

--- a/source/_docs/solr-drupal-7.md
+++ b/source/_docs/solr-drupal-7.md
@@ -174,7 +174,7 @@ Exception: SolrPhpClient library not found! Please follow the instructions in se
 
 #### Did you post the schema into all your environments?
 
-It needs to be done for Dev, Test, and Live individually. You can do this at `admin/config/search/pantheon`.
+It needs to be done for Dev, Test, and Live individually. You can do this at `admin/config/search/pantheon/schema`.
 
 #### Re-Index Content
 

--- a/source/_docs/solr-drupal-7.md
+++ b/source/_docs/solr-drupal-7.md
@@ -178,7 +178,9 @@ It needs to be done for Dev, Test, and Live individually. You can do this at `ad
 
 #### Re-Index Content
 
-You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
+ApacheSolr module: You can do this at `admin/config/search/apachesolr`. This will add any new content that has not yet been indexed to the Solr index (within the provided numbers-per-indexing setting).
+
+Search API Solr module: Navigate to your Search Index list page at `admin/config/search/search_api` and click the index you need to rebuild. On the index view page, you can either queue all items for reindexing or clear your existing index and re-index in batches.
 
 ## Safely Remove Solr
 The following code changes are required before Solr can be safely uninstalled and disabled:


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Fix path to Schema Post admin page in D7
- Include `search_api_solr` path to the "Re-Index Content" troubleshooting section

## Remaining Work
- [x] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
