### PR TITLE
Distinguish btn-contribute when it's focused

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -5,7 +5,7 @@ title: Pantheon Docs
 subtitle: Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform
 url: /docs
 site_url: https://pantheon.io
-assets_version: 12.5
+assets_version: 12.6
 
 #######################################################################################################
 # The contributors. Include your info here, under the "contributors" key, using the following template:

--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -2280,7 +2280,13 @@ a.panel-drop-title {
     margin-right: 5px;
     font-size: 75%;
     padding: 2px 5px 2px 5px;
-    }
+}
+.btn-contribute:active,
+.btn-contribute:focus,
+.btn-contribute:hover {
+  background-image: linear-gradient(rgba(0,0,0,0.05), rgba(0,0,0,0.1));
+  color: #44525E;
+}
 .dropdown-menu {
   font-size: 75%;
   top: 20px;
@@ -2300,9 +2306,6 @@ a.panel-drop-title {
   background-color: #fff;
   opacity: inherit;
 
-}
-.btn-contribute:hover {
-    color: #44525E;
 }
 
 .btn-primary, .btn-primary:visited, .btn-primary:focus {


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Darkens the "Contribute" button when hovered over or is in focus when tabbing through the site with a keyboard.

## Remaining Work
- [ ] Technical review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
