### PR TITLE
Update composer-convert.md

### DIFF
--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -236,9 +236,9 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
      Git Host   codeserver.dev.1887c5fa-...-8fe90727d85b.drush.in
     ```
 
-    Copy the URL.
+2.  Copy the URL.
 
-2.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
+3.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
     ```
     ssh -vT codeserver.dev.<SITE_UUID>.drush.in
     ```

--- a/source/_docs/guides/composer-convert.md
+++ b/source/_docs/guides/composer-convert.md
@@ -94,7 +94,7 @@ A Composer managed site should be able to include all custom code via Composer. 
 composer require drupal/module_name
 ```
 
-Where `module_name` is the machine name of the module in question.
+Where `module_name` is the machine name of the module in question. To specify a version of the module, view the syntax examples in the [Drupal.org Guide to Using Composer](https://www.drupal.org/docs/develop/using-composer/using-composer-to-install-drupal-and-manage-dependencies#specify-version){.external}.
 
 #### Themes
 Repeat the same process with themes, checking `/themes`, `/themes/contrib`, `/sites/all/themes`, and `/sites/all/themes/contrib`. Use Composer in the same way as above to require these.

--- a/source/_docs/localdev.md
+++ b/source/_docs/localdev.md
@@ -20,7 +20,7 @@ Localdev is in active development, with new features and updates coming soon.
 
 If you have an older version of Localdev already installed on your machine, remove it to avoid potential compatibility issues. Newer versions of Localdev include support for automatic updates.
 
-1.  Download and install the [latest Localdev](http://pantheon-localdev.s3.amazonaws.com/localdev-latest-dev.dmg){.external} `.dmg`
+1.  Download and install the [latest Localdev](https://pantheon-localdev.s3.amazonaws.com/localdev-stable.dmg){.external} `.dmg`
 1.  Localdev checks the Docker installation. Once it's done, click **Continue installation**
 1.  Enter the machine token you created for Localdev.
     - Click **View your Pantheon machine tokens** to open a browser to the *Machine Tokens* tab of your account.


### PR DESCRIPTION
Add link to Drupal.org Using Composer Guide for module version syntax examples.

Closes #

## Effect
PR includes the following changes:
- Adds link to Drupal.org Using Composer Guide for module version syntax examples.
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
