### PR TITLE
Add status-frozen text/link to organizations doc

### DIFF
--- a/source/_docs/organizations.md
+++ b/source/_docs/organizations.md
@@ -37,6 +37,8 @@ All Organization Dashboards have five tabs: Sites, People, Upstreams, Support, a
 
 The Sites tab shows all sites your organization has access to. You can quickly tag, sort, and filter your sites. All of the people in the organization will have access to all of the sites. You can add users to specific sites by checking the box to select the site and clicking **Team** > **Add to Team**.
 
+A <strong><span class="glyphicons glyphicons-snowflake"></span>frozen icon</strong> in the site's status column indicates that a site is [frozen due to inactivity](/docs/platform-considerations/#inactive-site-freezing).
+
 For more details on the Sites tab, see
 [Managing Sites and Teams with the Pantheon Organization Dashboard](/docs/organization-dashboard/).
 


### PR DESCRIPTION
Closes #4373

## Effect
PR includes the following changes:
- Text change to include sites tab frozen status info and link.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
