### PR TITLE
Update sftp get logs command

### DIFF
--- a/source/_docs/logs.md
+++ b/source/_docs/logs.md
@@ -85,7 +85,7 @@ Logs are stored within application containers that house your site's codebase an
 4. Run the following SFTP command in terminal:
 
    ```nohighlight
-   get -r logs
+   get -r *.log
    ```
 
 You now have a local copy of the logs directory, which contains the following:


### PR DESCRIPTION
`get -r logs` throws an error: 

`sftp> get -r logs`
```File "/srv/bindings/<binding_id>/logs/logs" not found.```

This works however: 
`sftp> get -r *.log`

## Effect
PR includes the following changes:
- Update sftp command line get logs command

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
