### PR TITLE
Update drupal-caching-modules.md

### DIFF
--- a/source/content/drupal-caching-modules.md
+++ b/source/content/drupal-caching-modules.md
@@ -56,8 +56,10 @@ If you're generating a block, this will expose the block to Drupal's built-in bl
 4. Click the option next to Block Caching.
 5. Block Caching Type: Choose an option for Drupal's built-in block caching method.
 
-## Views Caching Plugins
+## Views Caching Modules
 
+D7: 
 You can also force caching for all your views using a module like [Views cache bully](https://drupal.org/project/views_cache_bully).
 
-Views cache can also be aware of when the content itself changes with [Views content cache](https://drupal.org/project/views_content_cache).
+D8: 
+You can replace the hardcoded cache tag with a form that allows developers to set different cache tags based on configuration of the view using a module like [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag)

--- a/source/content/drupal-caching-modules.md
+++ b/source/content/drupal-caching-modules.md
@@ -40,17 +40,19 @@ If you're generating a block, this will expose the block to Drupal's built-in bl
 
 ### Configure Views Caching
 
-1. Go to /admin/structure/views/
+1. Go to `/admin/structure/views/`
 2. Edit the View in question.
 3. Select the display and click **Advanced**.
 4. Click the option next to Caching.
 5. Choose **Time-Based Caching** and click **Apply**.
-  Rendered output: (something other than Never Cache)
-  Query results: (something other than Never Cache)
+
+   Rendered output: (something other than Never Cache)
+
+   Query results: (something other than Never Cache)
 
 ### Configure Views Block Caching
 
-1. Go to /admin/structure/views/
+1. Go to `/admin/structure/views/`
 2. Edit the View in question.
 3. Select the block display and click **Advanced**.
 4. Click the option next to Block Caching.
@@ -58,8 +60,8 @@ If you're generating a block, this will expose the block to Drupal's built-in bl
 
 ## Views Caching Modules
 
-D7: 
-You can also force caching for all your views using a module like [Views cache bully](https://drupal.org/project/views_cache_bully).
+### Drupal 7
+You can force caching for all your views using a module like [Views cache bully](https://drupal.org/project/views_cache_bully){.external}.
 
-D8: 
-You can replace the hardcoded cache tag with a form that allows developers to set different cache tags based on configuration of the view using a module like [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag)
+### Drupal 8
+You can replace the hard-coded cache tag with a form that allows developers to set different cache tags based on configuration of the view using a module like [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag){.external}.

--- a/source/content/drupal-caching-modules.md
+++ b/source/content/drupal-caching-modules.md
@@ -41,10 +41,10 @@ If you're generating a block, this will expose the block to Drupal's built-in bl
 ### Configure Views Caching
 
 1. Go to `/admin/structure/views/`
-2. Edit the View in question.
-3. Select the display and click **Advanced**.
-4. Click the option next to Caching.
-5. Choose **Time-Based Caching** and click **Apply**.
+1. Edit the View in question.
+1. Select the display and click **Advanced**.
+1. Click the option next to Caching.
+1. Choose **Time-Based Caching** and click **Apply**.
 
    Rendered output: (something other than Never Cache)
 
@@ -53,15 +53,15 @@ If you're generating a block, this will expose the block to Drupal's built-in bl
 ### Configure Views Block Caching
 
 1. Go to `/admin/structure/views/`
-2. Edit the View in question.
-3. Select the block display and click **Advanced**.
-4. Click the option next to Block Caching.
-5. Block Caching Type: Choose an option for Drupal's built-in block caching method.
+1. Edit the View in question.
+1. Select the block display and click **Advanced**.
+1. Click the option next to Block Caching.
+1. Block Caching Type: Choose an option for Drupal's built-in block caching method.
 
 ## Views Caching Modules
 
 ### Drupal 7
-You can force caching for all your views using a module like [Views cache bully](https://drupal.org/project/views_cache_bully){.external}.
+You can force caching for all your views using a module like [Views cache bully](https://drupal.org/project/views_cache_bully).
 
 ### Drupal 8
-You can replace the hard-coded cache tag with a form that allows developers to set different cache tags based on configuration of the view using a module like [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag){.external}.
+You can replace the hard-coded cache tag with a form that allows developers to set different cache tags based on configuration of the view using a module like [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag).


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Line 40 - changed word "Plugins" to "Modules"
- Line 42-43 - added "D7" and removed the reference to Views Content Cache module (never made it out of Alpha)
- Line 45-46 - added "D8" and included the Views Custom Cache Tags module link. 

## Remaining Work
- [ ] Decide whether or not to keep this documentation page. @sarahg suggested removing the page in favor of referring people to d.o from the performance debugging page, since views caching isn't a Pantheon specific topic.
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)