### PR TITLE
Update sso-organizations.md

### DIFF
--- a/source/_docs/sso-organizations.md
+++ b/source/_docs/sso-organizations.md
@@ -26,13 +26,13 @@ New and existing members outside the organization are not redirected to the conf
 
 ## Configure your IdP
 
-Refer to your IdP for general SAML 2.0 setup instructions. Pantheon will supply the string to be used in place of `<Pantheon-SSO-Connection-Name>` in the examples below.
+Refer to your IdP for general SAML 2.0 setup instructions. Pantheon will supply the string to be used in place of `Pantheon-SSO-Connection-Name` in the examples below.
 
 You will need to enter the following:
 
-1.  **Single sign-on URL**: `https://pantheon.auth0.com/login/callback?connection=<Pantheon-SSO-Connection-Name>`
+1.  **Single sign-on URL**: `https://pantheon.auth0.com/login/callback?connection=Pantheon-SSO-Connection-Name`
 
-2.  **Audience URI (SP Entity ID)**: `urn:auth0:pantheon:<Pantheon-SSO-Connection-Name>`
+2.  **Audience URI (SP Entity ID)**: `urn:auth0:pantheon:Pantheon-SSO-Connection-Name`
 
 3.  **Add an Attribute Statement** to map `mail` to `email`. If using [Okta](https://www.okta.com/), map the attribute `email` to `user:email`.
 

--- a/source/_docs/sso-organizations.md
+++ b/source/_docs/sso-organizations.md
@@ -26,20 +26,13 @@ New and existing members outside the organization are not redirected to the conf
 
 ## Configure your IdP
 
-Refer to your IdP for general SAML 2.0 setup instructions. In the examples below, replace `<Example-Org-Name>` with your organization name. Separate words with hyphens, and remember to append `-SSO`.
+Refer to your IdP for general SAML 2.0 setup instructions. Pantheon will supply the string to be used in place of `<Pantheon-SSO-Connection-Name>` in the examples below.
 
 You will need to enter the following:
 
-1.  **Single sign-on URL**: `https://pantheon.auth0.com/login/callback?connection=<Example-Org-Name>-SSO`
+1.  **Single sign-on URL**: `https://pantheon.auth0.com/login/callback?connection=<Pantheon-SSO-Connection-Name>`
 
-2.  **Audience URI (SP Entity ID)**: `urn:auth0:pantheon:<Example-Org-Name>-SSO`
-
-    <div class="alert alert-info" role="alert">
-    <h4 class="info">Note</h4>
-    <ul>
-    <li> The connection name must start with an alphanumeric character and can only contain alphanumeric characters and hyphens (-).</li>
-    <li> The max length for a connection name is 35 characters, including the appended 'SSO'.</li></ul>
-    </div>
+2.  **Audience URI (SP Entity ID)**: `urn:auth0:pantheon:<Pantheon-SSO-Connection-Name>`
 
 3.  **Add an Attribute Statement** to map `mail` to `email`. If using [Okta](https://www.okta.com/), map the attribute `email` to `user:email`.
 


### PR DESCRIPTION
customer was confused about using his own organization's name; updated doc to reflect that pantheon will supply this information.

Closes # n/a

## Effect
PR includes the following changes:
- replace all `<Example-Org-Name>-SSO` with `<Pantheon-SSO-Connection-Name>`
- remove alert about connection name criteria since customers don't choose that

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
