### PR TITLE
Fix typo in connecting domain launch essentials description.

### DIFF
--- a/source/content/guides/launch/03-domains.md
+++ b/source/content/guides/launch/03-domains.md
@@ -1,7 +1,7 @@
 ---
 title: Launch Essentials
 subtitle: Connect a Domain Name
-description: Part three of our Launch Essentials guide covers connectin your domain to your Pantheon-hosted site.
+description: Part three of our Launch Essentials guide covers connecting your domain to your Pantheon-hosted site.
 launch: true
 anchorid: domains
 generator: pagination


### PR DESCRIPTION
## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
