### PR TITLE
Ps documentation page update v2

### DIFF
--- a/source/_docs/load-and-performance-testing.md
+++ b/source/_docs/load-and-performance-testing.md
@@ -8,7 +8,7 @@ Load and performance tests are critical steps in going live procedures, as they 
 
 <div class="alert alert-info" role="alert">
 <h4 class="info">Note</h4>
-<p markdown="1">Load testing is one of the services offered by our [Professional Services](/docs/professional-services/#load-testing) team.</p>
+<p markdown="1">Load testing is one of the services offered by our [Professional Services](/docs/professional-services/#pre-launch-load-testing) team.</p>
 </div>
 
 ## Load vs Performance Testing

--- a/source/_docs/migrate-manual.md
+++ b/source/_docs/migrate-manual.md
@@ -18,7 +18,7 @@ If none of the above apply to your project, use the [standard migration procedur
 
 <div class="alert alert-info" markdown="1">
 #### Note {.info}
-Site migrations are one of the services offered by our [Professional Services](/docs/professional-services/#migrations) team.
+Site migrations are one of the services offered by our [Professional Services](/docs/professional-services/#site-migrations) team.
 </div>
 
 ## Before You Begin
@@ -406,7 +406,7 @@ This error may occur when trying to merge Pantheon's codebase into your existing
 Not possible to fast-forward, aborting.
 ```
 
-Depending on your Git version, you may see the following error instead: 
+Depending on your Git version, you may see the following error instead:
 
 ```
 fatal: refusing to merge unrelated histories
@@ -420,7 +420,7 @@ rebase = TRUE
 ff = only
 ```
 
-In this case, you will want to remove `ff = only` from your `.gitconfig` file and try the merge command again. 
+In this case, you will want to remove `ff = only` from your `.gitconfig` file and try the merge command again.
 
 ## See Also
 Check our standard migration procedure for related <a href="/docs/migrate#frequently-asked-questions-faqs" data-proofer-ignore>Frequently Asked Questions</a> and [Troubleshooting](/docs/migrate#troubleshooting) tips.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -41,21 +41,21 @@ Your Engagement Manager monitors the process and works with you to ensure that u
 Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pantheon Enterprise Gateway (PEG)
-Provides a static outgoing IP address for use in IP whitelisting connections to external services. [Contact us](https://pantheon.io/professional-services){.external} for details.
+Provides a static outgoing IP address for use in IP whitelisting connections to external services. [Learn more about PEG](https://pantheon.io/docs/pantheon-enterprise-gateway){.external} or [contact us](https://pantheon.io/professional-services) for details.
 
 ## SSO/SAML
-Single Sign-on to both the Pantheon Dashboard and the application itself. [Contact us](https://pantheon.io/professional-services){.external} for details.
-
-## Custom Application Services
-Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon. [Contact us](https://pantheon.io/professional-services){.external} for details.
+Single Sign-on to both the Pantheon Dashboard and the application itself. [Learn more about SSO](https://pantheon.io/docs/sso){.external} or [contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pre-launch Load Testing
-Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the PS team we generate traffic to your Live site, if needed simulating complexe user interactions. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
 
 Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Performance Deep Dive
 Performance tests expose the root cause of performance bottlenecks and allow us to suggest application-level solutions to optimize performance and reduce errors. [Contact us](https://pantheon.io/professional-services){.external} for details.
+
+## Custom Application Services
+Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Customer Success Management
 Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -6,24 +6,17 @@ tags: []
 
 Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
 
-## Site Migrations
-Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly.
+## Site Migrations 
+The Site Migration service lowers the barrier to entru by utilisaing our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
 
-Our hands-on, white-glove migration services for organizations and agencies remove the burden of migrations from your shoulders. By migrating the sites for you, you can concentrate on what matters most to your end users. We do all the heavy lifting and let you focus on delivering better, faster websites for your colleagues, constituents, or clients. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
+TODO: be more verbose, establish a level of conficence... e.g. walk through of process... 6 steps, automation, etc... one or two sentences for each.
+* Qualification. access to servers; talk to team about business critical functionality to smoke test it
+* Initial migration: automation, "tools that automate moving code/db/file to Pant and standing up..."
+* Test and patch: we implement all the thing to ensure that everything is working as expected and building out additional scripting to be able to do pre-launch content syncing
+* UAT: test the site yourself, supported by Visual Regression tools; have mechanism to report any issues that are found and work to resolve those issues.
+* Launch Planning: work with your team to do launch planning like... content resyncs, etc.
+* Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch... (todo : see pp) 
 
-## Load Testing
-Load and performance tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes.
-
-Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
-
-| Service                         | Included with Diamond <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Availabile for Gold, Platinum and Diamond" data-content="Limited inclusion with Diamond"><em class="fa fa-info-circle"></em></a> |
-|:----------------------------------- |:------------------------ |
-| Load Testing: Anonymous traffic     | Yes (1/Qtr)              |
-| Load Testing: Authenticated traffic | Yes (1/Qtr)              |
-| Load Testing: E-commerce traffic    | Yes (1/Qtr)              |
-
-## Consulting and Specialty Services
-If you need advice on architecting a solution, planning for the future, preparing for expansion, tackling a particularly complex use case, or just need problem solving expertise, Pantheon's Professional Services (**PS**) team can help you achieve your goals. Our Professional Services team has the broad experience and deep expertise to guide you through your implementation needs. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
 ### Managed Updates
 Allow Pantheon’s PS team to apply core and contributed plugins/module updates. Includes visual regression testing (**VRT**) to ensure that no issues arise from the updates.
@@ -31,29 +24,34 @@ Allow Pantheon’s PS team to apply core and contributed plugins/module updates.
 ### Advanced CDN
 Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation.
 
-### Custom Application Services
-Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon.
+## Load Testing
+Load and performance tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes.
 
-### Load Testing / Performance Deep Dive
-Identify bottlenecks and fine tune your site to improve performance. Engagement Managers will test load against current peak or anticipated load increases to ensure growth. We will utilize New Relic and other tools to produce a performance report.
+Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
-### Pantheon Enterprise Gateway (PEG)
+## Managed Updates
+Allow Pantheon’s PS team to apply core and contributed plugins/module updates. Includes visual regression testing (**VRT**) to ensure that no issues arise from the updates.
+
+## Advanced CDN
+Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation.
+
+## Pantheon Enterprise Gateway (PEG)
 Provides a static outgoing IP address for use in IP whitelisting connections to external services.
 
 ### SSO/SAML
 Single Sign-on to both the Pantheon Dashboard and the application itself.
 
+## Custom Application Services
+Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon.
+
+## Pre-launch Load Testing
+Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes and ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings.
+
+## Performance Deep Dive
+Performance testing expose the root cause of performance bottlenecks and allow us to suggest application level solution to optimize performance and reduce errors.
+
 ## Customer Success Management
 Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals. Customer Success Managers (**CSMs** )work proactively with you, helping you build agile website operations, achieve business goals, adopt best practices, and stay ahead of the competition. A dedicated Customer Success Manager is included with all Diamond support plans and is available for Gold and Platinum plans. Your dedicated CSM meets with you regularly to provide site performance audits, review team usage of the platform, extend early access to new features, and ensure that you are getting the most value possible from the platform. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
-| Service                                                  | Included with Diamond |
-|:-------------------------------------------------------- |:--------------------- |
-| Dedicated CSM with Executive Business Reviews; Recurring | Yes                   |
-
 ## Expert Training
 We provide highly customized, one-on-one training from Pantheon experts for your development team to apply custom workflows to active Pantheon projects. Tailored DevOps training for your entire team is also available. We review your current projects and workflow to deliver trainings designed specifically to improve website operations for your team. These trainings can be delivered remotely, onsite or online for multiple offices. [Contact us](https://pantheon.io/agencies/learn-pantheon){.external} for details.
-
-| Service                                                   | Available with Gold, Platinum and Diamond |
-|:--------------------------------------------------------- |:----------------------------------------- |
-| Expert Training - Personalized; 4 hours. Online           | Yes                                       |
-| Expert Training - Personalized; Full Day. Travel Possible | Yes                                       |

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -4,34 +4,36 @@ description: Pantheon Professional Services include consulting, migrations, load
 tags: []
 ---
 
-Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
+Pantheon Professional Services (**PS**) works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
-## Site Migrations 
-The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. 
+## Site Migrations
+The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably.
 
-Overview of the process:
-* Qualification: We get access to the servers or site archives we'll need to undertake the migration and identify business critical functionality that require special attention and testing.
-* Initial migration: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
-* Test and patch: We fine tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.
-* User Acceptance Testing (UAT): You test the site yourself. We have mechanisms in place to report any issues that are found and work to resolve those issues.
-* Launch Planning: We work with your team to do launch planning like, such as content resyncs, load testing, SSL certificate pro-provisioning, etc.
-* Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch.
+### Site migration process overview
+
+- **Qualification**: We get access to the servers or site archives we'll need to undertake the migration and identify business critical functionality that require special attention and testing.
+- **Initial migration**: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
+- **Test and patch**: We fine-tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.
+- **User Acceptance Testing (UAT)**: You test the site yourself. We have mechanisms in place to report any issues that are found and work to resolve those issues.
+- **Launch Planning**: We work with your team to do launch planning such as content resyncs, load testing, SSL certificate pro-provisioning, and more.
+- **Launch**: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch.
 
 [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
 
 ## Managed Updates
-Keep your site up to date with as little interruption to the site’s end users as possible. Allow Pantheon’s PS team to apply core and contributed plugins/module updates. 
+Keep your site up to date with minimal interruption to end users. Allow Pantheon’s PS team to apply core and contributed plugins/module updates.
 
-Your Engagement Manager monitors the process and works with you to ensure that updates are being applied cleanly, and minimizing interference with your day-to-day operations. 
+Your Engagement Manager monitors the process and works with you to ensure that updates are being applied cleanly, and minimizing interference with your day-to-day operations.
 
-Overview of the process:
-* Updates are detected per specifications provided from client
-* A Multidev environment is spun up, cloning db/files from Live
-* Updates are applied to the Multidev environment and Visual Rregression Tests (VRT) are run
-* A brief window of time is provided to allow for manual testing if required from client
-* If VRT passes, we merge the Multidev branch into Master and run VRT again.
-* Repeat same process on Test.
-* Backup Live environment and deploy updates to Live
+### Managed updates process overview
+
+- Updates are detected per client-provided specifications.
+- A Multidev environment is spun up, cloning DB/files from Live.
+- Updates are applied to the Multidev environment and Visual Regression Tests (**VRT**) are run.
+- Manual testing if required.
+- If VRT passes, we merge the Multidev branch into Master and run VRT again.
+- Repeat same process on Test.
+- Backup Live environment and deploy updates to Live.
 
 [Contact us](https://pantheon.io/professional-services){.external} for details.
 
@@ -48,13 +50,17 @@ Single Sign-on to both the Pantheon Dashboard and the application itself. [Conta
 Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pre-launch Load Testing
-Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes and ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.
+Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+
+Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Performance Deep Dive
-Performance testing expose the root cause of performance bottlenecks and allow us to suggest application level solution to optimize performance and reduce errors. [Contact us](https://pantheon.io/professional-services){.external} for details.
+Performance tests expose the root cause of performance bottlenecks and allow us to suggest application-level solutions to optimize performance and reduce errors. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Customer Success Management
-Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals. Customer Success Managers (**CSMs** )work proactively with you, helping you build agile website operations, achieve business goals, adopt best practices, and stay ahead of the competition. A dedicated Customer Success Manager is included with all Diamond support plans and is available for Gold and Platinum plans. Your dedicated CSM meets with you regularly to provide site performance audits, review team usage of the platform, extend early access to new features, and ensure that you are getting the most value possible from the platform. [Contact us](https://pantheon.io/contact-us){.external} for details.
+Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals.
+
+Pantheon Customer Success Managers (**CSMs**) work proactively with you, helping you build agile website operations, achieve business goals, adopt best practices, and stay ahead of the competition. A dedicated CSM is included with all Diamond support plans and is available for Gold and Platinum plans. Your dedicated CSM meets with you regularly to provide site performance audits, review team usage of the platform, extend early access to new features, and ensure that you are getting the most value possible from the platform. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
 ## Expert Training
-We provide highly customized, one-on-one training from Pantheon experts for your development team to apply custom workflows to active Pantheon projects. Tailored DevOps training for your entire team is also available. We review your current projects and workflow to deliver trainings designed specifically to improve website operations for your team. These trainings can be delivered remotely, onsite or online for multiple offices. [Contact us](https://pantheon.io/agencies/learn-pantheon){.external} for details.
+We provide highly customized, one-on-one training from Pantheon experts to help your development team apply custom workflows to active Pantheon projects. Tailored DevOps training for your entire team is also available. We review your current projects and workflow to deliver trainings designed specifically to improve website operations for your team. These trainings can be delivered remotely, on-site or online for multiple offices. [Contact us](https://pantheon.io/agencies/learn-pantheon){.external} for details.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -4,7 +4,7 @@ description: Pantheon Professional Services include consulting, migrations, load
 tags: []
 ---
 
-Pantheon Professional Services can be brought in as needed to overcome any barriers to entry. Working closely with partners we can help overcome any challenges you are facing, and provide customized solutions for the most complex technical challenges.
+Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges.
 
 ## Consulting and Specialty Services
 If you need advice on architecting a solution, planning for the future, preparing for expansion, tackling a particularly complex use case, or just need problem solving expertise, Pantheon's Professional Services (**PS**) team can help you achieve your goals. Our Professional Services team has the broad experience and deep expertise to guide you through your implementation needs. [Contact us](https://pantheon.io/contact-us){.external} for details.
@@ -27,7 +27,7 @@ Provides a static outgoing IP address for use in IP whitelisting connections to 
 ### SSO/SAML
 Single Sign-on to both the Pantheon Dashboard and the application itself.
 
-## Migrations
+## Site Migrations
 Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly.
 
 Our hands-on, white-glove migration services for organizations and agencies remove the burden of migrations from your shoulders. By migrating the sites for you, you can concentrate on what matters most to your end users. We do all the heavy lifting and let you focus on delivering better, faster websites for your colleagues, constituents, or clients. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -6,6 +6,22 @@ tags: []
 
 Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
 
+## Site Migrations
+Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly.
+
+Our hands-on, white-glove migration services for organizations and agencies remove the burden of migrations from your shoulders. By migrating the sites for you, you can concentrate on what matters most to your end users. We do all the heavy lifting and let you focus on delivering better, faster websites for your colleagues, constituents, or clients. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
+
+## Load Testing
+Load and performance tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes.
+
+Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
+
+| Service                         | Included with Diamond <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Availabile for Gold, Platinum and Diamond" data-content="Limited inclusion with Diamond"><em class="fa fa-info-circle"></em></a> |
+|:----------------------------------- |:------------------------ |
+| Load Testing: Anonymous traffic     | Yes (1/Qtr)              |
+| Load Testing: Authenticated traffic | Yes (1/Qtr)              |
+| Load Testing: E-commerce traffic    | Yes (1/Qtr)              |
+
 ## Consulting and Specialty Services
 If you need advice on architecting a solution, planning for the future, preparing for expansion, tackling a particularly complex use case, or just need problem solving expertise, Pantheon's Professional Services (**PS**) team can help you achieve your goals. Our Professional Services team has the broad experience and deep expertise to guide you through your implementation needs. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
@@ -26,22 +42,6 @@ Provides a static outgoing IP address for use in IP whitelisting connections to 
 
 ### SSO/SAML
 Single Sign-on to both the Pantheon Dashboard and the application itself.
-
-## Site Migrations
-Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly.
-
-Our hands-on, white-glove migration services for organizations and agencies remove the burden of migrations from your shoulders. By migrating the sites for you, you can concentrate on what matters most to your end users. We do all the heavy lifting and let you focus on delivering better, faster websites for your colleagues, constituents, or clients. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
-
-## Load Testing
-Load and performance tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes.
-
-Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
-
-| Service                         | Included with Diamond <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-title="Availabile for Gold, Platinum and Diamond" data-content="Limited inclusion with Diamond"><em class="fa fa-info-circle"></em></a> |
-|:----------------------------------- |:------------------------ |
-| Load Testing: Anonymous traffic     | Yes (1/Qtr)              |
-| Load Testing: Authenticated traffic | Yes (1/Qtr)              |
-| Load Testing: E-commerce traffic    | Yes (1/Qtr)              |
 
 ## Customer Success Management
 Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals. Customer Success Managers (**CSMs** )work proactively with you, helping you build agile website operations, achieve business goals, adopt best practices, and stay ahead of the competition. A dedicated Customer Success Manager is included with all Diamond support plans and is available for Gold and Platinum plans. Your dedicated CSM meets with you regularly to provide site performance audits, review team usage of the platform, extend early access to new features, and ensure that you are getting the most value possible from the platform. [Contact us](https://pantheon.io/contact-us){.external} for details.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -9,7 +9,7 @@ Pantheon Professional Services works closely with partners to provide customized
 ## Site Migrations 
 The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
 
-TODO: be more verbose, establish a level of confidence... e.g. walk through of process... 6 steps, automation, etc... one or two sentences for each.
+Overview of the process:
 * Qualification: We get access to ther servers or site archives we'll need to undertake the migration and identify business critical functionality that will require special attention and testing.
 * Initial migration: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
 * Test and patch: We fine tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -15,7 +15,7 @@ The Site Migration service lowers the barrier to entry by leveraging our PS team
 - **Initial migration**: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
 - **Test and patch**: We fine-tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.
 - **User Acceptance Testing (UAT)**: You test the site yourself. We have mechanisms in place to report any issues that are found and work to resolve those issues.
-- **Launch Planning**: We work with your team to do launch planning such as content resyncs, load testing, SSL certificate pro-provisioning, and more.
+- **Launch Planning**: We work with your team to do launch planning such as content resyncs, load testing, SSL certificate pre-provisioning, and more.
 - **Launch**: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch.
 
 [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
@@ -23,7 +23,7 @@ The Site Migration service lowers the barrier to entry by leveraging our PS team
 ## Managed Updates
 Keep your site up to date with minimal interruption to end users. Allow Pantheon’s PS team to apply core and contributed plugins/module updates.
 
-Your Engagement Manager monitors the process and works with you to ensure that updates are being applied cleanly, and minimizing interference with your day-to-day operations.
+Your Engagement Manager monitors the process and works with you to ensure that updates are being applied cleanly, minimizing interference with your day-to-day operations.
 
 ### Managed updates process overview
 

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -23,13 +23,13 @@ Keep your site up to date with as little interruption to the site’s end users 
 Efforts are made to ensure that updates do not interfere with your day-to-day operations and your Engagement Manager will monitor the process and work with you to ensure that updates are being applied cleanly.
 
 Overview of the process:
-1. Updates are detected per specifications provided from client
-1. A Multidev environment is spun up, cloning db/files from Live
-1. Updates are applied to the Multidev environment and Visual Rregression Tests (VRT) are run
-1. A brief window of time is provided to allow for manual testing if required from client
-1. If VRT passes, we merge the Multidev branch into Master and run VRT again.
-1. Repeat same process on Test.
-1. Backup Live environment and deploy updates to Live
+* Updates are detected per specifications provided from client
+* A Multidev environment is spun up, cloning db/files from Live
+* Updates are applied to the Multidev environment and Visual Rregression Tests (VRT) are run
+* A brief window of time is provided to allow for manual testing if required from client
+* If VRT passes, we merge the Multidev branch into Master and run VRT again.
+* Repeat same process on Test.
+* Backup Live environment and deploy updates to Live
 
 [Contact us](https://pantheon.io/professional-services){.external} for details.
 

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -4,7 +4,7 @@ description: Pantheon Professional Services include consulting, migrations, load
 tags: []
 ---
 
-Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges.
+Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
 
 ## Consulting and Specialty Services
 If you need advice on architecting a solution, planning for the future, preparing for expansion, tackling a particularly complex use case, or just need problem solving expertise, Pantheon's Professional Services (**PS**) team can help you achieve your goals. Our Professional Services team has the broad experience and deep expertise to guide you through your implementation needs. [Contact us](https://pantheon.io/contact-us){.external} for details.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -7,32 +7,29 @@ tags: []
 Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
 
 ## Site Migrations 
-The Site Migration service lowers the barrier to entru by utilisaing our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
+The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
 
-TODO: be more verbose, establish a level of conficence... e.g. walk through of process... 6 steps, automation, etc... one or two sentences for each.
-* Qualification. access to servers; talk to team about business critical functionality to smoke test it
-* Initial migration: automation, "tools that automate moving code/db/file to Pant and standing up..."
-* Test and patch: we implement all the thing to ensure that everything is working as expected and building out additional scripting to be able to do pre-launch content syncing
-* UAT: test the site yourself, supported by Visual Regression tools; have mechanism to report any issues that are found and work to resolve those issues.
-* Launch Planning: work with your team to do launch planning like... content resyncs, etc.
-* Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch... (todo : see pp) 
+TODO: be more verbose, establish a level of confidence... e.g. walk through of process... 6 steps, automation, etc... one or two sentences for each.
+* Qualification: We get access to ther servers or site archives we'll need to undertake the migration and identify business critical functionality that will require special attention and testing.
+* Initial migration: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
+* Test and patch: We fine tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.
+* User Acceptance Testing (UAT): You test the site yourself. We have mechanisms in place for you to report any issues that are found and work to resolve those issues.
+* Launch Planning: We work with your team to do launch planning like, such as content resyncs, load testing, SSL certificate pro-provisioning, etc.
+* Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch.
 
 ## Managed Updates
 Keep your site up to date with as little interruption to the site’s end users as possible. Allow Pantheon’s PS team to apply core and contributed plugins/module updates. 
 
-EM monitoring and working with you to ensure that updates are being applied cleanly.
+Efforts are made to ensure that updates do not interfere with your day-to-day operations and your Engagement Manager will monitor the process and work with you to ensure that updates are being applied cleanly.
 
-Efforts are made to ensure that updates do not interfere with your day-to-day operations.
-
-TODO: see other document...  
-
-1 - Update detected per specifications provided from client
-2 - Multidev is spun up cloning db/files from Live
-3 - Updates are applied to the multidev env and VRT tests are ran.
-3.1 - A brief window of time if provided to allow for manual testing if required from client.
-4 - If VRT passes, we merge the MD branch into Master and run VRT again.
-5 - Repeat same process on Test.
-6 - Backup Live environment and deploy updates to Live
+Overview of the process:
+1. Updates are detected per specifications provided from client
+1. A Multidev environment is spun up, cloning db/files from Live
+1. Updates are applied to the Multidev environment and Visual Rregression Tests (VRT) are run
+1. A brief window of time is provided to allow for manual testing if required from client
+1. If VRT passes, we merge the Multidev branch into Master and run VRT again.
+1. Repeat same process on Test.
+1. Backup Live environment and deploy updates to Live
 
 [Contact us](https://pantheon.io/professional-services){.external} for details.
 

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -4,6 +4,8 @@ description: Pantheon Professional Services include consulting, migrations, load
 tags: []
 ---
 
+Pantheon Professional Services can be brought in as needed to overcome any barriers to entry. Working closely with partners we can help overcome any challenges you are facing, and provide customized solutions for the most complex technical challenges.
+
 ## Consulting and Specialty Services
 If you need advice on architecting a solution, planning for the future, preparing for expansion, tackling a particularly complex use case, or just need problem solving expertise, Pantheon's Professional Services (**PS**) team can help you achieve your goals. Our Professional Services team has the broad experience and deep expertise to guide you through your implementation needs. [Contact us](https://pantheon.io/contact-us){.external} for details.
 

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -4,7 +4,7 @@ description: Pantheon Professional Services include consulting, migrations, load
 tags: []
 ---
 
-Pantheon Professional Services (**PS**) works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon. [Contact us](https://pantheon.io/contact-us){.external} for details.
+Pantheon Professional Services (**PS**) works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Site Migrations
 The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably.
@@ -41,13 +41,13 @@ Your Engagement Manager monitors the process and works with you to ensure that u
 Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pantheon Enterprise Gateway (PEG)
-Provides a static outgoing IP address for use in IP whitelisting connections to external services. [Learn more about PEG](https://pantheon.io/docs/pantheon-enterprise-gateway){.external} or [contact us](https://pantheon.io/professional-services) for details.
+Provides a static outgoing IP address for use in IP whitelisting connections to external services. [Learn more about PEG](/docs/pantheon-enterprise-gateway/) or [contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## SSO/SAML
-Single Sign-on to both the Pantheon Dashboard and the application itself. [Learn more about SSO](https://pantheon.io/docs/sso){.external} or [contact us](https://pantheon.io/professional-services){.external} for details.
+Single Sign-on to both the Pantheon Dashboard and the application itself. [Learn more about SSO](/docs/sso/) or [contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pre-launch Load Testing
-Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the PS team we generate traffic to your Live site, if needed simulating complexe user interactions. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the PS team we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
 
 Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.
 

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -17,7 +17,6 @@ TODO: be more verbose, establish a level of conficence... e.g. walk through of p
 * Launch Planning: work with your team to do launch planning like... content resyncs, etc.
 * Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch... (todo : see pp) 
 
-
 ### Managed Updates
 Allow Pantheon’s PS team to apply core and contributed plugins/module updates. Includes visual regression testing (**VRT**) to ensure that no issues arise from the updates.
 
@@ -30,7 +29,23 @@ Load and performance tests are critical steps in ensuring a successful launch. T
 Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
 
 ## Managed Updates
-Allow Pantheon’s PS team to apply core and contributed plugins/module updates. Includes visual regression testing (**VRT**) to ensure that no issues arise from the updates.
+Keep your site up to date with as little interruption to the site’s end users as possible. Allow Pantheon’s PS team to apply core and contributed plugins/module updates. 
+
+EM monitoring and working with you to ensure that updates are being applied cleanly.
+
+Efforts are made to ensure that updates do not interfere with your day-to-day operations.
+
+TODO: see other document...  
+
+1 - Update detected per specifications provided from client
+2 - Multidev is spun up cloning db/files from Live
+3 - Updates are applied to the multidev env and VRT tests are ran.
+3.1 - A brief window of time if provided to allow for manual testing if required from client.
+4 - If VRT passes, we merge the MD branch into Master and run VRT again.
+5 - Repeat same process on Test.
+6 - Backup Live environment and deploy updates to Live
+
+[Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Advanced CDN
 Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -7,20 +7,22 @@ tags: []
 Pantheon Professional Services works closely with partners to provide customized solutions for the most complex technical challenges and ensure your success on Pantheon.
 
 ## Site Migrations 
-The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. [Contact our migrations team](https://pantheon.io/migrations){.external} for details.
+The Site Migration service lowers the barrier to entry by leveraging our PS team and partners. Whether you are moving one or hundreds of sites to or within Pantheon, Pantheon Migration Services will help you get it done quickly and reliably. 
 
 Overview of the process:
-* Qualification: We get access to ther servers or site archives we'll need to undertake the migration and identify business critical functionality that will require special attention and testing.
+* Qualification: We get access to the servers or site archives we'll need to undertake the migration and identify business critical functionality that require special attention and testing.
 * Initial migration: We use automated tools and processes to move code, databases and files, and to stand-up your new environments on Pantheon.
 * Test and patch: We fine tune the migration routine to ensure that everything is working as expected, supported by Visual Regression tools, and build out additional scripting and automated testing as needed. This provides a repeatable and auditable process, and enables pre-launch content syncing.
-* User Acceptance Testing (UAT): You test the site yourself. We have mechanisms in place for you to report any issues that are found and work to resolve those issues.
+* User Acceptance Testing (UAT): You test the site yourself. We have mechanisms in place to report any issues that are found and work to resolve those issues.
 * Launch Planning: We work with your team to do launch planning like, such as content resyncs, load testing, SSL certificate pro-provisioning, etc.
 * Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch.
+
+[Contact our migrations team](https://pantheon.io/migrations){.external} for details.
 
 ## Managed Updates
 Keep your site up to date with as little interruption to the site’s end users as possible. Allow Pantheon’s PS team to apply core and contributed plugins/module updates. 
 
-Efforts are made to ensure that updates do not interfere with your day-to-day operations and your Engagement Manager will monitor the process and work with you to ensure that updates are being applied cleanly.
+Your Engagement Manager monitors the process and works with you to ensure that updates are being applied cleanly, and minimizing interference with your day-to-day operations. 
 
 Overview of the process:
 * Updates are detected per specifications provided from client
@@ -34,16 +36,16 @@ Overview of the process:
 [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Advanced CDN
-Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation.
+Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pantheon Enterprise Gateway (PEG)
-Provides a static outgoing IP address for use in IP whitelisting connections to external services.
+Provides a static outgoing IP address for use in IP whitelisting connections to external services. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## SSO/SAML
-Single Sign-on to both the Pantheon Dashboard and the application itself.
+Single Sign-on to both the Pantheon Dashboard and the application itself. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Custom Application Services
-Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon.
+Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Pre-launch Load Testing
 Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes and ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.

--- a/source/_docs/professional-services.md
+++ b/source/_docs/professional-services.md
@@ -17,17 +17,6 @@ TODO: be more verbose, establish a level of conficence... e.g. walk through of p
 * Launch Planning: work with your team to do launch planning like... content resyncs, etc.
 * Launch: Our team stands by during the DNS cutover to handle any potential migration issues and we stick around post-launch... (todo : see pp) 
 
-### Managed Updates
-Allow Pantheon’s PS team to apply core and contributed plugins/module updates. Includes visual regression testing (**VRT**) to ensure that no issues arise from the updates.
-
-### Advanced CDN
-Implement additional services like extended WAF, Image Optimization, and Domain Masking using our advanced CDN implementation.
-
-## Load Testing
-Load and performance tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes.
-
-Diamond support plans include load tests, ensuring that your website launches smoothly and is ready to absorb the high traffic that success brings. Expert load tests are also available for Gold and Platinum plans. [Contact us](https://pantheon.io/contact-us){.external} for details.
-
 ## Managed Updates
 Keep your site up to date with as little interruption to the site’s end users as possible. Allow Pantheon’s PS team to apply core and contributed plugins/module updates. 
 
@@ -53,17 +42,17 @@ Implement additional services like extended WAF, Image Optimization, and Domain 
 ## Pantheon Enterprise Gateway (PEG)
 Provides a static outgoing IP address for use in IP whitelisting connections to external services.
 
-### SSO/SAML
+## SSO/SAML
 Single Sign-on to both the Pantheon Dashboard and the application itself.
 
 ## Custom Application Services
 Ad hoc solutions to ensure the success of your application on Pantheon. Typically scoped on an hourly basis and provided by our Engagement Managers at Pantheon.
 
 ## Pre-launch Load Testing
-Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes and ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings.
+Load tests are critical steps in ensuring a successful launch. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site. Load tests provide critical insight for how a site will perform in the wild and under peak traffic spikes and ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Performance Deep Dive
-Performance testing expose the root cause of performance bottlenecks and allow us to suggest application level solution to optimize performance and reduce errors.
+Performance testing expose the root cause of performance bottlenecks and allow us to suggest application level solution to optimize performance and reduce errors. [Contact us](https://pantheon.io/professional-services){.external} for details.
 
 ## Customer Success Management
 Agile website operations teams iterate constantly to move in lockstep with organizational needs and deliver on business goals. Customer Success Managers (**CSMs** )work proactively with you, helping you build agile website operations, achieve business goals, adopt best practices, and stay ahead of the competition. A dedicated Customer Success Manager is included with all Diamond support plans and is available for Gold and Platinum plans. Your dedicated CSM meets with you regularly to provide site performance audits, review team usage of the platform, extend early access to new features, and ensure that you are getting the most value possible from the platform. [Contact us](https://pantheon.io/contact-us){.external} for details.


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Frames as "working with partners"
- Restructures to highlight some services over others
- Fleshes out a couple sections to provide details and inspire confidence in the services 
- Removes service-level/qualification indicators
- Some wordsmithing and standardizing.

## Remaining Work
- [ ] Get final review from @bentekwork 

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
