### PR TITLE
Clarify that migrate_drush_path is only for Drupal 7

### DIFF
--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -115,9 +115,9 @@ Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/termi
 
 ### What if I run into a timeout when using the Drupal Migrate UI?
 
-As [recommended in the Migrate module documentation](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). 
+As [recommended in the Migrate module documentation](https://www.drupal.org/node/1806824){.external}, use Drush, which can be invoked through [Terminus](/docs/terminus/).
 
-If you're migrating to a Drupal 7 site, you can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
+If you're migrating to a Drupal 7 site, you can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170){.external} by configuring the `migrate_drush_path` variable to:
 
 ```
 $conf['migrate_drush_path'] = $_ENV['HOME'] . '/bin/drush';

--- a/source/_docs/timeouts.md
+++ b/source/_docs/timeouts.md
@@ -115,7 +115,9 @@ Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/docs/termi
 
 ### What if I run into a timeout when using the Drupal Migrate UI?
 
-As [strongly recommended by the Migrate module](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). You can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
+As [recommended in the Migrate module documentation](https://www.drupal.org/node/1806824), use Drush, which can be invoked through [Terminus](/docs/terminus/). 
+
+If you're migrating to a Drupal 7 site, you can also configure Migrate to [trigger Drush imports from the UI](https://www.drupal.org/node/1958170) by configuring the `migrate_drush_path` variable to:
 
 ```
 $conf['migrate_drush_path'] = $_ENV['HOME'] . '/bin/drush';


### PR DESCRIPTION
Closes #4312 and #4195

## Effect
PR includes the following changes:
- Clarify that the migrate_drush_path variable is only present/configurable in Drupal 7

## Remaining Work
- [x] copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
