### PR TITLE
fix: css style for responsive images

### DIFF
--- a/gatsby/src/styles/global.css
+++ b/gatsby/src/styles/global.css
@@ -413,12 +413,23 @@ h2 > .glyphicons {
 	margin-bottom: 50px;
 }
 
-#doc img,
 .changelog-wrapper img {
 	border: 1px solid #ddd;
 	border-radius: 4px;
 	padding: 10px;
 }
+
+#doc .gatsby-resp-image-wrapper {
+	border: 1px solid #ddd;
+	padding: 5px;
+}
+
+#doc img {
+    border: none;
+    border-radius: 4px;
+    padding: 0px;
+}
+
 /*  */
 .algolia-autocomplete.algolia-autocomplete-right .ds-dropdown-menu {
 	right: auto !important;


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: css style for responsive images
- Apply a border to image wrapper and remove the padding on `img`  element.

![image](https://user-images.githubusercontent.com/366275/62676060-51af0600-b95e-11e9-850b-d72bf66a537d.png)


## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
