### PR TITLE
Add details regarding the gzip feature of the platform

### DIFF
--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -488,7 +488,7 @@ The new filename will cause clients to get the new file, even if they have a cac
 A redirect will add at least one extra HTTP request-response cycle. As a result, eliminating extraneous redirects can make your website more snappy. Despite your best efforts it still may be necessary to include the occasional [redirect to a primary domain](/docs/guides/launch/redirects/) using HTTPS with or without the WWW.
 
 ## GZIP Compression
-By default, gzip compression is already enabled server-side and the response headers already includes `content-encoding: gzip` which will serve the site's HTML, stylesheets and JavaScipt files in a reduced size before sending it to the browser resulting to a faster Time To First Byte(TTFB). Users won't need to modify and Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
+By default, gzip compression is already enabled server-side and the response headers already includes `content-encoding: gzip` which will serve the site's HTML, stylesheets and JavaScipt files in a reduced size before sending it to the browser resulting to a faster Time To First Byte(TTFB). Users won't need to modify any Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
 
 If there are any assets that are not being gzipped, most likely, they are assets loaded outside Pantheon. Users will need to put the assets in Pantheon so they will also be gzipped by default.
 

--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -487,14 +487,14 @@ The new filename will cause clients to get the new file, even if they have a cac
 ## Avoid Redirects
 A redirect will add at least one extra HTTP request-response cycle. As a result, eliminating extraneous redirects can make your website more snappy. Despite your best efforts it still may be necessary to include the occasional [redirect to a primary domain](/docs/guides/launch/redirects/) using HTTPS with or without the WWW.
 
-## GZIP Compression
-By default, gzip compression is already enabled server-side and the response headers already includes `content-encoding: gzip` which will serve the site's HTML, stylesheets and JavaScipt files in a reduced size before sending it to the browser resulting to a faster Time To First Byte(TTFB). Users won't need to modify any Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
-
-If there are any assets that are not being gzipped, most likely, they are assets loaded outside Pantheon. Users will need to put the assets in Pantheon so they will also be gzipped by default.
-
 Other considerations:
 
 - Avoid mobile-specific subdomains and use responsive web design techniques.
 - A DNS service provider such as [Cloudflare](https://support.cloudflare.com/hc/en-us/articles/200170536-How-do-I-redirect-all-visitors-to-HTTPS-SSL-){.external} may allow speedier redirects in some circumstances, but it’s still faster not to redirect at all.
 - Avoid several chained redirects that make small changes such as redirecting to HTTPS, adding or removing WWW, or adding a trailing slash. Instead, [redirect to a primary domain](/docs/guides/launch/redirects/) that has all of these standardized.
 - Pantheon doesn’t read changes to the `.htaccess` file or support NGINX customization, so redirections via those methods will not work. For details, see [Configure Redirects](/docs/redirects/#php-vs-htaccess).
+
+## GZIP Compression
+By default, gzip compression is already enabled server-side. The response headers include `content-encoding: gzip` which will serve the site's HTML, stylesheets and JavaScipt files in a reduced size before sending it to the browser, resulting to a faster Time To First Byte (**TTFB**). Users don't need to modify any Nginx/.htaccess configuration, nor install any 3rd party plugins/modules for gzip compression.
+
+If there are any assets that are not being gzipped, most likely they are assets loaded from outside Pantheon.

--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -488,7 +488,7 @@ The new filename will cause clients to get the new file, even if they have a cac
 A redirect will add at least one extra HTTP request-response cycle. As a result, eliminating extraneous redirects can make your website more snappy. Despite your best efforts it still may be necessary to include the occasional [redirect to a primary domain](/docs/guides/launch/redirects/) using HTTPS with or without the WWW.
 
 ## GZIP Compression
-By default, Pantheon hosted sites is already gzip compressed and the response headers already includes `content-encoding: gzip` so users won't need to modify and Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
+By default, gzip compression is already enabled server-side and the response headers already includes `content-encoding: gzip` which will serve the site's HTML, stylesheets and JavaScipt files in a reduced size before sending it to the browser resulting to a faster Time To First Byte(TTFB). Users won't need to modify and Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
 
 If there are any assets that are not being gzipped, most likely, they are assets loaded outside Pantheon. Users will need to put the assets in Pantheon so they will also be gzipped by default.
 

--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -487,6 +487,11 @@ The new filename will cause clients to get the new file, even if they have a cac
 ## Avoid Redirects
 A redirect will add at least one extra HTTP request-response cycle. As a result, eliminating extraneous redirects can make your website more snappy. Despite your best efforts it still may be necessary to include the occasional [redirect to a primary domain](/docs/guides/launch/redirects/) using HTTPS with or without the WWW.
 
+## GZIP Compression
+By default, Pantheon hosted sites is already gzip compressed and the response headers already includes `content-encoding: gzip` so users won't need to modify and Nginx/.htaccess configuration or they don't have to install any 3rd party plugins/modules for gzip compression.
+
+If there are any assets that are not being gzipped, most likely, they are assets loaded outside Pantheon. Users will need to put the assets in Pantheon so they will also be gzipped by default.
+
 Other considerations:
 
 - Avoid mobile-specific subdomains and use responsive web design techniques.


### PR DESCRIPTION
Closes #4510 

## Effect
PR includes the following changes:
- Add details that Pantheon hosted sites are gzip compressed by default so they wont be looking plugin/modules that does that feature or modify the Nginx configuration

## Remaining Work
- [ ] List any outstanding todos
- [ ] If needed

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
