### PR TITLE
Add wp-newrelic plugin to known-issues list

### DIFF
--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -461,6 +461,10 @@ This error sometimes leads users to believe that ManageWP's IP addresses need to
 **Issue**: Seems to break WP-CLI, which is used by many of our workflows (clone, clear cache).
 <hr>
 
+### [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/){.external}
+**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in duplicate data in New Relic reports.
+<hr>
+
 ### [NextGEN Gallery](https://wordpress.org/plugins/nextgen-gallery/){.external}
 **Issue**: NextGEN Gallery assumes write access to the site's codebase within the `wp-content/gallery` directory, which is not granted on Test and Live environments on Pantheon by design. For additional details, see [Using Extensions That Assume Write Access](/docs/assuming-write-access).
 

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -462,7 +462,7 @@ This error sometimes leads users to believe that ManageWP's IP addresses need to
 <hr>
 
 ### [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/){.external}
-**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in new applications in New Relic. This behavior may break compatibility with existing Quicksilver scripts, and any other integration designed to use the application reports Pantheon creates.
+**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in new applications in New Relic. This behavior may break compatibility with New Relic integrations such as [QuickSilver scripts](/docs/quicksilver/).
 <hr>
 
 ### [NextGEN Gallery](https://wordpress.org/plugins/nextgen-gallery/){.external}

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -462,7 +462,7 @@ This error sometimes leads users to believe that ManageWP's IP addresses need to
 <hr>
 
 ### [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/){.external}
-**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in duplicate data in New Relic reports.
+**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in duplicate data in New Relic reports and other unexpected behavior.
 <hr>
 
 ### [NextGEN Gallery](https://wordpress.org/plugins/nextgen-gallery/){.external}

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -462,7 +462,7 @@ This error sometimes leads users to believe that ManageWP's IP addresses need to
 <hr>
 
 ### [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/){.external}
-**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in duplicate data in New Relic reports and other unexpected behavior.
+**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in new applications in New Relic. This behavior breaks compatibility with existing Quicksilver scripts, and any other integration designed to use the application reports Pantheon creates.
 <hr>
 
 ### [NextGEN Gallery](https://wordpress.org/plugins/nextgen-gallery/){.external}

--- a/source/_docs/modules-plugins-known-issues.md
+++ b/source/_docs/modules-plugins-known-issues.md
@@ -462,7 +462,7 @@ This error sometimes leads users to believe that ManageWP's IP addresses need to
 <hr>
 
 ### [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/){.external}
-**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in new applications in New Relic. This behavior breaks compatibility with existing Quicksilver scripts, and any other integration designed to use the application reports Pantheon creates.
+**Issue:** This plugin sets up redundant configurations (`appname` and `framework`) with the [Pantheon New Relic](/docs/new-relic/) configuration, resulting in new applications in New Relic. This behavior may break compatibility with existing Quicksilver scripts, and any other integration designed to use the application reports Pantheon creates.
 <hr>
 
 ### [NextGEN Gallery](https://wordpress.org/plugins/nextgen-gallery/){.external}


### PR DESCRIPTION
Closes #4726

## Effect
PR includes the following changes:
- Adds [New Relic Reporting for WordPress](https://wordpress.org/plugins/wp-newrelic/) to the list of plugins with known issues.

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)