### PR TITLE
Adding another example symlinking

### DIFF
--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -78,10 +78,11 @@ The best solution is to communicate with the maintainer of the module or plugin 
 
 ## Examples
 
-## Symlinking files: Making the WP debug log file write in the uploads folder
+### Write Debug Logs to Uploads
 
-### For MacOS & Linux:
-From the root directory or where your `wp-config.php` is:
+#### For MacOS & Linux:
+
+From the codebase root, where your `wp-config.php` is, create the symlink:
 
 ```bash
 ln -s ./uploads/debug.log ./wp-content/debug.log
@@ -93,7 +94,7 @@ To verify, use `ls -al` in the `wp-content` folder and you should have:
 debug.log -> ./uploads/debug.log
 ```
 
-### For Windows:
+#### For Windows:
 Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
 
 ```bash
@@ -113,17 +114,17 @@ You can also verify success using `dir`:
 <SYMLINKD>        debug.log [.\uploads\debug.log]
 ```
 
-## Symlinking folder example
+### Plugins Assuming Write Access
 
-As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to a couple of folders in the code base.
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/) assumes write access to a couple of folders in the code base.
 
-<Alert  title="Note" type="alert">
+<Alert title="Note" type="info">
 
 You must manually create the target folders `wp-content\uploads\cache` and `wp-content\uploads\wp-rocket-config` for Dev, Test, Live, and any Multidev environments.
 
 </Alert>
 
-### For MacOS & Linux:
+#### For MacOS & Linux:
 From the `wp-content` directory:
 
 ```bash
@@ -139,7 +140,7 @@ cache -> ./uploads/cache
 wp-rocket-config -> ./uploads/wp-rocket-config
 ```
 
-### For Windows:
+#### For Windows:
 Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
 
 ```bash

--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -76,9 +76,46 @@ The best solution is to communicate with the maintainer of the module or plugin 
 7. Deploy to Test and confirm results.
 8. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
-## Example
+## Examples
 
-As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
+## Symlinking files: Making the WP debug log file write in the uploads folder
+
+### For MacOS & Linux:
+From the root directory or where your `wp-config.php` is:
+
+```bash
+ln -s ./uploads/debug.log ./wp-content/debug.log
+```
+
+To verify, use `ls -al` in the `wp-content` folder and you should have:
+
+```nohighlight
+debug.log -> ./uploads/debug.log
+```
+
+### For Windows:
+Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
+
+```bash
+mklink .\wp-content\debug.log .\uploads\debug.log
+```
+
+The command will return the following upon success:
+
+```nohighlight
+symbolic link created for .\wp-content\debug.log <<===>> .\uploads\debug.log
+```
+
+To verify that you have done it correctly, you should have these when you list your folders in `wp-content` directory:
+You can also verify success using `dir`:
+
+```nohighlight
+<SYMLINKD>        debug.log [.\uploads\debug.log]
+```
+
+## Symlinking folder example
+
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to a couple of folders in the code base.
 
 <Alert  title="Note" type="alert">
 
@@ -95,7 +132,7 @@ ln -s ./uploads/wp-rocket-config ./wp-content/wp-rocket-config
 ```
 
 
-To verify, use `ls -al`:
+To verify, use `ls -al` in the `wp-content` folder and you should have:
 
 ```
 cache -> ./uploads/cache
@@ -106,8 +143,8 @@ wp-rocket-config -> ./uploads/wp-rocket-config
 Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
 
 ```bash
-mklink /d ./wp-content/cache ./uploads/cache
-mklink /d ./wp-content/wp-rocket-config ./uploads/wp-rocket-config
+mklink /d .\wp-content\cache .\uploads\cache
+mklink /d .\wp-content\wp-rocket-config .\uploads\wp-rocket-config
 ```
 
 Each command will return the following upon success:


### PR DESCRIPTION
Closes #4740 

## Effect
PR includes the following changes:
- Adding another example symlinking. This time with the wp debug.log file being symlinked to the uploads folder
- Also corrected the windows forward slashes instead of backslash

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
