### PR TITLE
Added a real world example in implementing symlink

### DIFF
--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -77,6 +77,11 @@ The best solution is to communicate with the maintainer of the module or plugin 
 
 As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
 
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+You must manually create the target folders `wp-content\uploads\cache` and `wp-content\uploads\wp-rocket-config` for Dev, Test, Live, and any Multidev environments.
+</div>
+
 ### For MacOS & Linux:
 From the `wp-content` directory:
 
@@ -115,11 +120,6 @@ You can also verify success using `dir`:
 <SYMLINKD>        cache [.\uploads\cache]
 <SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
 ```
-
-<div class="alert alert-info" role="alert" markdown="1">
-#### Note {.info}
-You must still manually create the target folders `wp-content\uploads\cache` and `wp-content\uploads\wp-rocket-config` for Dev, Test, Live, and any Multidev environments.
-</div>
 
 ## Troubleshooting
 

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -73,38 +73,44 @@ The best solution is to communicate with the maintainer of the module or plugin 
 7. Deploy to Test and confirm results.
 8. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
-## Examples
+## Example
 
-### [WP-Rocket](https://wp-rocket.me/){.external}
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
 
-#### For Mac/Linux:
+### For Mac/Linux:
+From the `wp-content` directory:
+
 ```bash
 ln -s ./uploads/cache ./wp-content/cache
 ln -s ./uploads/wp-rocket-config ./wp-content/wp-rocket-config
 ```
 
-To verify that you have done it correctly, you should have this when you list your folders in `wp-content` directory:
+
+To verify, use `ls -al`:
+
 ```bash
-$ ls -al
 cache -> ./uploads/cache
 wp-rocket-config -> ./uploads/wp-rocket-config
 ```
 
-#### For Windows:
+### For Windows:
+
 ```bash
 mklink /d ./wp-content/cache ./uploads/cache
 mklink /d ./wp-content/wp-rocket-config ./uploads/wp-rocket-config
 ```
 
-To verify that you have done it correctly, you should have this response:
+Each command will return the following upon success:
+
 ```bash
 symbolic link created for .\wp-content\cache <<===>> .\uploads\cache
 symbolic link created for .\wp-content\wp-rocket-config <<===>> .\uploads\wp-rocket-config
 ```
 
 To verify that you have done it correctly, you should have these when you list your folders in `wp-content` directory:
+You can also verify success using `dir`:
+
 ```bash
-> dir
 <SYMLINKD>        cache [.\uploads\cache]
 <SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
 ```

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -94,6 +94,7 @@ wp-rocket-config -> ./uploads/wp-rocket-config
 ```
 
 ### For Windows:
+Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
 
 ```bash
 mklink /d ./wp-content/cache ./uploads/cache

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -66,7 +66,7 @@ The best solution is to communicate with the maintainer of the module or plugin 
     <div class="alert alert-info">
     <h4 class="info">Note</h4>
     <p markdown="1">
-    In our example, we created the target directory of the symlink as ./wp-content/uploads/new-directory. Make sure this directory is created via SFTP if it does not exist yet.
+    In our example, we created the target directory of the symlink as `./wp-content/uploads/new-directory`. Make sure this directory is created via SFTP if it does not exist yet.
     </p>
     </div>
 
@@ -77,7 +77,7 @@ The best solution is to communicate with the maintainer of the module or plugin 
 
 As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
 
-### For Mac/Linux:
+### For MacOS & Linux:
 From the `wp-content` directory:
 
 ```bash
@@ -88,7 +88,7 @@ ln -s ./uploads/wp-rocket-config ./wp-content/wp-rocket-config
 
 To verify, use `ls -al`:
 
-```bash
+```nohighlight
 cache -> ./uploads/cache
 wp-rocket-config -> ./uploads/wp-rocket-config
 ```
@@ -102,7 +102,7 @@ mklink /d ./wp-content/wp-rocket-config ./uploads/wp-rocket-config
 
 Each command will return the following upon success:
 
-```bash
+```nohighlight
 symbolic link created for .\wp-content\cache <<===>> .\uploads\cache
 symbolic link created for .\wp-content\wp-rocket-config <<===>> .\uploads\wp-rocket-config
 ```
@@ -110,16 +110,15 @@ symbolic link created for .\wp-content\wp-rocket-config <<===>> .\uploads\wp-roc
 To verify that you have done it correctly, you should have these when you list your folders in `wp-content` directory:
 You can also verify success using `dir`:
 
-```bash
+```nohighlight
 <SYMLINKD>        cache [.\uploads\cache]
 <SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
 ```
 
-Note: Deploying to Test and Live will not automatically create these folders so you'll need to manually created them via SFTP. 
-```bash
-wp-content\uploads\cache
-wp-content\uploads\wp-rocket-config
-```
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+You must still manually create the target folders `wp-content\uploads\cache` and `wp-content\uploads\wp-rocket-config` for Dev, Test, Live, and any Multidev environments.
+</div>
 
 ## Troubleshooting
 

--- a/source/_docs/assuming-write-access.md
+++ b/source/_docs/assuming-write-access.md
@@ -73,6 +73,48 @@ The best solution is to communicate with the maintainer of the module or plugin 
 7. Deploy to Test and confirm results.
 8. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
+## Examples
+
+### [WP-Rocket](https://wp-rocket.me/){.external}
+
+#### For Mac/Linux:
+```bash
+ln -s ./uploads/cache ./wp-content/cache
+ln -s ./uploads/wp-rocket-config ./wp-content/wp-rocket-config
+```
+
+To verify that you have done it correctly, you should have this when you list your folders in `wp-content` directory:
+```bash
+$ ls -al
+cache -> ./uploads/cache
+wp-rocket-config -> ./uploads/wp-rocket-config
+```
+
+#### For Windows:
+```bash
+mklink /d ./wp-content/cache ./uploads/cache
+mklink /d ./wp-content/wp-rocket-config ./uploads/wp-rocket-config
+```
+
+To verify that you have done it correctly, you should have this response:
+```bash
+symbolic link created for .\wp-content\cache <<===>> .\uploads\cache
+symbolic link created for .\wp-content\wp-rocket-config <<===>> .\uploads\wp-rocket-config
+```
+
+To verify that you have done it correctly, you should have these when you list your folders in `wp-content` directory:
+```bash
+> dir
+<SYMLINKD>        cache [.\uploads\cache]
+<SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
+```
+
+Note: Deploying to Test and Live will not automatically create these folders so you'll need to manually created them via SFTP. 
+```bash
+wp-content\uploads\cache
+wp-content\uploads\wp-rocket-config
+```
+
 ## Troubleshooting
 
 ### Removing a Symlink


### PR DESCRIPTION
Symlinks is tricky to implement. This will beneficial for onboarding CSE's and customers alike as there is a sample for a wide array of OS where they will know the behavior if it is successfully done or not

Closes #4720 

## Effect
PR includes the following changes:
- Added a real world example in implementing symlink for a wide array of OS where they will know the behavior if it is successfully done or not

## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
