### PR TITLE
update terminus build tools plugin for t2

### DIFF
--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -82,7 +82,7 @@ GitHub pull requests (PRs) are a formalized way of reviewing and merging a propo
 8. Install the [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin):
 
     ```bash
-    composer create-project -n -d $HOME/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:~1
+    composer create-project -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta12
     ```
 
   <Alert title="Note" type="info">

--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -82,7 +82,7 @@ GitHub pull requests (PRs) are a formalized way of reviewing and merging a propo
 8. Install the [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin):
 
     ```bash
-    composer create-project -d ~/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta12
+    composer create-project -d $HOME/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta12
     ```
 
   <Alert title="Note" type="info">


### PR DESCRIPTION
Closes #4850

## Effect
PR includes the following changes:
- updates link for Terminus Build Tools Plugin to Terminus 2

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
