### PR TITLE
comprised of vs comprises

### DIFF
--- a/source/_docs/files.md
+++ b/source/_docs/files.md
@@ -10,7 +10,7 @@ Files are user uploads, usually images or documents. They are excluded from vers
 - [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore){.external}
 - [WordPress](https://github.com/pantheon-systems/WordPress/blob/master/.gitignore){.external}
 
-The Pantheon architecture is comprised of highly available [application containers](/docs/application-containers/) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
+The Pantheon architecture comprises highly available [application containers](/docs/application-containers/) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 
 Valhalla symbolically links the `wp-content/uploads` directory for WordPress and the `sites/default/files` directory for Drupal to the Valhalla files directory mount point, `/files` if viewed via an SFTP client. It is important to note that this directory is not part of the document root and is not directly web-accessible. Should you wish to make this accessible, you will need to create an additional symbolic link from within the document root.  Any [non-standard file locations](/docs/non-standard-file-paths/) should be symbolically linked to `/files` or moved manually.
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- quick grammar fix - comprises vs is comprised of

## Remaining Work
nadda

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
