### PR TITLE
Remove reference to SFTP mode

### DIFF
--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -42,7 +42,7 @@ Pantheon also makes PHP [7.0](https://v70-php-info.pantheonsite.io/){.external},
 </p></div>
 
 ## Configure PHP Version
-Manage PHP versions by committing a `pantheon.yml` configuration file to the root of your site's code repository. Navigate to the `code` directory. If the `pantheon.yml` file is not present, create one to look like the following:
+Manage PHP versions by committing a `pantheon.yml` configuration file to the root of your site's code repository. If you have a local git clone of your site, this is the project root. When looking at the site over an SFTP connection, look in the `code` directory. If the `pantheon.yml` file is not present, create one to look like the following:
 
 ```yaml
 api_version: 1

--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -42,7 +42,7 @@ Pantheon also makes PHP [7.0](https://v70-php-info.pantheonsite.io/){.external},
 </p></div>
 
 ## Configure PHP Version
-Manage PHP versions by committing a `pantheon.yml` configuration file to the root of your site's code repository. When using SFTP mode, navigate to the `code` directory. If the `pantheon.yml` file is not present, create one to look like the following:
+Manage PHP versions by committing a `pantheon.yml` configuration file to the root of your site's code repository. Navigate to the `code` directory. If the `pantheon.yml` file is not present, create one to look like the following:
 
 ```yaml
 api_version: 1


### PR DESCRIPTION
I had a chat customer who was confused by the reference to SFTP mode. Since creating a pantheon.yml file is possible by both git and sftp, I attempted to clarify the docs.

Closes #n/a

## Effect
PR includes the following changes:
- Changes initial statement of how to create pantheon.yml

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
