### PR TITLE
IonCube Decoder Support

### DIFF
--- a/source/_docs/settings-php.md
+++ b/source/_docs/settings-php.md
@@ -180,6 +180,16 @@ Drupal doesn't ship with a `settings.php` in place; as the error suggests, you s
 ### Can I edit settings.pantheon.php?
 No; `settings.pantheon.php` is for Pantheon's use only and you should only modify the `settings.php` file. The `settings.pantheon.php` file may change in future updates, and modifying it would cause conflicts.
 
+### How do I enable IonCube Decoder support?
+
+If you are using a licensed plugin that requires IonCube Decoder support, first ensure you are running [PHP 7.1](/docs/php-versions/) or later. Then, enable IonCube Decoder support site-wide by adding a single line to `settings.php`:
+
+```php
+ini_set('ioncube.loader.encoded_paths', '/');
+```
+
+*(More information can be found in our [PHP 7.1 & IonCube Decoder Now Available for All Sites on Pantheon](https://pantheon.io/blog/php-71-ioncube-decoder-now-available-all-sites-pantheon) blog post.)*
+
 ## Troubleshooting
 ### Request to a Remote API Does Not Return Expected Response
 

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -121,6 +121,16 @@ You don't have to! Pantheon automatically injects database credentials into the
 - [Pantheon WordPress](https://github.com/pantheon-systems/WordPress/blob/master/wp-config.php){.external}
 - [WordPress Core](https://github.com/WordPress/WordPress/blob/master/wp-config-sample.php){.external}
 
+### How do I enable IonCube Decoder support?
+
+If you are using a licensed plugin that requires IonCube Decoder support, first ensure you are running [PHP 7.1](/docs/php-versions/) or later. Then, enable IonCube Decoder support site-wide by adding a single line to `wp-config.php`:
+
+```php
+ini_set('ioncube.loader.encoded_paths', '/');
+```
+
+*(More information can be found in our [PHP 7.1 & IonCube Decoder Now Available for All Sites on Pantheon](https://pantheon.io/blog/php-71-ioncube-decoder-now-available-all-sites-pantheon) blog post.)*
+
 ## Troubleshooting
 ### Request to a Remote API Does Not Return Expected Response
 


### PR DESCRIPTION
Closes #4080 

## Effect
PR includes the following changes:
- Adds IonCube documentation to settings.php and wp-config.php pages

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
