### PR TITLE
Adding a note that users can skip the htaccess configuration in the Multisite setup

### DIFF
--- a/source/_docs/guides/multisite/03-config.md
+++ b/source/_docs/guides/multisite/03-config.md
@@ -100,8 +100,6 @@ In order for things to run smoothly on Pantheon, we need to adjust the configura
   define( 'SITE_ID_CURRENT_SITE', 1 );
   define( 'BLOG_ID_CURRENT_SITE', 1 );
   ```
-  
-  Note: You will have a warning from the WP dashboard that you need to update your `.htaccess` file, since Pantheon is Nginx based and your site is already pre-configured for multisite setup by your Account Manager, you can safely skip this step.
 
 6. Add the following code block to your `wp-config.php` file, under the lines mentioned in the previous step:
 
@@ -134,6 +132,11 @@ In order for things to run smoothly on Pantheon, we need to adjust the configura
   The astute programmer will notice the `test` and `dev` cases are redundant. Feel free to remove if you don't intend to add custom domains to those environments. Generally, the key idea is that you're conditionally defining the `DOMAIN_CURRENT_SITE` constant based on the current Pantheon environment (Dev, Test, Live or Multidev).
 
 7. Save your changes and upload the `wp-config.php` file to Pantheon's Dev environment once edits are complete.
+
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+A warning may appear in the WordPress dashboard that you need to update your `.htaccess` file. Since Pantheon used Nginx and your site is already pre-configured for multisite by your Account Manager, you can ignore this warning.
+</div>
 
 ## Developing the Site Network
 Congratulations on setting up your first WordPress Site Network. You are on your way to glory! When logged in to the WordPress Dashboard, you'll see a new **My Sites** menu item in the toolbar:

--- a/source/_docs/guides/multisite/03-config.md
+++ b/source/_docs/guides/multisite/03-config.md
@@ -100,6 +100,8 @@ In order for things to run smoothly on Pantheon, we need to adjust the configura
   define( 'SITE_ID_CURRENT_SITE', 1 );
   define( 'BLOG_ID_CURRENT_SITE', 1 );
   ```
+  
+  Note: You will have a warning from the WP dashboard that you need to update your `.htaccess` file, since Pantheon is Nginx based and your site is already pre-configured for multisite setup by your Account Manager, you can safely skip this step.
 
 6. Add the following code block to your `wp-config.php` file, under the lines mentioned in the previous step:
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adding a note that users can skip the `.htaccess` configuration in the Multisite setup

## Remaining Work
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
