### PR TITLE
D8 & Composer no CI - remove extra automation pieces removal steps

### DIFF
--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -85,14 +85,11 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
     - `.circleci`
     - `tests`
 
-2.  Modify `composer.json`:
+1.  Modify `composer.json`:
     - Remove all dependencies in the `require-dev` section.
     - Update the `scripts` section to remove the `lint`, `code-sniff`, and `unit-test` lines.
-    - Remove the `find .circleci/scripts/pantheon/ -type f | xargs chmod 755,` line from the `post-update-cmd` section of `scripts`.
-    - Remove the `find tests/scripts/ -type f | xargs chmod 755` line from the `post-update-cmd` section of `scripts`.
-        - You may need to remove a trailing comma from the end of the last item in the `post-update-cmd` section, otherwise the JSON will be invalid.
 
-3. Remove the following section from `pantheon.yml`:
+1.  Remove the following section from `pantheon.yml`:
 
     ```yml
       sync_code:
@@ -101,6 +98,8 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
             description: Push changes back to GitHub if needed
             script: private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php
     ```
+
+    If there is a `workflows:` line, remove that as well.
 
 ## Managing Drupal with Composer
 

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -3,7 +3,7 @@ title: Drupal 8 and Composer on Pantheon Without Continuous Integration
 description: Learn how to manage Drupal 8 using Composer with Pantheon.
 tags: [moreguides, composer]
 categories: [drupal]
-type: guide
+layout: doc
 permalink: docs/guides/:basename/
 contributors: [ataylorme, dwayne, davidneedham]
 ---
@@ -13,6 +13,7 @@ In this guide, we’re going to run through the bare necessities to use [Compose
 Using a Composer managed site **removes** the ability to [apply Drupal core updates via the site dashboard](/docs/core-updates/).  This is for advanced users who are comfortable taking complete responsibility for the management of site updates with Composer.
 
 <Alert title="Note" type="info">
+
 As packages pulled by Composer are updated (along with their dependencies), version compatibility issues can pop up. Sometimes you may need to manually alter the version constraints on a given package within the `require` or `require-dev` section of `composer.json` in order to update packages. See the [updating dependencies](https://getcomposer.org/doc/01-basic-usage.md#updating-dependencies-to-their-latest-versions) section of Composer's documentation for more information.
 
 As a first troubleshooting step, try running `composer update` to bring `composer.lock` up to date with the latest available packages (as constrained by the version requirements in `composer.json`).
@@ -103,7 +104,9 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
 ## Managing Drupal with Composer
 
 <Alert title="Note" type="info">
+
 When possible, use tagged versions of Composer packages. Untagged versions will include `.git` directories, and the [Pantheon platform is not compatible with git submodules](/docs/git-faq/#does-pantheon-support-git-submodules). If you remove the `.git` directories, be sure to put them back again after you push your commit up to Pantheon (see instructions below). To do this, remove the vendor directory and run `composer install`.
+
 </Alert>
 
 ### Downloading Drupal Dependencies with Composer
@@ -181,7 +184,9 @@ Now that the code for Drupal core exists on our Pantheon site, we need to actual
 ### Adding a New Module with Composer
 
 <Alert title="Note" type="info">
+
 To maintain best practice, some of the steps in this section require access to the [Multidev](/docs/multidev/) feature. Those steps can be skipped, but it isn't recommended.
+
 </Alert>
 
 1. Next, let’s add a new module to our site. For this example, we’ll add the address module. We advocate working in feature branches on Pantheon, so let's create a Git branch and spin up a Multidev environment:

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -92,14 +92,13 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
 1.  Remove the following section from `pantheon.yml`:
 
     ```yml
+    workflows:
       sync_code:
         after:
           - type: webphp
             description: Push changes back to GitHub if needed
             script: private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php
     ```
-
-    If there is a `workflows:` line, remove that as well.
 
 ## Managing Drupal with Composer
 


### PR DESCRIPTION
Closes #4773 
Closes #4780 

## Effect
PR includes the following changes:
In `## Removing Automation Pieces`
- omits the lines in `composer.json` from #4773
- adds a line regarding `workflows:` in `pantheon.yml` from #4780 

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
