### PR TITLE
specify git over ssh vs https

### DIFF
--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -47,7 +47,7 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
   git clone git@github.com:pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME
   ```
 
-   This command assumes you have [SSH keys](/docs/ssh-keys/) added to your GitHub account. If not, you can clone the repository over HTTPS:
+   This command assumes you have [SSH keys](/docs/ssh-keys/) added to your GitHub account. If you don't, you can clone the repository over HTTPS:
 
   ```bash
   git clone https://github.com/pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -47,7 +47,7 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
   git clone git@github.com:pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME
   ```
 
-   This command assume you have [SSH keys](/docs/ssh-keys/) added to your GitHub account. If not, you can clone the repository over HTTPS:
+   This command assumes you have [SSH keys](/docs/ssh-keys/) added to your GitHub account. If not, you can clone the repository over HTTPS:
 
   ```bash
   git clone https://github.com/pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME

--- a/source/_docs/guides/drupal-8-composer-no-ci.md
+++ b/source/_docs/guides/drupal-8-composer-no-ci.md
@@ -47,6 +47,12 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
   git clone git@github.com:pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME
   ```
 
+   This command assume you have [SSH keys](/docs/ssh-keys/) added to your GitHub account. If not, you can clone the repository over HTTPS:
+
+  ```bash
+  git clone https://github.com/pantheon-systems/example-drops-8-composer.git $PANTHEON_SITE_NAME
+  ```
+
 2. `cd` into the cloned directory:
 
   ```bash


### PR DESCRIPTION
Closes #4731 

## Effect
PR includes the following changes:
- Specify git command requires an SSH key, and shows HTTPS alternative.

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)