### PR TITLE
hunt down and fix /docs/ links

### DIFF
--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -50,7 +50,7 @@ A Custom Upstream based off Pantheon's example repositories would need to commit
 
 This workflow has one very serious shortcoming, that is site-specific dependencies are likely to cause a lot of conflicts. The practical use case for this workflow is for a large group of sites that require a single set of dependencies. You should only use this method if you don’t intend to use site specific themes, modules, or plugins downstream.
 
-You can also prevent upstream updates by [setting an empty upstream](/docs/guides/composer-convert/#change-upstreams). This action is available to Site Owner, Organization Administrator, and Users in Charge roles.
+You can also prevent upstream updates by [setting an empty upstream](/guides/composer-convert/#change-upstreams). This action is available to Site Owner, Organization Administrator, and Users in Charge roles.
 
 ## Next Steps
 Follow the [Build Tools Guide](/guides/build-tools/) to learn best practices for Composer on Pantheon, or [Drupal 8 and Composer on Pantheon Without Continuous Integration](/guides/drupal-8-composer-no-ci/) if you don't want to use CI tools in your development process.
@@ -64,4 +64,4 @@ If you're not ready to go all in with a Composer workflow and you want to see ho
 
 ## See Also
 
- - [Convert a Standard Drupal 8 Site to a Composer Managed Site](/docs/guides/composer-convert/)
+ - [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert/)

--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -8,7 +8,7 @@ earlynote: The documentation on this page discusses features and options that ar
 contributors: [edwardangert]
 ---
 
-Pantheon offers a number of [ways to connect to your site](/guides/quickstart/connection-modes/). In addition to Git and SFTP modes, [Pantheon Localdev](https://pantheon.io/localdev) gives you a graphical interface to your Pantheon sites, complete with a containerized local environment that makes it easy to develop and preview your site locally while still maintaining the [Pantheon Workflow](/docs/pantheon-workflow/).
+Pantheon offers a number of [ways to connect to your site](/guides/quickstart/connection-modes/). In addition to Git and SFTP modes, [Pantheon Localdev](https://pantheon.io/localdev) gives you a graphical interface to your Pantheon sites, complete with a containerized local environment that makes it easy to develop and preview your site locally while still maintaining the [Pantheon Workflow](/pantheon-workflow/).
 
 Localdev lets you [use an integrated development environment (**IDE**)](#use-a-local-ide-to-develop-your-pantheon-site) to edit files and code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview, even when you don't have an internet connection.
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
