### PR TITLE
set max width for multipage guides

### DIFF
--- a/gatsby/src/styles/main.css
+++ b/gatsby/src/styles/main.css
@@ -546,6 +546,7 @@ span#changelog-rsaquo {
 	.guide-doc-body {
 		border-left: none !important;
 		padding-left: 10px !important;
+		max-width: 995px;
 	}
 }
 @media (min-width: 995px) {
@@ -2230,7 +2231,6 @@ input.gsc-search-button:focus {
 }
 .guide-doc-body {
 	padding-left: 30px;
-	max-width: 995px;
 }
 /* .manual-toc {
   padding: 0px;

--- a/gatsby/src/styles/main.css
+++ b/gatsby/src/styles/main.css
@@ -2230,6 +2230,7 @@ input.gsc-search-button:focus {
 }
 .guide-doc-body {
 	padding-left: 30px;
+	max-width: 995px;
 }
 /* .manual-toc {
   padding: 0px;


### PR DESCRIPTION
Closes #4687

## Effect
PR includes the following changes:
- Sets the max width for multipage guide body to 995px.
-

## Remaining Work
- [ ] :+1: from @davidneedham, @rachelwhitton, and/or @mcdwayne
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)