### PR TITLE
Add missing cache-busting cookie pattern

### DIFF
--- a/source/partials/cache-busting.md
+++ b/source/partials/cache-busting.md
@@ -6,6 +6,7 @@ S+ESS[a-z0-9]+
 fbs[a-z0-9_]+
 SimpleSAML[A-Za-z]+
 PHPSESSID
+Drupal[a-zA-Z0-9_\.-]+
 wordpress[A-Za-z0-9_]*
 wp-[A-Za-z0-9_]+
 comment_author_[a-z0-9_]+


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds `Drupal[a-zA-Z0-9_\.-]+` to cache-busting cookie.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
