### PR TITLE
Update WinSCP install link

### DIFF
--- a/source/content/winscp.md
+++ b/source/content/winscp.md
@@ -12,13 +12,13 @@ Make sure you have the Pantheon SFTP connection information for your site ready.
 
 ## Download WinSCP
 
-If you do not have WinSCP installed, [download and install the latest version](https://winscp.net/eng/index.php).
+If you do not have WinSCP installed, [download and install the latest version](https://winscp.net/eng/docs/installation#download).
 
 ## Start the WinSCP Client
 
 Start the WinSCP application and enter the connection information. Be sure to take note of the port as Pantheon uses a **non-standard port** for SFTP.
 
-## Add the rsa2 Key Fingerprint
+## Add the RSA2 Key Fingerprint
 
 Click **Yes** to accept the server's host key for the current session so it is stored in cache. This allows you to connect to the server and manage your files for the current session.
 


### PR DESCRIPTION
Closes #4504 

## Effect
PR includes the following changes:
- just updates the link to official installation docs
  - while I was looking to delete this doc, having it as a pass-through so that we can remind users about SFTP and RSA2 is useful. So while it's a bit of a stub, it might help whomever ends up finding it.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
