### PR TITLE
remove psl recommendation

### DIFF
--- a/source/content/https.md
+++ b/source/content/https.md
@@ -138,9 +138,8 @@ Pantheon requests new certificates frequently in order to add domains to existin
 
 If you encounter rate limits, we recommend the following approaches:
 
-- [Ask Let's Encrypt to increase your rate limit](https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform).
-- Request that your apex domain (e.g., `example.edu`) be added to the public suffix list by submitting a [pull request](https://github.com/publicsuffix/list/wiki/Guidelines), which will cause Let's Encrypt to treat every subdomain of the main domain as independent for limit purposes. Also, browsers and malware scanners will treat the subdomains as independent.
-- Consider using another certificate service for sites that are not on Pantheon. For example, educational institutions may want to consider using the [Incommon Certificate Service](https://www.incommon.org/certificates/) as a workaround.
+- [Ask Let's Encrypt to increase your rate limit](https://docs.google.com/forms/d/e/1FAIpQLSetFLqcyPrnnrom2Kw802ZjukDVex67dOM2g4O8jEbfWFs3dA/viewform){.external}.
+- Consider using another certificate service for sites that are not on Pantheon. For example, educational institutions may want to consider using the [Incommon Certificate Service](https://www.incommon.org/certificates/){.external} as a workaround.
 
 `markdown:cname-workaround.md`
 


### PR DESCRIPTION
[The PSL maintainers are not accepting these requests](https://publicsuffix.org/learn/): "Let's Encrypt uses it for rate limiting applications to their CA. If you just need an exception from their rate limits, please do not request a change to the list, but instead use their form, linked from their documentation. This is a faster way to achieve what you want."