### PR TITLE
Revert "Clarify IPv6 Compatibility"

### DIFF
--- a/source/_docs/dns-providers/network-solutions.md
+++ b/source/_docs/dns-providers/network-solutions.md
@@ -7,9 +7,9 @@ tags: [providers]
 permalink: docs/:basename/
 editpath: dns-providers/network-solutions.md/
 ---
-<div class="alert alert-danger">
-<h4 class="info">Warning</h4>
-<p>Network Solutions does not support AAAA records for IPv6 traffic which can negatively impact performance, especially on mobile devices. We recommend transferring DNS services to a provider that supports IPv6.</p></div>
+<div class="alert alert-danger" markdown="1">
+#### Warning {.info}
+Network Solutions does not support AAAA records for IPv6 traffic which can negatively impact performance, especially on mobile devices. We recommend transferring DNS services to a provider that supports IPv6.</div>
 
 ## Before You Begin
 Be sure that you have a:

--- a/source/_docs/dns-providers/network-solutions.md
+++ b/source/_docs/dns-providers/network-solutions.md
@@ -7,6 +7,9 @@ tags: [providers]
 permalink: docs/:basename/
 editpath: dns-providers/network-solutions.md/
 ---
+<div class="alert alert-danger">
+<h4 class="info">Warning</h4>
+<p>Network Solutions does not support AAAA records for IPv6 traffic which can negatively impact performance, especially on mobile devices. We recommend transferring DNS services to a provider that supports IPv6.</p></div>
 
 ## Before You Begin
 Be sure that you have a:
@@ -60,12 +63,11 @@ A CNAME record is required to configure a subdomain (e.g., `www.example.com`).
 
 
 ### AAAA Records
-In order to add any IPv6 records (like AAAA), you must email Network Solutions and work with their team to configure and stage them.
+Unfortunately, Network Solutions does not support AAAA records, which means you can't route IPv6 traffic to your bare domain with Network Solutions. Failure to route IPv6 traffic to your site can negatively impact performance, especially for mobile devices. If you'd like to add AAAA records, then consider transferring your domain or name server to another DNS host.
 
 ## Network Solutions Docs
 
-* <a href="http://www.networksolutions.com/support/how-to-manage-advanced-dns-records/" target="blank">Managing Advanced DNS Records <span class="glyphicons glyphicons-new-window-alt"></span></a>
-* <a href="http://www.networksolutions.com/support/Adding-an-IPv6-record/" target="blank">Adding an IPv6 record <span class="glyphicons glyphicons-new-window-alt"></span></a>
+<a href="http://www.networksolutions.com/support/how-to-manage-advanced-dns-records/" target="blank">Managing Advanced DNS Records <span class="glyphicons glyphicons-new-window-alt"></span></a>
 
 ## Next Steps
 


### PR DESCRIPTION
Closes #4688 
Reverts pantheon-systems/documentation#4301

It would appear that Network Solutions does **not** support AAAA records, at least in a way that works with external hosting.

I spoke to someone there on the phone, and over chat to confirm. Let this be the end of this back-and-forth on the subject.