### PR TITLE
Add PHP version to CSV script example

### DIFF
--- a/source/_docs/terminus/scripting.md
+++ b/source/_docs/terminus/scripting.md
@@ -92,7 +92,7 @@ Just like the example above, this example saves the output various Terminus comm
 PANTHEON_ORG="722c5f3b-....-6c8a"
 
 # Get a list of all sites in the org
-PANTHEON_SITES="$(terminus org:site:list -n '${PANTHEON_ORG}' --format=list --field=Name)"
+PANTHEON_SITES="$(terminus org:site:list -n ${PANTHEON_ORG} --format=list --field=Name)"
 
 # Name the CSV output file
 CSV_FILE='pantheon-site-php-versions.csv'

--- a/source/_docs/terminus/scripting.md
+++ b/source/_docs/terminus/scripting.md
@@ -25,7 +25,7 @@ If so, you consider how you can turn the task into a script.
 
 Terminus needs to be authenticated in order to execute most commands. Before running any script you must ensure Terminus is authenticated with a [machine token](/docs/terminus/install#machine-token) that has the proper permissions
 
-## Examples
+## Example Repositories
 
  - The [Pantheon Example Terminus Auto Update Script](https://github.com/pantheon-systems/example-terminus-auto-update-script){.external} demonstrates how you can use Terminus to automate plugin and theme updating for multiple sites.
 
@@ -45,6 +45,9 @@ PANTHEON_MULTIDEV_LIST="$(terminus multidev:list -n ${TERMINUS_SITE} --format=li
 This example assumes the variable `TERMINUS_SITE` is already set. Now you can iterate through `$PANTHEON_MULTIDEV_LIST` using something like a `while read` loop to perform tasks on each multidev environment.
 
 
+## Example Bash Scripts
+
+### Take a backup of the live environment of all sites in an organization
 Here's a more complete example. This script goes through every site in an organization, skips any that are frozen, and takes a backup of the Live environment:
 
 ```bash
@@ -79,3 +82,46 @@ done <<< "$PANTHEON_SITES"
 
 This script requires that you set the variable `ORG_UUID` within the script itself. You can find the UUID using `terminus org:list`.
 
+### Save the PHP version of the live environment of all sites in an organization to a CSV file
+Just like the example above, this example saves the output various Terminus commands to variables for reuse.
+
+```bash
+#!/bin/bash
+
+# Save the desired org UUID or name
+PANTHEON_ORG="722c5f3b-....-6c8a"
+
+# Get a list of all sites in the org
+PANTHEON_SITES="$(terminus org:site:list -n '${PANTHEON_ORG}' --format=list --field=Name)"
+
+# Name the CSV output file
+CSV_FILE='pantheon-site-php-versions.csv'
+
+# Add heading to the CSV file
+# > is overwrite
+echo 'site name,php version,frozen' > $CSV_FILE
+
+# Loop through each site in the list
+while read -r PANTHEON_SITE_NAME; do
+	# Check if the site is frozen
+	IS_FROZEN="$(terminus site:info $PANTHEON_SITE_NAME --field=frozen)"
+	# If the site is frozen
+    if [[ "true" == "${IS_FROZEN}" ]]
+    then
+		# The PHP version is unknown
+		PHP_VERSION='FROZEN'
+	else
+		# Get the site's PHP version
+		PHP_VERSION=$(terminus env:info $PANTHEON_SITE_NAME.live --field php_version)
+	fi
+
+	# Save the info to the CSV file
+	# >> is append
+	echo "$PANTHEON_SITE_NAME,$PHP_VERSION,$IS_FROZEN" >> $CSV_FILE
+done <<< "$PANTHEON_SITES"
+
+# All done
+echo "Site PHP information has been saved to $CSV_FILE"
+```
+
+This script requires that you set the variable `PANTHEON_ORG` within the script itself. This can be either the organization name or UUID, both of which can be found using `terminus org:list`. Optionally, you can also update the name and path of the CSV file if you prefer something other than `pantheon-site-php-versions.csv`.


### PR DESCRIPTION
## Effect
@rachelwhitton thanks for the idea/starting code.

PR includes the following changes:
- Adds an example script to the Terminus scripts docs page showing how to use Terminus to save the PHP version of all sites in an organization to a CSV file


## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
