### PR TITLE
WP REST API Cache Control

### DIFF
--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -106,6 +106,29 @@ Some web developers choose to aggregate all of their caching logic in one place,
   function add_header_nocache() {
         header( 'Cache-Control: no-cache, must-revalidate, max-age=0' );
   }
+  
+  
+  /* For WP REST API specific paths, we use a different approach by using the rest_post_dispatch filter */ 
+  
+  // wp-json paths or any custom endpoints 
+  $regex_json_path_patterns = array(
+    '#^/wp-json/wp/v2?#',
+    '#^/wp-json/?#'
+  );
+
+  foreach ($regex_path_patterns as $regex_path_pattern) {
+    if (preg_match($regex_path_pattern, $_SERVER['REQUEST_URI'])) {
+        // re-use the rest_post_dispatch filter in the Pantheon page cache plugin  
+        add_filter( 'rest_post_dispatch', 'filter_rest_post_dispatch_send_cache_control', 12, 2 );
+
+        // Re-define the send_header value with any custom Cache-Control header
+        function filter_rest_post_dispatch_send_cache_control( $response, $server ) {
+            $server->send_header( 'Cache-Control', 'no-cache, must-revalidate, max-age=0' );
+            return $response;
+        }
+        break;
+    }
+  }
   ```
   </div>
 </div>

--- a/source/_docs/cache-control.md
+++ b/source/_docs/cache-control.md
@@ -116,8 +116,8 @@ Some web developers choose to aggregate all of their caching logic in one place,
     '#^/wp-json/?#'
   );
 
-  foreach ($regex_path_patterns as $regex_path_pattern) {
-    if (preg_match($regex_path_pattern, $_SERVER['REQUEST_URI'])) {
+  foreach ($regex_json_path_patterns as $regex_json_path_pattern) {
+    if (preg_match($regex_json_path_pattern, $_SERVER['REQUEST_URI'])) {
         // re-use the rest_post_dispatch filter in the Pantheon page cache plugin  
         add_filter( 'rest_post_dispatch', 'filter_rest_post_dispatch_send_cache_control', 12, 2 );
 


### PR DESCRIPTION
Cache control snippet to work with WP REST API endpoints

Closes #3884 

## Effect
PR includes the following changes:
- Additional code snippet for WP Cache control
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
