### PR TITLE
Add clear cache permissions to site team chart

### DIFF
--- a/source/content/change-management.md
+++ b/source/content/change-management.md
@@ -38,6 +38,7 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 | Access the site Dashboard                | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Work in Dev environments                 | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Deploy to Test and Live                  | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  |
+| Clear cache on Test and Live             | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  |
 | Manage user roles                        | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Delete sites or remove users from a site | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Manage a site's plan                     | <span  style="color:green">✔</span> <Popover title="Owner" content="When an organization is the owner of a site, users in charge cannot change the site plan." /> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |


### PR DESCRIPTION
Customer in chat today couldn't clear cache in test and CSE ended up testing to find out that Developer role is not allowed to clear cache in Test/Live.

Closes # n/a

## Effect
PR includes the following changes:
- Adds a row to the site-team chart to highlight which roles can clear cache.

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
