### PR TITLE
remove superflous dashes from Terminus command examples

### DIFF
--- a/source/content/clamav.md
+++ b/source/content/clamav.md
@@ -37,8 +37,8 @@ This doc uses the [ClamAV Module for Drupal 7 & 8](https://www.drupal.org/projec
 1. Download and enable the module in the Drupal admin panel, or via [Terminus](/terminus/):
 
    ```bash
-   terminus drush $site.$env -- dl clamav
-   terminus drush $site.$env -- en clamav -y
+   terminus drush $site.$env dl clamav
+   terminus drush $site.$env en clamav -y
    ```
 
 2. From the module's configuration page, ensure that the scan method is set to to daemon mode, with the hostname `localhost` and the port number `3310`:

--- a/source/content/cms-admin.md
+++ b/source/content/cms-admin.md
@@ -29,8 +29,8 @@ Operations that require write access to the codebase must be executed while the 
 
  - Activating a new theme in the site admin,
  - Uploading a new module or plugin using an SFTP client,
- - Remote Drush commands, like `terminus remote:drush $site.$env -- pm-enable hsts --yes` <Popover content="Run Drush commands with <a href='/docs/terminus/'>Terminus</a>. For details, see <a href='/docs/drush/'>Drupal Drush Command-Line Utility</a>." />
- - Remote WP-CLI commands, like `terminus remote:wp $site.$env -- plugin install lh-hsts --activate` <Popover content="Run WP-CLI commands with <a href='/docs/terminus/'>Terminus</a>. For details, see <a href='/docs/wp-cli/'>Using WP-CLI On The Pantheon Platform</a>." />
+ - Remote Drush commands, like `terminus remote:drush $site.$env pm-enable hsts --yes` <Popover content="Run Drush commands with <a href='/docs/terminus/'>Terminus</a>. For details, see <a href='/docs/drush/'>Drupal Drush Command-Line Utility</a>." />
+ - Remote WP-CLI commands, like `terminus remote:wp $site.$env plugin install lh-hsts --activate` <Popover content="Run WP-CLI commands with <a href='/docs/terminus/'>Terminus</a>. For details, see <a href='/docs/wp-cli/'>Using WP-CLI On The Pantheon Platform</a>." />
 
 ## WordPress Dashboard
 WordPress' admin interface has built in tools to manage plugins and themes, allowing you to install and manage popular themes and plugins from the main WordPress.org repository.
@@ -144,7 +144,7 @@ In order to run WP-CLI or Drush commands on Pantheon's development environments,
 SFTP mode supports [Drush](https://github.com/drush-ops/drush/), the command-line interface for Drupal. For example, you can download multiple contrib modules and a theme to the Dev environment:
 
 ```
-$ terminus drush $site.$env -- dl pathauto devel admin_menu zen search_api search_api_solr
+$ terminus drush $site.$env dl pathauto devel admin_menu zen search_api search_api_solr
 Running drush dl pathauto devel admin_menu zen search_api search_api_solr on community-plumbing-20-dev
 Project pathauto (7.x-1.2) downloaded to [success]
 /srv/bindings/.../code/sites/all/modules/pathauto.
@@ -171,7 +171,7 @@ terminus env:commit $site.$env --message="Download pathauto devel admin_menu zen
 ### Install WordPress Plugins with WP-CLI
 SFTP mode supports [WP-CLI](https://make.wordpress.org/cli/handbook/), the official command line tool for interfacing with WordPress sites. For example, you can install multiple plugins on the Dev environment:
 ```
-$ terminus remote:wp bensons-big-demo.dev -- plugin install akismet wordpress-seo jetpack google-sitemap-generator
+$ terminus remote:wp bensons-big-demo.dev plugin install akismet wordpress-seo jetpack google-sitemap-generator
 Running wp plugin install akismet wordpress-seo jetpack google-sitemap-generator on bensons-big-demo-dev
 dev.f8277b1a-ed45-4390-a257-8d@appserver.dev.f8277b1a-ed45-4390-a257-8dda0b50ff21.drush.in's password:
 Installing Akismet (3.0.0)

--- a/source/content/continuous-integration.md
+++ b/source/content/continuous-integration.md
@@ -38,7 +38,7 @@ To run tests on Pantheon:
 1. Enable `site_test`:
 
    ```bash
-   terminus drush $SITE_NAME.$ENV_NAME -- en site_test -y
+   terminus drush $SITE_NAME.$ENV_NAME en site_test -y
    ```
 
   This command will also enable `simpletest` as a dependency of `site_test`.
@@ -46,7 +46,7 @@ To run tests on Pantheon:
 1. Clear the cache immediately before running tests to avoid strange failures:
 
    ```bash
-   terminus drush $SITE_NAME.$ENV_NAME -- cc all
+   terminus drush $SITE_NAME.$ENV_NAME cc all
    ```
 
   This step should be repeated each time tests are to be run moving forward.
@@ -54,7 +54,7 @@ To run tests on Pantheon:
 1. Get the absolute path before you can run the script:
 
    ```bash
-   terminus drush $SITE_NAME.$ENV_NAME -- eval "echo DRUPAL_ROOT"
+   terminus drush $SITE_NAME.$ENV_NAME eval "echo DRUPAL_ROOT"
    ```
 
   In the command above, you may need to strip out warnings by ending the command with `2>/dev/null`.
@@ -63,7 +63,7 @@ The full command will look something like this:
 
 ```bash
 export TERMINUS_HIDE_UPDATE_MESSAGE=1
-terminus drush $SITE_NAME.$ENV_NAME -- exec php `terminus drush $SITE_NAME.$ENV_NAME -- eval "echo DRUPAL_ROOT" 2>/dev/null`/scripts/run-tests.sh --url http://$ENV_NAME-$SITE_NAME.pantheonsite.io OptionalTestGroup
+terminus drush $SITE_NAME.$ENV_NAME exec php `terminus drush $SITE_NAME.$ENV_NAME eval "echo DRUPAL_ROOT" 2>/dev/null`/scripts/run-tests.sh --url http://$ENV_NAME-$SITE_NAME.pantheonsite.io OptionalTestGroup
 ```
 
 In the above command the `--url` option is required to be passed as multidevs do not respond to `localhost`.
@@ -77,16 +77,16 @@ A full CircleCI command might look similar to this:
             if [ "${CIRCLE_BRANCH}" != "master" ]; then
 
               export TERMINUS_HIDE_UPDATE_MESSAGE=1
-              terminus drush $SITE_NAME.$ENV_NAME -- en site_test -y
+              terminus drush $SITE_NAME.$ENV_NAME en site_test -y
 
               # If you don't clear the cache immediately before running tests
               # we get the html gibberish instead of a passing test.
-              terminus drush $SITE_NAME.$ENV_NAME -- cc all
+              terminus drush $SITE_NAME.$ENV_NAME cc all
 
               # NOTE: Use the latest version of Terminus to avoid warning messages in the output, which will break the test.
               # in order to exclude the notice in shell output of the
               # embedded command to find the absolute path.
-              terminus drush $SITE_NAME.$ENV_NAME -- exec php `terminus drush $SITE_NAME.$ENV_NAME -- eval "echo DRUPAL_ROOT" 2>/dev/null`/scripts/run-tests.sh --url http://$ENV_NAME-$SITE_NAME.pantheonsite.io OptionalTestGroup
+              terminus drush $SITE_NAME.$ENV_NAME exec php `terminus drush $SITE_NAME.$ENV_NAME eval "echo DRUPAL_ROOT" 2>/dev/null`/scripts/run-tests.sh --url http://$ENV_NAME-$SITE_NAME.pantheonsite.io OptionalTestGroup
 
             fi
 ```

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -40,13 +40,13 @@ Using Terminus, you can complete the above process from the command line.
 
 In the commands below, replace `site` with your site name and the correct environment:
 
-1.  `terminus drush <site>.dev -- cex -y`
+1.  `terminus drush <site>.dev cex -y`
 2.  `terminus env:commit <site>.dev --message="Export configuration to code"`
 3.  `terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Deploy configuration to test"`
-4.  `terminus drush <site>.test -- cim -y`
+4.  `terminus drush <site>.test cim -y`
 5.  `open https://test-mysite.pantheonsite.io`
 6.  `terminus env:deploy <site>.live --cc --note="Deploy configuration to live"`
-7.  `terminus drush <site>.live -- cim -y`
+7.  `terminus drush <site>.live cim -y`
 8.  `open https://live-mysite.pantheonsite.io`
 
 ## Configuration Tools for Drupal 8

--- a/source/content/drupal-cron.md
+++ b/source/content/drupal-cron.md
@@ -40,7 +40,7 @@ You can manage cron via Drupal's admin interface at `admin/config/system/cron`.
     - Alternatively, you can run all scheduled cron tasks with the following [Terminus](/terminus/) command:
 
       ```bash
-      terminus drush <site>.<env> -- cron
+      terminus drush <site>.<env> cron
       ```
 
 2.  To ensure that cron tasks have been run, check the reports via the Drupal Admin interface at **Reports** > **Recent log messages**.
@@ -109,7 +109,7 @@ You can check the log messages through the Drupal Admin interface.
 
 You can also use [Terminus](/terminus/) to see when cron was last run with the following command:
 ```bash
-terminus drush <site>.<env> -- wd-show --type='cron'
+terminus drush <site>.<env> wd-show --type='cron'
 ```
 
 ### Can I add tasks to cron through Drupal?

--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -47,12 +47,12 @@ The Dashboard integration is intended to provide developers with the most action
 
 You can get a list of all available site audit reports using [Terminus](/terminus/):
 ```
-terminus remote:drush <site>.<env> -- help --filter=site_audit
+terminus remote:drush <site>.<env> help --filter=site_audit
 ```
 
 You can also execute a full report in HTML format.
 ```bash
-terminus remote:drush <site>.<env> -- aa --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
+terminus remote:drush <site>.<env> aa --skip=insights --html --bootstrap --detail --vendor=pantheon > report.html
 ```
 
 ### Are there plans to support Drupal 6 sites?
@@ -89,7 +89,7 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/terminus/) command to execute Site Audit directly on your Pantheon site:
 ```bash
-terminus drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon --strict=0
+terminus drush <site>.<env> aa --skip=insights --detail --vendor=pantheon --strict=0
 ```
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 

--- a/source/content/drupal-s3.md
+++ b/source/content/drupal-s3.md
@@ -97,14 +97,14 @@ Before you begin:
 Install the [Libraries API](https://www.drupal.org/project/libraries) and [S3 File System](https://www.drupal.org/project/s3fs) modules:
 
 ```
-terminus drush <site>.<env> -- en libraries s3fs -y
+terminus drush <site>.<env> en libraries s3fs -y
 ```
 Get the [AWS SDK Library 2.x](https://github.com/aws/aws-sdk-php/releases):
 
 ```
-terminus drush <site>.<env> -- make --no-core sites/all/modules/s3fs/s3fs.make code/
+terminus drush <site>.<env> make --no-core sites/all/modules/s3fs/s3fs.make code/
   //or if you have a contrib subfolder for modules use:
-  //terminus drush <site>.<env> -- make --no-core sites/all/modules/contrib/s3fs/s3fs.make code/
+  //terminus drush <site>.<env> make --no-core sites/all/modules/contrib/s3fs/s3fs.make code/
 ```
 
 The above command will add the AWS SDK version 2.x library into the `sites/all/libraries/awssdk2` directory.
@@ -115,7 +115,7 @@ Use the [S3 File System CORS Upload](https://www.drupal.org/project/s3fs_cors) m
 Install s3fs_cors module using Drush:
 
 ```
-terminus drush <site≥.<env> -- en jquery_update s3fs_cors -y
+terminus drush <site≥.<env> en jquery_update s3fs_cors -y
 ```
 
 </Tab>
@@ -191,14 +191,14 @@ Periodically, you'll need to run Actions provided by the S3 File System module e
 ###If you have files on S3 already that are not known to Drupal, refresh the files metadata cache:
 
 ```
-terminus drush <site>.<env> -- s3fs-refresh-cache
+terminus drush <site>.<env> s3fs-refresh-cache
 ```
 
 
 ### If you have files in Drupal that need inclusion with S3 run:
 
 ```
-terminus drush <site>.<env> -- s3fs-copy-local
+terminus drush <site>.<env> s3fs-copy-local
 ```
 
 If you receive an access denied error message from Amazon, check the permissions on your bucket and policies. Verify all your configuration settings in Drupal are complete and accurate.

--- a/source/content/drupal-updates.md
+++ b/source/content/drupal-updates.md
@@ -53,18 +53,18 @@ The critical commands are:
 
 
 ```
-terminus drush my-drupal-8-site.dev -- migrate-upgrade --legacy-db-key=drupal_7 --configure-only --legacy-root=https://drupal7.example.com
+terminus drush my-drupal-8-site.dev migrate-upgrade --legacy-db-key=drupal_7 --configure-only --legacy-root=https://drupal7.example.com
 ```
 This command configures (but does not run) the migrations from Drupal 6 or 7 to Drupal 8. In this example, the Drupal 8 site is named `my-drupal-8-site` and the command is running on the `dev` environment. The `--legacy-db-key` parameter indicates how to get the login credentials to the source Drupal 6 or 7 database. In our example, we use the [Terminus secrets](https://github.com/pantheon-systems/terminus-secrets-plugin) plugin to supply the connection info. [See our blog post for more information on how this flag is used](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush). The `--legacy-root` flag lets Drupal 8 know from where it can grab images and other uploaded media assets.
 
 The following command generates a report on how many items have been imported by each migration:
 ```
-terminus drush my-drupal-8-site.dev -- migrate-status
+terminus drush my-drupal-8-site.dev migrate-status
 ```
 
 The following command runs the migration configured via `drush migrate-upgrade --configure-only`:
 ```
-terminus drush my-drupal-8-site.dev -- migrate-import --all
+terminus drush my-drupal-8-site.dev migrate-import --all
 ```
 
 ## Updating DNS

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -20,7 +20,7 @@ When running Drush locally, we highly recommend running Drush version 8.1.15 or 
 ## Verify Current Drush Version
 Verify the current version of Drush running remotely on Pantheon using [Terminus](/terminus):
 ```bash
-terminus drush <site>.<env> -- status | grep "Drush version"
+terminus drush <site>.<env> status | grep "Drush version"
 ```
 
 ## Configure Drush Version

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -13,7 +13,7 @@ Refer to Drush's [install documentation](http://docs.drush.org/en/master/install
 
 Drush-savvy developers should also install and utilize [Terminus](/terminus/), a command-line interface that allows you to control your Pantheon account and sites. Virtually anything you can do in the Dashboard, you can script with Terminus. It can also make remote Drush calls on your environments without having Drush installed locally, eliminating incompatibility issues between locally and remotely installed versions of Drush.
 
-You can run all of the commands below from Terminus instead of using Drush aliases. For more information, see [Managing Drupal Sites with Terminus and Drush](/guides/terminus-drupal-site-management/). For example, you can run `terminus drush <site>.<env> -- cc drush` instead of `drush @pantheon.SITENAME.dev cc drush`.
+You can run all of the commands below from Terminus instead of using Drush aliases. For more information, see [Managing Drupal Sites with Terminus and Drush](/guides/terminus-drupal-site-management/). For example, you can run `terminus drush <site>.<env> cc drush` instead of `drush @pantheon.SITENAME.dev cc drush`.
 
 
 ## Drush Versions
@@ -72,7 +72,7 @@ Drupal's list of PHP classes and files can get corrupted or out-of-date, typical
 **Do not attempt to install the module on your site.** This command is provided as-is, without warranty, so make a backup first.  
 
 ```bash
-terminus drush <site>.<env> -- rr
+terminus drush <site>.<env> rr
 ```
 
 ## Run SQL Queries Using Drush on Pantheon
@@ -89,7 +89,7 @@ echo 'show tables;' | $(drush @pantheon.SITENAME.ENV sql-connect)
 Or, you can use Terminus as follows:
 
 ```bash
-terminus drush SITENAME.ENV -- sql-query "SELECT * FROM users WHERE uid=1"
+terminus drush SITENAME.ENV sql-query "SELECT * FROM users WHERE uid=1"
 ```
 
 ## Execute PHP Code Using Drush on Pantheon
@@ -100,7 +100,7 @@ echo 'print "hello world";' | drush @pantheon.SITENAME.ENV php-script -
 ```
 Also, the interactive PHP shell works as well:
 ```bash
-terminus drush <site>.<env> -- core-cli
+terminus drush <site>.<env> core-cli
 ```
 
 ## Drush Commands That Alter Site Code

--- a/source/content/email.md
+++ b/source/content/email.md
@@ -79,7 +79,7 @@ This is a common error with the SMTP Authentication Support module. It can be fi
 
 4. [Clear the cache](https://github.com/pantheon-systems/cli):
 
-        terminus drush <site>.<env> -- cc all
+        terminus drush <site>.<env> cc all
 
 See [available patch](https://drupal.org/node/1369736#comment-5644064).
 

--- a/source/content/environment-indicator.md
+++ b/source/content/environment-indicator.md
@@ -20,7 +20,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 2. Install and activate [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=pantheon+hud`) or with Terminus:
 
  ```
- terminus wp <site>.<env> -- plugin install pantheon-hud --activate
+ terminus wp <site>.<env> plugin install pantheon-hud --activate
  ```
 
 3. Deploy the plugin to the Test environment within the Site Dashboard or with Terminus:
@@ -32,7 +32,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 4. Activate the plugin within the WordPress Dashboard on the Test environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```
- terminus wp <site>.test -- plugin activate pantheon-hud
+ terminus wp <site>.test plugin activate pantheon-hud
  ```
 
 5. Deploy the plugin to the Live environment within the Site Dashboard or with Terminus:
@@ -44,7 +44,7 @@ The Pantheon HUD plugin is developed and maintained on GitHub. [Create an issue]
 6. Activate the plugin within the WordPress Dashboard on the Live environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```
- terminus wp <site>.live -- plugin activate pantheon-hud
+ terminus wp <site>.live plugin activate pantheon-hud
  ```
 
 All environments will now show the following indicator for logged-in users with the `manage_options` capability:
@@ -76,7 +76,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 2. Install and enable the [Environment Indicator](https://www.drupal.org/project/environment_indicator) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with Terminus:
 
  ```
- terminus drush <site>.dev -- en environment_indicator -y
+ terminus drush <site>.dev en environment_indicator -y
  ```
 
 3. Add the following within `settings.php`:

--- a/source/content/environment-specific-config-d8.md
+++ b/source/content/environment-specific-config-d8.md
@@ -144,9 +144,9 @@ This issue can be caused by a number of scenarios related to cache tags, such as
 3. Verify overridden configurations for each config.name on the Dev environment within the Drupal UI using the Configuration Manager core module (`/admin/config/development/configuration/single/export`) or via [Terminus](/terminus):
 
    ```bash
-   terminus drush <site>.<env> -- config-get system.performance --include-overidden
-   terminus drush <site>.<env> -- config-get system.logging --include-overidden
-   terminus drush <site>.<env> -- config-get views.settings --include-overidden
+   terminus drush <site>.<env> config-get system.performance --include-overidden
+   terminus drush <site>.<env> config-get system.logging --include-overidden
+   terminus drush <site>.<env> config-get views.settings --include-overidden
    ```
 
    <Alert title="Note" type="info">

--- a/source/content/guides/build-tools/05-extend.md
+++ b/source/content/guides/build-tools/05-extend.md
@@ -76,13 +76,13 @@ This section will be performed from the command line, to prepare your local syst
 3. Enable the Pathauto module on the Pantheon Multidev environment from the command line using Terminus and Drush:
 
     ```bash
-    terminus drush $SITE.$ENV -- pm-enable pathauto --yes
+    terminus drush $SITE.$ENV pm-enable pathauto --yes
     ```
 
 4. You can use the [method described in an earlier lesson](/guides/build-tools/configure/) to export configuration changes made in the last step or you can do it from the command line using Terminus and Drush:
 
     ```bash
-    terminus drush $SITE.$ENV -- config-export --yes
+    terminus drush $SITE.$ENV config-export --yes
     ```
 
 

--- a/source/content/guides/build-tools/08-custom-theme.md
+++ b/source/content/guides/build-tools/08-custom-theme.md
@@ -36,7 +36,7 @@ This lesson demonstrates how to create a custom theme from the default [Bartik](
 1. Wait for CircleCI to build a new Pantheon Multidev environment (`pr-custom-t`), then use the `generate:theme` command as shown below to start the process of creating a subtheme:
 
   ```bash
-  terminus drupal $SITE.$ENV -- generate:theme
+  terminus drupal $SITE.$ENV generate:theme
   ```
 
   <Accordion title="Drupal Console Generate Theme" id="understand-drupal-console" icon="lightbulb">
@@ -106,7 +106,7 @@ This lesson demonstrates how to create a custom theme from the default [Bartik](
 11. Once the build finishes from the last step, active your new theme and rebuild the cache:
 
     ```bash
-    terminus drupal $SITE.$ENV -- theme:install --set-default amazing_theme
+    terminus drupal $SITE.$ENV theme:install --set-default amazing_theme
     ```
 
     Visit the site in the web browser, it should reflect the change provided by the custom theme:
@@ -120,7 +120,7 @@ This lesson demonstrates how to create a custom theme from the default [Bartik](
 12. You can use the [method described in an earlier lesson](/guides/build-tools/configure/) to export configuration changes made in the last step or you can do it from the command line using Terminus and Drush:
 
     ```bash
-    terminus drush $SITE.$ENV -- config-export --yes
+    terminus drush $SITE.$ENV config-export --yes
     ```
 
 

--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -178,7 +178,7 @@ You should see a large amount of files committed to the new branch we created ea
 
 ## Deploy
 
-You've now committed the code to a branch. If your site has multidev, you can deploy that branch directly to a new multidev and test the site in the browser. If the site doesn't load properly, clear the cache. If there are any issues, utilize your site's logs via `terminus drush $site.composify -- wd-show` to inspect the watchdog logs, or follow the directions on [our documentation on log collection](/logs).
+You've now committed the code to a branch. If your site has multidev, you can deploy that branch directly to a new multidev and test the site in the browser. If the site doesn't load properly, clear the cache. If there are any issues, utilize your site's logs via `terminus drush $site.composify wd-show` to inspect the watchdog logs, or follow the directions on [our documentation on log collection](/logs).
 
 Once you have confirmed the site is working, merge `composify` into `master`, and follow the standard workflow to QA a code change before going live.
 

--- a/source/content/guides/drupal-8-advanced-page-cache.md
+++ b/source/content/guides/drupal-8-advanced-page-cache.md
@@ -43,7 +43,7 @@ First, set up a new Drupal 8 site and add the Pantheeon Advanced Page Cache modu
 2. Install Drupal:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- site-install -y
+  terminus drush $TERMINUS_SITE.dev site-install -y
   ```
 
 
@@ -56,8 +56,8 @@ First, set up a new Drupal 8 site and add the Pantheeon Advanced Page Cache modu
 4. Add and enable the Pantheon Advanced Page Cache module, which is responsible for sending cache metadata to the Pantheon Global CDN:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- dl pantheon_advanced_page_cache
-  terminus drush $TERMINUS_SITE.dev -- en pantheon_advanced_page_cache -y
+  terminus drush $TERMINUS_SITE.dev dl pantheon_advanced_page_cache
+  terminus drush $TERMINUS_SITE.dev en pantheon_advanced_page_cache -y
   ```
 
 5. Commit the new code:
@@ -69,7 +69,7 @@ First, set up a new Drupal 8 site and add the Pantheeon Advanced Page Cache modu
 6. Log in to your newly created site. This command will give you a one-time log-in link for the admin user:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- user-login
+  terminus drush $TERMINUS_SITE.dev user-login
   ```
 
 7. Turn on full page caching by setting the **Page cache maximum age** field to "10 min", then clear caches. We can do this from our Drupal site at `/admin/config/development/performance`:
@@ -80,8 +80,8 @@ First, set up a new Drupal 8 site and add the Pantheeon Advanced Page Cache modu
   You can also make those same changes using Drush via Terminus:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- cset system.performance cache.page.max_age 600 -y
-  terminus drush $TERMINUS_SITE.dev -- cr
+  terminus drush $TERMINUS_SITE.dev cset system.performance cache.page.max_age 600 -y
+  terminus drush $TERMINUS_SITE.dev cr
   ```
 
 ## View HTTP Headers
@@ -335,7 +335,7 @@ Now we're going to add a custom module that uses a hook to clear the cache tag f
 5. Enable the new custom module and commit your code:
 
     ```bash
-    terminus drush $TERMINUS_SITE.dev -- en custom_cache_tags -y
+    terminus drush $TERMINUS_SITE.dev en custom_cache_tags -y
     ```
 
     ```bash
@@ -345,7 +345,7 @@ Now we're going to add a custom module that uses a hook to clear the cache tag f
 6. Clear all caches so that the new hook you added is detected by Drupal:
 
     ```bash
-    terminus drush $TERMINUS_SITE.dev -- cr
+    terminus drush $TERMINUS_SITE.dev cr
     ```
 
 7. Now whenever you add content, the referenced taxonomy term pages are automatically cleared. To test, check on the age of your taxonomy listing again by curling a few times.
@@ -380,11 +380,11 @@ The code we added clears all references to each taxonomy term every time a node 
 1. Download and enable the [Views Custom Cache Tags](https://www.drupal.org/project/views_custom_cache_tag) module:
 
     ```bash
-    terminus drush $TERMINUS_SITE.dev -- dl views_custom_cache_tag
+    terminus drush $TERMINUS_SITE.dev dl views_custom_cache_tag
     ```
 
     ```bash
-    terminus drush $TERMINUS_SITE.dev -- en views_custom_cache_tag -y
+    terminus drush $TERMINUS_SITE.dev en views_custom_cache_tag -y
     ```
 
 2. Commit your code changes:
@@ -404,7 +404,7 @@ The code we added clears all references to each taxonomy term every time a node 
 5. To see the change, you may need to clear all caches:
 
     ```bash
-    terminus drush $TERMINUS_SITE.dev -- cr
+    terminus drush $TERMINUS_SITE.dev cr
     ```
 
 6. Curl the listing page a few times again:

--- a/source/content/guides/drupal-8-commerce.md
+++ b/source/content/guides/drupal-8-commerce.md
@@ -100,7 +100,7 @@ In addition to Pantheon, you will need accounts at:
 
    ```bash
    terminus connection:set $SITENAME.dev sftp
-   terminus drush $SITENAME.dev -- site-install commerce
+   terminus drush $SITENAME.dev site-install commerce
    ```
 
    Review the last two lines of output to identify the username and password created:

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -172,13 +172,13 @@ Now that the code for Drupal core exists on our Pantheon site, we need to actual
 1. Use Terminus Drush to install Drupal:
 
    ```bash
-   terminus drush $PANTHEON_SITE_NAME.dev -- site-install -y
+   terminus drush $PANTHEON_SITE_NAME.dev site-install -y
    ```
 
 2. Log in to your new Drupal 8 site to verify it is working. You can get a one-time login link using Drush:
 
    ```bash
-   terminus drush $PANTHEON_SITE_NAME.dev -- uli
+   terminus drush $PANTHEON_SITE_NAME.dev uli
    ```
 
 ### Adding a New Module with Composer
@@ -214,7 +214,7 @@ To maintain best practice, some of the steps in this section require access to t
 4. Log in to your new environment and verify that the address module exists:
 
    ```bash
-   terminus drush $PANTHEON_SITE_NAME.addr-module -- uli
+   terminus drush $PANTHEON_SITE_NAME.addr-module uli
    ```
 
    <Image alt="Image of installing address module" src="guides/drupal-8-composer-no-ci/drops-8-composer-drupal-8-address-module-install.png" />

--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -74,13 +74,13 @@ The next few sections of this guide use the example variables `steve-site-d8` an
 1. Use the Drush [`site-install`](https://drushcommands.com/drush-8x/core/site-install/) command to install Drupal 8 on the Dev environment:
 
   ```bash
-  terminus drush steve-site-d8.dev -- site-install -y
+  terminus drush steve-site-d8.dev site-install -y
   ```
 
   Use the password included in the output of that command to sign into the site with your browser, or use this command to get a one-time login link:
 
    ```bash
-   terminus drush  steve-site-d8.dev  -- user-login
+   terminus drush  steve-site-d8.dev  user-login
   ```
 
 1. Create the Test environment:
@@ -136,7 +136,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. Download and install the latest stable release of the `devel` package from drupal.org:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- pm-download devel
+  terminus drush $TERMINUS_SITE.dev pm-download devel
   ```
 
 1. Review the file changes:
@@ -154,7 +154,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. Enable the modules:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- pm-enable devel devel_generate kint webprofiler -y
+  terminus drush $TERMINUS_SITE.dev pm-enable devel devel_generate kint webprofiler -y
   ```
 
   All of these modules are helpful during active development. We use Devel Generate later in this walkthrough to make nodes on the Live environment.
@@ -162,7 +162,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. If you haven't done so yet, sign into your Dev environment, where you will see a footer of helpful development information provided by the `webprofiler` module we just installed:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- user-login
+  terminus drush $TERMINUS_SITE.dev user-login
   ```
 
   <Image alt="The webprofiler toolbar" src="drupal8-commandline--webprofiler.png" />
@@ -170,7 +170,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. Export the configuration in the Dev environment:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- config-export -y
+  terminus drush $TERMINUS_SITE.dev config-export -y
   ```
 
   [Configuration management is a complex topic with its own detailed recommendations](/drupal-8-configuration-management/). For this guide, all you need to know is that by default, Drupal 8 configuration is stored in the database and can be cleanly exported to `yml` files. Once exported to files and committed to git, these configuration changes can be deployed to different environments (like Test and Live) where they can then be imported to the database.
@@ -196,19 +196,19 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. With the `yml` configuration files now present on the Test environment, they can be imported to the database there:
 
   ```bash
-  terminus drush $TERMINUS_SITE.test -- config-import -y
+  terminus drush $TERMINUS_SITE.test config-import -y
   ```
 
 1. Sign into Drupal in the Test environment to see the enabled modules:
 
   ```bash
-  terminus drush $TERMINUS_SITE.test -- user-login
+  terminus drush $TERMINUS_SITE.test user-login
   ```
 
 1. Sign into Drupal in the Live environment to see that the modules aren't there yet:
 
   ```bash
-  terminus drush $TERMINUS_SITE.live -- user-login
+  terminus drush $TERMINUS_SITE.live user-login
   ```
 
   Now that you are signed into all three environments you should be seeing the development footer in Dev and Test but not Live.
@@ -222,7 +222,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. Import the configuration on the Live environment:
 
   ```
-  terminus drush $TERMINUS_SITE.live -- config-import -y
+  terminus drush $TERMINUS_SITE.live config-import -y
   ```
 
   Once this command completes you will be able to refresh the Live environment in your browser and see the development footer.
@@ -233,7 +233,7 @@ In the lifecycle of managing a site, you can expect content editors to add new m
 1. As a demonstration of the typical workflow on Pantheon, let's create some content in Live using [the `generate-content` command](https://drushcommands.com/drush-8x/devel-generate/generate-content/):
 
   ```bash
-  terminus drush $TERMINUS_SITE.live -- generate-content 25
+  terminus drush $TERMINUS_SITE.live generate-content 25
   ```
 
 1. Copy the database and media files from Live into the Dev environment:
@@ -245,13 +245,13 @@ In the lifecycle of managing a site, you can expect content editors to add new m
 1. Make some configuration change on the Dev environment, such as enabling the [Views Glossary](https://www.drupal.org/project/views_glossary) module:
 
   ```bash
-  terminus drush $TERMINUS_SITE.dev -- views-enable glossary
+  terminus drush $TERMINUS_SITE.dev views-enable glossary
   ```
 
 1. Export the configuration change so it can be managed in code:
 
   ```
-  terminus drush $TERMINUS_SITE.dev -- config-export -y
+  terminus drush $TERMINUS_SITE.dev config-export -y
   ```
 
 1. Commit your code changes to the Dev environment:
@@ -269,7 +269,7 @@ In the lifecycle of managing a site, you can expect content editors to add new m
   ```bash
   terminus env:deploy $TERMINUS_SITE.test --sync-content --updatedb --cc --note="Deploying glossary View"
 
-  terminus drush $TERMINUS_SITE.test -- config-import -y
+  terminus drush $TERMINUS_SITE.test config-import -y
   ```
 
 1. Check the Test environment and visit `/glossary` and `/admin/content` again. You should see both the glossary View and a full list of content on the administrative page.
@@ -279,7 +279,7 @@ In the lifecycle of managing a site, you can expect content editors to add new m
   ```bash
   terminus env:deploy $TERMINUS_SITE.live --updatedb --cc --note="Deploying glossary View"
 
-  terminus drush $TERMINUS_SITE.live -- config-import -y
+  terminus drush $TERMINUS_SITE.live config-import -y
   ```
 
   With the change to the glossary View deployed and imported on the Live environment you should be able to see the glossary page (`/glossary`).

--- a/source/content/guides/jenkins.md
+++ b/source/content/guides/jenkins.md
@@ -254,7 +254,7 @@ Under the **Build** tab is a button labeled **Add build step**. These tasks will
 
     ```
     echo "Run database updates and clear cache"
-    terminus drush -n ${SITE_ID}.ci-${BUILD_ID} -- updatedb -y
+    terminus drush -n ${SITE_ID}.ci-${BUILD_ID} updatedb -y
     terminus drush ${SITE_ID}.ci-${BUILD_ID} cr
     ```
 

--- a/source/content/guides/lockr.md
+++ b/source/content/guides/lockr.md
@@ -49,7 +49,7 @@ Visit the [GitHub page](https://github.com/lockr/lockr-patches/tree/wp) for a li
 2. Install and activate the [Lockr](https://wordpress.org/plugins/lockr) plugin from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=lockr`) or with [Terminus](/terminus):
 
  ```
- terminus wp <site>.<env> -- plugin install lockr --activate
+ terminus wp <site>.<env> plugin install lockr --activate
  ```
 3. Click **Lockr** from within the WordPress Dashboard to visit the Lockr Configuration page  (`/wp-admin/admin.php?page=lockr-site-config`):
 
@@ -60,7 +60,7 @@ Visit the [GitHub page](https://github.com/lockr/lockr-patches/tree/wp) for a li
 6. Visit the [Lockr patch library](https://github.com/lockr/lockr-patches/tree/wp) for the latest patches to your favorite plugins or apply patches with [Terminus](/terminus):
 
  ```
- terminus wp <site>.<env> -- lockr lockdown
+ terminus wp <site>.<env> lockr lockdown
  ```
 
 ### WP-CLI Commands
@@ -72,7 +72,7 @@ The Lockr plugin contains a number of WP-CLI commands to quickly register a site
 This command will register the site with Lockr to the email address provided. The password is only necessary for existing Lockr accounts. This is useful for automated deployment from a Custom Upstream using [Quicksilver](/quicksilver).
 
 ```
-terminus wp <site>.<env> -- lockr register-site --email=[<Lockr email address>] --password=[<Lockr account password>]
+terminus wp <site>.<env> lockr register-site --email=[<Lockr email address>] --password=[<Lockr account password>]
 ```
 
 #### Use Lockr to patch existing plugins
@@ -80,7 +80,7 @@ terminus wp <site>.<env> -- lockr register-site --email=[<Lockr email address>] 
 Run this command and Lockr will go to the [patch library](https://github.com/lockr/lockr-patches/tree/wp) and automatically patch your existing plugins that do not currently integrate natively with Lockr.
 
 ```
-terminus wp <site>.<env> -- lockr lockdown
+terminus wp <site>.<env> lockr lockdown
 ```
 
 #### Get and decrypt a key from Lockr
@@ -88,7 +88,7 @@ terminus wp <site>.<env> -- lockr lockdown
 Run this command to get and decrypt a key from Lockr. This is a useful command to program in automated functionality in Quicksilver.
 
 ```
-terminus wp <site>.<env> -- lockr get-key [key name]
+terminus wp <site>.<env> lockr get-key [key name]
 ```
 
 #### Encrypt a key and sends it to Lockr
@@ -96,7 +96,7 @@ terminus wp <site>.<env> -- lockr get-key [key name]
 This command encrypts a key and sends it to Lockr. This is useful during site migrations or automated deployments of new sites through Quicksilver.
 
 ```
-terminus wp <site>.<env> -- lockr set-key --name=[key name] --label=[key label] --value=[key value]
+terminus wp <site>.<env> lockr set-key --name=[key name] --label=[key label] --value=[key value]
 ```
 
 ## Drupal Installation
@@ -127,18 +127,18 @@ Lockr is currently available for Drupal 7 and Drupal 8 (development release). Se
 Use Drush to download and install Lockr in a few simple commands.
 
 ```
-terminus drush <site>.<env> -- dl lockr
+terminus drush <site>.<env> dl lockr
 ```
 ```
-terminus drush <site>.<env> -- en lockr
+terminus drush <site>.<env> en lockr
 ```
 ```
-terminus drush <site>.<env> -- lockr-register --email=[<Lockr account email >] --password=[<Lockr account password>]
+terminus drush <site>.<env> lockr-register --email=[<Lockr account email >] --password=[<Lockr account password>]
 ```
 This command registers the site with Lockr to the email address provided. The password is only necessary for email addresses already with a Lockr account. This is useful for automated deployment from a Custom Upstream using Quicksilver.
 
 ```
-terminus drush <site>.<env> -- lockr-lockdown
+terminus drush <site>.<env> lockr-lockdown
 ```
 Run this command and Lockr will go to a [patch library](https://github.com/lockr/lockr-patches/tree/drupal7) and automatically patch your existing plugins that do not currently integrate natively with Lockr.
 

--- a/source/content/guides/multisite/03-config.md
+++ b/source/content/guides/multisite/03-config.md
@@ -58,13 +58,13 @@ Using [Terminus](/terminus/) is our recommended way to install a WordPress Site 
   </Alert>
 
   ```bash
-  terminus wp <site>.<env> -- core multisite-install --url=<url> --title=<site-title> --admin_user=<username> --admin_email=<email>
+  terminus wp <site>.<env> core multisite-install --url=<url> --title=<site-title> --admin_user=<username> --admin_email=<email>
   ```
 
   When you install a new WordPress Site Network, you should see a success notice similar to this:
 
   ```bash
-  $ terminus wp sitenetworks.dev -- core multisite-install --url=dev-sitenetworks.pantheonsite.io --title="Site Networks" --admin_user=aghost --admin_email=aghost@pantheon.io
+  $ terminus wp sitenetworks.dev core multisite-install --url=dev-sitenetworks.pantheonsite.io --title="Site Networks" --admin_user=aghost --admin_email=aghost@pantheon.io
   Admin password: abcdefgnotarealpassword
   Created single site database tables.
   Set up multisite database tables.

--- a/source/content/guides/multisite/04-workflows.md
+++ b/source/content/guides/multisite/04-workflows.md
@@ -32,7 +32,7 @@ After you've configured a WordPress Site Network in the Dev environment, you'll 
 4. From the command line, perform a `wp search-replace` on the Test environment's database via Terminus:
 
     ```bash
-    terminus wp <site>.test -- search-replace <dev-domain> <test-domain> --url=<dev-domain> --network
+    terminus wp <site>.test search-replace <dev-domain> <test-domain> --url=<dev-domain> --network
     ```
 
     Ensure the database connection error is resolved on the Test environment's URL.
@@ -47,7 +47,7 @@ For better or for worse, WordPress stores full URLs in the database. These URLs 
 WP-CLI's `search-replace` command is a good tool for this job, in large part because it also gracefully handles URL references inside of PHP serialized data. The general pattern you'll want to follow is:
 
 ```bash
-terminus wp <site>.<env> -- search-replace <old-domain> <new-domain> --network --url=<old-domain>
+terminus wp <site>.<env> search-replace <old-domain> <new-domain> --network --url=<old-domain>
 ```
 
 In this example:
@@ -62,7 +62,7 @@ See the [full documentation](https://developer.wordpress.org/cli/commands/search
 Using WP-CLI with Terminus is simply a matter of calling Terminus with the correct `<site>` and `<env>` arguments:
 
 ```bash
-terminus wp <site>.<env> -- search-replace --network
+terminus wp <site>.<env> search-replace --network
 ```
 
 Now that you've performed the search and replace on your database, WordPress has the correct stored configuration.
@@ -73,7 +73,7 @@ If you use Redis as a persistent storage backend for your object cache, you'll n
 With Terminus and WP-CLI, you can flush cache globally with one operation:
 
 ```bash
-terminus wp <site>.<env> -- cache flush
+terminus wp <site>.<env> cache flush
 ```
 
 The Terminus command to clear all caches for an environment is:
@@ -101,7 +101,7 @@ terminus env:clone-content <site>.live dev
 Once the clone process is complete, you'll need to run `wp search-replace` to update all domain configuration references:
 
 ```bash
-terminus wp <site>.<env> -- search-replace <live-domain> <dev-domain> --network --url=<live-domain>
+terminus wp <site>.<env> search-replace <live-domain> <dev-domain> --network --url=<live-domain>
 ```
 
 Lastly, flush the cache for the entire Dev environment:
@@ -134,7 +134,7 @@ In a stock WordPress install (e.g. no custom plugins), there are a few key place
 Try running `wp search-replace` against this limited subset of data:
 
 ```bash
-terminus wp <site>.<env> -- search-replace <old-domain> <new-domain> wp_blogs wp_site $(terminus wp <site>.<env> -- wp db tables "wp_*options" --network | paste -s -d ' ' -) --url=<old-domain>
+terminus wp <site>.<env> search-replace <old-domain> <new-domain> wp_blogs wp_site $(terminus wp <site>.<env> wp db tables "wp_*options" --network | paste -s -d ' ' -) --url=<old-domain>
 ```
 
 In this example:

--- a/source/content/guides/rerouting-outbound-email.md
+++ b/source/content/guides/rerouting-outbound-email.md
@@ -125,11 +125,11 @@ Push the code to Test and Live and enable the module in all environments.
 You can do this through the Site Dashboard and the Drupal Admin UI (/admin/modules) or by using [Terminus](/terminus) and drush:
 ```
 $ terminus auth:login
-$ terminus drush <site>.test -- en reroute_email -y
+$ terminus drush <site>.test en reroute_email -y
 $ terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Intial deploy. Reroute Email demo"
 $ terminus env:deploy <site>.live --cc --updatedb --note="Intial deploy. Reroute Email demo"
-$ terminus drush <site>.test -- en reroute_email -y
-$ terminus drush <site>.live -- en reroute_email -y
+$ terminus drush <site>.test en reroute_email -y
+$ terminus drush <site>.live en reroute_email -y
 ```
 Now the Dev environment’s settings page for reroute_email (/admin/config/development/reroute_email) should look something like this:
 

--- a/source/content/guides/sendgrid.md
+++ b/source/content/guides/sendgrid.md
@@ -89,7 +89,7 @@ A stable release for Drupal 8 is not yet available for the [SMTP Authentication 
 1. Install the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/terminus):
 
   ```bash
-  terminus drush <site>.<env> -- en smtp -y
+  terminus drush <site>.<env> en smtp -y
   ```
 2. Visit `/admin/config/system/smtp` once you've logged in as an administrator.
 3. From within Install Options, select **On**.
@@ -176,8 +176,8 @@ protected_web_paths:
 1. Enable *Composer Vendor*, followed by *SendGrid Integration*. Order is important here, SendGrid Integration will refuse to activate if the library file is not autoloaded:
 
   ```bash
-  terminus drush $SITE.<env> -- en composer_vendor -y
-  terminus drush $SITE.<env> -- en sendgrid_integration -y
+  terminus drush $SITE.<env> en composer_vendor -y
+  terminus drush $SITE.<env> en sendgrid_integration -y
   ```
 
 1.  From within your SendGrid account, navigate to **Settings** > **API Keys** and create a site-specific API Key. Click the key to copy it to your keyboard.
@@ -206,7 +206,7 @@ Then commit and push the symlink to Pantheon.
 1. Install the [SMTP Authentication Support](https://www.drupal.org/project/smtp) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with [Terminus](/terminus):
 
      ```bash
-     terminus drush <site>.<env> -- en smtp -y
+     terminus drush <site>.<env> en smtp -y
      ```
 2. Visit `/admin/config/system/smtp` once you've logged in as administrator.
 3. From within Install Options, select **On**.

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -69,7 +69,7 @@ $ terminus site:list
 Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal set ready to go for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
 
 ```bash
-terminus drush <site>.<env> -- site-install
+terminus drush <site>.<env> site-install
 Running drush site-install  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Could not find a Drupal settings.php file at ./sites/default/settings.php.
@@ -113,13 +113,13 @@ $ terminus env:list <site>
 While the site's Dev environment is still in SFTP mode, we can use Drush to download and install some Drupal contrib modules, such as Views and Administration Menu.
 
 ```
-$ terminus drush <site>.<env> -- dl admin_menu
+$ terminus drush <site>.<env> dl admin_menu
 Running drush dl admin_menu  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project admin_menu (7.x-3.0-rc5) downloaded to                         [success]
 /srv/bindings/c183403f14224eac8471ec0000f9e653/code/sites/all/modules/admin_menu.
 Project admin_menu contains 3 modules: admin_devel, admin_menu_toolbar, admin_menu.
-tests-MacBook-Pro:~ erikmathy$ terminus drush <site>.<env> -- en admin_menu,admin_menu_toolbar
+tests-MacBook-Pro:~ erikmathy$ terminus drush <site>.<env> en admin_menu,admin_menu_toolbar
 Running drush en admin_menu,admin_menu_toolbar  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 The following extensions will be enabled: admin_menu, admin_menu_toolbar
@@ -151,7 +151,7 @@ Open the Pantheon Dashboard, and you'll see the new files are shown in the Git c
 To see what a commit message looks like, let's download Bootstrap and then commit it as well.
 
 ```
-$ terminus drush <site>.<env> -- dl bootstrap
+$ terminus drush <site>.<env> dl bootstrap
 Running drush dl bootstrap  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project bootstrap (7.x-3.0) downloaded to                              [success]

--- a/source/content/guides/two-factor-authentication.md
+++ b/source/content/guides/two-factor-authentication.md
@@ -27,7 +27,7 @@ For a single site, there are many different [WordPress plugins for two-factor au
 4. Install and activate the [Duo Two-Factor Authentication](https://wordpress.org/plugins/duo-wordpress/) plugin on your WordPress site. You can do this through the WordPress admin panel, or with Terminus:
 
   ```bash
-  terminus remote:wp $SITENAME.dev -- plugin install duo-wordpress --activate
+  terminus remote:wp $SITENAME.dev plugin install duo-wordpress --activate
   ```
 
 5. Open the settings page for the Duo plugin. Configure Duo with your **integration key**, **secret key**, and **API hostname** from the Duo WordPress application you created earlier at duo.com:

--- a/source/content/guides/wordpress-commandline.md
+++ b/source/content/guides/wordpress-commandline.md
@@ -82,13 +82,13 @@ The next few secions of this guide use the example variables `tessa-site-wp` and
 4. Use the [WP-CLI `core install`](https://developer.wordpress.org/cli/commands/core/install/) command to install WordPress on the Dev environment:
 
   ```bash
-  terminus wp tessa-site-wp.dev -- core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
+  terminus wp tessa-site-wp.dev core install --url=https://dev-tessa-site-wp.pantheonsite.io --title="Terminus Demo Site" --admin_user=admin --admin_password=changemelater --admin_email=name@yoursite.com
   ```
 
   As a reminder, WP-CLI is the command line utility for WordPress itself.	Terminus is simply passing through the WP-CLI commands to the site on Pantheon. To get a full list of WP-CLI commands run:
 
   ```bash
-  terminus wp tessa-site-wp.dev -- help
+  terminus wp tessa-site-wp.dev help
   ```
 
   The `--` signifies the end of the Terminus options, anything after `--` gets passed straight to WP-CLI.
@@ -134,7 +134,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 1. Install and activate the [Contact Form 7](https://wordpress.org/plugins/contact-form-7/) plugin:
 
   ```bash
-  terminus wp $TERMINUS_SITE.dev -- plugin install contact-form-7 --activate
+  terminus wp $TERMINUS_SITE.dev plugin install contact-form-7 --activate
   ```
 
   If you have the Site Dashboard open, you'll see that 78 files have changed and are ready to commit in the yellow box. You can use the Site Dashboard interface to review file changes and commit, but we'll continue on the command line.
@@ -172,7 +172,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 5. Activate the Contact Form 7 plugin on the Test environment by making a manual configuration change:
 
   ```bash
-  terminus wp $TERMINUS_SITE.test -- plugin activate contact-form-7
+  terminus wp $TERMINUS_SITE.test plugin activate contact-form-7
   ```
 
 6. Once you've experimented in the Test environment and verified that your new plugin is working, and everything else is still in working order, deploy to Live:
@@ -190,7 +190,7 @@ The [WordPress plugin repository](https://wordpress.org/plugins/) has loads of f
 7. Activate the Contact Form 7 plugin on the Live environment by making a manual configuration change:
 
   ```bash
-  terminus wp $TERMINUS_SITE.live -- plugin activate contact-form-7
+  terminus wp $TERMINUS_SITE.live plugin activate contact-form-7
   ```
 
 For this example, manually applying configuration changes is a simple and short task. We're only activating one plugin on each environment. However, complex configuration changes are [best managed in code](/pantheon-workflow/#configuration-management) so you can pull fresh content from Live while bringing in the site settings from Dev.
@@ -202,7 +202,7 @@ Now that you have WordPress installed, let's make it look a little better by add
 1. Install and activate the [Shapely](https://wordpress.org/themes/shapely/) theme:
 
   ```bash
-  terminus wp $TERMINUS_SITE.dev -- theme install shapely --activate
+  terminus wp $TERMINUS_SITE.dev theme install shapely --activate
   ```
 
 2. Check out the Dev environment's site URL to see the new theme in action. The `terminus env:info` command from earlier gives us the URL. Here it is again with our environment variable:
@@ -220,7 +220,7 @@ Now that you have WordPress installed, let's make it look a little better by add
 4. No WordPress site is ready for development without a [child theme](https://codex.wordpress.org/Child_Themes). Let's create one! Run [the `scaffold child-theme` WP-CLI command](https://developer.wordpress.org/cli/commands/scaffold/child-theme/) (replace `Tessa-child-theme` and `shapely`):
 
   ```bash
-  terminus wp $TERMINUS_SITE.dev -- scaffold child-theme Tessa-child-theme --parent_theme=shapely
+  terminus wp $TERMINUS_SITE.dev scaffold child-theme Tessa-child-theme --parent_theme=shapely
   ```
 
   You should see the new theme within **Appearance** > **Themes** of the WordPress Dashboard:

--- a/source/content/guides/wordpress-git/03-themes.md
+++ b/source/content/guides/wordpress-git/03-themes.md
@@ -123,7 +123,7 @@ The child theme inherits all the features of the Bento theme. It's simply a spot
    You can do the exact same process from the command line using [Terminus](/terminus/), the Pantheon CLI. Install Terminus, then run a WP-CLI command against the **<span class="glyphicons glyphicons-wrench" aria-hidden="true"></span> Dev** environment to create the child theme scaffold for you automatically. That's right, go from all the steps above to a one-liner to kick things into warp speed:
 
    ```
-   terminus wp <site>.<env> -- scaffold child-theme bento-child --parent_theme=bento
+   terminus wp <site>.<env> scaffold child-theme bento-child --parent_theme=bento
    ```
   </Accordion>   
 

--- a/source/content/hsts.md
+++ b/source/content/hsts.md
@@ -21,7 +21,7 @@ The HTTP Strict-Transport-Security response header (often abbreviated as **HS
 Install and activate the [LH HSTS](https://wordpress.org/plugins/lh-hsts/) plugin using the WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=lh+hsts`) or with [Terminus](/terminus/):
 
 ```bash
-terminus remote:wp <site>.<env> -- plugin install lh-hsts --activate
+terminus remote:wp <site>.<env> plugin install lh-hsts --activate
 ```
 
 Once enabled, the following header will be sent in responses:
@@ -66,7 +66,7 @@ See the [WordPress documentation](https://codex.wordpress.org/Plugin_API/Action_
 1. Install the [HTTP Strict Transport Security](https://drupal.org/project/hsts) module using the [Drupal interface](https://www.drupal.org/docs/8/extending-drupal-8/installing-modules) or with [Terminus](/terminus/):
 
     ```bash
-    terminus remote:drush <site>.<env> -- pm-enable hsts --yes
+    terminus remote:drush <site>.<env> pm-enable hsts --yes
     ```
 
 2. Visit the module configuration page (`/admin/config/system/hsts`).
@@ -85,7 +85,7 @@ strict-transport-security: max-age=31536000
 1. Install the [HTTP Strict Transport Security](https://drupal.org/project/hsts) module using the [Drupal interface](https://www.drupal.org/docs/7/extending-drupal/installing-modules) or with [Terminus](/terminus):
 
   ```bash
-  terminus remote:drush <site>.<env> -- pm-enable hsts --yes
+  terminus remote:drush <site>.<env> pm-enable hsts --yes
   ```
 
 2. Visit the module configuration page (`/admin/config/security/hsts`).

--- a/source/content/http-to-https.md
+++ b/source/content/http-to-https.md
@@ -67,7 +67,7 @@ Use the following techniques to replace insecure references to your domain in th
   If you'd rather not add another plugin to the site you can use [Terminus](/terminus) to run `wp search-replace` to converts URLs from HTTP to HTTPS:
 
   ```
-  terminus remote:wp <site>.<env> -- search-replace 'http://www.example.com' 'https://www.example.com' --all-tables --verbose
+  terminus remote:wp <site>.<env> search-replace 'http://www.example.com' 'https://www.example.com' --all-tables --verbose
   ```
 
   **Via Site Dashboard**

--- a/source/content/ldap-and-ldaps.md
+++ b/source/content/ldap-and-ldaps.md
@@ -89,7 +89,7 @@ The majority of problems with LDAP on Pantheon come from misconfigurations. Pant
 Use the following script to troubleshoot a variety of configuration problems. Customize it with your settings, then place it in your site root with a name like ldap-test.php. This script requires PHP 7.1 to execute properly without PHP errors.  If you are connecting via a Pantheon Secure Integration, use the alternate $settings array below the full script instead.  You can execute it remotely using [Terminus](/terminus/) to fully bootstrap Drupal and include the environmental configurations from your settings.php:
 
 ```bash
-terminus drush <site>.<env> -- scr ldap-test.php
+terminus drush <site>.<env> scr ldap-test.php
 ```
 
 The entire script:

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -179,13 +179,13 @@ By default, Drupal logs events using the Database Logging module (dblog). PHP fa
 * Using [Terminus](/terminus/):
 
  ```bash
- terminus drush <site>.<env> -- watchdog-show
+ terminus drush <site>.<env> watchdog-show
  ```
 
  * Terminus can invoke Drush commands to "watch" events in real-time; `--tail` can be used to continuously show new watchdog messages until  interrupted (Control+C).
 
   ```bash
-  terminus drush <site>.<env> -- watchdog-show --tail
+  terminus drush <site>.<env> watchdog-show --tail
   ```
 
   <Alert title="Note" type="info">

--- a/source/content/migrate-wordpress-site-networks.md
+++ b/source/content/migrate-wordpress-site-networks.md
@@ -171,7 +171,7 @@ When you imported your database, all of the URLs remained active at the previous
 **Pro Tip**: Include the `--dry-run` flag to get a preview of the changes without destructively transforming the database and use `--verbose` to receive additional details in the output (optional).
 
 ```bash
-terminus wp <site>.<env> -- search-replace example.com dev-example-network.pantheonsite.io --url=example.com --network
+terminus wp <site>.<env> search-replace example.com dev-example-network.pantheonsite.io --url=example.com --network
 ```
 
 Visit the Development environment and confirm your site was imported correctly!

--- a/source/content/phpinfo.md
+++ b/source/content/phpinfo.md
@@ -37,5 +37,5 @@ Drupal makes the phpinfo available to privileged users at `https://example.com/a
 As an alternative to exposing these values on a web accessible URL, you can use [Terminus](/terminus/) to check these values:
 
 ```
-terminus remote:drush <SITE>.<ENV> -- ev "print(phpinfo())"
+terminus remote:drush <SITE>.<ENV> ev "print(phpinfo())"
 ```

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -246,13 +246,13 @@ $databases['default']['default']['collation'] = 'utf8mb4_general_ci';
 Existing sites that already have an active database must install the [UTF8MB4 Convert](https://www.drupal.org/project/utf8mb4_convert) Drush command and convert the database. Note that this is not a Drupal module that can be enabled, it's a Drush command that should be placed within `/sites/all/drush`. Once you've installed the command in `/sites/all/drush`, you must clear Drush cache for the new command to run. Clear Drush cache using [Terminus](/terminus/):
 
 ```bash
-terminus drush <site>.<env> -- cc drush
+terminus drush <site>.<env> cc drush
 ```
 
 Start by making a [backup](/backups/) of the site database, then place the site in maintenance mode and run the following:
 
 ```bash
-terminus drush <site>.<env> -- utf8mb4-convert-databases
+terminus drush <site>.<env> utf8mb4-convert-databases
 ```
 
 This will convert the database tables in the existing installation to the proper encoding to support emoji characters. After making the conversion, test it out by placing an emoji in the site text.

--- a/source/content/private-paths.md
+++ b/source/content/private-paths.md
@@ -79,7 +79,7 @@ Make sure to set a relative path. This ensures the key path will work on all app
 You can either set the path in the Drupal admin interface, or with Terminus and Drush as below:
 
    ```bash
-   terminus drush <site>.<env> -- vset uc_credit_encryption_path <my_private_path>
+   terminus drush <site>.<env> vset uc_credit_encryption_path <my_private_path>
    ```
 
    `<my_private_path>` can be set to either of these non-web accessible private directories:
@@ -92,7 +92,7 @@ You can either set the path in the Drupal admin interface, or with Terminus and 
     * Optionally, verify that `uc_credit_encryption_path` is set correctly:
 
      ```bash
-     terminus drush <site>.<env> -- vget uc_credit_encryption_path
+     terminus drush <site>.<env> vget uc_credit_encryption_path
      ```
 
 <Alert title="Note" type="info">

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -38,13 +38,13 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
 2. Install the [WP Redis](https://wordpress.org/plugins/wp-redis/) plugin via SFTP or Git. To install via [Terminus](/terminus), [set the connection mode to SFTP](/sftp) then run:
 
     ```
-    terminus wp <site>.<env> -- plugin install wp-redis
+    terminus wp <site>.<env> plugin install wp-redis
     ```
 
     For site networks, you will need to specify the site URL by adding that to the command:
 
     ```
-    terminus wp <site>.<env> -- plugin install wp-redis --url=<url>
+    terminus wp <site>.<env> plugin install wp-redis --url=<url>
     ```
 3. Create a new file named `wp-content/object-cache.php` that contains the following:
 
@@ -63,7 +63,7 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
     When a new version of the WP Redis plugin is released, you can upgrade by the normal Plugin update mechanism in WordPress or via Terminus:
 
     ```bash
-    terminus wp <site>.<env> -- plugin update wp-redis
+    terminus wp <site>.<env> plugin update wp-redis
     ```
 
 <Alert title="Note" type="info">
@@ -134,7 +134,7 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
     You can install and enable the module from the command line using [Terminus](/terminus):
 
     ```bash
-    terminus remote:drush <site>.<env> -- en redis -y
+    terminus remote:drush <site>.<env> en redis -y
     ```
 
 3. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site.
@@ -176,7 +176,7 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 2. Add the [Redis](https://www.drupal.org/project/redis) module from Drupal.org. You can install and enable the module from the command line using [Terminus](/terminus):
 
     ```bash
-    terminus remote:drush <site>.<env> -- en redis -y
+    terminus remote:drush <site>.<env> en redis -y
     ```
 
 3. Ignore the directions bundled with the Redis module. Pantheon automatically manages the following `settings.php`/`$conf`/`variable_get` items for you:

--- a/source/content/resetting-passwords.md
+++ b/source/content/resetting-passwords.md
@@ -30,13 +30,13 @@ Please keep in mind that your site password is stored in a database, so whatever
 If you still can’t get access to your site using password reset, for example if you don't have access to the corresponding email address for the account, you can still generate a one-time password reset link by using the following [Terminus](/terminus/) command for generating one-time login links:
 
 ```bash
-terminus drush <site>.<env> -- user-login
+terminus drush <site>.<env> user-login
 ```
 
 Or you can reset any user's password from the command line by running the [`user-password` Drush command](https://drushcommands.com/drush-8x/user/user-password/) via [Terminus](/terminus/):
 
 ```bash
-terminus drush <site>.<env> -- user-password user_name --password='Astr0nGP455w0rD'
+terminus drush <site>.<env> user-password user_name --password='Astr0nGP455w0rD'
 ```
 
 Remember to change the password from the example above.
@@ -60,7 +60,7 @@ You will receive an email that contains a link you can use one time to reset you
 Or you can reset any user's password from the command line by running [WP-CLI's `user update` command](https://wp-cli.org/commands/user/update/) via [Terminus](/terminus/):
 
 ```bash
-terminus wp <site>.<env> -- user update you@example.com --user_pass=NEWPASSWORD
+terminus wp <site>.<env> user update you@example.com --user_pass=NEWPASSWORD
 ```
 
 Remember to change the password from the example above.

--- a/source/content/security.md
+++ b/source/content/security.md
@@ -58,7 +58,7 @@ Your site may also be locked and unlocked using [Terminus](/terminus).
 To lock a site:
 
 ```bash
-terminus lock:enable <site>:<env> -- user password
+terminus lock:enable <site>:<env> user password
 ```
 
 To unlock a site:
@@ -86,7 +86,7 @@ Alternatively, you can resolve 403 errors by using [Terminus](/terminus) to disa
 <Tab title="Drupal 8" id="d8" active={true}>
 
 ```bash
-terminus remote:drush <site>:<env> -- pm-uninstall basic_auth -y
+terminus remote:drush <site>:<env> pm-uninstall basic_auth -y
 ```
 
 </Tab>
@@ -94,7 +94,7 @@ terminus remote:drush <site>:<env> -- pm-uninstall basic_auth -y
 <Tab title="Drupal 7" id="d7">
 
 ```bash
-terminus remote:drush <site>:<env> -- pm-disable basic_auth -y
+terminus remote:drush <site>:<env> pm-disable basic_auth -y
 ```
 
 </Tab>

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -55,7 +55,7 @@ The `HASH_SALT` value should also be set within `settings.local.php`. See Drush 
 To use the Pantheon `HASH_SALT` in your local site (not necessary), you can get it via [Terminus](/terminus):
 
 ```
-terminus drush <site>.<env> -- ev 'return getenv("DRUPAL_HASH_SALT")'
+terminus drush <site>.<env> ev 'return getenv("DRUPAL_HASH_SALT")'
 ```
 
 Drupal 8 will not run locally without a hash salt, but it need not be the same one set on the Pantheon platform; any sufficiently long random string will do. Make sure to set one in `settings.local.php` :

--- a/source/content/solr-drupal-7.md
+++ b/source/content/solr-drupal-7.md
@@ -155,12 +155,12 @@ Keep in mind that newly indexed items have a 2-minute delay until cron has been 
 #### apachesolr.module
 If you're using the Apache Solr module, you can check for the existence of this variable using [Terminus](/terminus/):
 ```bash
-terminus drush <site>.<env> -- vget apachesolr_service_class
+terminus drush <site>.<env> vget apachesolr_service_class
 ```
 #### search_api_solr.module
 If you are using search_api_solr.module, you can check it with the command:
 ```bash
-terminus drush <site>.<env> -- vget search_api_solr_connection_class
+terminus drush <site>.<env> vget search_api_solr_connection_class
 ```
 
 ### Error During Search API Solr Installation

--- a/source/content/solr-drupal-8.md
+++ b/source/content/solr-drupal-8.md
@@ -101,7 +101,7 @@ After adding fields the configuration, make sure the index is full by clicking *
 It is a best practice in Drupal 8 to export your changes to `yml` files. You can quickly export configuration changes via [Terminus](/terminus):
 
 ```
-terminus drush site.env -- config-export -y
+terminus drush site.env config-export -y
 ```
 
 Replace `site` and `env` with your site name and the environment (Dev, Multidev, etc), respectively.

--- a/source/content/terminus/examples.md
+++ b/source/content/terminus/examples.md
@@ -151,7 +151,7 @@ terminus connection:set my-site.dev sftp
 Apply updates to all contrib projects:
 
 ```bash
-terminus drush my-site.dev -- pm-updatecode --no-core
+terminus drush my-site.dev pm-updatecode --no-core
 ```
 
 Commit contrib updates to the Dev environment:
@@ -173,13 +173,13 @@ terminus connection:set my-site.dev sftp
 Apply updates to all plugins:
 
 ```bash
-terminus wp my-site.dev -- plugin update --all
+terminus wp my-site.dev plugin update --all
 ```
 
 Apply updates to all themes:
 
 ```bash
-terminus wp my-site.dev -- theme update --all
+terminus wp my-site.dev theme update --all
 ```
 
 Commit plugin and theme updates to the Dev environment:

--- a/source/content/timeouts.md
+++ b/source/content/timeouts.md
@@ -35,7 +35,7 @@ Rules are for the good of the group, and timeouts are no exception. We've config
 
 ### Can I manually run Drupal cron for longer than the Pantheon executed Drupal cron?
 
-Yes, just use `terminus drush <site>.<env> -- cron` using [Terminus](/terminus/). With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an inefficient process, determine why it's slow and fix the root cause.
+Yes, just use `terminus drush <site>.<env> cron` using [Terminus](/terminus/). With that said, most slow cron executions are due to PHP errors or a slow external service. Rather than throwing more resources at an inefficient process, determine why it's slow and fix the root cause.
 
 ### What if I run into a timeout when using the Drupal Migrate UI?
 

--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -49,7 +49,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 Verify the setting by using [Terminus](/terminus/) to run `wp config get`:
 
 ```bash
-terminus wp $site.$env -- config get SOME_TMP_SETTING
+terminus wp $site.$env config get SOME_TMP_SETTING
 ```
 
 Output of this command should look something like the following Contact Form 7 example:
@@ -75,7 +75,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 Verify the setting by using [Terminus](/terminus/) to run `drush variable-get`:
 
 ```bash
-terminus drush $site.$env -- variable-get some_tmp_setting
+terminus drush $site.$env variable-get some_tmp_setting
 ```
 
 Output of this command should look something like the following Plupload example:
@@ -102,7 +102,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 Verify the setting by using [Terminus](/terminus/) to run `drush config-get` with `--include-overridden`:
 
 ```bash
-terminus drush $site.$env -- config-get some_module.settings some_tmp_setting --include-overridden
+terminus drush $site.$env config-get some_module.settings some_tmp_setting --include-overridden
 ```
 
 Output of this command should look something like the following Plupload example:
@@ -155,7 +155,7 @@ The `private` and `tmp` directories do not exist by default; you must create the
 Verify the setting by using [Terminus](/terminus/) to run `wp config get`:
 
 ```bash
-terminus wp $site.$env -- config get SOME_TMP_SETTING
+terminus wp $site.$env config get SOME_TMP_SETTING
 ```
 
 Output of this command should look something like the following Contact Form 7 example:
@@ -183,7 +183,7 @@ The `private` and `tmp` directories do not exist by default; you must create the
 Verify the setting by using [Terminus](/terminus/) to run `drush variable-get`:
 
 ```bash
-terminus drush $site.$env -- variable-get some_tmp_setting
+terminus drush $site.$env variable-get some_tmp_setting
 ```
 
 Output of this command should look something like the following Plupload example:
@@ -211,7 +211,7 @@ The `private` and `tmp` directories do not exist by default; you must create the
 Verify the setting by using [Terminus](/terminus/) to run `drush config-get` with `--include-overridden`:
 
 ```bash
-terminus drush $site.$env -- config-get some_module.settings some_tmp_setting --include-overridden
+terminus drush $site.$env config-get some_module.settings some_tmp_setting --include-overridden
 ```
 
 Output of this command should look something like the following Plupload example:

--- a/source/content/unwind-drupal-multisite.md
+++ b/source/content/unwind-drupal-multisite.md
@@ -23,9 +23,9 @@ This method will safely migrate a single site out of your Drupal Multisite and i
 
 6. [Backup the site](/backups/#create-a-backup) in the Dashboard, just in case.
 
-7. Run `terminus drush <site>.<env> -- sar --dry-run sites/sitename1 sites/default` to test the search and replace. This exact command can change depending on the name of your site, and broken assets in step 3.
+7. Run `terminus drush <site>.<env> sar --dry-run sites/sitename1 sites/default` to test the search and replace. This exact command can change depending on the name of your site, and broken assets in step 3.
 
-8. Once the dry run looks good, do it for real, e.g. `terminus drush <site>.<env> -- sar sites/sitename1 sites/default`.
+8. Once the dry run looks good, do it for real, e.g. `terminus drush <site>.<env> sar sites/sitename1 sites/default`.
 
 9. Check your site again for broken links and images. We recommend using a link checker.
 

--- a/source/content/videos/terminus.md
+++ b/source/content/videos/terminus.md
@@ -21,10 +21,10 @@ And deploy changes between Dev, Test, and Live environments. I’ll do this by r
 If it can be accomplished in the Pantheon dashboard, it can probably be accomplished with Terminus.
 
 
-You can also execute Drupal or WordPress-specific commands using Drush or WP-CLI. For example, the command  `terminus drush` followed by the site name and environment, then `user-create -- newuser1` with the email address of the user, can be used to create a new Drupal user.
+You can also execute Drupal or WordPress-specific commands using Drush or WP-CLI. For example, the command  `terminus drush` followed by the site name and environment, then `user-create newuser1` with the email address of the user, can be used to create a new Drupal user.
 
 
-Update WordPress plugins by running `terminus wp` the site name and environment, `-- plugin update --all`, to update all.
+Update WordPress plugins by running `terminus wp` the site name and environment, `plugin update --all`, to update all.
 
 Terminus also makes it easy to automate tasks. In this example, we’ve scripted a set of Terminus commands to identify, install, and test WordPress updates. If the tests pass, as they do here, our script pushes the WordPress updates to our Live environment.
 

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -46,7 +46,7 @@ You can also schedule your own jobs, execute existing jobs, and manage just abou
 One of the first things you'll want to do is test WP-Cron to make sure everything is working correctly. When you execute the command below, make sure to replace SITE_NAME with your site's name from your Pantheon Dashboard and replace ENV_NAME with the desired environment ("dev", "test", "live", or multidev branch name).
 
 ```
-$ terminus wp <site>.<env> -- cron test
+$ terminus wp <site>.<env> cron test
 ```
 
 If everything works correctly, the result looks like this:
@@ -58,7 +58,7 @@ Success: WP-Cron spawning is working as expected.
 This lets you know that WP-Cron is working properly on your site. From here, you can run any cron-related command with [WP-CLI](https://developer.wordpress.org/cli/commands/cron/ "wp-cli web site"). When using WP-CLI to manage your Pantheon hosted WordPress site, you should be using [Terminus](/terminus/). The command format is as follows:
 
 ```
-$ terminus wp <site>.<env> -- cron <your wp-cron command and switches here>
+$ terminus wp <site>.<env> cron <your wp-cron command and switches here>
 ```
 
 All `terminus wp` commands require a site name and environment to operate.

--- a/source/content/wordpress-development-versions.md
+++ b/source/content/wordpress-development-versions.md
@@ -22,7 +22,7 @@ Development versions and beta releases are not supported and should not be run o
 2. Install and activate the [WordPress Beta Tester](https://wordpress.org/plugins/wordpress-beta-tester/) plugin within the WordPress Dashboard or with Terminus:
 
  ```
- terminus wp <site>.<env> -- plugin install wordpress-beta-tester --activate --yes
+ terminus wp <site>.<env> plugin install wordpress-beta-tester --activate --yes
  ```
 
 3. Go to **Tools** > **WordPress Beta Tester** and select the update stream you want to use, then click **Save**:
@@ -31,7 +31,7 @@ Development versions and beta releases are not supported and should not be run o
 
 
 4. Go to **Dashboard** > **Updates** and click **Update Now**.
-5. Verify the WordPress version using `terminus wp <site>.<env> -- core version` or check the bottom of any WordPress Dashboard page:
+5. Verify the WordPress version using `terminus wp <site>.<env> core version` or check the bottom of any WordPress Dashboard page:
 
   > You are using a development version (4.5-beta1-36808). Cool! Please stay updated.
 

--- a/source/content/wordpress-s3.md
+++ b/source/content/wordpress-s3.md
@@ -107,7 +107,7 @@ This plugin has known [multisite issues](https://github.com/humanmade/S3-Uploads
 You can migrate existing media files to S3 with the following command:
 
 ```bash
-terminus wp $site.dev -- s3-uploads migrate-attachments
+terminus wp $site.dev s3-uploads migrate-attachments
 ```
 
 Optionally, add the `--delete-local` flag to remove the local copies of the media files.

--- a/source/content/wordpress-sessions.md
+++ b/source/content/wordpress-sessions.md
@@ -33,7 +33,7 @@ If `$_SESSIONs` are necessary for your application, install the [WordPress Nativ
 2. Install and activate  [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=wp+native-php-sessions`) or with Terminus:
 
  ```
- terminus wp <site>.<env> -- plugin install wp-native-php-sessions --activate
+ terminus wp <site>.<env> plugin install wp-native-php-sessions --activate
  ```
 
 3. Deploy the plugin to the Test environment within the Site Dashboard or with Terminus:
@@ -45,7 +45,7 @@ If `$_SESSIONs` are necessary for your application, install the [WordPress Nativ
 4. Activate the plugin within the WordPress Dashboard on the Test environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```
- terminus wp <site>.test -- plugin activate wp-native-php-sessions
+ terminus wp <site>.test plugin activate wp-native-php-sessions
  ```
 
 5. Deploy the plugin to the Live environment within the Site Dashboard or with Terminus:
@@ -57,7 +57,7 @@ If `$_SESSIONs` are necessary for your application, install the [WordPress Nativ
 6. Activate the plugin within the WordPress Dashboard on the Live environment (`/wp-admin/plugins.php`) or with Terminus:
 
  ```
- terminus wp <site>.live -- plugin activate wp-native-php-sessions
+ terminus wp <site>.live plugin activate wp-native-php-sessions
  ```
 
 Once enabled, your functionality will "just work". For more information, see [Fix WordPress PHP Session Problems on Pantheon with a Script](https://pantheon.io/blog/fix-wordpress-php-session-problems-pantheon-script).

--- a/source/content/wordpress-solr.md
+++ b/source/content/wordpress-solr.md
@@ -31,12 +31,12 @@ This plugins requires PHP version 7.1 or higher. See [Upgrade PHP versions](/php
 2. Install and activate the [Solr Search for WordPress (Solr Power)](https://wordpress.org/plugins/solr-power/) plugin on the Dev or Multidev environment using the WordPress Dashboard or with Terminus:
 
  ```bash
- terminus wp <site>.<env> -- plugin install --activate solr-power
+ terminus wp <site>.<env> plugin install --activate solr-power
  ```
 
  Or for WP Site Networks:
  ```bash
- terminus wp <site>.<env> -- plugin install --activate --network solr-power
+ terminus wp <site>.<env> plugin install --activate --network solr-power
  ```
 
 3. From the WordPress Dashboard, navigate to **Solr Options** (previously under **Settings**). You should see your site's Solr Server details within the **Info** tab.
@@ -50,12 +50,12 @@ This plugins requires PHP version 7.1 or higher. See [Upgrade PHP versions](/php
 5. Index all publicly queryable post types by navigating to the **Actions** tab and clicking **Execute** next to **Index Searchable Post Types**, or via Terminus:
 
  ```bash
- terminus wp <site>.<env> -- solr index
+ terminus wp <site>.<env> solr index
  ```
 
  For WP Site Networks, you will need to index all your subsites individually:
  ```bash
- terminus wp <site>.<env> -- url=example.pantheonsite.io/subsite solr index
+ terminus wp <site>.<env> url=example.pantheonsite.io/subsite solr index
  ```
 
 6. Deploy the plugin to the site's Test and Live environments after validation and testing.

--- a/source/content/wp-cfm.md
+++ b/source/content/wp-cfm.md
@@ -26,7 +26,7 @@ Each of the following steps can be done using the Pantheon and WordPress Dashboa
 
 2. Install the [WP-CFM](https://wordpress.org/plugins/wp-cfm/) plugin on the Dev Environment using the WordPress Dashboard or with Terminus:
  ```bash
- terminus wp <site>.<env> -- plugin install --activate wp-cfm
+ terminus wp <site>.<env> plugin install --activate wp-cfm
  ```
 
 3. Commit this change using the Site Dashboard or with Terminus:
@@ -43,8 +43,8 @@ Each of the following steps can be done using the Pantheon and WordPress Dashboa
 
 5. Activate the plugin on the Test and Live environments using the WordPress Dashboard or with Terminus:
  ```bash
- terminus wp <site>.test -- plugin activate wp-cfm
- terminus wp <site>.live -- plugin activate wp-cfm
+ terminus wp <site>.test plugin activate wp-cfm
+ terminus wp <site>.live plugin activate wp-cfm
  ```
 
 ## Configuration Bundling
@@ -75,7 +75,7 @@ To create a bundle:
  This creates a new file (e.g. `wp-content/config/bundle_name.json`) where configurations are stored for the bundle. Once the file exists, you can run the **Push** operation with Terminus, if preferred:
 
  ```bash
- terminus wp <site>.dev -- config push <bundle_name>
+ terminus wp <site>.dev config push <bundle_name>
  ```
 
 3. Commit your configuration to the codebase (`.json` bundle file) using the Site Dashboard or Terminus:
@@ -98,7 +98,7 @@ Deploy the `.json` file from Dev to Test.
 2. Import configuration from the codebase into the database by clicking **Pull** for your bundle(s) within the Test environment's WordPress Dashboard (`/wp-admin/options-general.php?page=wpcfm`) or with Terminus:
 
  ```
- terminus wp <site>.test -- config pull <bundle_name>
+ terminus wp <site>.test config pull <bundle_name>
  ```
 3. Test configuration on the Test environment URL with the content copied from Live.
 
@@ -112,7 +112,7 @@ Deploy the `.json` file from Dev to Test.
 2. Import configuration from the codebase into the database by clicking **Pull** within the Live environment's WordPress Dashboard (`/wp-admin/options-general.php?page=wpcfm`) or with Terminus:
 
  ```
- terminus wp <site>.live -- config pull <bundle_name>
+ terminus wp <site>.live config pull <bundle_name>
  ```
 3. Test the configuration on Live.
 

--- a/source/content/wp-cli.md
+++ b/source/content/wp-cli.md
@@ -25,7 +25,7 @@ Each of these global parameters define the **context** under which the command i
 
 Now that we've covered the most important basics, let's run a command:
 
-    $ terminus wp pantheon-demo.dev -- option get home
+    $ terminus wp pantheon-demo.dev option get home
     [2015-11-25 02:42:12] [info] Running wp option get home  on pantheon-demo
         cmd: 'option get home'
         flags: ''
@@ -52,7 +52,7 @@ Feeling comfortable with WP-CLI? Here are a [few of many commands](https://devel
 Use the `wp db query` command via [Terminus](/terminus/) to run SQL queries against the database on Pantheon:
 
 ```bash
-terminus wp <site>.<env> -- db query "SELECT * FROM wp_users WHERE ID=1"
+terminus wp <site>.<env> db query "SELECT * FROM wp_users WHERE ID=1"
 ```
 
 ## Extending WP-CLI With Subcommands


### PR DESCRIPTION
Closes #5009

## Effect
PR includes the following changes:
- Mass replace to remove `--` when not needed in Terminus commands.

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)