### PR TITLE
Remove -K option from ssh-add

### DIFF
--- a/source/_docs/ssh-keys.md
+++ b/source/_docs/ssh-keys.md
@@ -111,5 +111,5 @@ This error occurs when a user is attempting to make a direct connection to Panth
 Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
 
 ```bash
-ssh-add -K ~/.ssh/id_rsa
+ssh-add ~/.ssh/id_rsa
 ```

--- a/source/_docs/ssh-keys.md
+++ b/source/_docs/ssh-keys.md
@@ -111,5 +111,5 @@ This error occurs when a user is attempting to make a direct connection to Panth
 Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
 
 ```bash
-ssh-add -k ~/.ssh/id_rsa
+ssh-add ~/.ssh/id_rsa
 ```

--- a/source/_docs/ssh-keys.md
+++ b/source/_docs/ssh-keys.md
@@ -111,5 +111,5 @@ This error occurs when a user is attempting to make a direct connection to Panth
 Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
 
 ```bash
-ssh-add ~/.ssh/id_rsa
+ssh-add -k ~/.ssh/id_rsa
 ```


### PR DESCRIPTION
No longer seems to be an option of ssh-add.

Closes #

## Effect
PR includes the following changes:
-
-
-

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
