### PR TITLE
Rreplace dir tree with GH Links

### DIFF
--- a/source/_docs/migrate-manual.md
+++ b/source/_docs/migrate-manual.md
@@ -95,16 +95,9 @@ Now that you have a new site on Pantheon, you're ready to add the major componen
 
 ## Import Your Code
 Your **code** is all custom and contributed modules or plugins, themes, and libraries. The codebase should not include the `wp-content/uploads` (WordPress) / `sites/default/files` (Drupal) directory, or any other static assets you do not want tracked by version control.
-  <div class="panel panel-drop panel-guide" id="accordion">
-    <div class="panel-heading panel-drop-heading">
-      <a class="accordion-toggle panel-drop-title collapsed" data-toggle="collapse" data-parent="#accordion" data-proofer-ignore data-target="#unique-anchor">
-        <h3 class="panel-title panel-drop-title" style="cursor:pointer;"><span style="line-height:.9" class="glyphicons glyphicons-lightbulb"></span> Code Directory Structure</h3>
-      </a>
-    </div>
-    <div id="unique-anchor" class="collapse" markdown="1" style="padding:10px;">
-      {% include("content/code.html")%}
-    </div>
-  </div>
+
+  {% include("content/code.html")%}
+
   <div class="alert alert-info">
   <h4 class="info">Note</h4>
   <p markdown="1">If your existing site is already version controlled and you would like to preserve the commit history, import the code from the command line with Git using the instructions below. If you prefer to avoid the command line entirely, we suggest importing the codebase using an SFTP Client such as [Transmit](https://panic.com/transmit/){.external} or [Cyberduck](https://cyberduck.io/){.external}.</p></div>
@@ -406,7 +399,7 @@ This error may occur when trying to merge Pantheon's codebase into your existing
 Not possible to fast-forward, aborting.
 ```
 
-Depending on your Git version, you may see the following error instead: 
+Depending on your Git version, you may see the following error instead:
 
 ```
 fatal: refusing to merge unrelated histories
@@ -420,7 +413,7 @@ rebase = TRUE
 ff = only
 ```
 
-In this case, you will want to remove `ff = only` from your `.gitconfig` file and try the merge command again. 
+In this case, you will want to remove `ff = only` from your `.gitconfig` file and try the merge command again.
 
 ## See Also
 Check our standard migration procedure for related <a href="/docs/migrate#frequently-asked-questions-faqs" data-proofer-ignore>Frequently Asked Questions</a> and [Troubleshooting](/docs/migrate#troubleshooting) tips.

--- a/source/_partials/content/code.html
+++ b/source/_partials/content/code.html
@@ -1,51 +1,7 @@
-The codebase is comprised of the following files and directories:
-<!-- Nav tabs -->
-<ul class="nav nav-tabs" role="tablist">
-  <!-- Active tab -->
-  <li id="wp-code-id" role="presentation" class="active"><a href="#wp-code" aria-controls="wp-code" role="tab" data-toggle="tab">WordPress</a></li>
-  <!-- 2nd Tab Nav -->
-  <li id="drops-code-id" role="presentation"><a href="#drops-code" aria-controls="drops-code" role="tab" data-toggle="tab">Drupal</a></li>
+<p>The codebase for each CMS upstream offered by Pantheon can be found on GitHub:</p>
+
+<ul>
+  <li><a href="https://github.com/pantheon-systems/drops-7" class="external">Drupal 7</a></li>
+  <li><a href="https://github.com/pantheon-systems/drops-8" class="external">Drupal 8</a></li>
+  <li><a href="https://github.com/pantheon-systems/wordpress" class="external">WordPress</a></li>
 </ul>
-<!-- Tab panes -->
-<div class="tab-content">
-  <!-- Active pane content -->
-  <div role="tabpanel" class="tab-pane active" id="wp-code" markdown="1">
-<pre><code class="nohighlight">├── index.php
-├── wp-activate.php
-├── wp-config.php
-├── wp-comments-post.php
-├── wp-blog-header.php
-├── wp-admin
-├── wp-cron.php
-├── wp-load.php
-├── wp-links-opml.php
-├── wp-includes
-├── xmlrpc.php
-├── wp-trackback.php
-├── wp-signup.php
-├── wp-settings.php
-├── wp-mail.php
-├── wp-login.php
-├── wp-content
-    ├── index.php
-    ├── mu-plugins
-    ├── themes
-    ├── plugins</code></pre>
- </div>
-  <!-- 2nd pane content -->
-  <div role="tabpanel" class="tab-pane" id="drops-code" markdown="1">
-<pre><code class="nohighlight">├── includes
-├── index.php
-├── misc
-├── modules
-├── profiles
-├── scripts
-├── sites
-    └── all
-       ├── modules
-       └── themes
-    └── default
-       └── settings.php
-└── themes</code></pre>
-  </div>
-</div>


### PR DESCRIPTION
Closes #4017 

## Effect
PR includes the following changes:
- Removes the CMS code tree and replaces it with links to the GH repos
- Updates the formatting where this snippet is used in migrate-manual

## Remaining Work
- [x] Technical Review (@sarahg and/or @xq42)
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
