### PR TITLE
Changed <site>.<env> to <site>.test

### DIFF
--- a/source/_docs/drupal-8-configuration-management.md
+++ b/source/_docs/drupal-8-configuration-management.md
@@ -47,7 +47,7 @@ In the commands below, replace `site` and `env` with your site name and the corr
 1.  `terminus drush <site>.dev -- cex -y`
 2.  `terminus env:commit <site>.dev --message="Export configuration to code"`
 3.  `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
-4.  `terminus drush <site>.<env> -- cim -y`
+4.  `terminus drush <site>.test -- cim -y`
 5.  `open https://test-mysite.pantheonsite.io`
 6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
 7.  `terminus drush <site>.live -- cim -y`

--- a/source/_docs/drupal-8-configuration-management.md
+++ b/source/_docs/drupal-8-configuration-management.md
@@ -42,7 +42,7 @@ Using Terminus, you can complete the above process from the command line.
 
 ### Workflow Example
 
-In the commands below, replace `site` and `env` with your site name and the correct environment:
+In the commands below, replace `site` with your site name and the correct environment:
 
 1.  `terminus drush <site>.dev -- cex -y`
 2.  `terminus env:commit <site>.dev --message="Export configuration to code"`


### PR DESCRIPTION
Made the change to #4 in Workflow Example, to avoid confusion regarding the intended environment the example was using.

Closes #

## Effect
PR includes the following changes:
- Changed `<site>.<env>` to `<site>.test` in Workflow Example

## Remaining Work
- [ ] Technical review
- [x] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
