### PR TITLE
Update to remove mention of Elite load testing

### DIFF
--- a/source/_docs/traffic-limits.md
+++ b/source/_docs/traffic-limits.md
@@ -59,7 +59,7 @@ Although it places load on the platform, Pantheon excludes automated traffic fro
 Having high performance responses to crawlers is _beneficial_ to SEO, which is one reson people choose Pantheon, but we respect that you cannot control this kind of traffic. We are continually refining our model to ensure our traffic reports are as accurate as possible.
 
 ### What about load tests or penetration tests?
-We perform load tests prior to every Elite site launch, and we encourage customers to load test prior to releasing a big update. We also fully support customers who want to penetration test their site, which can result in significant spikes in traffic.
+We encourage customers to load test prior to releasing a big update. We also fully support customers who want to penetration test their site, which can result in significant spikes in traffic.
 
 However, if you are load or pen testing in extreme excess of your plan limits, or do so on a regular and repeated basis, we reserve the right to charge for a plan that is appropriate to the load placed on the platform. 
 


### PR DESCRIPTION
Elite sites no longer have automatic load testing - it must, instead, be added to an opportunity.

Closes # n/a

## Effect
PR includes the following changes:
- removes mention of automatically load testing Elite sites. 
-

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
