### PR TITLE
fix: remove sizeByPixelDensity warning

### DIFF
--- a/gatsby/gatsby-config.js
+++ b/gatsby/gatsby-config.js
@@ -103,7 +103,7 @@ module.exports = {
             resolve: "gatsby-remark-images",
             options: {
               maxWidth: 1035,
-              sizeByPixelDensity: true,
+              // sizeByPixelDensity: true,
               showCaptions: true,
               linkImagesToOriginal: false,
             },


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Remove `sizeByPixelDensity` warning

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
