### PR TITLE
fix broken contributor images

### DIFF
--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -18,7 +18,7 @@
   bio: Technical Manager, Training and Certification @zend
 - id: ari
   name: Ari Gold
-  avatar: //secure.gravatar.com/avatar/cde9ea6c0c1cd26527feaa8b4291a85d.jpg  
+  avatar: //secure.gravatar.com/avatar/cde9ea6c0c1cd26527feaa8b4291a85d.jpg
   twitter: http://twitter.com/AriAtPantheon
   github: //github.com/ari-gold
   drupal: //www.drupal.org/user/329006/
@@ -199,7 +199,7 @@
   twitter: davidneedham
   drupal: //www.drupal.org/u/davidneedham
   gplus: //plus.google.com/u/0/+DavidNeedham
-  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/David_Needham540x540.png
+  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/David%20Needham.png
 - id: dwayne
   name: Dwayne McDaniel
   url: //www.mcdwayne.com
@@ -224,7 +224,7 @@
   drupal: https://www.drupal.org/u/tessak22
   url: http://tessakriesel.com/
   github: https://github.com/tessak22
-  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/JMP_9650-800x800.jpg
+  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/1Headshot_IMG_4173.JPG
   linkedin: http://linkedin.com/in/tessak22
 - id: eabquina
   name: Eladio Abquina

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -250,7 +250,7 @@
   name: Drew Gorton
   twitter: dgorton
   bio: Director of Developer Relations
-  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/d0d17cbd-a445-4a69-bdc7-62b39bb90069.jpeg
+  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Drew.jpg
   github: //github.com/dgorton
 - id: dts
   name: David Strauss

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -270,7 +270,7 @@
   name: Dustin LeBlanc
   twitter: DustinLeblanc
   bio: Customer Success Engineer
-  avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Dustin%20LeBlanc.jpg
+  avatar: //drupal.org/files/styles/grid-2/public/user-pictures/picture-1731762-1472589456.png
   github: //github.com/dustinleblanc
   linkedin: https://www.linkedin.com/in/dustinleblanc
   url: https://dustinleblanc.com/


### PR DESCRIPTION
Closes #4959 

## Effect
PR includes the following changes:
- update paths to contributor images

## Remaining Work
- [ ] Gatsby seems to not like some image links, and I haven't found which yet - going directly to the image works, (with Jessi's, specifically, I think Alex's suffers the same)

## Post Launch
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
