### PR TITLE
Clarify use-case for PEG with LDAP

### DIFF
--- a/source/content/ldap-and-ldaps.md
+++ b/source/content/ldap-and-ldaps.md
@@ -14,7 +14,7 @@ PHP on Pantheon includes LDAP using OpenLDAP, so no changes to the platform are 
 
 <Alert title="Note" type="info">
 
-Pantheon supports IP authentication schemes *only* when implemented as part of a [Pantheon Secure Integration](/docs/secure-integration/) configuration. We recommend certificate-based authentication to be compatible with distributed application containers.
+Pantheon supports IP-based defense-in-depth firewall configuration schemes *only* when implemented as part of a [Pantheon Secure Integration](/docs/secure-integration/) configuration. We recommend certificate-based authentication to be compatible with distributed application containers.
 
 </Alert>
 


### PR DESCRIPTION
Closes #4781

## Effect
PR includes the following changes:
- Specify that PEG is needed for specific firewall implementations, and should not be used as basic auth.


## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)