### PR TITLE
Add guide survey to last page of SS EDT

### DIFF
--- a/source/_docs/guides/edt/08-going-live.md
+++ b/source/_docs/guides/edt/08-going-live.md
@@ -5,6 +5,7 @@ anchorid: going-live
 edt: true
 layout: guide
 type: guide
+survey: true
 generator: pagination
 pagination:
     provider: data.edtpages
@@ -17,7 +18,7 @@ editpath: edt/08-going-live.md
 image: launchGuide-twitterLarge
 ---
 
-In this lesson, we’re going to explore the Developer Workflow. 
+In this lesson, we’re going to explore the Developer Workflow.
 All links from the video are provided below.
 
 **Watch the video:**


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds guide survey to the last page of SS EDT guide 

cc @mcdwayne @davidneedham 

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
