### PR TITLE
all headings now have a space between the # and the heading

### DIFF
--- a/source/content/cloud-optimization.md
+++ b/source/content/cloud-optimization.md
@@ -9,14 +9,14 @@ Pantheon as a platform attempts to balance the tradeoff between high performance
 A traditional single server has a high risk of being impacted by any unexpected event because it is a single point of failure. If a single service becomes unavailable due to a webserver problem, database failure, network degradation, or even because of high traffic, the entire site goes down.
 
 
-##Benefits and Concerns
+## Benefits and Concerns
 As distributed web architecture has evolved, best practices for high availability have emerged: application containers can be put behind load balancers, database servers can be replicated, backups can be hosted at remote locations.
 
 Cloud-based file systems, such as our Valhalla cluster, also reduce the impact of even the most severe outages. This evolution has other advantages: our cloud-based distributed architecture allows for smooth scaling in seconds via software, rather than through adding servers.
 
 However, there are tradeoffs to the cloud. On a single server, where the database is sharing an operating system with the webserver, there is no communication latency executing a MySQL query during a page load. In a distributed scenario, this same transaction may take one or two milliseconds to traverse servers. While this does not seem like a prohibitively long time, loading a single page may execute hundreds of mysql queries. The aggregate result will be that moving to the cloud can slow an inefficient site down.
 
-##Solutions
+## Solutions
 
 There are a number of solutions for optimizing your site for the cloud. A site should be built with a clear idea of what an acceptable performance profile is for anonymous and logged in users. Establishing this first can drive the site architecture and caching strategy. Here are other important steps:
 

--- a/source/content/debug-connections.md
+++ b/source/content/debug-connections.md
@@ -36,10 +36,10 @@ dig @8.8.8.8 dig codeserver.dev.<xxx>.drush.in +short
 ```
 If an IP address is returned, [configure your network settings to use Google Public DNS](https://developers.google.com/speed/public-dns/docs/using#configure_your_network_settings_to_use_google_public_dns).
 
-###Port 2222 or Other Blocked Ports
+### Port 2222 or Other Blocked Ports
 Make sure the port number is not blocked by your internal firewall. For example, to test whether port 2222 is blocked visit [http://portquiz.net:2222/](http://portquiz.net:2222/)
 
 If you are not able to access port 2222, you can try our [workaround](/port-2222/).
 
-##Test Connection on the Command Line
+## Test Connection on the Command Line
 We recommend using the command line when troubleshooting connection issues as GUIs can hide underlying errors. From the site Dashboard, copy the provided connection command for the desired service and run it in terminal.

--- a/source/content/doc-template.md
+++ b/source/content/doc-template.md
@@ -95,7 +95,7 @@ Images of terminal output is frowned upon. When small changes are required to co
  - Only assume as much knowledge from the reader as specified in [Before You Begin](#before-you-begin). Otherwise explain everything.
  - Notice the `draft: true` line in this template's header? If keeps this page from being visible in the live site. Be sure to remove it from your doc.
 
-##See Also
+## See Also
 
 If you can, end your doc with links to external resources that can be used to improve the reader's comprehension, or to guides on logical next steps in a common development workflow.
 

--- a/source/content/drupal-security-patches.md
+++ b/source/content/drupal-security-patches.md
@@ -99,6 +99,6 @@ done
 
 ```
 
-##See Also
+## See Also
 
  - [Drupal Security Advisory](https://www.drupal.org/security)

--- a/source/content/guides/rerouting-outbound-email.md
+++ b/source/content/guides/rerouting-outbound-email.md
@@ -57,7 +57,7 @@ Now check your Site Dashboard and you’ll see that the module’s code has been
 
 
 
-##Configuration
+## Configuration
 
 If you don’t have a settings.php file, copy the default.settings.php file.  You can copy the file however you like, but my preference is from the command line:
 ```
@@ -98,7 +98,7 @@ A few notes:
 For more about Reroute Email’s settings, see the README.txt that ships with the module.
 
 
-###Stage and Commit Settings.php
+### Stage and Commit Settings.php
 ```
 $ git add sites/default/settings.php
 $ git commit
@@ -139,11 +139,11 @@ If you don’t see what you’re expecting, review your settings.php and ensure 
 
 <Image alt="The dashboard showing the code was deployed to the Dev environment" src="dashboard/verify-reroute-email-dashboard-commits2.png" />
 
-##Go Forth and Test
+## Go Forth and Test
 
 That’s it! Now when Drupal sends out an email from any environment (except Live), it will get rerouted to the email address specified in settings.php. Our settings.php will make sure email is not rerouted on Live, so it’s business as usual. Make sure you’re using a [SMTP gateway](/email/#outgoing-email) on Live to ensure email deliverability.
 
-###See Reroute Email In Action
+### See Reroute Email In Action
 To see exactly what we did, I forked a new [MultiDev](/multidev/) Multidev environment called ```demo``` and requested a new account:
 
 <Image alt="Drupal site showing account requested and emails sent" src="reroute-email-account-requested.png" />
@@ -152,5 +152,5 @@ Requesting a new account fires off two emails: one to the requestor and another 
 
 <Image alt="Email showing the reroute was successful" src="reroute-email-confirmation.png" />
 
-##See Also
+## See Also
 [Manage Email Handling for Development or Testing](https://www.drupal.org/node/201981)

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -64,7 +64,7 @@ $ terminus site:list
 
 ```
 
-###Update the Code
+### Update the Code
 
 Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal set ready to go for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
 
@@ -109,7 +109,7 @@ $ terminus env:list <site>
 ------ --------------------- ------------------------------------ ----------------- -------- -------------
 ```
 
-###Install Contrib Modules and Themes
+### Install Contrib Modules and Themes
 While the site's Dev environment is still in SFTP mode, we can use Drush to download and install some Drupal contrib modules, such as Views and Administration Menu.
 
 ```

--- a/source/content/guides/two-factor-authentication.md
+++ b/source/content/guides/two-factor-authentication.md
@@ -184,7 +184,7 @@ We recommend adding an [SSH Key](/ssh-keys) to authenticate yourself on Pantheon
 ### Single Sign-On for Orgs
 Single sign-on (SSO) allows users to authenticate against your Identity Provider (IdP) when logging into the Pantheon Dashboard. For more information, see [Single Sign-On for Pantheon Organizations](/sso-organizations/).
 
-##See Also
+## See Also
 - [Security on Pantheon](https://pantheon.io/security)
 - [WordPress Two Step Authentication](https://codex.wordpress.org/Two_Step_Authentication)
 - [Drupal Modules For Two-Factor Authentication](https://groups.drupal.org/node/235938)

--- a/source/content/load-and-performance-testing.md
+++ b/source/content/load-and-performance-testing.md
@@ -53,7 +53,7 @@ Ultimately, it doesn't matter what tool(s) you use as long as you test your site
   * **Load Tests**: Determine how many concurrent users the site is expected to serve based on historical analytics for the site. Identify the peak hourly sessions and average session duration, then do some math: `hourly_sessions / (60 / average_duration) = Concurrent Users`
 
 
-##Running the Tests
+## Running the Tests
 If this is a performance test, be sure to run the test on a development environment (Dev or [Multidev](/multidev)) without caching. Run load tests on the Live environment before launching the site. If the site is already launched, use the Test environment instead.
 
 <Alert title="Warning" type="danger">

--- a/source/content/single-application-sites.md
+++ b/source/content/single-application-sites.md
@@ -16,6 +16,6 @@ While we can't give specific recommendations for your sites, we can give general
 - Domain access on a single site install. For a Drupal site, try the [Subfolders Domain (sub domains)](https://www.drupal.org/project/subfolders_domain) module but there is no guarantee it will work.
 - [Organic Groups](https://www.drupal.org/project/og)  
 
-##See Also
+## See Also
 [Why Drupal Multisite Is Not Enterprise Grade](https://pantheon.io/blog/why-drupal-multisite-not-enterprise-grade)  
 [Drupal Multisite: Much Ado About Drupal Multisite](https://pantheon.io/blog/drupal-multisite-much-ado-about-drupal-multisite)  

--- a/style-guide.md
+++ b/style-guide.md
@@ -1,6 +1,6 @@
 **DOCUMENTATION STYLE GUIDE**
 
-#About This Guide
+# About This Guide
 
 This style guide will help contributors who create technical content write in consistent voice, tone, and style.
 
@@ -82,7 +82,7 @@ Use headings in a logical manner. The system we use should generate these from t
 
 Use headings in a logical manner. The site will automatically generate anchor links for H2 and H3 tags, and place them in a Table of Contents in the right column. Generated links will be "pretty".
 
-#A-Z Usage  
+# A-Z Usage
 
 ## Accessibility
 
@@ -109,7 +109,7 @@ For more information regarding accessibility guidelines, see [W3C Web Content Ac
 
 See below for when to use title or sentence case. Never use all caps. If you need to make content prominent, use bold rather than all caps or italics.
 
-###Title Case
+### Title Case
 
 Use title case for all headers, buttons, tab names, and links, and when referring to these elements in technical documentation. However, do not use title case for the words button, link, page, tab. Only capitalize the name displayed on the element, not the type of element.
 
@@ -129,7 +129,7 @@ Click **Clear Caches**.
 
 Select the **Settings** tab.
 
-###Sentence Case
+### Sentence Case
 
 Use sentence case for body content and short phrases, even when the content is a link. Sentence case means you only capitalize the first letter of the sentence.
 
@@ -146,7 +146,7 @@ I use Git on my local machine.
 
 Run "`git add`".
 
-##Contrib Directory
+## Contrib Directory
 
 All Drupal sites used for generating documentation must install contributed modules to sites/all/modules/contrib.
 All references must be to:
@@ -154,7 +154,7 @@ All references must be to:
 sites/all/modules/contrib
 ```
 
-##Cross-Referencing Documents
+## Cross-Referencing Documents
 
 When linking to an article in a sentence, use the exact title of the article if possible. If using the exact title, display it in title case. The link should be blue with no other formatting (bold, italics, quotations).   **Example**:
 
@@ -246,7 +246,7 @@ When writing an outline for a guide or article, decide what the main topics are.
 ## Configuration
 The configuration topic may have a 1-3 paragraphs on its own, as well as several subtopics.
 
-###Stage and Commit Settings.php
+### Stage and Commit Settings.php
 This is a subtopic of Configuration. Specific information related to settings.php will be shown here.
 
 
@@ -262,11 +262,11 @@ If there are tasks a user needs to have completed before continuing on with the 
 
 **Example**:
 
-####Before You Begin
+#### Before You Begin
 
 You’ll need to enable the ApacheSolr module. Visit the [ApacheSolr](https://drupal.org/project/apachesolr "Drupal.org, apache solr project page") page on Drupal.org for more information.
 
-##Pantheon_Environment
+## Pantheon_Environment
 TBD: We should standardize on either using the constant PANTHEON_ENVIRONMENT or the superglobals `$_ENV['PANTHEON_ENVIRONMENT']` (always around) or `$_SERVER['PANTHEON_ENVIRONMENT']` (only around on web-originated requests).
 
 
@@ -292,7 +292,7 @@ For all numbers under 10, spell out the number. For 10 and above, use the numera
 
 **Incorrect**: Joe has 9 sites and needs to add twelve more.
 
-##Procedures
+## Procedures
 
 When writing about procedures, you can include an overview, prerequisites, a list of steps involved in the task, images, goals, and related procedures. The document may or may not include all of those items.
 
@@ -378,7 +378,7 @@ Best Practices:
 
 * Use for uncommon or difficult terms and concepts.
 
-##Referring to Tabs in the Platform
+## Referring to Tabs in the Platform
 
 There are two ways to display tab/page names, depending on usage. In either case, always use title case for the tab/page name.
 


### PR DESCRIPTION
fixes the markdown in docs where there's no space between the `#` and the heading