### PR TITLE
add multiple url redirects

### DIFF
--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -113,8 +113,12 @@ if ((in_array($_SERVER['REQUEST_URI'], $redirects)) && (php_sapi_name() != "cli"
 }
 ```
 
-### Redirect Multiple Urls to Another
-The following configuration will redirect requests for `example.com/old-url1` to `example.com/new-url1`, `example.com/old-url2` to `example.com/new-url2` and `example.com/old-url3` to `example.com/new-url3`
+### Redirect Multiple URLs
+The following configuration will redirect requests for:
+
+ - `example.com/old-url1` to `example.com/new-url1`
+ - `example.com/old-url2` to `example.com/new-url2`
+ - `example.com/old-url3` to `example.com/new-url3`
 
 ```php
 // You can easily put a list of many 301 url redirects in this format

--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -113,6 +113,30 @@ if ((in_array($_SERVER['REQUEST_URI'], $redirects)) && (php_sapi_name() != "cli"
 }
 ```
 
+### Redirect Multiple Urls to Another
+The following configuration will redirect requests for `example.com/old-url1` to `example.com/new-url1`, `example.com/old-url2` to `example.com/new-url2` and `example.com/old-url3` to `example.com/new-url3`
+
+```php
+// You can easily put a list of many 301 url redirects in this format
+// Trailing slashes matters here so /old-url1 is different from /old-url1/
+$redirect_targets = array(
+  '/old-url1' => '/new-url1',
+  '/old-url2' => '/new-url2',
+  '/old-url3' => '/new-url3',
+);
+
+if ( (isset($redirect_targets[ $_SERVER['REQUEST_URI'] ] ) ) && (php_sapi_name() != "cli") ) {
+  echo 'https://'. $_SERVER['HTTP_HOST'] . $redirect_targets[ $_SERVER['REQUEST_URI'] ];
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . $redirect_targets[ $_SERVER['REQUEST_URI'] ]);
+
+  if (extension_loaded('newrelic')) {
+    newrelic_name_transaction("redirect");
+  } 
+  exit();
+}
+```
+
 ### Redirect Multiple Subdomains
 The following configuration will redirect requests for `sub1.example.com`, `sub2.example.com`, `sub3.example.com`, and `sub4.example.com` to `https://new.example.com`:
 


### PR DESCRIPTION
Closes #4379 

## Effect
PR includes the following changes:
- added sample snippet for multiple url redirects 

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
