### PR TITLE
Added uncode symlink issue as an example for reference in the WP themes that has issues in the platform

### DIFF
--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -129,9 +129,9 @@ You can also verify success using `dir`:
 
 ### Uncode Theme
 
-As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/) assumes write access its css files to the code base.
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/) assumes write access to its CSS files and the code base.
 
-1. Manually move over the target folders:
+1. Manually move the target folders:
 
   `wp-content\themes\uncode\core\assets\css`
 
@@ -143,7 +143,7 @@ As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-kn
 
   To: `wp-content\uploads\uncode\library\css` in Dev.
 
-1. Copy over the files generated from:
+1. Copy the files generated from:
 
   `wp-content\themes\uncode\library\css`
 
@@ -157,11 +157,11 @@ As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-kn
 From the `wp-content` directory:
 
 ```bash
-ln -s ../../../../uploads/uncode/assets/css ./themes/uncode/core/assets 
+ln -s ../../../../uploads/uncode/assets/css ./themes/uncode/core/assets
 ln -s ../../../uploads/uncode/library/css ./themes/uncode/library
 ```
 
-To verify, use `ls -al` in the `wp-content/themes/uncode/core/assets` folder :
+To verify, use `ls -al` in the `wp-content/themes/uncode/core/assets` folder:
 
 ```
 css -> ../../../../uploads/uncode/assets/css

--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -76,7 +76,7 @@ The best solution is to communicate with the maintainer of the module or plugin 
 7. Deploy to Test and confirm results.
 8. Deploy to Live and perform the plugin operation that creates the desired files, then confirm results.
 
-## Example
+## Examples
 
 As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
 
@@ -123,6 +123,63 @@ You can also verify success using `dir`:
 ```
 <SYMLINKD>        cache [.\uploads\cache]
 <SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
+```
+
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/){.external} assumes write access its css files to the code base.
+
+<div class="alert alert-info" role="alert" markdown="1">
+#### Note {.info}
+You must manually move over the target folders `wp-content\themes\uncode\core\assets\css` to `wp-content\uploads\uncode\assets\css` and `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Dev.
+
+You must also need to copy over the files generated from `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Test, Live, and any Multidev environments after deploying codes for the theme to take effect in different environments.
+</div>
+
+### For MacOS & Linux:
+From the `wp-content` directory:
+
+```bash
+ln -s ../../../../uploads/uncode/assets/css ./themes/uncode/core/assets 
+ln -s ../../../uploads/uncode/library/css ./themes/uncode/library
+```
+
+To verify, use `ls -al` in the `wp-content/themes/uncode/core/assets` folder :
+
+```nohighlight
+css -> ../../../../uploads/uncode/assets/css
+```
+
+As well as in the `wp-content/themes/uncode/library` folder :
+
+```nohighlight
+css -> ../../../uploads/uncode/library/css
+```
+
+### For Windows:
+Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target and backslash is used to denote folders. In the `wp-content` folder create the symlinks by:
+
+```bash
+mklink /d .\themes\uncode\core\assets ..\..\..\..\uploads\uncode\assets\css
+mklink /d .\themes\uncode\library ..\..\..\uploads\uncode\library\css
+```
+
+Each command will return the following upon success:
+
+```nohighlight
+symbolic link created for .\themes\uncode\core\assets <<===>> ..\..\..\..\uploads\uncode\assets\css
+symbolic link created for .\themes\uncode\library <<===>> ..\..\..\uploads\uncode\library\css
+```
+
+To verify that you have done it correctly, you should have these when you list your folders in `wp-content\themes\uncode\core\assets` directory:
+You can also verify success using `dir`:
+
+```nohighlight
+<SYMLINKD>        css [..\..\..\..\uploads\uncode\assets\css]
+```
+
+And in the `themes\uncode\library` directory:
+
+```nohighlight
+<SYMLINKD>        css [..\..\..\uploads\uncode\library\css]
 ```
 
 ## Troubleshooting

--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -78,15 +78,17 @@ The best solution is to communicate with the maintainer of the module or plugin 
 
 ## Examples
 
-As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/){.external} assumes write access to the code base.
+### WP-Rocket
 
-<Alert  title="Note" type="alert">
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [WP-Rocket](https://wp-rocket.me/) assumes write access to the code base.
+
+<Alert  title="Note" type="info">
 
 You must manually create the target folders `wp-content\uploads\cache` and `wp-content\uploads\wp-rocket-config` for Dev, Test, Live, and any Multidev environments.
 
 </Alert>
 
-### For MacOS & Linux:
+#### For MacOS & Linux:
 From the `wp-content` directory:
 
 ```bash
@@ -102,7 +104,7 @@ cache -> ./uploads/cache
 wp-rocket-config -> ./uploads/wp-rocket-config
 ```
 
-### For Windows:
+#### For Windows:
 Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target:
 
 ```bash
@@ -125,17 +127,33 @@ You can also verify success using `dir`:
 <SYMLINKD>        wp-rocket-config [.\uploads\wp-rocket-config]
 ```
 
-As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/){.external} assumes write access its css files to the code base.
+### Uncode Theme
 
-<Alert title="Note" type="alert">
+As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/) assumes write access its css files to the code base.
 
-You must manually move over the target folders `wp-content\themes\uncode\core\assets\css` to `wp-content\uploads\uncode\assets\css` and `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Dev.
+1. Manually move over the target folders:
 
-You must also need to copy over the files generated from `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Test, Live, and any Multidev environments after deploying codes for the theme to take effect in different environments.
+  `wp-content\themes\uncode\core\assets\css`
 
-</Alert>
+  To: `wp-content\uploads\uncode\assets\css`
 
-### For MacOS & Linux:
+  And:
+
+  `wp-content\themes\uncode\library\css`
+
+  To: `wp-content\uploads\uncode\library\css` in Dev.
+
+1. Copy over the files generated from:
+
+  `wp-content\themes\uncode\library\css`
+
+  To:
+
+  `wp-content\uploads\uncode\library\css`
+
+  In Test, Live, and any Multidev environments after deploying codes for the theme to take effect in different environments.
+
+#### For MacOS & Linux:
 From the `wp-content` directory:
 
 ```bash
@@ -155,7 +173,7 @@ As well as in the `wp-content/themes/uncode/library` folder :
 css -> ../../../uploads/uncode/library/css
 ```
 
-### For Windows:
+#### For Windows:
 Note that the syntax for Windows is opposite from MacOS and Linux, requiring the symlink path *before* the target and backslash is used to denote folders. In the `wp-content` folder create the symlinks by:
 
 ```bash

--- a/source/content/assuming-write-access.md
+++ b/source/content/assuming-write-access.md
@@ -127,12 +127,13 @@ You can also verify success using `dir`:
 
 As discussed in [Modules and Plugins with Known Issues](/docs/modules-plugins-known-issues/), [Uncode theme](https://undsgn.com/uncode/){.external} assumes write access its css files to the code base.
 
-<div class="alert alert-info" role="alert" markdown="1">
-#### Note {.info}
+<Alert title="Note" type="alert">
+
 You must manually move over the target folders `wp-content\themes\uncode\core\assets\css` to `wp-content\uploads\uncode\assets\css` and `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Dev.
 
 You must also need to copy over the files generated from `wp-content\themes\uncode\library\css` to `wp-content\uploads\uncode\library\css` in Test, Live, and any Multidev environments after deploying codes for the theme to take effect in different environments.
-</div>
+
+</Alert>
 
 ### For MacOS & Linux:
 From the `wp-content` directory:
@@ -144,13 +145,13 @@ ln -s ../../../uploads/uncode/library/css ./themes/uncode/library
 
 To verify, use `ls -al` in the `wp-content/themes/uncode/core/assets` folder :
 
-```nohighlight
+```
 css -> ../../../../uploads/uncode/assets/css
 ```
 
 As well as in the `wp-content/themes/uncode/library` folder :
 
-```nohighlight
+```
 css -> ../../../uploads/uncode/library/css
 ```
 

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -871,7 +871,7 @@ define('FTP_PLUGIN_DIR', __DIR__ .'/wp-content/plugins/');
 
 **Issue 2**: This theme throws a PHP Fatal error in its settings page for Dev's and Multidev's Git mode, Test and Live.
 
-**Solution**: This theme to assumes write to theme folders `wp-content\themes\uncode\core\assets\css` and `wp-content\themes\uncode\library\css` for it to work properly in git mode. For additional details, see [Using Extensions That Assume Write Access](/docs/assuming-write-access/#uncodetheme).
+**Solution**: This theme assumes write to theme folders `wp-content\themes\uncode\core\assets\css` and `wp-content\themes\uncode\library\css` for it to work properly in git mode. For additional details, see [Using Extensions That Assume Write Access](/docs/assuming-write-access/#uncodetheme).
 
 <hr />
 

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -851,6 +851,29 @@ define('FTP_PLUGIN_DIR', __DIR__ .'/wp-content/plugins/');
 
 <hr />
 
+### [Uncode](https://undsgn.com/uncode/)
+
+**Issue 1**: This theme presents a form requesting FTP credentials in order to automatically update its components. This will appear on Dev, Test and Live environments and can be hidden with CSS, but is still present.
+
+**Solution**: The form can be disabled by adding the following to `wp-config.php`, above the line `/* That's all, stop editing! Happy Pressing. */`:
+
+```php
+/** Changes to disable Uncode theme FTP form */
+define('FS_METHOD', 'direct');
+define('FS_CHMOD_DIR', ( 0755 & ~ umask() ) );
+define('FS_CHMOD_FILE', ( 0755 & ~ umask() ) );
+define('FTP_BASE', __DIR__);
+define('FTP_CONTENT_DIR', __DIR__ .'/wp-content/');
+define('FTP_PLUGIN_DIR', __DIR__ .'/wp-content/plugins/');
+```
+
+<br />
+
+**Issue 2**: This theme throws a PHP Fatal error in its settings page for Dev's and Multidev's Git mode, Test and Live.
+
+**Solution**: This theme to assumes write to theme folders `wp-content\themes\uncode\core\assets\css` and `wp-content\themes\uncode\library\css` for it to work properly in git mode. For additional details, see [Using Extensions That Assume Write Access](/docs/assuming-write-access/#uncodetheme).
+
+<hr />
 
 ## WordPress Functions
 


### PR DESCRIPTION
Closes #4769 

## Effect
PR includes the following changes:
- Added symlink fix for the uncode theme as an added example in the symlinks page


## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
