### PR TITLE
Sodium not available on PHP 7.2

### DIFF
--- a/source/_docs/application-containers.md
+++ b/source/_docs/application-containers.md
@@ -28,7 +28,7 @@ Attempts to remotely access services, such as MySQL or SFTP connections, will fa
     - LDAP
     - SOAP
     - GD
-    - Mcrypt (when running PHP versions under 7.2) or Sodium (when running PHP version 7.2 and later)
+    - Mcrypt (when running PHP versions under 7.2) or Sodium (when running PHP version 7.3 and later)
     - MySQL
     - Imagick (ImageMagick)
     - PDO


### PR DESCRIPTION
Closes # n/a

## Effect
PR includes the following changes:
- Document that Sodium is not available on PHP 7.2.  Customers must upgrade to PHP 7.3 if they want encryption APIs.

## Remaining Work
- [x] Ensure JIRA work description matches desired outcome
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
