### PR TITLE
fix: front-matter contributors as array and colons on title

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -52,7 +52,7 @@ All of our documentation is generated from markdown files, found at [`source/_do
 title: Git FAQs
 description: Answers to commonly asked questions about Git, Drupal 7, Drupal 6 and Pantheon.
 tags: [performance, cache]
-contributors: mrfelton
+contributors: [mrfelton]
 ---
 ```
 ### Taxonomies

--- a/source/_docs/add-client-site.md
+++ b/source/_docs/add-client-site.md
@@ -3,7 +3,7 @@ title: Add a Client Site to Your Organization Dashboard
 description: Learn how to add a client to your Partner Agency to share special features and pricing.
 tags: [manage, billing]
 categories: []
-contributors: edwardangert
+contributors: [edwardangert]
 searchboost: 150
 ---
 [Partner Agencies](https://pantheon.io/plans/partner-program){.external} on Pantheon receive additional levels of support and [Preferred Pricing](https://pantheon.io/plans/agency-preferred-pricing){.external} for themselves and their clients. This doc explains how to share those benefits by adding a client's site to your Agency.

--- a/source/_docs/caching-advanced-topics.md
+++ b/source/_docs/caching-advanced-topics.md
@@ -1,5 +1,5 @@
 ---
-title: Caching: Advanced Topics
+title: 'Caching: Advanced Topics'
 description: Advanced details about Pantheon's edge caching layer, cookies, and PHP sessions.
 tags: [cacheedge]
 categories: []

--- a/source/_docs/deprecated-constructor-notices.md
+++ b/source/_docs/deprecated-constructor-notices.md
@@ -3,7 +3,7 @@ title: Debug Intermittent PHP 7 Notices
 description: Debug and fix "Deprecated Constructor" notices in your Pantheon site.
 categories: []
 tags: [debugcode]
-contributors: greg-1-anderson
+contributors: [greg-1-anderson]
 ---
 
 PHP notices are usually handled automatically by the Pantheon Platform as described on the page [PHP Errors and Exceptions](/docs/php-errors); however, occasionally a PHP notice might be emitted directly into the web page content.

--- a/source/_docs/dns.md
+++ b/source/_docs/dns.md
@@ -4,7 +4,7 @@ description: Learn what DNS is, and how to utilize it to configure your domain n
 tags: [dns]
 use: [docs_tags]
 categories: []
-contributors: alexfornuto
+contributors: [alexfornuto]
 ---
 
 **DNS** stands for Domain Name System, and it's the protocol by which domain names are pointed to the servers that host content. When adding a [custom domain](/docs/domains/#custom-domains) to your site, we provide the values for your DNS records, to be assigned with your DNS service provider:

--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -3,7 +3,7 @@ title: Git FAQs
 description: Answers to commonly asked questions about Git, Drupal, WordPress and Pantheon.
 tags: [git]
 categories: []
-contributors: mrfelton
+contributors: [mrfelton]
 ---
 [Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](/docs), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
 

--- a/source/_docs/guides/asana.md
+++ b/source/_docs/guides/asana.md
@@ -5,7 +5,7 @@ tags: [siteintegrations]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/4/2017
-contributors: scottmassey
+contributors: [scottmassey]
 ---
 
 [Asana](https://asana.com) is a flexible project management tool which helps teams to collaborate on projects in either an waterfall or kanban framework. It allows for projects to be spun up and managed quickly and easily, and has an extremely well designed user interface.

--- a/source/_docs/guides/jira.md
+++ b/source/_docs/guides/jira.md
@@ -5,7 +5,7 @@ tags: [siteintegrations]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/4/2017
-contributors: scottmassey
+contributors: [scottmassey]
 ---
 
 Atlassian's [Jira](https://www.atlassian.com/software/jira) issue tracking is one of the most common applications used to manage projects for application development teams. It is part of a larger suite of tools which includes [Bitbucket](https://bitbucket.org/), a code repository platform, and [HipChat](https://www.hipchat.com/), a team messaging and collaboration application. Jira is extremely customizable, through manual configuration or the use of installable plugins. It allows for integration with tools in the Atlassian suite as well as other common development tools.

--- a/source/_docs/guides/new-relic-deploys.md
+++ b/source/_docs/guides/new-relic-deploys.md
@@ -5,7 +5,7 @@ tags: [siteintegrations]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/1/2017
-contributors: scottmassey
+contributors: [scottmassey]
 ---
 New Relic is a powerful tool for monitoring the performance of a WordPress or Drupal site. It provides insight into how efficiently a website is using resources, and where improvements can be made in the application. Pantheon offers New Relic Pro within the Site Dashboard on all sites for free.
 

--- a/source/_docs/guides/pingdom-uptime-check.md
+++ b/source/_docs/guides/pingdom-uptime-check.md
@@ -5,7 +5,7 @@ tags: [siteintegrations]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/14/2017
-contributors: scottmassey
+contributors: [scottmassey]
 ---
 
 Monitoring services, such as [Pingdom](https://www.pingdom.com/), allow those responsible for site performance and uptime to know when a website is having problems delivering content. Pingdom provides several different types of uptime and performance checks.

--- a/source/_docs/guides/trello.md
+++ b/source/_docs/guides/trello.md
@@ -5,7 +5,7 @@ tags: [siteintegrations]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/4/2017
-contributors: scottmassey
+contributors: [scottmassey]
 ---
 [Trello](https://trello.com) is a simple yet powerful project management tool which helps teams to collaborate on projects in an agile framework. Trello lends itself to not only web projects, but also helps businesses keep [other](https://trello.com/inspiration) internal tasks and objectives organized.
 

--- a/source/_docs/hosts-file.md
+++ b/source/_docs/hosts-file.md
@@ -3,7 +3,7 @@ title: Modify the Local Hosts File
 description: How to find and modify a local hosts file.
 tags: [local, dns]
 categories: []
-contributors: alexfornuto
+contributors: [alexfornuto]
 ---
 
 The `hosts` file exists on all major operating systems. It's a list of IP addresses and domains that takes precedence over DNS assigned values. You can modify your `hosts` file to test domain-specific settings leading up to a migration, before DNS records have been updated.

--- a/source/_docs/migrate-wordpress-site-networks.md
+++ b/source/_docs/migrate-wordpress-site-networks.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate to Pantheon: WordPress Site Networks
+title: 'Migrate to Pantheon: WordPress Site Networks'
 description: Learn how to import a WordPress Site Network into Pantheon.
 tags: [migratemanual]
 categories: [wordpress]

--- a/source/_docs/reducing-large-repos.md
+++ b/source/_docs/reducing-large-repos.md
@@ -4,7 +4,7 @@ description: Learn how to reduce the size of large Drupal or WordPress site repo
 tags: [git]
 categories: [develop, git]
 draft: true
-contributors: curmudgeon
+contributors: [curmudgeon]
 ---
 Repositories that exceed 2GB may experience failures or degraded performance when interacting with code via Git on Pantheon. We recommend reducing the repository size by removing objects that are no longer referenced using [`git prune`](https://git-scm.com/docs/git-prune) in addition to optimizing via [`git gc`](https://git-scm.com/docs/git-gc). You may also want to review the repository for large files, then exclude them as needed.
 

--- a/source/_docs/required-reading.md
+++ b/source/_docs/required-reading.md
@@ -1,5 +1,5 @@
 ---
-title: Required Reading: Essential Pantheon Documentation
+title: 'Required Reading: Essential Pantheon Documentation'
 description: Recommended documentation to learn about Pantheon Website Management Platform's technologies.
 tags: [getstarted]
 categories: [getstarted]

--- a/source/_docs/ssh-tunnels.md
+++ b/source/_docs/ssh-tunnels.md
@@ -3,7 +3,7 @@ title: Secure Connections to Pantheon Services via TLS or SSH Tunnels
 description: Detailed information on securely connecting to your database and caching service using SSH tunnels.
 tags: [local, security]
 categories: []
-contributors: bwood
+contributors: [bwood]
 ---
 For additional security, Pantheon provides the ability to securely connect to your database and caching service over an encrypted connection using [secure shell tunneling](https://en.wikipedia.org/wiki/Tunneling_protocol#Secure_shell_tunneling){.external}. This will increase the security of your remote connection, especially in a public or untrusted environment.
 

--- a/source/_docs/wp-config-php.md
+++ b/source/_docs/wp-config-php.md
@@ -3,7 +3,7 @@ title: Configuring wp-config.php
 description: Understand how to adjust and customize the WordPress configuration file for your Pantheon WordPress site.
 tags: [variables]
 categories: [wordpress]
-contributors: masonjames
+contributors: [masonjames]
 ---
 ## Overview
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: front-matter contributors as an array on several md files
- Update `CONTRIBUTING.md ` file 
- fix: Add quotes `'` to titles including colon `:`

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
