### PR TITLE
make rsync verbose

### DIFF
--- a/scripts/deploy-multidev.sh
+++ b/scripts/deploy-multidev.sh
@@ -90,7 +90,7 @@ if [ "$CIRCLE_BRANCH_SLUG" != "master" ] && [ "$CIRCLE_BRANCH_SLUG" != "dev" ] &
   touch ./multidev-log.txt
   while true
   do
-    if ! rsync --checksum --delete-after -rtlzq --ipv4 --info=BACKUP,DEL --log-file=multidev-log.txt -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/; then
+    if ! rsync -vvvv --checksum --delete-after -rtlz --ipv4 --log-file=multidev-log.txt -e 'ssh -p 2222 -oStrictHostKeyChecking=no' output_prod/docs/ --temp-dir=../../tmp/ $normalize_branch.$STATIC_DOCS_UUID@appserver.$normalize_branch.$STATIC_DOCS_UUID.drush.in:files/docs/; then
       echo "Failed, retrying..."
       sleep 5
     else


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Changes the rsync flags used when transferring build artifacts to multidev environments.
- Purpose is to better identify the source of build failures during the transfer process.
- Should be reverted once the issue is resolved.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Stage a PR to revert
- [ ] Merge ^ when issue is resolved
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
