### PR TITLE
CORE-1268: Update existing docs to include consideration for Drush 9

### DIFF
--- a/source/content/continuous-integration.md
+++ b/source/content/continuous-integration.md
@@ -11,7 +11,7 @@ See our [Build Tools](/guides/build-tools/) guide for a more detailed look at a 
 
 ## Terminus Command-Line Interface
 
-[Terminus](/terminus/) is a Drush-based command-line interface (CLI) in the Pantheon core API. Most operations available through the Pantheon Dashboard can be performed with Terminus, including:
+[Terminus](/docs/terminus/) is a Symfony/Console-based command-line interface (CLI) in the Pantheon core API. Most operations available through the Pantheon Dashboard can be performed with Terminus, including:
 
 - Site creation
 - [Multidev environment](/multidev) creation and removal

--- a/source/content/continuous-integration.md
+++ b/source/content/continuous-integration.md
@@ -11,7 +11,7 @@ See our [Build Tools](/guides/build-tools/) guide for a more detailed look at a 
 
 ## Terminus Command-Line Interface
 
-[Terminus](/docs/terminus/) is a Symfony/Console-based command-line interface (CLI) in the Pantheon core API. Most operations available through the Pantheon Dashboard can be performed with Terminus, including:
+[Terminus](/terminus/) is a Symfony/Console-based command-line interface (CLI) in the Pantheon core API. Most operations available through the Pantheon Dashboard can be performed with Terminus, including:
 
 - Site creation
 - [Multidev environment](/multidev) creation and removal

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -18,19 +18,19 @@ Pantheon supports the [Drupal 8 Configuration Management system](https://www.dru
 
 1.  With the Development environment in SFTP mode, export your configuration to code:
 
-        drush cex -y
+        drush config:export -y
 
 2.  Return to the Dashboard and commit the configuration changes.
 3.  Deploy the code to Test.
 4.  Import the configuration from code into the test environment database:
 
-        drush cim -y
+        drush config:import -y
 
 5.  Test the site.
 6.  Deploy the code to Live.
 7.  Import the configuration from code into the live environment database:
 
-        drush cim -y
+        drush config:import -y
 
 8.  Profit.
 
@@ -40,13 +40,13 @@ Using Terminus, you can complete the above process from the command line.
 
 In the commands below, replace `site` with your site name and the correct environment:
 
-1.  `terminus drush <site>.dev -- cex -y`
+1.  `terminus drush <site>.dev -- config:export -y`
 2.  `terminus env:commit <site>.dev --message="Export configuration to code"`
 3.  `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
-4.  `terminus drush <site>.test -- cim -y`
+4.  `terminus drush <site>.test -- config:import -y`
 5.  `open https://test-mysite.pantheonsite.io`
 6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
-7.  `terminus drush <site>.live -- cim -y`
+7.  `terminus drush <site>.live -- config:import -y`
 8.  `open https://live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -16,23 +16,29 @@ Pantheon supports the [Drupal 8 Configuration Management system](https://www.dru
 
 ## Basic Workflow
 
-1.  With the Development environment in SFTP mode, export your configuration to code:
+1. With the Development environment in SFTP mode, export your configuration to code:
 
-        drush config:export -y
+   ```bash
+   drush config:export -y
+   ```
 
-2.  Return to the Dashboard and commit the configuration changes.
-3.  Deploy the code to Test.
-4.  Import the configuration from code into the test environment database:
+1. Return to the Dashboard and commit the configuration changes.
+1. Deploy the code to Test.
+1. Import the configuration from code into the test environment database:
 
-        drush config:import -y
+   ```bash
+   drush config:import -y
+   ```
 
-5.  Test the site.
-6.  Deploy the code to Live.
-7.  Import the configuration from code into the live environment database:
+1. Test the site.
+1. Deploy the code to Live.
+1. Import the configuration from code into the live environment database:
 
-        drush config:import -y
+   ```bash
+   drush config:import -y
+   ```
 
-8.  Profit.
+1.  Profit.
 
 Using Terminus, you can complete the above process from the command line.
 
@@ -41,13 +47,20 @@ Using Terminus, you can complete the above process from the command line.
 In the commands below, replace `site` with your site name and the correct environment:
 
 1.  `terminus drush <site>.dev -- config:export -y`
-2.  `terminus env:commit <site>.dev --message="Export configuration to code"`
-3.  `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
-4.  `terminus drush <site>.test -- config:import -y`
-5.  `open https://test-mysite.pantheonsite.io`
-6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
-7.  `terminus drush <site>.live -- config:import -y`
-8.  `open https://live-mysite.pantheonsite.io`
+
+1.  `terminus env:commit <site>.dev --message="Export configuration to code"`
+
+1.  `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
+
+1.  `terminus drush <site>.test -- config:import -y`
+
+1.  `open https://test-mysite.pantheonsite.io`
+
+1.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
+
+1.  `terminus drush <site>.live -- config:import -y`
+
+1.  `open https://live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8
 With [Drupal 8](https://pantheon.io/drupal-8), much more powerful tools promise to greatly improve this situation. The new configuration management system provides complete and consistent import and export of all configuration settings, and Git already provides facilities for managing parallel work on different branches. When conflicts occur, it is  possible to back out the conflicting changes, take just the version provided in the central repository, or use three-way merge tools such as `kdiff3` to examine and manually resolve each difference. A new Drush project, [config-extra](https://github.com/drush-ops/config-extra), includes a `config-merge` command that streamlines the use of these tools.
@@ -90,13 +103,15 @@ $config_directories = array(
 ```
 
 <Alert title="Note" type="info">
+
 Care should be taken to ensure that this code is added after the `settings.pantheon.php` is included; otherwise, the `CONFIG_SYNC_DIRECTORY` will be overwritten with the Pantheon default value. The configuration directory must exist before this variable is changed.
+
 </Alert>
 
 Relocate the configuration directory for the default location using `git mv`:
 
-```
-$ git mv web/sites/default/files/config .
+```bash
+git mv web/sites/default/files/config .
 ```
 
 For additional details, see [this blog post by Greg Anderson](https://pantheon.io/blog/relocating-drupal-8-configuration-outside-document-root).

--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -46,6 +46,7 @@ The Dashboard integration is intended to provide developers with the most action
 ### How can I manually run site audit on my site?
 
 You can also execute a full report encoded in json format to your terminal:
+
 ```bash
 terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon
 ```
@@ -83,9 +84,11 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 ### Site Audit isn't running on my site.
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/terminus/) command to execute Site Audit directly on your Pantheon site:
+
 ```bash
 terminus drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon --strict=0
 ```
+
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 
 ## See Also

--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -45,14 +45,9 @@ The Dashboard integration is intended to provide developers with the most action
 
 ### How can I manually run site audit on my site?
 
-You can get a list of all available site audit reports using [Terminus](/terminus/):
-```
-terminus remote:drush <site>.<env> -- help --filter=site_audit
-```
-
-You can also execute a full report in HTML format.
+You can also execute a full report encoded in json format to your terminal:
 ```bash
-terminus remote:drush <site>.<env> -- aa --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
+terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon
 ```
 
 ### Are there plans to support Drupal 6 sites?

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -19,21 +19,26 @@ When running Drush locally, we highly recommend running Drush version 8.3.0 or h
 
 ## Verify Current Drush Version
 Verify the current version of Drush running remotely on Pantheon using [Terminus](/terminus):
+
 ```bash
 terminus drush <site>.<env> -- status | grep "Drush version"
 ```
 
 ## Configure Drush Version
 You can change a site's Drush version via the [pantheon.yml file](/pantheon-yml):
+
 ```yaml
 api_version: 1
 
 drush_version: 8
 ```
+
 Now your site’s Drush version is managed via `pantheon.yml`, so it’s in version control and deployed along with the rest of your code.
 
 <Alert title="Note" type="info">
+
 If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.yml` file exists, please do not edit it. It is used by the upstream updates repository and will cause a merge conflict if modified.
+
 </Alert>
 
 ### Available Drush Versions
@@ -43,34 +48,14 @@ Always use Drush 8 with Drupal 7 and Drupal 6 sites, as Drush 9 only works on Dr
 
 #### PHP Requirements
 
-<table class="table  table-bordered table-responsive">
-    <thead>
-      <tr>
-        <th>Drush Version</th>
-        <th>Minimum PHP Version</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr>
-        <td>Drush 5</td>
-        <td>PHP 5.2.0+</td>
-      </tr>
-      <tr>
-        <td>Drush 7</td>
-        <td>PHP 5.3.0+</td>
-      </tr>
-      <tr>
-        <td>Drush 8</td>
-        <td>PHP 5.4.5+</td>
-      </tr>
-      <tr>
-        <td>Drush 9</td>
-        <td>PHP 5.6.0+</td>
-      </tr>
-    </tbody>
-</table>
+| Drush Version | Minimum PHP Version |
+|:------------- |:------------------- |
+| Drush 5       | PHP 5.2.0+          |
+| Drush 7       | PHP 5.3.0+          |
+| Drush 8       | PHP 5.4.5+          |
+| Drush 9       | PHP 5.6.0+          |
 
-See our guide on [Upgrading PHP Versions](/docs/php-versions/).
+See our guide on [Upgrading PHP Versions](/php-versions/).
 
 ## Troubleshooting
 

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -10,9 +10,11 @@ The Drush version is set when the site is created. Sites created before Nov 4, 2
 
 <Alert title="Note" type="info">
 
-When running Drush locally, we highly recommend running Drush version 8.1.15 or higher.
-
-</Alert>
+<div class="alert alert-info" role="alert">
+<h4 class="info">Note</h4>
+<p markdown="1">
+When running Drush locally, we highly recommend running Drush version 8.3.0 or higher.
+</p></div>
 
 ## Terminus Drush and Local Drush
 [Terminus](/terminus/) makes remote Drush calls on sites without using a local installation, eliminating compatibility issues between local and remote installs. For more information, see our guide on [Managing Drupal Sites with Terminus and Drush](/guides/terminus-drupal-site-management/).
@@ -37,24 +39,47 @@ If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.ym
 </Alert>
 
 ### Available Drush Versions
-Pantheon currently supports Drush 8. While Drush 5 and 7 are available if needed, they are listed as [unsupported](http://docs.drush.org/en/master/install/#drupal-compatibility) by the Drush maintainers, and should be avoided unless absolutely necessary.
+Pantheon currently supports Drush 8 and Drush 9. Drush 9 is the preferred version of Drush to use with Drupal 8 sites. Drush 8 may be desired for sites that are not managed by Composer, or that use modules that provide additional Drush 8 commands.
+
+Always use Drush 8 with Drupal 7 and Drupal 6 sites, as Drush 9 only works on Drupal 8 and later. While Drush 5 and 7 are available on Pantheon if needed, they are listed as [unsupported](http://docs.drush.org/en/master/install/#drupal-compatibility){.external} by the Drush maintainers, and should be avoided unless absolutely necessary.
 
 #### PHP Requirements
 
-| Drush Version | Minimum PHP Version | 
-|:------------- |:------------------- |
-| Drush 5       | PHP 5.2.0+          |
-| Drush 7       | PHP 5.3.0+          |
-| Drush 8       | PHP 5.4.5+          |
+<table class="table  table-bordered table-responsive">
+    <thead>
+      <tr>
+        <th>Drush Version</th>
+        <th>Minimum PHP Version</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr>
+        <td>Drush 5</td>
+        <td>PHP 5.2.0+</td>
+      </tr>
+      <tr>
+        <td>Drush 7</td>
+        <td>PHP 5.3.0+</td>
+      </tr>
+      <tr>
+        <td>Drush 8</td>
+        <td>PHP 5.4.5+</td>
+      </tr>
+      <tr>
+        <td>Drush 9</td>
+        <td>PHP 5.6.0+</td>
+      </tr>
+    </tbody>
+</table>
 
-See our guide on [Upgrading PHP Versions](/php-versions/).
+See our guide on [Upgrading PHP Versions](/docs/php-versions/).
 
 ## Troubleshooting
 
 Sometimes even after updating the drush version in `pantheon.yml`, the correct version of drush is not called. This is usually caused by an outdated configuration file, `policy.drush.inc`, in your local `~/.drush` directory, overriding `pantheon.yml`. Remove the file, or comment out its contents, to resolve.
 
 ### Site-local Drush Usage
-If you need to specify a minor version or a version not available on the platform (such as Drush 9), you can add a site-local installation of Drush to your repository. This will redispatch Pantheon's platform Drush to the site-local installation. Do not select any major version of Drush lower than 8.
+If you need to specify a minor version or a version not available on the platform, you can add a site-local installation of Drush to your repository. This will redispatch Pantheon's platform Drush to the site-local installation. Do not select any major version of Drush lower than 8.2.3 or 9.6.0. In general, you will usually be better off not including a site-local Drush in your Pantheon site, as using the Pantheon-provided Drush will ensure that you are using the recommended and most-tested version for the Pantheon platform. Occasionally, using a site-local Drush may be necessary for avoiding conflicts with your site's dependencies.
 
 For more information, see [Avoiding “Dependency Hell” with Site-Local Drush](https://pantheon.io/blog/avoiding-dependency-hell-site-local-drush).
 

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -39,7 +39,7 @@ If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.ym
 </Alert>
 
 ### Available Drush Versions
-Pantheon currently supports Drush 8 and Drush 9. Drush 9 is the preferred version of Drush to use with Drupal 8 sites. Drush 8 may be desired for sites that are not managed by Composer, or that use modules that provide additional Drush 8 commands.
+Pantheon currently supports Drush 8 and Drush 9. Drush 9 is the preferred version of Drush to use with Drupal 8 sites that are managed by Composer. See [Drupal 8 and Composer on Pantheon Without Continuous Integration](https://pantheon.io/docs/guides/drupal-8-composer-no-ci/) and the [Build Tools Workflow](https://pantheon.io/docs/guides/build-tools/) for information on how to use Composer to manage Drupal sites on Pantheon. Drush 8 should be used for Drupal 8 sites that are not managed by Composer, or that use modules that provide additional Drush 8 commands.
 
 Always use Drush 8 with Drupal 7 and Drupal 6 sites, as Drush 9 only works on Drupal 8 and later. While Drush 5 and 7 are available on Pantheon if needed, they are listed as [unsupported](http://docs.drush.org/en/master/install/#drupal-compatibility){.external} by the Drush maintainers, and should be avoided unless absolutely necessary.
 

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -10,11 +10,9 @@ The Drush version is set when the site is created. Sites created before Nov 4, 2
 
 <Alert title="Note" type="info">
 
-<div class="alert alert-info" role="alert">
-<h4 class="info">Note</h4>
-<p markdown="1">
 When running Drush locally, we highly recommend running Drush version 8.3.0 or higher.
-</p></div>
+
+</Alert>
 
 ## Terminus Drush and Local Drush
 [Terminus](/terminus/) makes remote Drush calls on sites without using a local installation, eliminating compatibility issues between local and remote installs. For more information, see our guide on [Managing Drupal Sites with Terminus and Drush](/guides/terminus-drupal-site-management/).

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -41,6 +41,41 @@ If you add a site to your account, you will have to download a new copy of your 
 <p>You must use Drush 8.3.0 or 9.6.0 or later to use Drush aliases directly. Earlier versions are not compatible.
 </p></div>
 
+### Structure of Site Aliases
+
+The form Pantheon Drush aliases take depends on the version of Drush being used. Drush 8 aliases are all written to a single file, `$HOME/.drush/pantheon.aliases.drushrc.php`. A single alias record looks something like the example below:
+```
+$aliases['example.*'] = array(
+  'uri' => '${env-name}-example.pantheonsite.io',
+  'remote-host' => 'appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in',
+  'remote-user' => '${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1',
+  'ssh-options' => '-p 2222 -o "AddressFamily inet"',
+  'path-aliases' => array(
+    '%files' => 'files',
+    '%drush-script' => 'drush',
+   ),
+);
+```
+
+Drush 9 aliases are written one file per site to the directory `$HOME/.drush/sites/pantheon`. The site name is used to generate the filename, e.g. `example.site.yml`. The contents of a Drush 9 alias file looks something like the following exampe:
+
+```
+'*':
+  host: appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in
+  paths:
+    files: files
+    drush-script: drush9
+  uri: ${env-name}-example.pantheonsite.io
+  user: ${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1
+  ssh:
+    options: '-p 2222 -o "AddressFamily inet"'
+    tty: false
+```
+
+Note that these are both "wildcard" aliases. The same wildcard alias is used for every environment available for a given site. The variable `${env-name}` is replaced with the appropriate environment name when used.
+
+Pantheon also uses "policy files" to validate aliases before they are used. The policy files are written by the `terminus aliases` command; the Drush 8 policy file is written to `$HOME/.drush/pantheon/drush8/pantheon_policy.drush.inc`, and the Drush 9 policy file is written to `$HOME/.drush/pantheon/Commands/PantheonAliasPolicyCommands.php`. These files should not be deleted.
+
 ### List Available Site Aliases
 Once the Pantheon Drush aliases have been copied, verify that the site aliases are available by listing every site alias known to Drush:
 ```

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -20,7 +20,7 @@ You can run all of the commands below from Terminus instead of using Drush alias
 For details on managing remote and local Drush versions, see [Managing Drush Versions on Pantheon](/drush-versions).
 
 ## Download Drush Aliases Locally
-Downloading the Pantheon aliases to your local Drush aliases file allows you to run Drush calls against your Pantheon site environments. Use Terminus to download your Drush aliases.
+Downloading the Pantheon aliases to your local Drush aliases file allows you to run Drush calls against your Pantheon site environments. Use [Terminus](/terminus/) to download your Drush aliases.
 
 Authenticate Terminus with [machine tokens](/docs/machine-tokens/) or your Pantheon Dashboard credentials, then update your local aliases file in a single step:
 
@@ -36,14 +36,16 @@ $ terminus aliases --all
 
 If you add a site to your account, you will have to download a new copy of your Drush aliases. You do not need to update your Drush aliases when you add new mulitdev environments to your sites.
 
-<div class="alert alert-info">
-<h4 class="info">Note</h4>
-<p>You must use Drush 8.3.0 or 9.6.0 or later to use Drush aliases directly. Earlier versions are not compatible.
-</p></div>
+<Alert type="info" title="Note">
+
+You must use Drush 8.3.0 or 9.6.0 or later to use Drush aliases directly. Earlier versions are not compatible.
+
+</Alert>
 
 ### Structure of Site Aliases
 
 The form Pantheon Drush aliases take depends on the version of Drush being used. Drush 8 aliases are all written to a single file, `$HOME/.drush/pantheon.aliases.drushrc.php`. A single alias record looks something like the example below:
+
 ```
 $aliases['example.*'] = array(
   'uri' => '${env-name}-example.pantheonsite.io',
@@ -78,6 +80,7 @@ Pantheon also uses "policy files" to validate aliases before they are used. The 
 
 ### List Available Site Aliases
 Once the Pantheon Drush aliases have been copied, verify that the site aliases are available by listing every site alias known to Drush:
+
 ```
 $ drush sa
 ```

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -24,14 +24,14 @@ Downloading the Pantheon aliases to your local Drush aliases file allows you to 
 
 Authenticate Terminus with [machine tokens](/docs/machine-tokens/) or your Pantheon Dashboard credentials, then update your local aliases file in a single step:
 
-```
-$ terminus aliases
+```bash
+terminus aliases
 ```
 
 This command will write both Drush 8 and Drush 9 aliases into the directory `$HOME/.drush` for your sites that you are a direct member of. To create aliases for all sites that you can use, including sites that you have access to via team membership, run:
 
-```nohighlight
-$ terminus aliases --all
+```bash
+terminus aliases --all
 ```
 
 If you add a site to your account, you will have to download a new copy of your Drush aliases. You do not need to update your Drush aliases when you add new mulitdev environments to your sites.
@@ -46,7 +46,7 @@ You must use Drush 8.3.0 or 9.6.0 or later to use Drush aliases directly. Earlie
 
 The form Pantheon Drush aliases take depends on the version of Drush being used. Drush 8 aliases are all written to a single file, `$HOME/.drush/pantheon.aliases.drushrc.php`. A single alias record looks something like the example below:
 
-```
+```php
 $aliases['example.*'] = array(
   'uri' => '${env-name}-example.pantheonsite.io',
   'remote-host' => 'appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in',
@@ -61,7 +61,7 @@ $aliases['example.*'] = array(
 
 Drush 9 aliases are written one file per site to the directory `$HOME/.drush/sites/pantheon`. The site name is used to generate the filename, e.g. `example.site.yml`. The contents of a Drush 9 alias file looks something like the following exampe:
 
-```
+```yaml
 '*':
   host: appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in
   paths:
@@ -74,6 +74,12 @@ Drush 9 aliases are written one file per site to the directory `$HOME/.drush/sit
     tty: false
 ```
 
+<Alert type="info" title="Note">
+
+You must be a [site team member](/team-management/#manage-site-team-members) of the site for it to be included within your local alias file. Organization administrators will not see all associated sites within their alias file, but only sites for which they are site team members. The alternative is to execute Drush commands via [Terminus](/terminus) for sites in which you are not a direct site team member.
+
+</Alert>
+
 Note that these are both "wildcard" aliases. The same wildcard alias is used for every environment available for a given site. The variable `${env-name}` is replaced with the appropriate environment name when used.
 
 Pantheon also uses "policy files" to validate aliases before they are used. The policy files are written by the `terminus aliases` command; the Drush 8 policy file is written to `$HOME/.drush/pantheon/drush8/pantheon_policy.drush.inc`, and the Drush 9 policy file is written to `$HOME/.drush/pantheon/Commands/PantheonAliasPolicyCommands.php`. These files should not be deleted.
@@ -81,13 +87,13 @@ Pantheon also uses "policy files" to validate aliases before they are used. The 
 ### List Available Site Aliases
 Once the Pantheon Drush aliases have been copied, verify that the site aliases are available by listing every site alias known to Drush:
 
-```
-$ drush sa
+```bash
+drush sa
 ```
 ## Execute a Drush Command on a Pantheon Site Environment
 Once you see the target site in the list of site aliases, you can execute a command on any remote site listed. The syntax is:  
 
-```
+```bash
 drush @pantheon.SITENAME.ENV COMMAND
 ```
 
@@ -99,7 +105,7 @@ drush @pantheon.SITENAME.ENV COMMAND
 
 ### Registry Rebuild
 
-<Alert title="Note"  type="info" >
+<Alert title="Note" type="info" >
 
 [Registry Rebuild ](https://www.drupal.org/project/registry_rebuild) is [deprecated](https://www.drupal.org/project/registry_rebuild/issues/1785672) for Drupal 8 and will only work on Drupal 7.
 
@@ -159,9 +165,9 @@ While we have the full spectrum of Drush core already available for your use, yo
 1. Push your code up to Pantheon.
 1. Clear your Drush cache on each environment. Example:
 
- ```
- drush @pantheon.SITENAME.dev cc drush
- ```
+   ```bash
+   drush @pantheon.SITENAME.dev cc drush
+   ```
 
 For Drupal 9, place Drush commands in `drush/Commands`.
 
@@ -179,6 +185,7 @@ function policy_drush_sitealias_alter(&$alias_record) {
   }
 }
 ```
+
 Replace `SITENAME` with your Pantheon site name, and `example.com` with the correct URI for that site.
 
 
@@ -186,7 +193,7 @@ Replace `SITENAME` with your Pantheon site name, and `example.com` with the corr
 
 ### Reading the Pantheon Environment from Drush
 
-Since Drush does not run via the web server, reliance on the `$_SERVER` superglobal is problematic as some of the contents of that array will be missing, `['PANTHEON_ENVIRONMENT']` in particular. Drush commands and policy files should instead reference `$_ENV` when reading Pantheon environment information. For more information, please see our documentation on [using the `$_SERVER` superglobal in custom code](/read-environment-config/#using-$_server).
+Since Drush does not run via the web server, reliance on the `$_SERVER` superglobal is problematic as some of the contents of that array will be missing, `['PANTHEON_ENVIRONMENT']` in particular. Drush commands and policy files should instead reference `$_ENV` when reading Pantheon environment information. For more information, please see our documentation on [using the `$_SERVER` superglobal in custom code](/read-environment-config/#using-_server).
 
 ### Terminus Drush Silent Failure
 The following silent failure occurs when executing `terminus drush` commands on environments that use redirect logic without checking to see if Drupal is running via the command line:
@@ -218,8 +225,8 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) &&
 
 Some Drush 5 commands need to be executed from outside the context of a local Drupal installation, due to a [known issue with Drush 5](https://github.com/drush-ops/drush/issues/313). The output from a Drush 5 command run in this context looks like the following:
 
-```
-$ drush @pantheon.SITENAME.ENV status
+```bash
+drush @pantheon.SITENAME.ENV status
  PHP configuration : /srv/bindings/754cbef0a7b54a07ab07167ef8de7377/php53.in
                         i
                         /srv/bindings/754cbef0a7b54a07ab07167ef8de7377/php53.in
@@ -231,19 +238,19 @@ $ drush @pantheon.SITENAME.ENV status
 
 To make your Drush 5 commands work on Pantheon aliases, change your directory to a context outside of a working local Drupal installation:
 
-```
-$ pwd
+```bash
+pwd
 /Users/USERNAME/Sites/SITENAME
 
 
-$ cd ..
+cd ..
 
 
-$ pwd
+pwd
 /Users/USERNAME/Sites/
 
 
-$ drush @pantheon.SITENAME.ENV status
+drush @pantheon.SITENAME.ENV status
  Drupal version : 7.26
  Site URI : ENV-SITENAME.pantheonsite.io
  Database driver : mysql
@@ -273,14 +280,16 @@ $ drush @pantheon.SITENAME.ENV status
 
 ### Drush Error: "Unknown option: --db-url"
 
-```
-$ drush @pantheon.SITENAME.ENV cc all
+```bash
+drush @pantheon.SITENAME.ENV cc all
 Unknown option: --db-url. See `drush help cache-clear` for available [error]
 options. To suppress this error, add the option --strict=0.
 ```
+
 To resolve this error, follow the suggestion and add the option `--strict=0`:
-```
-$ drush @pantheon.SITENAME.ENV cc all --strict=0
+
+```bash
+drush @pantheon.SITENAME.ENV cc all --strict=0
 'all' cache was cleared in [success]
 /srv/bindings/BINDINGID/code#ENV-SITENAME.pantheonsite.io
 ```
@@ -313,8 +322,8 @@ terminus env:wake SITENAME.ENV
 
 Some ISPs have issues resolving a drush.in hostname; if you're having trouble connecting to a drush.in hostname, you can use the `dig` command to investigate further.
 
-```
-$ dig appserver.live.38f2bd91-0000-46cb-9278-0000000000000.drush.in
+```bash
+dig appserver.live.38f2bd91-0000-46cb-9278-0000000000000.drush.in
 ;; Truncated, retrying in TCP mode.
 
 
@@ -337,8 +346,8 @@ $ dig appserver.live.38f2bd91-0000-46cb-9278-0000000000000.drush.in
 
 As you can see in the output above, the status REFUSED suggests improper resolution. The next step is to run `dig` with a specified DNS server. We recommend using Google's DNS (8.8.8.8):
 
-```
-$ dig @8.8.8.8 appserver.live.38f2bd91-0000-46cb-9278-0000000000000.drush.in
+```bash
+dig @8.8.8.8 appserver.live.38f2bd91-0000-46cb-9278-0000000000000.drush.in
 ;; Truncated, retrying in TCP mode.
 
 
@@ -397,7 +406,7 @@ This indicates that the vendor directory contains Drush binaries that should be 
  ```
  To resolve this error, conditionally set `$uri` based on the environment in `drushrc.php`, such as:
 
- ```
+ ```php
    if (isset($_ENV['PANTHEON_ENVIRONMENT']) &&
      ($_ENV['PANTHEON_ENVIRONMENT'] === 'live')) {
        $uri = 'https://www.example.com';

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -20,44 +20,32 @@ You can run all of the commands below from Terminus instead of using Drush alias
 For details on managing remote and local Drush versions, see [Managing Drush Versions on Pantheon](/drush-versions).
 
 ## Download Drush Aliases Locally
-Downloading the Pantheon aliases to your local Drush aliases file allows you to run Drush calls against your Pantheon site environments.
+Downloading the Pantheon aliases to your local Drush aliases file allows you to run Drush calls against your Pantheon site environments. Use Terminus to download your Drush aliases.
 
-There are two ways to obtain the aliases, either with Terminus or through the Dashboard.
-
-### Download with Terminus, the Pantheon CLI
-Authenticate Terminus with [machine tokens](/machine-tokens/) or your Pantheon Dashboard credentials, then update your local aliases file in a single step:
+Authenticate Terminus with [machine tokens](/docs/machine-tokens/) or your Pantheon Dashboard credentials, then update your local aliases file in a single step:
 
 ```
 $ terminus aliases
 ```
 
-### Download Using the Dashboard
+This command will write both Drush 8 and Drush 9 aliases into the directory `$HOME/.drush` for your sites that you are a direct member of. To create aliases for all sites that you can use, including sites that you have access to via team membership, run:
 
-![Link to Pantheon Drush Aliases](../images/dashboard/drush-aliases.png)
+```nohighlight
+$ terminus aliases --all
+```
 
-Download your Pantheon site aliases to manually update your local aliases file:
+If you add a site to your account, you will have to download a new copy of your Drush aliases. You do not need to update your Drush aliases when you add new mulitdev environments to your sites.
 
-1. From your Pantheon User Dashboard, click **Sites** > **Drush Aliases**
-2. Move the generated `pantheon.aliases.drushrc.php` into your local Drush site-aliases directory (e.g. `$HOME/.drush/site-aliases`).
-3. Clear Drush cache:
-
- ```
- drush cc drush
- ```
-
-If you add a site to your account, you will have to download a new copy of your Drush aliases.
+<div class="alert alert-info">
+<h4 class="info">Note</h4>
+<p>You must use Drush 8.3.0 or 9.6.0 or later to use Drush aliases directly. Earlier versions are not compatible.
+</p></div>
 
 ### List Available Site Aliases
 Once the Pantheon Drush aliases have been copied, verify that the site aliases are available by listing every site alias known to Drush:
 ```
 $ drush sa
 ```
-<Alert title="Note" type="info">
-
-You must be a [site team member](/team-management/#manage-site-team-members) of the site for it to be included within your local alias file. Organization administrators will not see all associated sites within their alias file, but only sites for which they are site team members. The alternative is to execute Drush commands via [Terminus](/terminus) for sites in which you are not a direct site team member.
-
-</Alert>
-
 ## Execute a Drush Command on a Pantheon Site Environment
 Once you see the target site in the list of site aliases, you can execute a command on any remote site listed. The syntax is:  
 
@@ -87,6 +75,8 @@ Drupal's list of PHP classes and files can get corrupted or out-of-date, typical
 terminus drush <site>.<env> -- rr
 ```
 
+Note that the Registry Rebuild command is only ever necessary on Drupal 7 and Drupal 6 sites. The command `drush cache:rebuild` for Drupal 8 serves the same function that `registry rebuild` does for older versions of Drupal.
+
 ## Run SQL Queries Using Drush on Pantheon
 
 The `drush sql-cli` and `drush sql-connect` commands are not supported on Pantheon. For security reasons, the SQL database is not directly accessible from your local machine.
@@ -94,7 +84,7 @@ The `drush sql-cli` and `drush sql-connect` commands are not supported on Panthe
 You can, however, use Terminus as follows:
 
 ```bash
-terminus drush SITENAME.ENV -- sql-query "SELECT * FROM users WHERE uid=1"
+echo 'SELECT * FROM users WHERE uid=1;' | terminus drush SITENAME.ENV sql:cli
 ```
 
 Note that certain characters such as `;` cannot be used in the query. If you use an illegal character, you will get an error message "Command not supported as typed."
@@ -125,7 +115,7 @@ While we have the full spectrum of Drush core already available for your use, yo
 
 1. Put the site in Git mode.
 1. Clone locally.
-1. Create a Drush folder in the Drupal root.
+1. Create a `drush` folder in the Drupal root.
 1. Add the “sar” Drush command to the Drush folder.
 1. Commit drush/sar.
 1. Push your code up to Pantheon.
@@ -134,6 +124,9 @@ While we have the full spectrum of Drush core already available for your use, yo
  ```
  drush @pantheon.SITENAME.dev cc drush
  ```
+
+For Drupal 9, place Drush commands in `drush/Commands`.
+
 
 ## Drush Alias Strict Control
 Create a file called `policy.drush.inc`, and place in in the `.drush` folder of your home directory.  You can create a new file or use the example policy file in Drush’s `examples` folder to get started.
@@ -165,7 +158,7 @@ The following silent failure occurs when executing `terminus drush` commands on 
 [error]
 ```
 
-Redirects kill the PHP process before Drush is executed. You can resolve this error by adding `php_sapi_name() != "cli"` as a conditional statement to all redirect logic within `settings.php`:
+Redirects kill the PHP process before Drush execution is complete. You can resolve this error by adding `php_sapi_name() != "cli"` as a conditional statement to all redirect logic within `settings.php`:
 
 ```php
 // Require HTTPS, www.

--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -292,3 +292,4 @@ Here are some suggestions on where to go from here:
  - [Use the Pantheon Workflow](/pantheon-workflow/)
  - [Configuration Workflow for Drupal 8 Sites](/drupal-8-configuration-management/)
  - [The Terminus Manual](/terminus/)
+ - [Drupal Drush Command-Line Utility](/drush/)


### PR DESCRIPTION
Closes #n/a

## Effect
PR includes the following changes:
- Update documentation for release of Drush 9

## Remaining Work
- [x] Explain Drush 9 aliases vs Drush 8 aliases 
- [x] Why to use Drush 9
- [x] Considerations when using Drush 9
- [x] Blocked on [Download Drush aliases via Terminus core](https://getpantheon.atlassian.net/browse/CORE-1274)
- [x] Technical review
- [x] Copy Review
- [ ] Review from @ari-gold 

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
