### PR TITLE
Add -all option to upstream:list

### DIFF
--- a/source/content/start-state.md
+++ b/source/content/start-state.md
@@ -41,7 +41,7 @@ Use the following direct links to create a new site on Pantheon from a public di
 There is a UUID for all the different systems you can install on Pantheon. WordPress on Pantheon is `e8fe8550-1ab9-4964-8838-2b9abdccf4bf`. To see all available products, run the following [Terminus](/terminus/) command:
 
 ```
-$ terminus upstream:list
+$ terminus upstream:list --all
 ```
 
 ## Create Sites with Terminus


### PR DESCRIPTION
Gets the unfiltered list of all available products.

Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
