### PR TITLE
gatsby: updates max custom domains for elite

### DIFF
--- a/source/partials/tables/custom-domains-limit.md
+++ b/source/partials/tables/custom-domains-limit.md
@@ -20,7 +20,7 @@
       <td>15</td>
       <td>35</td>
       <td>70</td>
-      <td>200</td>
+      <td>270</td>
     </tr>
     <tr>
       <th scope="row" class="thead-inverse">Free and managed HTTPS</th>


### PR DESCRIPTION
## Effect
PR includes the following changes:
- updates the table in /docs/domains to reflect the right max number of custom domains for elite

## Remaining Work
- [x] +1 from @davidwegbreit