### PR TITLE
FAQ answer to running tail on logs

### DIFF
--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -278,7 +278,7 @@ done
 
 Not directly. You can download your logs locally using [SFTP](#access-logs-via-sftp) then review them with any tool on your workstation.
 
-You can also use the `logwatcher.sh` script below, which uses [Terminus](/docs/terminus/) and the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin){.external} to download log files repeatedly. Remember to update the variables to match your site name, environment, path, and the log file you want to watch:
+You can also use the `logwatcher.sh` script below, which uses [Terminus](/docs/terminus/) and the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin){.external} to download log files and display the last several lines. Remember to update the variables to match your site name, environment, path, and the log file you want to watch:
 
 ```bash
 #!/bin/bash

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -274,6 +274,10 @@ done
 - Adjust to `appserver.test.$SITE_UUID.drush.in` to pull logs from Test.
 - Adjust to `mget *` to include archived log files.
 
+### Can I `tail` server logs?
+
+Not directly. You can download your logs locally using [SFTP](#access-logs-via-sftp) then review them with any tool on your workstation.
+
 ## See Also
 - [MySQL Slow Log](/docs/mysql-slow-log/)
 - [PHP Slow Log](/docs/php-slow-log/)

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -278,6 +278,29 @@ done
 
 Not directly. You can download your logs locally using [SFTP](#access-logs-via-sftp) then review them with any tool on your workstation.
 
+You can also use the `logwatcher.sh` script below, which uses [Terminus](/docs/terminus/) and the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin){.external} to download log files repeatedly. Remember to update the variables to match your site name, environment, path, and the log file you want to watch:
+
+```bash
+#!/bin/bash
+LOGPATH=~/logs
+LOGFILE=php-error.log
+SITE=sitename
+ENV=environment
+TERMINUS_HIDE_UPDATE_MESSAGE=1
+
+touch $LOGPATH/$LOGFILE
+terminus rsync $SITE.$ENV:logs/$LOGFILE $LOGPATH
+
+tail $LOGPATH/$LOGFILE
+
+```
+
+Once you create this script and give it executable permissions (`chmod +x`), you can use `watch` (available on macOS via Homebrew), to keep an updated view of the logs:
+
+```bash
+watch -n2 logwatcher.sh
+```
+
 ## See Also
 - [MySQL Slow Log](/docs/mysql-slow-log/)
 - [PHP Slow Log](/docs/php-slow-log/)

--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -278,28 +278,49 @@ done
 
 Not directly. You can download your logs locally using [SFTP](#access-logs-via-sftp) then review them with any tool on your workstation.
 
-You can also use the `logwatcher.sh` script below, which uses [Terminus](/docs/terminus/) and the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin){.external} to download log files and display the last several lines. Remember to update the variables to match your site name, environment, path, and the log file you want to watch:
+You can also create the `logwatcher.sh` script below, which uses [Terminus](/docs/terminus/) and the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin){.external} to download log files and display the last several lines.
 
-```bash
-#!/bin/bash
-LOGPATH=~/logs
-LOGFILE=php-error.log
-SITE=sitename
-ENV=environment
-TERMINUS_HIDE_UPDATE_MESSAGE=1
+1. If you're working on multiple projects locally, create a `logs` directory in the local Git repository for each one you want to watch logs for.
 
-touch $LOGPATH/$LOGFILE
-terminus rsync $SITE.$ENV:logs/$LOGFILE $LOGPATH
+1. Add `logs/*` to the project's [`.gitignore` file](/docs/git-faq/#can-i-use-gitignore-on-pantheon).
 
-tail $LOGPATH/$LOGFILE
+1. In your project's `logs` directory, create `logwatcher.sh`:
 
-```
 
-Once you create this script and give it executable permissions (`chmod +x`), you can use `watch` (available on macOS via Homebrew), to keep an updated view of the logs:
+   ```bash
+   #!/bin/bash
+   TERMINUS_HIDE_UPDATE_MESSAGE=1
 
-```bash
-watch -n2 logwatcher.sh
-```
+   LOGPATH=~/projects/mysite/logs
+   LOGFILE=php-error.log
+   SITE=sitename
+   ENV=environment
+
+   touch $LOGPATH/$LOGFILE
+   terminus rsync $SITE.$ENV:logs/$LOGFILE $LOGPATH
+
+   tail $LOGPATH/$LOGFILE
+   ```
+
+1. Update the variables:
+
+    - `LOGPATH` points to the `logs` directory in your project,
+    - `SITE` should match your [site name](/docs/terminus/examples/#siteenv),
+    - `ENV` is the environment you want to watch logs from
+
+1. Make the script executable:
+
+   ```bash
+   chmod +x ~/projects/mysite/logs/logwatcher.sh
+   ```
+
+1. Now you can use `watch` (available on macOS via Homebrew), to keep an updated view of the logs:
+
+   ```bash
+   watch -n2 ~/projects/mysite/logs/logwatcher.sh
+   ```
+
+   Stop the process with **CTRL-C**.
 
 ## See Also
 - [MySQL Slow Log](/docs/mysql-slow-log/)


### PR DESCRIPTION
Closes #4624

## Effect
PR includes the following changes:
- Answers the question "Can I run `tail`on my server logs?"
- Provide a script to automatically download and watch log files.

## Remaining Work
- [x] Technical review (@rachelwhitton and/or @sarahg)
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle