### PR TITLE
fix: missing page title on landing pages

### DIFF
--- a/gatsby/src/templates/landing.js
+++ b/gatsby/src/templates/landing.js
@@ -8,6 +8,7 @@ import SubTopicGroup from '../layout/subtopic-group';
 import YoutubeVideo from '../layout/youtube-video';
 import GuideItem from '../layout/guide-item';
 import IntegrationGuideItem from '../layout/integration-guide-item';
+import SEO from "../layout/seo"
 
 class LandingTemplate extends Component {
 	render() {
@@ -15,6 +16,11 @@ class LandingTemplate extends Component {
 		const topic = landingsYaml;
 		return !topic ? null : (
 			<Layout>
+				<SEO
+					title={topic.title}
+					description={topic.title}
+					image={"/assets/images/default-thumb-doc.png"}
+				/>
 				<div style={{ marginTop: '-20px' }} className="container">
 					<div className="row doc-content-well">
 						<div className="row">


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: missing page title on landing pages

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
