### PR TITLE
Removing Glossary reference to the advanced tab

### DIFF
--- a/source/_docs/guides/quickstart/02-user-dashboard.md
+++ b/source/_docs/guides/quickstart/02-user-dashboard.md
@@ -57,8 +57,6 @@ In this lesson, we’re going to explore the User Dashboard.
  - **Billing:** View and update your billing information for sites you own.
 
  - **Delete Account:** Delete your Pantheon account. This is useful for consolidating multiple accounts under a single user account.
-
-- **<span class="glyphicons glyphicons-embed-close" aria-hidden="true"></span> Advanced:** Find information about using our command line tool, [Terminus](/docs/terminus).
 </div>
 </div>
 </div>


### PR DESCRIPTION
Closes #4262 

## Effect
PR includes the following changes:
- Removes the reference to the Advanced tab that no longer exists.

## Remaining Work
- [x] Update the video on the page.

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
