### PR TITLE
Composer .gitignore

### DIFF
--- a/source/_docs/nested-docroot.md
+++ b/source/_docs/nested-docroot.md
@@ -179,6 +179,8 @@ You'll need to move the CMS code into the `web` subdirectory, either manually or
 
 After using one of these commands, verify the new file locations with `git status` before committing and pushing.
 
+Now that the site will be served from the web/ directory, you'll need to update the `.gitignore` file to reflect this, i.e. edit `sites/` to `web/sites`, `!core/**/*.gz` to `!web/core/**/*.gz` for Drupal, and `wp-content`, `wp-includes` to `web/wp-content`, `web/wp-includes` for WordPress. 
+
 ## Troubleshooting
 
 #### Quicksilver Script Location


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- For a Composer managed site, the `.gitignore` file must be updated to account for the `web/` nested docroot

## Remaining Work
- [ ] Technical review: Need to account for differences between Composer workflows (CI vs non-CI) and their respective `.gitignore` files, e.g. what about committing dependencies? 
- [ ] Technical review: WordPress `.gitignore` (cf. https://github.com/ataylorme/WordPress-Composer-Example/blob/master/.gitignore) 

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
