### PR TITLE
add composer version note

### DIFF
--- a/source/_docs/guides/build-tools/02-create-project.md
+++ b/source/_docs/guides/build-tools/02-create-project.md
@@ -42,6 +42,9 @@ In this section we'll use the Terminus Build Tools Plugin to create a new Panthe
         <a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#troubleshoot-install"><h3 class="info panel-title panel-drop-title" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-wrench"></span> Troubleshooting</h3></a>
       </div>
       <div id="troubleshoot-install" class="collapse" markdown="1" style="padding:10px;">
+
+      {% include("content/composer-updating.html")%}
+
       ### Composer Content-Length Mismatch and/or Degraded Mode
       If you encounter an issue such as:
 

--- a/source/_docs/guides/composer-convert.md
+++ b/source/_docs/guides/composer-convert.md
@@ -14,6 +14,8 @@ contributors: [dustinleblanc]
 
 ## Before You Begin
 
+{% include("content/composer-updating.html")%}
+
  - Review our documentation on [Git](/docs/git/), [Composer](/docs/composer/), and [Terminus](/docs/terminus/), and have them installed and configured on your local computer.
  - [Clone](/docs/git#clone-your-site-codebase) your _current_ Pantheon site repository to a working directory on your local computer.
  - Review [Serving Sites from the Web Subdirectory](/docs/nested-docroot/)

--- a/source/_docs/guides/drupal-8-commerce.md
+++ b/source/_docs/guides/drupal-8-commerce.md
@@ -17,6 +17,7 @@ This process uses Composer to manage modules and dependencies. Before proceeding
  - [Composer Fundamentals and Workflows](/docs/composer)
  - [Build Tools](/docs/guides/build-tools)
 
+{% include("content/composer-updating.html")%}
 
 In addition to Pantheon, you will need accounts at:
 

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -15,6 +15,8 @@ In this guide, we’re going to run through the bare necessities to use [Compose
 
 Using a Composer managed site **removes** the ability to [apply Drupal core updates via the site dashboard](/docs/core-updates/).  This is for advanced users who are comfortable taking complete responsibility for the management of site updates with Composer.
 
+{% include("content/composer-updating.html")%}
+
 ## Creating the Pantheon Site
 
 To begin, we’ll want to start a brand new Drupal 8 site on Pantheon from our empty upstream. This upstream is different from the Drupal 8 upstream in that it does not come with any Drupal files. As such, you must use Composer to download Drupal.

--- a/source/_partials/content/composer-updating.html
+++ b/source/_partials/content/composer-updating.html
@@ -2,5 +2,5 @@
   <h4 class="info">Note</h4>
   <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the <code>require</code> or <code>require-dev</code> section of <code>composer.json</code> in order to update packages. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
   <br>
-  <p>As a first troubleshooting step, try running <code>composer update</code> to bring <code>composer.lock</code> up to date with <code>composer.json</code>.</p>
+  <p>As a first troubleshooting step, try running <code>composer update</code> to bring <code>composer.lock</code> up to date with the latest available packages.</p>
 </div>

--- a/source/_partials/content/composer-updating.html
+++ b/source/_partials/content/composer-updating.html
@@ -1,4 +1,4 @@
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. `composer.lock` prevents the updating of packages beyond the version limits specified within, and need to be manually reviewed/updated from time to time. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
+  <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the `require` or `require-dev` section of `composer.json` in order to update packages. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
 </div>

--- a/source/_partials/content/composer-updating.html
+++ b/source/_partials/content/composer-updating.html
@@ -2,5 +2,5 @@
   <h4 class="info">Note</h4>
   <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the <code>require</code> or <code>require-dev</code> section of <code>composer.json</code> in order to update packages. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
   <br>
-  <p>As a first troubleshooting step, try running <code>composer update</code> to bring <code>composer.lock</code> up to date with the latest available packages.</p>
+  <p>As a first troubleshooting step, try running <code>composer update</code> to bring <code>composer.lock</code> up to date with the latest available packages (as constrained by the version requirements in <code>composer.json</code>).</p>
 </div>

--- a/source/_partials/content/composer-updating.html
+++ b/source/_partials/content/composer-updating.html
@@ -1,0 +1,4 @@
+<div class="alert alert-info" role="alert">
+  <h4 class="info">Note</h4>
+  <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. `composer.lock` prevents the updating of packages beyond the version limits specified within, and need to be manually reviewed/updated from time to time. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
+</div>

--- a/source/_partials/content/composer-updating.html
+++ b/source/_partials/content/composer-updating.html
@@ -1,4 +1,6 @@
 <div class="alert alert-info" role="alert">
   <h4 class="info">Note</h4>
-  <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the `require` or `require-dev` section of `composer.json` in order to update packages. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
+  <p>As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the <code>require</code> or <code>require-dev</code> section of <code>composer.json</code> in order to update packages. See the <a href="https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions" class="external">updating dependencies</a> section of Composer's documentation for more information.</p>
+  <br>
+  <p>As a first troubleshooting step, try running <code>composer update</code> to bring <code>composer.lock</code> up to date with <code>composer.json</code>.</p>
 </div>


### PR DESCRIPTION
~Closes~ Need raised by #4517 
~Closes~ Need raised by #3890

## Effect
PR includes the following changes:
- Creates a new partial file with a note describing how composer lock files may need to be updates as software dependencies and versioning is updated.
- Adds the warning to a couple docs.

## Remaining Work
- [x] Technical review of the note itself (@dustinleblanc ?)
- [x] Confirm it relates to both issues referenced above (@stevector ? )
- [x] Check for additional composer-based docs this should be added to.
- [x] Copy review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
