### PR TITLE
add empty upstream info and see also section

### DIFF
--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -50,6 +50,8 @@ A Custom Upstream based off Pantheon's example repositories would need to commit
 
 This workflow has one very serious shortcoming, that is site-specific dependencies are likely to cause a lot of conflicts. The practical use case for this workflow is for a large group of sites that require a single set of dependencies. You should only use this method if you don’t intend to use site specific themes, modules, or plugins downstream.
 
+You can also prevent upstream updates by [setting an empty upstream](/docs/guides/composer-convert/#change-upstreams). This action is available to Site Owner, Organization Administrator, and Users in Charge roles.
+
 ## Next Steps
 Follow the [Build Tools Guide](/guides/build-tools/) to learn best practices for Composer on Pantheon, or [Drupal 8 and Composer on Pantheon Without Continuous Integration](/guides/drupal-8-composer-no-ci/) if you don't want to use CI tools in your development process.
 
@@ -58,5 +60,8 @@ If you already have a Drupal 8 site that you need to convert to a Composer-manag
 ### Partial Adoption
 If you're not ready to go all in with a Composer workflow and you want to see how it works on a smaller scale, follow the [Manage Some Dependencies with Composer](/guides/partial-composer/) guide to get started.
 
-
 <Partial file="notes/partial-composer-adoption-warning.md" />
+
+## See Also
+
+ - [Convert a Standard Drupal 8 Site to a Composer Managed Site](/docs/guides/composer-convert/)

--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -6,6 +6,7 @@ permalink: docs/guides/:basename/
 tags: [moreguides, workflow, composer]
 contributors: [dustinleblanc]
 ---
+
 <Alert title="Note" type="info">
 
 Converting to a Composer managed site *removes* the ability to [apply updates via the site dashboard](/core-updates/). This is for advanced users who are comfortable taking complete responsibility for the management of site updates.


### PR DESCRIPTION
Closes #4752

## Effect
PR includes the following changes:
- Adds a link to instructions to set an empty upstream, and lists roles with that permission.
- Adds a **See Also** section linking to the D8 Composer guide.

## Remaining Work
- [x] :+1: from @dficker
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)