### PR TITLE
Add FAQ for payment methods to site-billing

### DIFF
--- a/source/_docs/site-billing.md
+++ b/source/_docs/site-billing.md
@@ -65,6 +65,9 @@ After [downgrading from a paid plan to Sandbox](/docs/site-plan/#cancel-current-
 
 ## Frequently Asked Questions
 
+### What forms of payment are accepted? 
+Sites purchased online through the Pantheon Site Dashboard accept credit card payments only. Pantheon does not currently accept alternative methods of payment for online site purchases (e.g., checks, PayPal, etc.). 
+
 ### Does Pantheon accept PayPal?
 Pantheon currently does not accept PayPal.
 


### PR DESCRIPTION
Closes #4232 
## Effect
PR includes the following changes:
- Add new FAQ that specifies payment method for online sites is cc only

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
