### PR TITLE
open live url in Drupal 8 configuration management example missing https

### DIFF
--- a/source/_docs/drupal-8-configuration-management.md
+++ b/source/_docs/drupal-8-configuration-management.md
@@ -51,7 +51,7 @@ In the commands below, replace `site` with your site name and the correct enviro
 5.  `open https://test-mysite.pantheonsite.io`
 6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
 7.  `terminus drush <site>.live -- cim -y`
-8.  `open live-mysite.pantheonsite.io`
+8.  `open https://live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8
 With [Drupal 8](https://pantheon.io/drupal-8){.external}, much more powerful tools promise to greatly improve this situation. The new configuration management system provides complete and consistent import and export of all configuration settings, and Git already provides facilities for managing parallel work on different branches. When conflicts occur, it is  possible to back out the conflicting changes, take just the version provided in the central repository, or use three-way merge tools such as `kdiff3` to examine and manually resolve each difference. A new Drush project, [config-extra](https://github.com/drush-ops/config-extra){.external}, includes a `config-merge` command that streamlines the use of these tools.


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- `open live-mysite.pantheonsite.io` in workflow example attempted to open file, not url due to missing `https://`.

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
