### PR TITLE
Disable Link Proofer in Builds

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,10 +46,10 @@ jobs:
           name: Merge Conflicts
           command: |
             scripts/merge_conflicts.sh
-      - run:
-          name: htmlProofer
-          command: |
-            htmlproofer --assume-extension  ./output_prod/ --disable-external true
+#      - run:
+#          name: htmlProofer
+#          command: |
+#            htmlproofer --assume-extension  ./output_prod/ --disable-external true
       - run:
           name: Speedtest
           command: |


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Comments out the HTML proofer step in the build process, which throws lots of false positives.

## Remaining Work
- [x] Technical review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Archive from **Done** in Waffle