### PR TITLE
Instructs user to contact support when they don't know site owner user/pass

### DIFF
--- a/source/partials/recover-account-after-owner-leaves.md
+++ b/source/partials/recover-account-after-owner-leaves.md
@@ -7,4 +7,4 @@
 ### The Email and Password are Unknown
 1. [Sign up for a Pantheon account](https://dashboard.pantheon.io/register) if you don't already have one.
 1. Notify an existing team member that you need access to the account and give them your email address. The team member should contact you directly to confirm who you are and give you to the access to that site’s Dashboard. For instructions on adding and inviting new team members, see [Team Management](/team-management/).
-1. Once you have access, [add your credit card](/site-billing#add-new-credit-card) to the site to make your account the site owner.
+1. Once you have access, [contact Support](/support/) to have the ownership of the account transferred to you. You’ll be asked to verify the last four numbers of the existing credit card.


### PR DESCRIPTION
Closes #4660

## Effect
PR includes the following changes:
- removes the part that infers that adding a CC automatically makes you owner and clarifies that contacting CS is necessary + adds verification bit

## Remaining Work
- [x] Technical review - +1 from @rachelwhitton on Slack
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [x] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
