### PR TITLE
who can 1) add supporting org; 2) manage site plan

### DIFF
--- a/source/content/change-management.md
+++ b/source/content/change-management.md
@@ -41,7 +41,8 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 | Clear cache on Test and Live             | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  |
 | Manage user roles                        | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Delete sites or remove users from a site | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
-| Manage a site's plan                     | <span  style="color:green">✔</span> <Popover title="Owner" content="When an organization is the owner of a site, users in charge cannot change the site plan." /> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
+| Add a Supporting Organization            | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
+| Manage a site's plan                     | <span  style="color:green">✔ Org admin or Owner</span> <Popover title="Owner" content="When an organization is the owner of a site, users in charge cannot change the site plan." /> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 
 ## Manage People in an Organization
 
@@ -77,6 +78,8 @@ For Sandbox sites, within the Team modal, the current site owner can click **Mak
 2. Enter the user's email address, select a role, and click **Add Team Member**.
 
 ### Add a Supporting Organization to a Site
+Organization administrators, Users in Charge, or Site Owners can add a Supporting Organization.
+
 1. At the Site Dashboard, click **Team**.
 2. Click **Add a Supporting Organization**, enter the organization's name in the search box, and click **Search**.
 3. Select a role, and click **Add**.

--- a/source/content/change-management.md
+++ b/source/content/change-management.md
@@ -34,7 +34,7 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 ### Site-Level: Roles and Permissions
 
 | Permissions                              | User in Charge / Owner <Popover title="Owner" content="Partner organizations only" /> | Team Member | Developer <a rel="popover" data-proofer-ignore data-toggle="tooltip" data-html="true" data-content="Enterprise organizations only"><em class="fa fa-info-circle"></em></a> |
-|:---------------------------------------- |:-------------------------------- |:-------------------------------- |:-------------------------------- |
+|:---------------------------------------- |:----------------------------------- |:----------------------------------- |:----------------------------------- |
 | Access the site Dashboard                | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Work in Dev environments                 | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Deploy to Test and Live                  | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  |
@@ -42,7 +42,7 @@ If you are an administrator for a Pantheon organization, [contact support](/docs
 | Manage user roles                        | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Delete sites or remove users from a site | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Add a Supporting Organization            | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
-| Manage a site's plan                     | <span  style="color:green">✔ Org admin or Owner</span> <Popover title="Owner" content="When an organization is the owner of a site, users in charge cannot change the site plan." /> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
+| Manage a site's plan                     | <span  style="color:green">✔</span> Org admin or Owner <Popover title="Owner" content="When an organization is the owner of a site, users in charge cannot change the site plan." /> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 
 ## Manage People in an Organization
 
@@ -78,7 +78,7 @@ For Sandbox sites, within the Team modal, the current site owner can click **Mak
 2. Enter the user's email address, select a role, and click **Add Team Member**.
 
 ### Add a Supporting Organization to a Site
-Organization administrators, Users in Charge, or Site Owners can add a Supporting Organization.
+Organization Administrators, Users in Charge, or Site Owners can add a Supporting Organization.
 
 1. At the Site Dashboard, click **Team**.
 2. Click **Add a Supporting Organization**, enter the organization's name in the search box, and click **Search**.


### PR DESCRIPTION
Closes #4719 
Closes #4760 

## Effect
PR includes the following changes:
- adds info about who can add a supporting org to table and FAQ
- more info to the table re who can manage a site's plan

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [x] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
