### PR TITLE
CORE-344: Remove 'alpha' designation from 'metrics' command

### DIFF
--- a/source/content/metrics.md
+++ b/source/content/metrics.md
@@ -46,7 +46,7 @@ Pantheon-identified bots are excluded from the Visits and Pages Served Metrics.
 Only requests with a 2xx status count as pages served, so 301 redirects will not be included in metrics.
 
 ### Can I see metrics for other environments?
-Yes! Metrics are now available for the entire site or by environment via the Terminus `metrics` command.
+Yes! Metrics are now available for the entire site or by environment via the [Terminus](/terminus) `metrics` command.
 
 ### Why don't I see any data, or why don't I see a full 12 months of data?
 Data is shown for dates after March 18, 2018. If your site is not yet on the Global CDN data will not be available. To upgrade, see [Pantheon Global CDN](/global-cdn/).

--- a/source/content/metrics.md
+++ b/source/content/metrics.md
@@ -46,7 +46,7 @@ Pantheon-identified bots are excluded from the Visits and Pages Served Metrics.
 Only requests with a 2xx status count as pages served, so 301 redirects will not be included in metrics.
 
 ### Can I see metrics for other environments?
-Yes! Metrics are now available for the entire site or by environment via the Terminus `alpha:metrics` command, when [installed via Git](https://github.com/pantheon-systems/terminus#installing-with-git).
+Yes! Metrics are now available for the entire site or by environment via the Terminus `metrics` command.
 
 ### Why don't I see any data, or why don't I see a full 12 months of data?
 Data is shown for dates after March 18, 2018. If your site is not yet on the Global CDN data will not be available. To upgrade, see [Pantheon Global CDN](/global-cdn/).
@@ -55,7 +55,7 @@ Data is shown for dates after March 18, 2018. If your site is not yet on the Glo
 Yes. For example, multiple devices on the same home network visiting your site would each be considered a unique visitor.
 
 ### Can I check metrics from the command line with Terminus?
-Yes! Access to metrics via Terminus is currently available as an alpha command, meaning the command structure may change before full release. [Install Terminus](/terminus/install/) or update to the [current release](/terminus/updates#update-to-the-current-release-) for access to the `alpha:metrics` command.
+Yes! Access to metrics via the  Terminus `metrics` command. [Install Terminus](/terminus/install/) or update to the [current release](/terminus/updates#updates) for access to the `metrics` command.
 
 ## See Also
 - [Traffic Limits and Overages](/traffic-limits/)


### PR DESCRIPTION
Closes #3565

## Effect
PR includes the following changes:
- Remove the 'alpha' prefix from the 'metrics' command. 

## Remaining Work
- [x] Wait for a new Terminus release with the updated 'metrics' command to be published.
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
