### PR TITLE
fix improper plural in WP Solr doc

### DIFF
--- a/source/_docs/git-faq.md
+++ b/source/_docs/git-faq.md
@@ -236,9 +236,9 @@ This occurs when you have multiple SSH keys. For more information, see [Permissi
      Git Host   codeserver.dev.1887c5fa-...-8fe90727d85b.drush.in
     ```
 
-    Copy the URL.
+2.  Copy the URL.
 
-2.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
+3.  Find out which SSH keys your Git client is using with the following command, replacing `codeserver.dev.<SITE_UUID>.drush.in` with the URL copied in step 2:
     ```
     ssh -vT codeserver.dev.<SITE_UUID>.drush.in
     ```

--- a/source/_docs/localdev.md
+++ b/source/_docs/localdev.md
@@ -20,7 +20,7 @@ Localdev is in active development, with new features and updates coming soon.
 
 If you have an older version of Localdev already installed on your machine, remove it to avoid potential compatibility issues. Newer versions of Localdev include support for automatic updates.
 
-1.  Download and install the [latest Localdev](http://pantheon-localdev.s3.amazonaws.com/localdev-latest-dev.dmg){.external} `.dmg`
+1.  Download and install the [latest Localdev](https://pantheon-localdev.s3.amazonaws.com/localdev-stable.dmg){.external} `.dmg`
 1.  Localdev checks the Docker installation. Once it's done, click **Continue installation**
 1.  Enter the machine token you created for Localdev.
     - Click **View your Pantheon machine tokens** to open a browser to the *Machine Tokens* tab of your account.

--- a/source/_docs/wordpress-solr.md
+++ b/source/_docs/wordpress-solr.md
@@ -18,7 +18,7 @@ First, you will need to add the Index Server to your site. From your Dashboard, 
 
 Pantheon supports and maintains [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/){.external}.  This plugin replaces the [default search mechanism](https://codex.wordpress.org/Class_Reference/WP_Query#Search_Parameter){.external} within WordPress while preserving the familiar integration methods within themes and widgets.
 
-This plugins requires PHP version 7.1 or higher. See [Upgrade PHP versions](/docs/php-versions/) for more information on switching PHP versions.
+This plugin requires PHP version 7.1 or higher. See [Upgrade PHP versions](/docs/php-versions/) for more information on switching PHP versions.
 
 
 ## Install and Configure Plugin


### PR DESCRIPTION
## Effect
PR includes the following changes:
- "plugins" -> "plugin"

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
