### PR TITLE
Add password reset options

### DIFF
--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -39,31 +39,8 @@ Or you can reset any user's password from the command line by running the [`user
 $ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
-#### Option C: Reset your password directly in the database (advanced)
-Since Drupal does not store passwords in plain text, you need to generate a hashed version of the password before updating it directly in your database. Drupal core provides a script to do this:
-
-* Drupal 7: `scripts/password-hash.sh`
-* Drupal 8: `core/scripts/password-hash.sh`
-
-Note that the Drupal 8 version of this script requires a working [local site](https://pantheon.io/docs/local-development/).
-
-Run the password-hash script over the command-line and pass in your new password as an argument:
-
-```bash
-./core/scripts/password-hash.sh newpassword
-```
-
-Then [connect to MySQL](/docs/mysql-access/) and use the hashed password in a query on your database to actually update your user account:
-
-```bash
-mysql> UPDATE users_field_data set pass='yourhashedpassword' where uid=1;
-```
-
-In Drupal 8, you may also need to clear your user entity cache for this to take effect:
-
-```bash
-mysql> DELETE FROM cache_entity WHERE cid = 'values:user:1';
-```
+#### Option C: Reset your password directly in the database
+<to do>
 
 ### WordPress Site User Login
 

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -39,8 +39,10 @@ Or you can reset any user's password from the command line by running the [`user
 $ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
-#### Option C: Reset your password directly in the database
-<to do>
+#### Option C: Reset your password directly in the database (advanced)
+
+If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [drupal.org](https://www.drupal.org/node/44164){.external} and [Accessing MySQL Databases](/docs/mysql-access) for more information.
+
 
 ### WordPress Site User Login
 
@@ -61,5 +63,6 @@ $ terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWOR
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.
 
-#### Option C: Reset your password directly in the database
-<todo>
+#### Option C: Reset your password directly in the database (advanced)
+
+If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [wordpress.org](https://codex.wordpress.org/Resetting_Your_Password#Through_MySQL.2FMariaDB_Command_Line){.external} and [Accessing MySQL Databases](/docs/mysql-access) for more information.

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -39,6 +39,8 @@ Or you can reset any user's password from the command line by running the [`user
 terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
+Remember to change the password from the example above.
+
 ### Option C: Reset your password directly in the database (advanced)
 
 If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [drupal.org](https://www.drupal.org/node/44164){.external} and [Accessing MySQL Databases](/docs/mysql-access/) for more information.
@@ -60,6 +62,8 @@ Or you can reset any user's password from the command line by running [WP-CLI's 
 ```bash
 terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWORD
 ```
+
+Remember to change the password from the example above.
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.
 

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -7,9 +7,17 @@ categories: []
 ## Pantheon Dashboard Login
 If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password) and follow the instructions.
 
+## Site User Logins
 
-## Drupal Site User Login
+If you need to reset your password for your account on your Drupal or WordPress site, you have three options:
 
+A) Use the password reset link provided by Drupal or WordPress (easiest).
+B) Use Terminus to set your password via either Drush or WP-CLI.
+C) Reset your password directly in the MySQL database (advanced).
+
+### Drupal Site User Login
+
+#### Option A: Password reset
 If you need to reset your Drupal site user login, append `/user/password` to your site's URL and follow the directions to reset your password. For example, to reset the password for the development environment of mysite, you would visit the following example link:
 ```http
 https://dev-mysite.pantheonsite.io/user/password
@@ -18,6 +26,7 @@ In the password reset form, enter either the username or email address you used 
 
 Please keep in mind that your site password is stored in a database, so whatever you set in the Development environment may be different than Test or live, unless you keep the database content synced between the environments using the tools in Database / Files tab of the Pantheon Dashboard or during deployment.
 
+#### Option B: Use Terminus Drush to set a password
 If you still can’t get access to your site using password reset, for example if you don't have access to the corresponding email address for the account, you can still generate a one-time password reset link by using the following [Terminus](/docs/terminus/) command for generating one-time login links:
 
 ```bash
@@ -30,7 +39,12 @@ Or you can reset any user's password from the command line by running the [`user
 $ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
-## WordPress User Login
+#### Option C: Reset your password directly in the database
+<to do>
+
+### WordPress Site User Login
+
+#### Option A: Password reset
 If your site is powered by WordPress you have two options. The first is to request a password reset from the log in form and the second is to update via the [Terminus CLI](/docs/terminus/).
 
 1. From the main login form, click **Lost Your Password?**.  
@@ -38,6 +52,7 @@ If your site is powered by WordPress you have two options. The first is to reque
 
 You will receive an email that contains a link you can use one time to reset your password. When you click the link, enter your new password twice. It will also show you the strength of your new password; however, it will not prevent you from using a weak password.
 
+#### Option B: Use Terminus WP-CLI to set a password
 Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/) via [Terminus](/docs/terminus):
 
 ```nohighlight
@@ -45,3 +60,6 @@ $ terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWOR
 ```
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.
+
+#### Option C: Reset your password directly in the database
+<todo>

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -39,8 +39,31 @@ Or you can reset any user's password from the command line by running the [`user
 $ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
-#### Option C: Reset your password directly in the database
-<to do>
+#### Option C: Reset your password directly in the database (advanced)
+Since Drupal does not store passwords in plain text, you need to generate a hashed version of the password before updating it directly in your database. Drupal core provides a script to do this:
+
+* Drupal 7: `scripts/password-hash.sh`
+* Drupal 8: `core/scripts/password-hash.sh`
+
+Note that the Drupal 8 version of this script requires a working [local site](https://pantheon.io/docs/local-development/).
+
+Run the password-hash script over the command-line and pass in your new password as an argument:
+
+```bash
+./core/scripts/password-hash.sh newpassword
+```
+
+Then [connect to MySQL](/docs/mysql-access/) and use the hashed password in a query on your database to actually update your user account:
+
+```bash
+mysql> UPDATE users_field_data set pass='yourhashedpassword' where uid=1;
+```
+
+In Drupal 8, you may also need to clear your user entity cache for this to take effect:
+
+```bash
+mysql> DELETE FROM cache_entity WHERE cid = 'values:user:1';
+```
 
 ### WordPress Site User Login
 

--- a/source/_docs/resetting-passwords.md
+++ b/source/_docs/resetting-passwords.md
@@ -5,20 +5,20 @@ tags: [debugdb]
 categories: []
 ---
 ## Pantheon Dashboard Login
-If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password) and follow the instructions.
-
-## Site User Logins
+If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password){.external} and follow the instructions.
 
 If you need to reset your password for your account on your Drupal or WordPress site, you have three options:
 
-A) Use the password reset link provided by Drupal or WordPress (easiest).
-B) Use Terminus to set your password via either Drush or WP-CLI.
-C) Reset your password directly in the MySQL database (advanced).
+ - A) Use the password reset link provided by Drupal or WordPress (easiest).
+ - B) Use Terminus to set your password via either Drush or WP-CLI.
+ - C) Reset your password directly in the MySQL database (advanced).
 
-### Drupal Site User Login
+## Drupal Site User Login
 
-#### Option A: Password reset
+### Option A: Password reset
+
 If you need to reset your Drupal site user login, append `/user/password` to your site's URL and follow the directions to reset your password. For example, to reset the password for the development environment of mysite, you would visit the following example link:
+
 ```http
 https://dev-mysite.pantheonsite.io/user/password
 ```
@@ -26,27 +26,27 @@ In the password reset form, enter either the username or email address you used 
 
 Please keep in mind that your site password is stored in a database, so whatever you set in the Development environment may be different than Test or live, unless you keep the database content synced between the environments using the tools in Database / Files tab of the Pantheon Dashboard or during deployment.
 
-#### Option B: Use Terminus Drush to set a password
+### Option B: Use Terminus Drush to set a password
 If you still can’t get access to your site using password reset, for example if you don't have access to the corresponding email address for the account, you can still generate a one-time password reset link by using the following [Terminus](/docs/terminus/) command for generating one-time login links:
 
 ```bash
-$ terminus drush <site>.<env> -- user-login
+terminus drush <site>.<env> -- user-login
 ```
 
-Or you can reset any user's password from the command line by running the [`user-password` Drush command](https://drushcommands.com/drush-8x/user/user-password/) via [Terminus](/docs/terminus):
+Or you can reset any user's password from the command line by running the [`user-password` Drush command](https://drushcommands.com/drush-8x/user/user-password/){.external} via [Terminus](/docs/terminus/):
 
 ```bash
-$ terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
+terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
 ```
 
-#### Option C: Reset your password directly in the database (advanced)
+### Option C: Reset your password directly in the database (advanced)
 
-If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [drupal.org](https://www.drupal.org/node/44164){.external} and [Accessing MySQL Databases](/docs/mysql-access) for more information.
+If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [drupal.org](https://www.drupal.org/node/44164){.external} and [Accessing MySQL Databases](/docs/mysql-access/) for more information.
 
 
-### WordPress Site User Login
+## WordPress Site User Login
 
-#### Option A: Password reset
+### Option A: Password reset
 If your site is powered by WordPress you have two options. The first is to request a password reset from the log in form and the second is to update via the [Terminus CLI](/docs/terminus/).
 
 1. From the main login form, click **Lost Your Password?**.  
@@ -54,15 +54,15 @@ If your site is powered by WordPress you have two options. The first is to reque
 
 You will receive an email that contains a link you can use one time to reset your password. When you click the link, enter your new password twice. It will also show you the strength of your new password; however, it will not prevent you from using a weak password.
 
-#### Option B: Use Terminus WP-CLI to set a password
-Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/) via [Terminus](/docs/terminus):
+### Option B: Use Terminus WP-CLI to set a password
+Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/){.external} via [Terminus](/docs/terminus/):
 
-```nohighlight
-$ terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWORD
+```bash
+terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWORD
 ```
 
 As a side note, `terminus 'wp user update'` can be used to change almost any property of a WordPress user's account. `wp_update_user()` gives a complete list of all the fields that can be changed. You can change any of them by using `--field=value`. In the above command, field is "user_pass" and value is NEWPASSWORD.
 
-#### Option C: Reset your password directly in the database (advanced)
+### Option C: Reset your password directly in the database (advanced)
 
-If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [wordpress.org](https://codex.wordpress.org/Resetting_Your_Password#Through_MySQL.2FMariaDB_Command_Line){.external} and [Accessing MySQL Databases](/docs/mysql-access) for more information.
+If an application issue is preventing a password reset via Terminus, you may need to do a password reset or add a new user account directly in the MySQL database. Please see documentation on [wordpress.org](https://codex.wordpress.org/Resetting_Your_Password#Through_MySQL.2FMariaDB_Command_Line){.external} and [Accessing MySQL Databases](/docs/mysql-access/) for more information.


### PR DESCRIPTION
Closes #4432

## Effect
PR includes the following changes:
- Adds headings to clarify the 3 password reset options for each CMS
- Adds a new PW reset method, doing this directly in the database. This is not the easiest option, but it may be necessary for users who can't use Terminus (e.g Windows users).

## Remaining Work
- [x] add the MySQL password reset options
- [ ] maybe split Drupal/WP into separate tabs?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
