### PR TITLE
Note typical provision time

### DIFF
--- a/source/_docs/relaunch.md
+++ b/source/_docs/relaunch.md
@@ -46,6 +46,8 @@ The permission to manage billing and plans is granted only to the role of **Site
 
   {% include("content/notes/https-success.html")%}
 
+   This process typically takes about an hour.
+
 5. From the DNS hosting service (not Pantheon), replace values in DNS records pointed to Pantheon with new values provided in the Site Dashboard.
 
  {% include("content/standard-dns-config2.html") %}


### PR DESCRIPTION
Closes #3832

## Effect
PR includes the following changes:
- Indicates that provisioning a TLS certificate usually takes about an
hour.

## Remaining Work
- [x] Review from @thomas-thackery
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle