### PR TITLE
fix: file edit path

### DIFF
--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -2,7 +2,6 @@ import React from "react"
 import './style.css';
 
 const Github = ({ pageTitle, path }) => {
-  const repoPath = path.replace("docs/", "_docs/").replace(".md", "")
   return (
     <div className="dropdown">
       <button
@@ -19,7 +18,7 @@ const Github = ({ pageTitle, path }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/source/${repoPath}.md`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/source/_docs/${path}.md`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -18,7 +18,7 @@ const Github = ({ pageTitle, path }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/source/_docs/${path}.md`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/source/content/${path}.md`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/styles/global.css
+++ b/gatsby/src/styles/global.css
@@ -577,3 +577,13 @@ h2 > .glyphicons {
 		right: 0px;
 	}
 }
+
+/* contributor template style */
+.guest-info__img img {
+	margin: 20px;
+	border-radius: 50% !important;
+	height: auto;
+	border: none !important;
+	width: 200px;
+	padding: unset !important;
+}


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix file edit path
- add style for contributor page template

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
