### PR TITLE
Docs/terminus newrelic apiplugin

### DIFF
--- a/source/content/terminus/plugins/directory.md
+++ b/source/content/terminus/plugins/directory.md
@@ -54,6 +54,12 @@ Fetches metric data from the New Relic API.
 
   </Card>
 
+  <Card title="New Relic API" isOfficial author="Brian Hasselbeck" authorLink="https://github.com/bhasselbeck" link="https://github.com/pantheon-systems/terminus-newrelic-api">
+
+  Fetches New Relic REST API (v2) datapoints; apdex, recent deployments, key transations, error rates, memory usage, response times, etc.
+
+  </Card>
+
   <Card title={"Pancakes"} author={"Dave Wikoff"} authorLink={"https://github.com/derimagia"} link={"https://github.com/terminus-plugin-project/terminus-pancakes-plugin"}>
 
 Open Pantheon Site Databases in your favorite SQL Client.

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -322,3 +322,9 @@
   github: //github.com/szipfel
   twitter: https://twitter.com/szipfel
   bio: Technical Engagement Manager
+- id: bhasselbeck
+  name: Brian Hasselbeck
+  github: //github.com/bhasselbeck
+  linkedin: //www.linkedin.com/in/brianhasselbeck
+  drupal: //drupal.org/u/inertialacoustic
+  avatar: //avatars.githubusercontent.com/u/1899716


### PR DESCRIPTION
This pull request serves as an ask to the docs team to open source and allow for the CSM powered New Relic API plugin to be added to our overall documentation.

## Effect
PR includes the following changes:
- Adds the New Relic API plugin to the terminus plugin listings.
- Adds bhasselbeck as a contributor

## Remaining Work
- The New Relic API plugin will need to be open sources as it's currently private right now.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
