### PR TITLE
Valid identifiers for termins site:upstream:set

### DIFF
--- a/source/_docs/terminus/examples.md
+++ b/source/_docs/terminus/examples.md
@@ -256,6 +256,8 @@ If your organization has a <a href="/docs/custom-upstream/">Custom Upstream</a>,
   <button class="btn btn-default btn-clippy" data-clipboard-target="#upstream-set">Copy</button>
   <figure><pre id="upstream-set"><code class="command bash" data-lang="bash">terminus site:upstream:set my-site "My Custom Upstream"</code></pre></figure>
   </div>
+  
+You can use any valid identifier (upstream name, upstream machine name, upstream UUID) returned in `terminus upstream:list` to set a new upstream. For example, the upstream name "My Custom Upstream" is used above. 
 
 As a safeguard, Terminus will prevent a framework switch such as moving from Drupal to WordPress or vice versa.
 


### PR DESCRIPTION
Closes #4192 

## Effect
PR includes the following changes:
- Explain which identifiers are accepted for upstream in `site:upstream:set`

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
