### PR TITLE
Note about default Drush versions - Fixes #4216

### DIFF
--- a/source/_docs/drush-versions.md
+++ b/source/_docs/drush-versions.md
@@ -6,6 +6,8 @@ categories: [drupal]
 ---
 By default, Pantheon runs Drush 8 on newly created Drupal sites. Drush 8 is compatible with Drupal 6, 7, and 8.
 
+The Drush version is set when the site is created. Sites created a few years ago or more may use an older version of Drush that is incompatible with later versions of PHP. Updating Drush can be accomplished by [a simple addition to your pantheon.yml file](#configure-drush-version).
+
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
 <p markdown="1">
@@ -29,6 +31,12 @@ api_version: 1
 drush_version: 8
 ```
 Now your site’s Drush version is managed via `pantheon.yml`, so it’s in version control and deployed along with the rest of your code.
+
+<div class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">
+If the `pantheon.yml` file does not exist, please create it. If a `pantheon.upstream.yml` file exists, please do not edit it. It is used by the upstream updates repository and should not be edited.
+</p></div>
 
 ### Available Drush Versions
 Pantheon currently supports Drush 8. While Drush 5 and 7 are available if needed, they are listed as [unsupported](http://docs.drush.org/en/master/install/#drupal-compatibility){.external} by the Drush maintainers, and should be avoided unless absolutely necessary.

--- a/source/_docs/drush-versions.md
+++ b/source/_docs/drush-versions.md
@@ -32,11 +32,10 @@ drush_version: 8
 ```
 Now your site’s Drush version is managed via `pantheon.yml`, so it’s in version control and deployed along with the rest of your code.
 
-<div class="alert alert-info" role="alert">
-<h4 class="info">Note</h4>
-<p markdown="1">
-If the `pantheon.yml` file does not exist, please create it. If a `pantheon.upstream.yml` file exists, please do not edit it. It is used by the upstream updates repository and should not be edited.
-</p></div>
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.yml` file exists, please do not edit it. It is used by the upstream updates repository and will cause a merge conflict if modified.
+</div>
 
 ### Available Drush Versions
 Pantheon currently supports Drush 8. While Drush 5 and 7 are available if needed, they are listed as [unsupported](http://docs.drush.org/en/master/install/#drupal-compatibility){.external} by the Drush maintainers, and should be avoided unless absolutely necessary.


### PR DESCRIPTION
Closes #4216

## Effect
PR includes the following changes:
- Added note at top to say that some old sites may be running an older version.
- Also added a note saying not to edit the pantheon;upstream.yml file.
-

## Remaining Work
- [ ] Maybe just look over the verbiage?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
