### PR TITLE
feat: add contributor guest component

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -116,15 +116,26 @@ exports.createPages = ({ graphql, actions }) => {
     // Create guide pages.
     const guides = result.data.allGuides.edges
     guides.forEach(guide => {
-      const template = calculateTemplate(guide.node, "guide")
-      createPage({
-        path: guide.node.fields.slug,
-        component: path.resolve(`./src/templates/${template}.js`),
-        context: {
-          slug: guide.node.fields.slug,
-          guide_directory: guide.node.fields.guide_directory,
-        },
-      })
+      if (guide.node.fields.guide_directory !== null) {
+        const template = calculateTemplate(guide.node, "guide")
+        createPage({
+          path: guide.node.fields.slug,
+          component: path.resolve(`./src/templates/${template}.js`),
+          context: {
+            slug: guide.node.fields.slug,
+            guide_directory: guide.node.fields.guide_directory,
+          },
+        })
+      } else {
+        const template = calculateTemplate(guide.node, "doc")
+        createPage({
+          path: guide.node.fields.slug,
+          component: path.resolve(`./src/templates/${template}.js`),
+          context: {
+            slug: guide.node.fields.slug,
+          },
+        })
+      }
     })
 
     // Create contributor pages.
@@ -155,13 +166,15 @@ exports.onCreateNode = ({ node, getNode, actions }) => {
       value: slug,
     })
 
-    // Add guide_directory field
     if (slug.includes("docs/guides")) {
-      createNodeField({
-        name: `guide_directory`,
-        node,
-        value: `${getNode(node.parent).relativeDirectory}`,
-      })
+      if (getNode(node.parent).relativeDirectory !== 'guides') {
+        // Add guide_directory field
+        createNodeField({
+          name: `guide_directory`,
+          node,
+          value: `${getNode(node.parent).relativeDirectory}`,
+        })
+      }
     }
   }
 

--- a/gatsby/src/components/contributorGuest.js
+++ b/gatsby/src/components/contributorGuest.js
@@ -1,0 +1,50 @@
+import React from "react"
+import { Link } from "gatsby"
+
+const ContributorGuest = ({ contributor }) => {
+  if (contributor == null) {
+    return <></>
+  }
+
+  return (
+    <>
+      <div className="guest-contributor">
+          <div claclassName="media">
+              <div className="pull-left">
+                <div className="preview-info__img">
+                  <Link
+                    to={`/docs/contributors/${contributor.id}`}
+                    title={contributor.id}
+                  >
+                    <img
+                      alt="Author photo"
+                      typeof="foaf:Image"
+                      src={contributor.avatar}
+                      width="540"
+                      height="540"
+                    />
+                  </Link>
+                </div>
+              </div>
+              <div claclassName="media-body__featured">
+                <div claclassName="media-heading">
+                  <h3 className="toc-ignore">By
+                    <Link
+                      to={`/docs/contributors/${contributor.id}`}
+                      title={contributor.id}
+                    >
+                      {contributor.name}
+                    </Link>
+                  </h3>
+                </div>
+                <div>
+                  <p>{contributor.bio}</p>
+                </div>
+              </div>
+          </div>
+      </div>
+    </>
+  )
+}
+
+export default ContributorGuest

--- a/gatsby/src/components/contributors.js
+++ b/gatsby/src/components/contributors.js
@@ -5,6 +5,7 @@ const Contributors = ({ contributors }) => {
   if (contributors == null || contributors.length < 1) {
     return <></>
   }
+
   return (
     <>
       <p>

--- a/gatsby/src/components/headerBody.js
+++ b/gatsby/src/components/headerBody.js
@@ -1,0 +1,46 @@
+import React from "react"
+
+import Contributors from "../components/contributors"
+import Github from "../components/github"
+import Twitter from "../components/twitter"
+import Slack from "../components/slack"
+import ContributorGuest from "../components/contributorGuest"
+
+const HeaderBody = ({ title, subtitle, description, slug, contributors, featured }) => {
+  const contributor = contributors ? contributors[0] : null;
+  return (
+    <>
+      <header className="buttons">
+        {!subtitle &&
+        <h1
+          style={{ marginBottom: "10px", marginTop: "0px" }}
+          className="pio-docs-title"
+        >
+          {title}
+        </h1>}
+
+        {subtitle && <h1>{subtitle}</h1>}
+
+        <p className="article-subhead">
+          {description}
+        </p>
+
+        {!featured && <Contributors contributors={contributors} />}
+
+        <Github
+          pageTitle={title}
+          path={slug}
+        />
+        <Twitter
+          pageTitle={title}
+          path={slug}
+        />
+        <Slack />
+
+        {featured && <ContributorGuest contributor={contributor} />}
+      </header>
+    </>
+  )
+}
+
+export default HeaderBody

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -4,19 +4,17 @@ import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import { MDXProvider } from "@mdx-js/react"
 
 import Layout from "../components/layout"
+import HeaderBody from "../components/headerBody"
+
 import Callout from "../components/callout"
 import Alert from "../components/alert"
 import Accordion from "../components/accordion"
 import ExternalLink from "../components/externalLink"
 import Icon from "../components/icon"
 import Popover from "../components/popover"
-import Contributors from "../components/contributors"
 import TabList from "../components/tabList"
 import Tab from "../components/tab"
 import TOC from "../components/toc"
-import Github from "../components/github"
-import Twitter from "../components/twitter"
-import Slack from "../components/slack"
 import GetFeedback from "../components/getFeedback"
 import Card from "../components/card"
 import CardGroup from "../components/cardGroup"
@@ -55,6 +53,7 @@ class DocTemplate extends React.Component {
 
   render() {
     const node = this.props.data.mdx
+
     return (
       <Layout>
         <SEO
@@ -66,27 +65,14 @@ class DocTemplate extends React.Component {
         <div className="container">
           <div className="row doc-content-well">
             <div id="doc" className="doc article col-md-9 md-70">
-              <header className="buttons">
-                <h1
-                  style={{ marginBottom: "10px", marginTop: "0px" }}
-                  className="pio-docs-title"
-                >
-                  {node.frontmatter.title}
-                </h1>
-                <p className="article-subhead">
-                  {node.frontmatter.description}
-                </p>
-                <Contributors contributors={node.frontmatter.contributors} />
-                <Github
-                  pageTitle={node.frontmatter.title}
-                  path={node.fields.slug}
-                />
-                <Twitter
-                  pageTitle={node.frontmatter.title}
-                  path={node.fields.slug}
-                />
-                <Slack />
-              </header>
+              <HeaderBody
+                title={node.frontmatter.title}
+                subtitle={node.frontmatter.subtitle}
+                description={node.frontmatter.description}
+                slug={node.fields.slug}
+                contributors={node.frontmatter.contributors}
+                featured={node.frontmatter.featuredcontributor}
+              />
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                 <MDXProvider components={shortcodes}>
                   <MDXRenderer>{node.code.body}</MDXRenderer>
@@ -137,7 +123,11 @@ export const pageQuery = graphql`
           id
           name
           twitter
+          bio
+          avatar
+          url
         }
+        featuredcontributor
       }
       fileAbsolutePath
     }

--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -4,19 +4,17 @@ import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import { MDXProvider } from "@mdx-js/react"
 
 import Layout from "../components/layout"
+import HeaderBody from "../components/headerBody"
+
 import Callout from "../components/callout"
 import Alert from "../components/alert"
 import Accordion from "../components/accordion"
 import ExternalLink from "../components/externalLink"
 import Icon from "../components/icon"
 import Popover from "../components/popover"
-import Contributors from "../components/contributors"
 import TabList from "../components/tabList"
 import Tab from "../components/tab"
 import TOC from "../components/toc"
-import Github from "../components/github"
-import Twitter from "../components/twitter"
-import Slack from "../components/slack"
 import Card from "../components/card"
 import CardGroup from "../components/cardGroup"
 import Navbar from "../components/navbar"
@@ -95,22 +93,14 @@ class GuideTemplate extends React.Component {
                   <div
                     className={`col-xs-${contentCols} col-md-${contentCols}`}
                   >
-                    <header className="buttons">
-                      <h1>{node.frontmatter.subtitle}</h1>
-                      <Contributors
-                        contributors={node.frontmatter.contributors}
-                      />
-                      <Github
-                        pageTitle={node.frontmatter.title}
-                        path={`docs/guides/${node.frontmatter.editpath}`}
-                      />
-                      <Twitter
-                        pageTitle={node.frontmatter.title}
-                        path={node.fields.slug}
-                      />
-                      <Slack />
-                      <hr style={{ marginTop: "10px", marginBottom: "10px" }} />
-                    </header>
+                    <HeaderBody
+                      title={node.frontmatter.title}
+                      subtitle={node.frontmatter.subtitle}
+                      description={node.frontmatter.description}
+                      slug={node.fields.slug}
+                      contributors={node.frontmatter.contributors}
+                      featured={node.frontmatter.featuredcontributor}
+                    />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>
                     </MDXProvider>
@@ -173,7 +163,11 @@ export const pageQuery = graphql`
           id
           name
           twitter
+          bio
+          avatar
+          url
         }
+        featuredcontributor
         getfeedbackform
       }
       fileAbsolutePath

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -4,19 +4,17 @@ import MDXRenderer from "gatsby-mdx/mdx-renderer"
 import { MDXProvider } from "@mdx-js/react"
 
 import Layout from "../components/layout"
+import HeaderBody from "../components/headerBody"
+
 import Callout from "../components/callout"
 import Alert from "../components/alert"
 import Accordion from "../components/accordion"
 import ExternalLink from "../components/externalLink"
 import Icon from "../components/icon"
 import Popover from "../components/popover"
-import Contributors from "../components/contributors"
 import TabList from "../components/tabList"
 import Tab from "../components/tab"
 import TOC from "../components/toc"
-import Github from "../components/github"
-import Twitter from "../components/twitter"
-import Slack from "../components/slack"
 import Card from "../components/card"
 import CardGroup from "../components/cardGroup"
 import Navbar from "../components/navbar"
@@ -133,22 +131,14 @@ class TerminusTemplate extends React.Component {
                   <div
                     className={`col-xs-${contentCols} col-md-${contentCols}`}
                   >
-                    <header className="buttons">
-                      <h1>{node.frontmatter.subtitle}</h1>
-                      <Contributors
-                        contributors={node.frontmatter.contributors}
-                      />
-                      <Github
-                        pageTitle={node.frontmatter.title}
-                        path={node.fields.slug}
-                      />
-                      <Twitter
-                        pageTitle={node.frontmatter.title}
-                        path={node.fields.slug}
-                      />
-                      <Slack />
-                      <hr style={{ marginTop: "10px", marginBottom: "10px" }} />
-                    </header>
+                    <HeaderBody
+                      title={node.frontmatter.title}
+                      subtitle={node.frontmatter.subtitle}
+                      description={node.frontmatter.description}
+                      slug={node.fields.slug}
+                      contributors={node.frontmatter.contributors}
+                      featured={node.frontmatter.featuredcontributor}
+                    />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>
                     </MDXProvider>


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Add `ContributorGuest` component
- Add `HeaderBody` component
- Assign `doc` template to single-page guides.
- 

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
