### PR TITLE
Context for gitignore files via info circle

### DIFF
--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -4,7 +4,7 @@ description: Detailed information on how to access and optimize the Pantheon fil
 tags: [infrastructure, sftpfiles]
 categories: []
 ---
-Files are user uploads, usually images or documents. They are excluded from version control via Pantheon's .gitignore files:
+Files are user uploads, usually images or documents. They are excluded from version control via Pantheon's .gitignore files <a class="pop" rel="popover" data-proofer-ignore data-toggle="popover" data-html="true" data-title=".gitignore" data-content="The <a class='external' href='https://git-scm.com/docs/gitignore'>.gitignore file</a> is located at the root of the site's codebase and instructs Git which paths should be ignored."><em class="fa fa-info-circle"></em></a>:
 
 - [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/master/.gitignore){.external}
 - [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore){.external}


### PR DESCRIPTION
Closes #4439 

## Effect
PR includes the following changes:
- Add info circle to define gitignore files with a link to Git documentation

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
