### PR TITLE
update contrib reference from Terminus 1.x to 2.x

### DIFF
--- a/source/_docs/terminus.md
+++ b/source/_docs/terminus.md
@@ -36,7 +36,7 @@ Use Terminus to perform these and other operations:
 
 <div class="alert alert-info">
 <h4 class="info">Note</h4>
-<p>If you are a plugin author, you will need to update your plugin to the Terminus 1.x syntax. See <a href="/docs/terminus/get-started/legacy">Legacy Terminus Versions</a> to compare the difference in command syntax.</p>
+<p>If you are a plugin author, you will need to update your plugin to the Terminus 2.x syntax. See <a href="/docs/terminus-2-0/">what's new in Terminus 2.x</a> to learn more.</p>
 </div>
 
 Terminus is open source! View the project on [GitHub](https://github.com/pantheon-systems/terminus) to contribute, file issues, and submit feature requests.


### PR DESCRIPTION
Closes #NA

## Effect
PR includes the following changes:
- Updated reference from Terminus 1.x to 2.x, and updated link/wording from /docs/terminus/get-started/legacy/ to /docs/terminus-2-0.

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
