### PR TITLE
Add a link to port 2222 workaround.

### DIFF
--- a/source/_docs/debug-connections.md
+++ b/source/_docs/debug-connections.md
@@ -39,5 +39,7 @@ If an IP address is returned, [configure your network settings to use Google Pub
 ###Port 2222 or Other Blocked Ports
 Make sure the port number is not blocked by your internal firewall. For example, to test whether port 2222 is blocked visit [http://portquiz.net:2222/](http://portquiz.net:2222/)
 
+If you are not able to access port 2222, you can try our [workaround])(/docs/port-2222).
+
 ##Test Connection on the Command Line
 We recommend using the command line when troubleshooting connection issues as GUIs can hide underlying errors. From the site Dashboard, copy the provided connection command for the desired service and run it in terminal.

--- a/source/_docs/debug-connections.md
+++ b/source/_docs/debug-connections.md
@@ -39,7 +39,7 @@ If an IP address is returned, [configure your network settings to use Google Pub
 ###Port 2222 or Other Blocked Ports
 Make sure the port number is not blocked by your internal firewall. For example, to test whether port 2222 is blocked visit [http://portquiz.net:2222/](http://portquiz.net:2222/)
 
-If you are not able to access port 2222, you can try our [workaround])(/docs/port-2222).
+If you are not able to access port 2222, you can try our [workaround](/docs/port-2222).
 
 ##Test Connection on the Command Line
 We recommend using the command line when troubleshooting connection issues as GUIs can hide underlying errors. From the site Dashboard, copy the provided connection command for the desired service and run it in terminal.

--- a/source/_docs/debug-connections.md
+++ b/source/_docs/debug-connections.md
@@ -39,7 +39,7 @@ If an IP address is returned, [configure your network settings to use Google Pub
 ###Port 2222 or Other Blocked Ports
 Make sure the port number is not blocked by your internal firewall. For example, to test whether port 2222 is blocked visit [http://portquiz.net:2222/](http://portquiz.net:2222/)
 
-If you are not able to access port 2222, you can try our [workaround](/docs/port-2222).
+If you are not able to access port 2222, you can try our [workaround](/docs/port-2222/).
 
 ##Test Connection on the Command Line
 We recommend using the command line when troubleshooting connection issues as GUIs can hide underlying errors. From the site Dashboard, copy the provided connection command for the desired service and run it in terminal.


### PR DESCRIPTION
It seemed reasonable to add a link to the workaround directly to this area to help customers troubleshoot and solve on their own.

Closes # n/a

## Effect
PR includes the following changes:
- Add a link to our Port 2222 Blocked Workaround docs

## Remaining Work
- none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
