### PR TITLE
New headline to reduce git/sftp mode confusion

### DIFF
--- a/source/_docs/guides/wordpress-git/01-introduction.md
+++ b/source/_docs/guides/wordpress-git/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Using Git with SFTP & WordPress
-subtitle: Add Git to Your Workflow
+subtitle: Add Git-Based Version Control to Your SFTP Workflow
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 layout: guide
 type: guide


### PR DESCRIPTION
Closes #4060 

## Effect
PR includes the following changes:
- Rewrote the section title (subheadline) in an attempt to better explain what the doc is for.

## Remaining Work
- [ ] none

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
