### PR TITLE
Added Wild Card redirect

### DIFF
--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -236,9 +236,9 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
      Git Host   codeserver.dev.1887c5fa-...-8fe90727d85b.drush.in
     ```
 
-    Copy the URL.
+2.  Copy the URL.
 
-2.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
+3.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
     ```
     ssh -vT codeserver.dev.<SITE_UUID>.drush.in
     ```

--- a/source/_docs/localdev.md
+++ b/source/_docs/localdev.md
@@ -20,7 +20,7 @@ Localdev is in active development, with new features and updates coming soon.
 
 If you have an older version of Localdev already installed on your machine, remove it to avoid potential compatibility issues. Newer versions of Localdev include support for automatic updates.
 
-1.  Download and install the [latest Localdev](http://pantheon-localdev.s3.amazonaws.com/localdev-latest-dev.dmg){.external} `.dmg`
+1.  Download and install the [latest Localdev](https://pantheon-localdev.s3.amazonaws.com/localdev-stable.dmg){.external} `.dmg`
 1.  Localdev checks the Docker installation. Once it's done, click **Continue installation**
 1.  Enter the machine token you created for Localdev.
     - Click **View your Pantheon machine tokens** to open a browser to the *Machine Tokens* tab of your account.

--- a/source/_docs/redirects.md
+++ b/source/_docs/redirects.md
@@ -169,6 +169,23 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && ($_ENV['PANTHEON_ENVIRONMENT'] === '
 }
 ```
 
+### Wild Card Redirect ###
+The following will redirect all links back to the homepage.
+
+```
+if (($_SERVER['REQUEST_URI'] != '/') && (php_sapi_name() != "cli")) {
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST']);
+
+  // Name transaction "redirect" in New Relic for improved reporting (optional).
+  if (extension_loaded('newrelic')) {
+    newrelic_name_transaction("redirect");
+  }
+
+  exit();
+}
+```
+
 ### Redirect Legacy UNIX-Style User Home Folder Paths
 When transitioning from a system that used a tilde to indicate a home directory, the syntax is slightly different. Here's how you can parse out the username and relative path that the request was made for:
 


### PR DESCRIPTION
WordPress WildCard Redirect will catch all /links and redirect to /.

CC @carl-alberto

## Effect
PR includes the following changes:
- Adds solution to wildcard redirect request in a way that is not Out of Scope

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
