### PR TITLE
copy tweak

### DIFF
--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -17,7 +17,7 @@ Verify current PHP settings from the Site Dashboard by clicking **Settings** > *
 
 <div class="alert alert-info" role="alert" markdown="1">
 #### Note {.info}
-Changes made to `pantheon.yml` file on a branch **are not** detected when creating the Multidev environment for that branch. See [Deploying Configuration Changes to Multidev](/docs/pantheon-yml/#deploying-configuration-changes-to-multidev) for more information.
+Changes made to the `pantheon.yml` file on a branch **are not** detected when creating the Multidev environment for that branch. See [Deploying Configuration Changes to Multidev](/docs/pantheon-yml/#deploying-configuration-changes-to-multidev) for more information.
 </div>
 
 ### Available PHP Versions


### PR DESCRIPTION
making it "the file" instead of just "file"

Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
