### PR TITLE
Gatsby version of #4805

### DIFF
--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -47,7 +47,7 @@ In the commands below, replace `site` with your site name and the correct enviro
 5.  `open https://test-mysite.pantheonsite.io`
 6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
 7.  `terminus drush <site>.live -- cim -y`
-8.  `open live-mysite.pantheonsite.io`
+8.  `open https://live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8
 With [Drupal 8](https://pantheon.io/drupal-8), much more powerful tools promise to greatly improve this situation. The new configuration management system provides complete and consistent import and export of all configuration settings, and Git already provides facilities for managing parallel work on different branches. When conflicts occur, it is  possible to back out the conflicting changes, take just the version provided in the central repository, or use three-way merge tools such as `kdiff3` to examine and manually resolve each difference. A new Drush project, [config-extra](https://github.com/drush-ops/config-extra), includes a `config-merge` command that streamlines the use of these tools.


### PR DESCRIPTION
Closes #4805

## Effect
PR includes the following changes:
- Implements @pwtyler's fix in @4805. I couldn't keep that commit when staging against the new Gatsby build.


## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)