### PR TITLE
Add large WP site migrate manually

### DIFF
--- a/source/_docs/migrate.md
+++ b/source/_docs/migrate.md
@@ -96,6 +96,7 @@ Pantheon provides a guided path for migrating existing sites to the platform, wh
 Manually migrate your site to Pantheon when any of the following apply:
 
 * **Large Drupal Site Archive**: Site archive is greater than the guided migration import limit of 500MB.
+* **Large WordPress Site**: WordPress site exceeds 500MB.
 * **Preserve Git History**: You'd like to preserve your site's existing Git commit history.
 * **[WordPress Site Networks](/docs/migrate-wordpress-site-networks/)**
 * **Plugin install unavailable on existing WordPress site**: For example, if your existing site is hosted on WordPress.com, you'll be unable to install the Pantheon Migrations plugin.


### PR DESCRIPTION
Closes #4367 

## Effect
PR includes the following changes:
- Added Large WordPress Site: WordPress site exceeds 500MB.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
