### PR TITLE
Adjust example Drush commands

### DIFF
--- a/source/_docs/drush.md
+++ b/source/_docs/drush.md
@@ -13,7 +13,7 @@ Refer to Drush's [install documentation](http://docs.drush.org/en/master/install
 
 Drush-savvy developers should also install and utilize [Terminus](/docs/terminus/), a command-line interface that allows you to control your Pantheon account and sites. Virtually anything you can do in the Dashboard, you can script with Terminus. It can also make remote Drush calls on your environments without having Drush installed locally, eliminating incompatibility issues between locally and remotely installed versions of Drush.
 
-You can run all of the commands below from Terminus instead of using Drush aliases. For more information, see [Managing Drupal Sites with Terminus and Drush](/docs/guides/terminus-drupal-site-management/). For example, you can run `terminus drush <site>.<env> -- cc` instead of `drush @pantheon.SITENAME.dev cc drush`.
+You can run all of the commands below from Terminus instead of using Drush aliases. For more information, see [Managing Drupal Sites with Terminus and Drush](/docs/guides/terminus-drupal-site-management/). For example, you can run `terminus drush <site>.<env> -- cc drush` instead of `drush @pantheon.SITENAME.dev cc drush`.
 
 
 ## Drush Versions


### PR DESCRIPTION
https://pantheon.io/docs/drush/#terminus-drush-and-local-drush

## Effect
PR includes the following changes:
- Adjusts example Drush commands shown where we explain that Terminus Drush and Drush aliases can do the same thing. This is clearer if the commands are the same ("drush cc" and "drush cc drush" are different commands).

## Remaining Work
- [x] technical review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
