### PR TITLE
clarify downgrades + duplicate note re contact agency for preferred

### DIFF
--- a/source/content/add-client-site.md
+++ b/source/content/add-client-site.md
@@ -18,8 +18,8 @@ While many of these steps are followed through the normal course of an Agency-Cl
 
 <Partial file="transfer-ownership-billing-steps.md" />
 
-## Send an Invitation to Pay to Your Client
-The Agency should follow these steps:
+## Send an Invitation to Pay to Share Preferred Pricing
+In order to share Preferred Pricing with a new client or to maintain Preferred Pricing through a plan change, the Agency should follow these steps:
 
 <Partial file="invite-to-pay.md" />
 

--- a/source/content/site-plan.md
+++ b/source/content/site-plan.md
@@ -25,8 +25,12 @@ Changing your site plan is typically done at launch time. For a comprehensive st
 ## Upgrades
 Site plan upgrades will change your site's resources and access to features immediately. The associated card will be charged a prorated amount for the remainder of the current billing period.
 
+If your site benefits from [Preferred Pricing](https://pantheon.io/plans/agency-preferred-pricing), contact your Supporting Organization for assistance, in order to retain your special pricing rate.
+
 ## Downgrades
-Site plan downgrades will change your site's resources and access to features immediately. Beginning on the next billing cycle, the associated card will be charged for the new site plan.
+Site plan downgrades will change your site's resources and access to features immediately. Beginning on the next billing cycle, the associated card will be charged for the new site plan. No prorated refunds or credits will be issues for site downgrades.
+
+If your site benefits from [Preferred Pricing](https://pantheon.io/plans/agency-preferred-pricing), contact your Supporting Organization for assistance, in order to retain your special pricing rate.
 
 ## Roles & Permissions
 The permission to manage a site's plan is granted only to the roles of **Site Owner** / **Organization Administrator**. Other roles do not have access to change the site plan as described on this page. For details, see [Role-Based Permissions & Change Management](/change-management/#site-level-roles-and-permissions).


### PR DESCRIPTION
## Effect
PR includes the following changes:
- clarifies that downgraded plans are effective immediately
- copies the note from up top about contacting the supporting org to maintain preferred
- change to `add-client-site` for better search results when looking for how to share or maintain preferred

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
