### PR TITLE
adds note about multidev to custom upstream doc

### DIFF
--- a/source/_docs/maintain-custom-upstream.md
+++ b/source/_docs/maintain-custom-upstream.md
@@ -33,6 +33,11 @@ This test site will be used later for evaluating the Custom Upstream changes we 
 
 ## Test and Release Pantheon Core Updates
 
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+To maintain best practice, some of the steps in this section require access to the [Multidev](/docs/multidev/) feature. Those steps can be skipped, but it isn't recommended.
+</div>
+
 1. From your local clone of your Custom Upstream repository, add Pantheon's Upstream as a [remote](https://git-scm.com/docs/git-remote){.external} if you haven't done so already:
 
     <!-- Nav tabs -->


### PR DESCRIPTION
Closes #4607 

## Effect
PR includes the following changes:
- adds note about multidev in Test and Release Pantheon Core Updates section
   - while most users with Custom Upstreams have access to Multidev, it's possible that they may not have the ability to create a new Multidev. This is explained better in the [Multidev](https://pantheon.io/docs/multidev/) doc than we'd have room for in this doc.

## Remaining Work
- [ ] Confirmation from Product that this is
   - [ ] accurate
   - [ ] intended behavior
- [x] +1 from @rubelyn (issue reporter)

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
