### PR TITLE
Private Paths for Files Considerations Closes #3883

### DIFF
--- a/source/_docs/private-paths.md
+++ b/source/_docs/private-paths.md
@@ -42,9 +42,9 @@ This Drupal example reads the key from the private file `stripe_live.json` only 
 
 ### Private Path for Files Plugins
 
-WordPress does not have a core feature to configure a private path folder for file uploads. There are several plugins on WordPress.org and projects on Drupal.org that will help protect direct access to files in the files area. However, these plugins commonly require an Apache HTTP server *.htaccess* (`mod_rewrite`) rule. Our NGINX servers [do not support *.htaccess* rules](/docs/platform-considerations/#htaccess).
+WordPress does not have a core feature to configure a private path folder for file uploads. There are several plugins on WordPress.org and projects on Drupal.org that will help protect direct access to files in the files area. However, these plugins commonly require an Apache HTTP server *.htaccess* (`mod_rewrite`) rule. Our NGINX servers <a href="/docs/platform-considerations/#htaccess" data-proofer-ignore>do not support *.htaccess* rules</a>.
 
-Site developers could author their own custom solution to provide authentication, access checks, and ultimately use PHP's [readfile()](http://php.net/readfile) or [fpassthru()](http://php.net/fpassthru) functions to read files from the `wp-content/uploads/private` (WordPress) or `sites/default/files/private` (Drupal) areas, respectively, and then output them to the authenticated web user's browser.
+Site developers could author their own custom solution to provide authentication, access checks, and ultimately use PHP's [readfile()](http://php.net/readfile/){.external} or [fpassthru()](http://php.net/fpassthru/){.external} functions to read files from the `wp-content/uploads/private` (WordPress) or `sites/default/files/private` (Drupal) areas, respectively, and then output them to the authenticated web user's browser.
 
 ### Additional Drupal Configuration
 

--- a/source/_docs/private-paths.md
+++ b/source/_docs/private-paths.md
@@ -40,6 +40,12 @@ else {
 ```
 This Drupal example reads the key from the private file `stripe_live.json` only when the request is made from the Live environment on Pantheon.
 
+### Private Path for Files Plugins
+
+WordPress does not have a core feature to configure a private path folder for file uploads. There are several plugins on WordPress.org and projects on Drupal.org that will help protect direct access to files in the files area. However, these plugins commonly require an Apache HTTP server *.htaccess* (`mod_rewrite`) rule. Our NGINX servers [do not support *.htaccess* rules](/docs/platform-considerations/#htaccess).
+
+Site developers could author their own custom solution to provide authentication, access checks, and ultimately use PHP's [readfile()](http://php.net/readfile) or [fpassthru()](http://php.net/fpassthru) functions to read files from the `wp-content/uploads/private` (WordPress) or `sites/default/files/private` (Drupal) areas, respectively, and then output them to the authenticated web user's browser.
+
 ### Additional Drupal Configuration
 
 These files will be web-accessible based on the access control rules that you set for your site and will use the following directory: `sites/default/files/private`


### PR DESCRIPTION
Closes #3883 

## Effect
PR includes the following changes:
- Explains that "path protecting" plugins require .htaccess, which we don't support.
- Provide developer-oriented recommendations for coding a custom solution.

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
