### PR TITLE
Adding the New Relic API terminus plugin for more accessible datapoints.

### DIFF
--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -344,3 +344,9 @@ contributors:
     github: //github.com/carl-alberto
     bio: Pantheon Customer Success Engineer
     avatar: //avatars.githubusercontent.com/u/5098765
+   bhasselbeck:
+    name: Brian Hasselbeck
+    avatar: http://url.to.a.valid/avatar.jpeg
+    github: http://github.com/bhasselbeck
+    linkedin: https://www.linkedin.com/in/brianhasselbeck/
+    drupal: https://www.drupal.org/u/inertialacoustic

--- a/app/config/sculpin_site.yml
+++ b/app/config/sculpin_site.yml
@@ -346,7 +346,6 @@ contributors:
     avatar: //avatars.githubusercontent.com/u/5098765
    bhasselbeck:
     name: Brian Hasselbeck
-    avatar: http://url.to.a.valid/avatar.jpeg
     github: http://github.com/bhasselbeck
     linkedin: https://www.linkedin.com/in/brianhasselbeck/
     drupal: https://www.drupal.org/u/inertialacoustic

--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -236,9 +236,9 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
      Git Host   codeserver.dev.1887c5fa-...-8fe90727d85b.drush.in
     ```
 
-    Copy the URL.
+2.  Copy the URL.
 
-2.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
+3.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
     ```
     ssh -vT codeserver.dev.<SITE_UUID>.drush.in
     ```

--- a/source/_docs/localdev.md
+++ b/source/_docs/localdev.md
@@ -20,7 +20,7 @@ Localdev is in active development, with new features and updates coming soon.
 
 If you have an older version of Localdev already installed on your machine, remove it to avoid potential compatibility issues. Newer versions of Localdev include support for automatic updates.
 
-1.  Download and install the [latest Localdev](http://pantheon-localdev.s3.amazonaws.com/localdev-latest-dev.dmg){.external} `.dmg`
+1.  Download and install the [latest Localdev](https://pantheon-localdev.s3.amazonaws.com/localdev-stable.dmg){.external} `.dmg`
 1.  Localdev checks the Docker installation. Once it's done, click **Continue installation**
 1.  Enter the machine token you created for Localdev.
     - Click **View your Pantheon machine tokens** to open a browser to the *Machine Tokens* tab of your account.

--- a/source/_docs/terminus/plugins/directory.md
+++ b/source/_docs/terminus/plugins/directory.md
@@ -99,6 +99,20 @@ The following plugins are just a few of the most popular available for Terminus 
   <div class="flex-panel-item">
     <div class="flex-panel-body">
       <div class="flex-panel-title">
+        <h3 class="plugin-title">New Relic API</h3>
+        <div class="pantheon-official">
+        <img alt="Official Pantheon Plugin" src="/source/docs/assets/images/official-plugin.svg" class="main-topic-info__plugin-image" >
+          <p class="pantheon-official">Pantheon Official</p>
+        </div>
+      </div>
+      <p class="topic-info__description">Author: <a href="https://github.com/bhasselbeck">Brian Hasselbeck</a></p>
+      <p class="topic-info__description">Fetches New Relic REST API (v2) datapoints; apdex, recent deployments, key transations, error rates, memory usage, response times, etc.</p>
+      <a href="https://github.com/pantheon-systems/terminus-newrelic-api" class="btn-primary btn get-plugin">Get Plugin</a>
+    </div>
+  </div>
+  <div class="flex-panel-item">
+    <div class="flex-panel-body">
+      <div class="flex-panel-title">
         <h3 class="plugin-title">Pancakes</h3>
       </div>
       <p class="topic-info__description">Author: <a href="https://github.com/derimagia">Dave Wikoff</a></p>


### PR DESCRIPTION
This pull request serves as an ask to the docs team to open source and allow for the CSM powered New Relic API plugin to be added to our overall documentation.

## Effect
PR includes the following changes:
- Adds the New Relic API plugin to the terminus plugin listings.
- Adds bhasselbeck as a contributor

## Remaining Work
- The New Relic API plugin will need to be open sources as it's currently private right now.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
