### PR TITLE
Update 08-onserver-dev-part1.md

### DIFF
--- a/source/_docs/guides/quickstart/08-onserver-dev-part1.md
+++ b/source/_docs/guides/quickstart/08-onserver-dev-part1.md
@@ -104,4 +104,4 @@ If you need help with this step, please reference the [WordPress Codex](https://
 
 15. When this is finished, you’ll again need to activate/enable the new theme on your Live site.
 
-Congratulations! You just performed on-server development. You made changes on your Dev site, reviewed them on your Live site, then deployed them to Live.
+Congratulations! You just performed on-server development. You made changes on your Dev site, reviewed them on your Test site, then deployed them to Live.


### PR DESCRIPTION
Summary listed "Dev, Live, Live" when it should be "Dev, Test, Live"

Closes #

## Effect
PR includes the following changes:
- Corrected one typo about which server the changes were reviewed upon.
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
To be completed by the docs team upon merge: 
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in Waffle
