### PR TITLE
Who can change upstream clarifier

### DIFF
--- a/source/_docs/create-custom-upstream.md
+++ b/source/_docs/create-custom-upstream.md
@@ -323,7 +323,7 @@ Once all sites have been updated to track the new Custom Upstream, you can safel
 <p markdown="1">Switching the upstream of an existing site is risky. Consider creating a new site from your Custom Upstream and migrating the contents. If you must switch upstreams, [back up](/docs/backups/) your site first, and consider our documentation on [upstream merge conflicts](/docs/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts).</p>
 </div>
 
-Only a Site Owner can change an existing site to use a new Custom Upstream. Site owners can [contact support](/docs/support/), or use [Terminus](/docs/terminus/):
+Only a Site Owner, User in Charge, or Organization Administrator can change an existing site to use a new Custom Upstream using [Terminus's](/docs/terminus/):
 
 ```bash
 terminus site:upstream:set $site $upstream_id

--- a/source/_docs/create-custom-upstream.md
+++ b/source/_docs/create-custom-upstream.md
@@ -323,7 +323,7 @@ Once all sites have been updated to track the new Custom Upstream, you can safel
 <p markdown="1">Switching the upstream of an existing site is risky. Consider creating a new site from your Custom Upstream and migrating the contents. If you must switch upstreams, [back up](/docs/backups/) your site first, and consider our documentation on [upstream merge conflicts](/docs/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts).</p>
 </div>
 
-Only a Site Owner, User in Charge, or Organization Administrator can change an existing site to use a new Custom Upstream using [Terminus's](/docs/terminus/):
+Only a Site Owner, User in Charge, or Organization Administrator can change an existing site to use a new Custom Upstream using [Terminus](/docs/terminus/):
 
 ```bash
 terminus site:upstream:set $site $upstream_id


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Includes UIC and org admin in addition to site owner of who can change custom upstream
- Remove direction to reach out to support since this is a self-serve action

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
