### PR TITLE
Note that Redis maxmemory varies based on plan level

### DIFF
--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -391,7 +391,7 @@ Install and enable the module to resolve.
 | BusinessXL             |               1024         |
 | Elite                  |               1024         |
 
-\*Redis is available on free Sandbox plans in development environments and will remain through upgrades to any other plan except for Basic. See the [Enable Redis](#enable-redis) section above for details about which account types have Redis on Live environments.
+\*Redis is available on free Sandbox plans in development environments and will remain through upgrades to any other plan except for Basic. See the <a href="#enable-redis" data-proofer-ignore>Enable Redis</a> section above for details about which account types have Redis on Live environments.
 
 ### What happens when Redis reaches maxmemory?
 The behavior is the same as a standard Redis instance. The overall process is described best in the top four answers of [this thread](https://stackoverflow.com/questions/8652388/how-does-redis-work-when-ram-starts-filling-up){.external}, keeping in mind our `maxmemory-policy` is `allkeys-lru`.

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -425,7 +425,7 @@ set-max-intset-entries 512
 activerehashing yes
 ```
 
-Note that the `maxmemory` value will vary [based on plan level](#how-much-redis-cache-is-available-for-each-plan-level).
+Note that the `maxmemory` value will vary <a href="#how-much-redis-cache-is-available-for-each-plan-level" data-proofer-ignore>based on plan level</a>.
 
 ### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
 Yes. There is a `redis.log` file that is available on the Redis container for each environment. To access the Redis container, copy the SFTP command line string from the **Connection Info** button, and replace `appserver` with `cacheserver`. You can see where the log files and configuration reside:

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -17,7 +17,7 @@ Most website frameworks like Drupal and WordPress use the database to cache inte
 Redis provides an alternative caching backend, taking that work off the database, which is vital for scaling to a larger number of logged-in users. It also provides a number of other nice features for developers looking to use it to manage queues, or do custom caching of their own.
 
 ## Enable Redis
-All plans except for a Basic plan can use Redis. Redis is available to Sandbox site plans for developmental purposes, but Redis will not be available going live on a Basic plan.
+All plans except for the Basic plan can use Redis. Sandbox site plans can enable and use Redis for developmental purposes, but if the site plan is upgraded to Basic, the feature will be disabled.
 
 | Plans         | Redis Support <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Available across all environments, including Multidevs."><em class="fa fa-info-circle"></em></a> |
 | ------------- | -------------------------------------- |
@@ -383,7 +383,6 @@ Install and enable the module to resolve.
 | Plan                   | Cache Memory Limit (in MB) |
 | ---------------------- | -------------------------- |
 | Sandbox*               |               64           |
-| Basic*                 |               64           |
 | Performance Small      |               64           |
 | Performance M, L, XL   |               512          |
 | Professional           |               256          |
@@ -392,7 +391,7 @@ Install and enable the module to resolve.
 | BusinessXL             |               1024         |
 | Elite                  |               1024         |
 
-\*Redis is available for development on free Sandbox environments, and is available to development environments on the Basic plan, but will not be available when going Live on that plan. See the [Enable Redis](#enable-redis) section above for details about which account types have Redis on Live environments.
+\*Redis is available on free Sandbox plans in development environments and will remain through upgrades to any other plan except for Basic. See the [Enable Redis](#enable-redis) section above for details about which account types have Redis on Live environments.
 
 ### What happens when Redis reaches maxmemory?
 The behavior is the same as a standard Redis instance. The overall process is described best in the top four answers of [this thread](https://stackoverflow.com/questions/8652388/how-does-redis-work-when-ram-starts-filling-up){.external}, keeping in mind our `maxmemory-policy` is `allkeys-lru`.

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -385,7 +385,7 @@ We are using [allkeys-lru](https://redis.io/topics/lru-cache){.external}. Here i
 
 ```nohighlight
 cat redis.conf
-port 11455
+port xxxxx
 timeout 300
 loglevel notice
 logfile /srv/bindings/xxxxxxxxx/logs/redis.log
@@ -396,7 +396,7 @@ save 60 10000
 rdbcompression yes
 dbfilename dump.rdb
 dir /srv/bindings/xxxxxxxxx/data/
-requirepass 278801a71e2c4264b7d7b155def62bea
+requirepass xxxxx
 maxclients 1024
 maxmemory 964689920
 maxmemory-policy allkeys-lru
@@ -408,6 +408,8 @@ list-max-ziplist-value 64
 set-max-intset-entries 512
 activerehashing yes
 ```
+
+Note that the `maxmemory` value will vary based on plan level.
 
 ### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
 Yes. There is a `redis.log` file that is available on the Redis container for each environment. To access the Redis container, copy the SFTP command line string from the **Connection Info** button, and replace `appserver` with `cacheserver`. You can see where the log files and configuration reside:

--- a/source/_docs/redis.md
+++ b/source/_docs/redis.md
@@ -377,6 +377,23 @@ You have requested a non-existent service "cache.backend.redis".
 Install and enable the module to resolve.
 
 ## Frequently Asked Questions
+
+### How Much Redis Cache is Available for Each Plan Level?
+
+| Plan                   | Cache Memory Limit (in MB) |
+| ---------------------- | -------------------------- |
+| Sandbox*               |               64           |
+| Basic*                 |               64           |
+| Performance Small      |               64           |
+| Performance M, L, XL   |               512          |
+| Professional           |               256          |
+| Flagship               |               512          |
+| Business               |               512          |
+| BusinessXL             |               1024         |
+| Elite                  |               1024         |
+
+\*Redis is available for development on free Sandbox environments, and is available to development environments on the Basic plan, but will not be available when going Live on that plan. See the [Enable Redis](#enable-redis) section above for details about which account types have Redis on Live environments.
+
 ### What happens when Redis reaches maxmemory?
 The behavior is the same as a standard Redis instance. The overall process is described best in the top four answers of [this thread](https://stackoverflow.com/questions/8652388/how-does-redis-work-when-ram-starts-filling-up){.external}, keeping in mind our `maxmemory-policy` is `allkeys-lru`.
 
@@ -409,7 +426,7 @@ set-max-intset-entries 512
 activerehashing yes
 ```
 
-Note that the `maxmemory` value will vary based on plan level.
+Note that the `maxmemory` value will vary [based on plan level](#how-much-redis-cache-is-available-for-each-plan-level).
 
 ### If Redis hits the upper limit of memory usage, is this logged on Pantheon?
 Yes. There is a `redis.log` file that is available on the Redis container for each environment. To access the Redis container, copy the SFTP command line string from the **Connection Info** button, and replace `appserver` with `cacheserver`. You can see where the log files and configuration reside:


### PR DESCRIPTION
Closes #4042 

## Effect
PR includes the following changes:
- Note that Redis maxmemory varies based on plan level
- Change other non-universal settings (port, password) to `xxxxxxx`

Internal ref #122819.

## Remaining Work
- [x] Copy review
- [x] Redis maxmemory used to be own the [plan resources page](https://pantheon.io/docs/platform-resources/), but this is not shown on the new pricing/plan resources pages. Should it be added and linked from here?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
