### PR TITLE
Advise how to be a bit safer when using phpinfo()

### DIFF
--- a/source/content/phpinfo.md
+++ b/source/content/phpinfo.md
@@ -21,11 +21,15 @@ Drupal makes the phpinfo available to privileged users at `https://example.com/a
 1. [Lock environment](/security/)  (if the environment does not currently need to be publicly accessible).
 2. Create a php file with an obscure filename that uses phpinfo.
 3. To minimize the information exposed over the web, omit sensitive sections from the phpinfo output. The recommended way to call `phpinfo` is:
-```
-phpinfo(INFO_GENERAL | INFO_CREDITS | INFO_MODULES | INFO_LICENSE);
-```
+
+   ```
+   phpinfo(INFO_GENERAL | INFO_CREDITS | INFO_MODULES | INFO_LICENSE);
+   ```
+
 4. Visit the file in a web browser to view phpinfo.
- ![obscure-phpinfo-filename](/source/docs/assets/images/obscure-phpinfo-delete-immediately.png)
+
+  ![obscure-phpinfo-filename](../images/obscure-phpinfo-delete-immediately.png)
+
 5. Delete the file immediately so you do not expose sensitive information, such as a password, to connect to the DB.
 
 ## Terminus

--- a/source/content/phpinfo.md
+++ b/source/content/phpinfo.md
@@ -20,9 +20,13 @@ Drupal makes the phpinfo available to privileged users at `https://example.com/a
 
 1. [Lock environment](/security/)  (if the environment does not currently need to be publicly accessible).
 2. Create a php file with an obscure filename that uses phpinfo.
-3. Visit the file in a web browser to view phpinfo.
- ![obscure-phpinfo-filename](../images/obscure-phpinfo-delete-immediately.png)
-4. Delete the file immediately so you do not expose sensitive information, such as a password, to connect to the DB.
+3. To minimize the information exposed over the web, omit sensitive sections from the phpinfo output. The recommended way to call `phpinfo` is:
+```
+phpinfo(INFO_GENERAL | INFO_CREDITS | INFO_MODULES | INFO_LICENSE);
+```
+4. Visit the file in a web browser to view phpinfo.
+ ![obscure-phpinfo-filename](/source/docs/assets/images/obscure-phpinfo-delete-immediately.png)
+5. Delete the file immediately so you do not expose sensitive information, such as a password, to connect to the DB.
 
 ## Terminus
 


### PR DESCRIPTION
Closes #n/a

## Effect
PR includes the following changes:
- Advise how to expose phpinfo() a bit more safely

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
