### PR TITLE
Explicitly say dbserver and, and a straight-up reference guide about …

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -31,6 +31,16 @@ When appservers are migrated as a regular part of platform maintenance, log file
 ## Access Logs Via SFTP
 Logs are stored within application containers that house your site's codebase and files. [Add an SSH key](/ssh-keys/) within your User Dashboard to enable passwordless access and avoid authentication prompts. Otherwise, provide your Pantheon Dashboard credentials when prompted.
 
+In the Connection Information section of the dashboard, we can see a pattern about the hostnames: 
+
+```
+<env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in
+```
+| Type        | Env           | Site UUID                                                |
+|:---------- |:-------------------------- |:------------------------------------------------------- |
+| `appserver`, <br> `dbserver`         |  `dev`, `test`, `live`, `<multidev-env>`                      | ex. `c5c75825-5cd4-418e-8cb0-fb9aa1a7f671`, as found in `https://dashboard.pantheon.io/sites/<site-uuid>` |
+
+
 ## Downloading Logs
 
 <Accordion title="Watch: Download Appserver and Database Log Files" id="logs-video" icon="facetime-video">
@@ -68,9 +78,15 @@ You now have a local copy of the logs directory, which contains the following:
 2. Click **Connection Info** and copy the **SFTP Command Line** command.
 3. Edit and execute the command by replacing `appserver` with `dbserver`:
 
- ```
- sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@dbserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in
- ```
+From:
+  ```
+   sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@appserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
+  ```
+
+To:
+  ```
+   sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@dbserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
+  ```
 
 4. Run the following SFTP command in terminal:
 

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -36,10 +36,17 @@ In the Connection Information section of the dashboard, we can see a pattern abo
 ```
 <env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in
 ```
-| Type        | Env           | Site UUID                                                |
-|:---------- |:-------------------------- |:------------------------------------------------------- |
-| `appserver`, <br> `dbserver`         |  `dev`, `test`, `live`, `<multidev-env>`                      | ex. `c5c75825-5cd4-418e-8cb0-fb9aa1a7f671`, as found in `https://dashboard.pantheon.io/sites/<site-uuid>` |
 
+<dl>
+
+<dt
+
+</dl>
+
+| Type         | Env                                     | Site UUID                                                                                                 |
+|:------------ |:--------------------------------------- |:--------------------------------------------------------------------------------------------------------- |
+| `appserver`  | `dev`, `test`, `live`, `<multidev-env>` | ex. `c5c75825-5cd4-418e-8cb0-fb9aa1a7f671`, as found in `https://dashboard.pantheon.io/sites/<site-uuid>` |
+| `dbserver`   |                                         |                                                                                                           |
 
 ## Downloading Logs
 

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -31,17 +31,11 @@ When appservers are migrated as a regular part of platform maintenance, log file
 ## Access Logs Via SFTP
 Logs are stored within application containers that house your site's codebase and files. [Add an SSH key](/ssh-keys/) within your User Dashboard to enable passwordless access and avoid authentication prompts. Otherwise, provide your Pantheon Dashboard credentials when prompted.
 
-In the Connection Information section of the dashboard, we can see a pattern about the hostnames: 
+In the Connection Information section of the dashboard, we can see a pattern about the hostnames:
 
 ```
 <env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in
 ```
-
-<dl>
-
-<dt
-
-</dl>
 
 | Type         | Env                                     | Site UUID                                                                                                 |
 |:------------ |:--------------------------------------- |:--------------------------------------------------------------------------------------------------------- |
@@ -85,15 +79,15 @@ You now have a local copy of the logs directory, which contains the following:
 2. Click **Connection Info** and copy the **SFTP Command Line** command.
 3. Edit and execute the command by replacing `appserver` with `dbserver`:
 
-From:
-  ```
-   sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@appserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
-  ```
+ From:
+ ```
+ sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@appserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
+ ```
 
-To:
-  ```
-   sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@dbserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
-  ```
+ To:
+ ```
+ sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@dbserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
+ ```
 
 4. Run the following SFTP command in terminal:
 


### PR DESCRIPTION
…hostnames

Closes #3800 

## Effect
PR includes the following changes:
- New section about the hostname patterns
- Highlight that there will be a difference in the hostname between appserver and dbserver

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
