### PR TITLE
Put notes that committed files are the ones only archived in Frozen s…

### DIFF
--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -20,7 +20,7 @@ Localdev is in active development, with new features and updates coming soon.
 
 If you have an older version of Localdev already installed on your machine, remove it to avoid potential compatibility issues. Newer versions of Localdev include support for automatic updates.
 
-1.  Download and install the [Pantheon Localdev](https://pantheon.io/localdev) `.dmg`
+1.  Download and install [Pantheon Localdev](https://pantheon.io/localdev) `.dmg`
 1.  Localdev checks the Docker installation. Once it's done, click **Continue installation**
 1.  Enter the machine token you created for Localdev.
     - Click **View your Pantheon machine tokens** to open a browser to the *Machine Tokens* tab of your account.

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -230,7 +230,7 @@ See [Modules and Plugins with Known Issues](/modules-plugins-known-issues) for a
 
 Sandbox sites that are over four months old that have not had code commits or other Git activity for three months are "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's Dashboard will be unavailable.
 
-You can easily reactivate a site by visiting your Pantheon User Dashboard, select the frozen site there, then click **Unfreeze site**. Within a few minutes, the site will be ready for development again. If you experience any issues, a backup of the site is available and can be restored via the Site Dashboard.
+You can easily reactivate a site by visiting your Pantheon User Dashboard, select the frozen site there, then click **Unfreeze site**. Within a few minutes, the site will be ready for development again. If you experience any issues, a backup of the site is available and can be restored via the Site Dashboard. Please note that committed files are only archived and cannot be retrieved after unfreezing.
 
 ## Emoji Support
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -230,7 +230,7 @@ See [Modules and Plugins with Known Issues](/modules-plugins-known-issues) for a
 
 Sandbox sites that are over four months old that have not had code commits or other Git activity for three months are "frozen". All requests to a frozen site will return a `530 Site Frozen` error code, and the site's Dashboard will be unavailable.
 
-You can easily reactivate a site by visiting your Pantheon User Dashboard, select the frozen site there, then click **Unfreeze site**. Within a few minutes, the site will be ready for development again. If you experience any issues, a backup of the site is available and can be restored via the Site Dashboard. Please note that committed files are only archived and cannot be retrieved after unfreezing.
+You can easily reactivate a site by visiting your Pantheon User Dashboard, select the frozen site there, then click **Unfreeze site**. Within a few minutes, the site will be ready for development again. If you experience any issues, a backup of the site is available and can be restored via the Site Dashboard. Please note that only files that have been committed will be available after unfreezing.
 
 ## Emoji Support
 


### PR DESCRIPTION
Closes #4931

## Effect
PR includes the following changes:
- Put notes that committed files are the ones only archived in Frozen sites

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
