### PR TITLE
align Autoptimize pathway to other docs

### DIFF
--- a/source/_docs/guides/frontend-performance.md
+++ b/source/_docs/guides/frontend-performance.md
@@ -409,7 +409,7 @@ Use the [Autoptimize](https://wordpress.org/plugins/autoptimize/){.external} plu
 
 ```php
 // Configure directory & filename of cached autoptimize files
-define('AUTOPTIMIZE_CACHE_CHILD_DIR','/uploads/resources/');
+define('AUTOPTIMIZE_CACHE_CHILD_DIR','/uploads/autoptimize/');
 define('AUTOPTIMIZE_CACHEFILE_PREFIX','aggregated_');
 ```
 


### PR DESCRIPTION
Closes #4523 

## Effect
PR includes the following changes:
- Standardizes the path we suggest for Autoptomize to use in `uploads`

## Remaining Work
- [x] Technical Review (provided [here](https://github.com/pantheon-systems/documentation/issues/4523#issuecomment-467564446))
- [ ] ~Copy Review~ C'mon... right?

## Post Launch
To be completed by the docs team upon merge: 
- [ ] ~Update Status Report~ Probably not.
- [ ] Archive from **Done** in Waffle
