### PR TITLE
Add warning to Build Tools guide

### DIFF
--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -19,6 +19,13 @@ editpath: build-tools/01-introduction.md
 image: buildToolsGuide-thumb
 multidev: true
 ---
+
+<Alert type="danger" title="Warning">
+
+The current version of the Build Tools plugin is designed for Terminus 1.x, and is not yet comptaible with [current versions](/terminus/updates/) of Terminus. We'll update this guide when the plugin is officially updated, or you can try the beta release (unsupported) [here]().
+
+</Alert>
+
 This guide describes how to use build tools such as GitHub and CircleCI with Composer to implement a collaborative, team-based Continuous Integration workflow using Pull Requests for Drupal 8 sites on Pantheon. While this guide demonstrates [Drupal 8](https://github.com/pantheon-systems/example-drops-8-composer), the same workflow can be applied to [WordPress](https://github.com/pantheon-systems/example-wordpress-composer) and [Drupal 7](https://github.com/pantheon-systems/example-drops-7-composer) sites.
 
 <BuildTools />

--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -22,7 +22,7 @@ multidev: true
 
 <Alert type="danger" title="Warning">
 
-The current version of the Build Tools plugin is designed for Terminus 1.x, and is not yet comptaible with [current versions](/terminus/updates/) of Terminus. We are working on a new version of the Terminus Build Tools plugin with Terminus 2 support and will update this guide once it is released. In the meantime, you can test the [beta release](https://github.com/pantheon-systems/terminus-build-tools-plugin/releases/latest).
+The current version of the Build Tools plugin is designed for Terminus 1.x, and is not yet compatible with [current versions](/terminus/updates/) of Terminus. We are working on a new version of the Terminus Build Tools plugin with Terminus 2 support and will update this guide once it is released. In the meantime, you can test the [beta release](https://github.com/pantheon-systems/terminus-build-tools-plugin/releases/latest).
 
 </Alert>
 
@@ -86,7 +86,7 @@ GitHub pull requests (PRs) are a formalized way of reviewing and merging a propo
     composer create-project -n -d $HOME/.terminus/plugins pantheon-systems/terminus-drupal-console-plugin:~1
     ```
 
-8. Install the [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin):
+8. Install the [Terminus Build Tools Plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin). Update the version number in this example from `2.0.0-beta12` to the current version:
 
     ```bash
     composer create-project -d $HOME/.terminus/plugins pantheon-systems/terminus-build-tools-plugin:^2.0.0-beta12

--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -22,7 +22,7 @@ multidev: true
 
 <Alert type="danger" title="Warning">
 
-The current version of the Build Tools plugin is designed for Terminus 1.x, and is not yet comptaible with [current versions](/terminus/updates/) of Terminus. We'll update this guide when the plugin is officially updated, or you can try the beta release (unsupported) [here]().
+The current version of the Build Tools plugin is designed for Terminus 1.x, and is not yet comptaible with [current versions](/terminus/updates/) of Terminus. We are working on a new version of the Terminus Build Tools plugin with Terminus 2 support and will update this guide once it is released. In the meantime, you can test the [beta release](https://github.com/pantheon-systems/terminus-build-tools-plugin/releases/latest).
 
 </Alert>
 


### PR DESCRIPTION
Closes #5072 

## Effect
PR includes the following changes:
- Adds a warning to the Build Tools doc that it's not yet compatible with Terminus 2.0

## Remaining Work
- [x] Add link from @ataylorme to beta release (once it's published)
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
