### PR TITLE
fix: youtube-video component

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -99,7 +99,7 @@ exports.createPages = ({ graphql, actions }) => {
         landings {
           title
           path
-          video_url
+          video_id
           cta {
             title
             subtitle

--- a/gatsby/src/layout/youtube-video/index.js
+++ b/gatsby/src/layout/youtube-video/index.js
@@ -1,17 +1,18 @@
-import React, { Component } from 'react';
-import PropTypes from 'prop-types';
+import React from 'react';
 
-class YoutubeVideo extends Component {
-	render() {
-		const { videoURL } = this.props;
-		return (
-			<div>
-        <iframe width="560" height="315" src={"https://www.youtube.com/embed/" + this.props.videoURL} frameborder="0" allow="accelerometer; encrypted-media; gyroscope;" allowfullscreen></iframe>
-			</div>
-		);
-	}
+const YoutubeVideo = ({ videoId }) => {
+	return(
+			<>
+				<iframe
+					width="560"
+					height="315"
+					src={`https://www.youtube.com/embed/${videoId}`}
+					frameborder="0"
+					allow="accelerometer; encrypted-media; gyroscope;"
+					allowfullscreen>
+				</iframe>
+			</>
+	)
 }
-
-YoutubeVideo.propTypes = {};
 
 export default YoutubeVideo;

--- a/gatsby/src/templates/landing.js
+++ b/gatsby/src/templates/landing.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link } from 'gatsby';
 import Layout from '../components/layout';
 import CallToAction from '../layout/call-to-action';
 import TopicGroup from '../layout/topic-group';
@@ -20,9 +19,9 @@ const LandingTemplate = (props) => {
 					<div className="row" style={{ marginBottom: '15px' }}>
 						<div className="col-md-12">
 							<div className="row call-to-action-section">
-								{topic.video_url && (
+								{topic.video_id && (
 									<div className="col-md-6 hero-video__video">
-                    <YoutubeVideo videoURL={topic.video_url} />
+										<YoutubeVideo videoId={topic.video_id} />
 									</div>
 								)}
 								{(topic.cta||topic.cta_alt) && <div className="col-md-6 ">

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -1,7 +1,7 @@
 landings:
   - title: 'Get Started'
     path: 'get-started'
-    video_url: 'qHHWonKfGsQ'
+    video_id: 'qHHWonKfGsQ'
     cta: 
       title: 'Quick Start Guide'
       subtitle: 'New to our platform? Check out our step-by-step guide to learn all the basics.'
@@ -81,7 +81,7 @@ landings:
                 url: '/docs/migrate-wordpress-site-networks/'
   - title: 'Develop'
     path: 'develop'
-    video_url: 'v7qe2_OZ95k'
+    video_id: 'v7qe2_OZ95k'
     cta: 
       title: 'Quick Start Guide'
       subtitle: 'New to our platform? Check out our step-by-step guide to learn all the basics.'
@@ -352,7 +352,7 @@ landings:
                 url: '/docs/wordpress-phpstorm/'
   - title: 'Go Live'
     path: 'go-live'
-    video_url: 'nZvf2CrLh9o'
+    video_id: 'nZvf2CrLh9o'
     cta: 
       title: 'Launch Essentials Guide'
       subtitle: "Ready to launch like a pro? Check out our step-by-step guide to see how it's done."


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- Fix youtube-video component
- Update `video_url` with `video_id`

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
