### PR TITLE
add formatted list of Terminus command fields

### DIFF
--- a/source/_docs/terminus/commands.md
+++ b/source/_docs/terminus/commands.md
@@ -12,8 +12,8 @@ image: terminus-thumbLarge
 searchboost: 100
 ---
 <div class="alert alert-info" markdown="1">
-<h4 class="info">Note</h4>
-If you would like additional information for a given command (e.g., available `--fields` or `--format` options) run the command with the `--help` option in your terminal.
+#### Note {.info}
+If you would like additional information for a given command (e.g., available `--format` options) run the command with the `--help` flag in your terminal.
 </div>
 
 <!--Note: The contents of the command reference table cannot be edited in the docs project. This table is automatically generated using Terminus (terminus list --format=json). Submit feedback and report issues related to the contents of this table on the Terminus repo: https://github.com/pantheon-systems/terminus/issues -->

--- a/source/_docs/terminus/commands.md
+++ b/source/_docs/terminus/commands.md
@@ -45,7 +45,7 @@ If you would like additional information for a given command (e.g., available `-
         <td><strong md-highlight-text="searchCommand">{[{ command.name }]}</strong><br><small md-highlight-text="searchCommand">{[{ command.description }]}</small></td>
         <td>
             <li class="terminus-usage">
-            <span style="white-space:pre-line;"><small md-highlight-text="searchCommand">{[{ command.usage[0] }]}</small></span>
+            <span style="white-space:pre-line;"><small md-highlight-text="searchCommand">{[{ command.usage[0] }]}</small><br><small>{[{ command.definition.options.fields.description | formatFields }]}</small></span>
             </li>
         </td>
       </tr>

--- a/source/_partials/navbar.html
+++ b/source/_partials/navbar.html
@@ -354,6 +354,16 @@ terminusCommandsApp.filter('search', function() {
 }
 });
 
+//Replace commas with new lines, to be used when printing field descriptions
+terminusCommandsApp.filter('formatFields', [function() {
+    return function(string) {
+        if (!angular.isString(string)) {
+            return string;
+        }
+        return string.replace(":", ": \n").replace(/,/g, '\n');
+    };
+}])
+
 
 terminusCompareApp.config(function($interpolateProvider) {
   $interpolateProvider.startSymbol('{[{');


### PR DESCRIPTION
Closes #4077 

## Effect
PR includes the following changes:
- Updates the Terminus commands page to include a list of available fields for each command.

## Remaining Work
- [ ] Review from @mcdwayne to see if this addresses his concerns.
- [x] Review from @rachelwhitton  for UX considerations.
- [ ] Review from anyone on @pantheon-systems/alchemy or whoever is the Terminus team, since this is documentation for their product.
- [x] Copy Review?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
