### PR TITLE
update solr.md - missing "x" in plan comparison

### DIFF
--- a/source/_docs/solr.md
+++ b/source/_docs/solr.md
@@ -18,7 +18,7 @@ All plans except for a Basic plan can use Solr. Solr is available to Sandbox sit
 | Plans         | Solr Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
 | ------------- | ------ |
 | Sandbox       | ✓      |
-| Basic         |        |
+| Basic         | x      |
 | Performance   | ✓      |
 | Elite         | ✓      |
 


### PR DESCRIPTION
cf. same kind of table in https://pantheon.io/docs/redis/

Closes #

## Effect
PR includes the following changes:
- add "x" in the plan comparison area

## Remaining Work
- [ ] Determine if entire table format should change to match https://pantheon.io/docs/redis/

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
