### PR TITLE
Add PHP 7.3 to list of supported versions.

### DIFF
--- a/source/_docs/php-versions.md
+++ b/source/_docs/php-versions.md
@@ -23,6 +23,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 ### Available PHP Versions
 The recommended PHP versions available on Pantheon are:
 
+- [7.3](https://v73-php-info.pantheonsite.io/){.external}
 - [7.2](https://v72-php-info.pantheonsite.io/){.external}
 - [7.1](https://v71-php-info.pantheonsite.io/){.external}
 


### PR DESCRIPTION
https://pantheon.io/blog/speed-your-wordpress-or-drupal-site-php-73

Closes n/a

## Effect
PR includes the following changes:
- Adds 7.3 to list of php supported versions

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
