### PR TITLE
Fix GitHub links

### DIFF
--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -37,7 +37,7 @@ const Github = ({ pageTitle, path }) => {
             href={`https://github.com/pantheon-systems/documentation/issues/new?title=New%20Doc%20Proposal%20&body=Priority%3A%20Low%2FMedium%2FHigh%20(choose%20one%2C%20remove%20the%20other%20options)%0A%0A%23%23%20Title%0A%0A%0A%23%23%20Description%0A%0A%0A%23%23%20Outline%0A%0A%0A%23%23%20Expected%20Audience%0A%0A%0A%23%23%20Path%0A(e.g.%20%60source%2Fdocs%2Farticles%2Fsites%2Fcode%60%20or%20%60source%2Fdocs%2Farticles%2Fwordpress%60)&labels=new%20doc`}
             target="blank"
           >
-            Suggest New Content
+            Suggest New Page
           </a>
         </li>
       </ul>

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -26,7 +26,7 @@ const Github = ({ pageTitle, path }) => {
         </li>
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/issues/new?title=${pageTitle}%20Doc%20Update%20&body=Re%3A%20%5B${pageTitle}%5D(https%3A%2F%2Fpantheon.io${path})%0A%0APriority%3A%20Low%2FMedium%2FHigh%20(choose%20one%2C%20remove%20the%20other%20options)%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution`}
+            href={`https://github.com/pantheon-systems/documentation/issues/new?title=${pageTitle}%20Doc%20Update%20&body=Re%3A%20%5B${pageTitle}%5D(https%3A%2F%2Fpantheon.io/docs${path})%0A%0APriority%3A%20Low%2FMedium%2FHigh%20(choose%20one%2C%20remove%20the%20other%20options)%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution`}
             target="blank"
           >
             Report Doc Issue


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Fixes the link to doc pages when creating a new issue from the site.
- Changes "Suggest New Content" to "Suggest New Page" to better align with the purpose of that link.

## Remaining Work
- [x] Agreement on copy change (@EdwardAngert, @allenfear, maybe @rachelwhitton)
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
