### PR TITLE
Exclude changelog backscroll from indexing

### DIFF
--- a/scripts/deploy-live.sh
+++ b/scripts/deploy-live.sh
@@ -14,12 +14,11 @@ do
   mkdir -p output_prod/docs/changelog/page/"$name"
   mv "$file" "output_prod/docs/changelog/page/"$name"/index.html"
 done
-# Lower search ranking for changelog backscroll
+# Don't index changelog backscroll
 for file in output_prod/docs/changelog/page/*/index.html
 do
-  sed -i '61i\'"        <meta name=\"addsearch-boost\" content=\"30\" />"'\' $file
+  sed -i '61i\'"        <meta name=\"robots\" content=\"noindex\">"'\' $file
 done
-
 
 #===============================================================#
 # Authenticate Terminus  and create json dump of help output    #


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds a tag to changelog backscroll pages to not be indexed by search engines.

## Remaining Work
- [ ] Technical review


## Post Launch
To be completed by the docs team upon merge: 
- [ ] exclude pages ^ respectively within docs search service provider
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
