### PR TITLE
Note set-cookie overload issue

### DIFF
--- a/source/_docs/cookies.md
+++ b/source/_docs/cookies.md
@@ -104,6 +104,8 @@ The Pantheon Edge size limit for Cookies is 10K. Any larger cookies are dropped,
 
 Knowing this, you can choose to configure your code to listen for this header and respond, with a custom error page for example.
 
+Note that too many `set-cookie` headers in the response can also create issues.
+
 ## See Also
 * [Clearing Caches for Drupal and WordPress](/docs/clear-caches/)
 * [Bypassing Cache with HTTP Headers](/docs/cache-control)


### PR DESCRIPTION
Closes #4381 

## Effect
PR includes the following changes:
- Notes that excessive set-cookie lines can cause issues.

## Remaining Work
- [x] Review de technique
- [ ] Review du cope`

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle