### PR TITLE
Add a link to the generic phpinfo files we make available.

### DIFF
--- a/source/_docs/phpinfo.md
+++ b/source/_docs/phpinfo.md
@@ -4,9 +4,7 @@ description: Important security considerations when working with phpinfo on your
 tags: [debugcode, services]
 categories: []
 ---
-We serve our customers by provisioning isolated linux containers with an optimized PHP stack. The php.ini is part of a highly tuned configuration and is not user-configurable.
-We continually deploy new builds of PHP and you also have the ability to [upgrade PHP versions](/docs/php-versions/). If you'd like to see
-a comprehensive list of what's installed with the version of PHP in use by a particular environment, you may use [phpinfo](https://secure.php.net/manual/en/function.phpinfo.php). We also have [example PHP info](docs/php-versions/#available-php-versions) for each version of PHP on the platform.
+We serve our customers by provisioning isolated linux containers with an optimized PHP stack. The php.ini is part of a highly tuned configuration and is not user-configurable. We continually deploy new builds of PHP and you also have the ability to [upgrade PHP versions](/docs/php-versions/). If you'd like to see a comprehensive list of what's installed with the version of PHP in use by a particular environment, you may use [phpinfo](https://secure.php.net/manual/en/function.phpinfo.php){.external}. We also have [example PHP info](/docs/php-versions/#available-php-versions) for each version of PHP on the platform.
 
 ## Important Security Notes
 
@@ -16,7 +14,7 @@ a comprehensive list of what's installed with the version of PHP in use by a par
 
 ### Drupal Note
 
-Drupal makes the phpinfo available to privileged users at: `https://example.com/admin/reports/status/php`
+Drupal makes the phpinfo available to privileged users at `https://example.com/admin/reports/status/php`.
 
 
 ## Review phpinfo
@@ -26,7 +24,6 @@ Drupal makes the phpinfo available to privileged users at: `https://example.com/
 3. Visit the file in a web browser to view phpinfo.
  ![obscure-phpinfo-filename](/source/docs/assets/images/obscure-phpinfo-delete-immediately.png)
 4. Delete the file immediately so you do not expose sensitive information, such as a password, to connect to the DB.
-
 
 ## Terminus
 

--- a/source/_docs/phpinfo.md
+++ b/source/_docs/phpinfo.md
@@ -6,7 +6,7 @@ categories: []
 ---
 We serve our customers by provisioning isolated linux containers with an optimized PHP stack. The php.ini is part of a highly tuned configuration and is not user-configurable.
 We continually deploy new builds of PHP and you also have the ability to [upgrade PHP versions](/docs/php-versions/). If you'd like to see
-a comprehensive list of what's installed with the version of PHP in use by a particular environment, you may use [phpinfo](https://secure.php.net/manual/en/function.phpinfo.php).
+a comprehensive list of what's installed with the version of PHP in use by a particular environment, you may use [phpinfo](https://secure.php.net/manual/en/function.phpinfo.php). We also have [example PHP info](docs/php-versions/#available-php-versions) for each version of PHP on the platform.
 
 ## Important Security Notes
 


### PR DESCRIPTION
The generic phpinfo sites are frequently sufficient for customers, so adding a link to them directly on the phpinfo page seemed helpful.

Closes #n/a

## Effect
PR includes the following changes:
- Adds a link to the generic phpinfo sites we provide

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
