### PR TITLE
Also added wp for the large sites

### DIFF
--- a/source/_docs/migrate-manual.md
+++ b/source/_docs/migrate-manual.md
@@ -6,7 +6,7 @@ categories: []
 ---
 Manually migrate your site to Pantheon when any of the following apply:
 
-* **Large Drupal Site Archive**: Site archive exceeds the import file size limit of 500MB.
+* **Large Drupal And WordPress Site Archive**: Site archive exceeds the import file size limit of 500MB.
 * **Preserve Git History**: You'd like to preserve your site's existing Git commit history.
 * **[WordPress Site Networks](/docs/guides/multisite/)**
 * **Plugin install unavailable on existing WordPress site**: For example, if your existing site is hosted on WordPress.com, you'll be unable to install the Pantheon Migrations plugin.

--- a/source/_docs/migrate-manual.md
+++ b/source/_docs/migrate-manual.md
@@ -6,7 +6,8 @@ categories: []
 ---
 Manually migrate your site to Pantheon when any of the following apply:
 
-* **Large Drupal And WordPress Site Archive**: Site archive exceeds the import file size limit of 500MB.
+* **Large Drupal Site Archive**: Site archive exceeds the import file size limit of 500MB.
+* **Large WordPress Site**: WordPress site exceeds 500MB.
 * **Preserve Git History**: You'd like to preserve your site's existing Git commit history.
 * **[WordPress Site Networks](/docs/guides/multisite/)**
 * **Plugin install unavailable on existing WordPress site**: For example, if your existing site is hosted on WordPress.com, you'll be unable to install the Pantheon Migrations plugin.


### PR DESCRIPTION
Closes #4347 

## Effect
PR includes the following changes:
- Change to Large Drupal and WordPress Site Archive


## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
