### PR TITLE
Suggest linting YAML files to debug syntax errors

### DIFF
--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -255,5 +255,5 @@ To maintain best practice, some of the steps in this section require access to t
 P.S. the [Pantheon Community](/pantheon-community/) Slack instance _#composer-workflow_ channel or [Pantheon Office Hours](https://pantheon.io/developers/office-hours) are great places to ask questions and chat about Composer.
 
 ## See Also
-- [Composer Fundamentals and WebOps Workflows](/docs/composer)
-- [Pantheon YAML Configuration Files](/docs/pantheon-yml)
+- [Composer Fundamentals and WebOps Workflows](/composer)
+- [Pantheon YAML Configuration Files](/pantheon-yml)

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -100,6 +100,7 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
             description: Push changes back to GitHub if needed
             script: private/scripts/quicksilver/quicksilver-pushback/push-back-to-github.php
     ```
+        
 
 ## Managing Drupal with Composer
 
@@ -252,3 +253,7 @@ To maintain best practice, some of the steps in this section require access to t
 #### Congratulations! You now have a Drupal 8 site on Pantheon that is managed by Composer.
 
 P.S. the [Pantheon Community](/pantheon-community/) Slack instance _#composer-workflow_ channel or [Pantheon Office Hours](https://pantheon.io/developers/office-hours) are great places to ask questions and chat about Composer.
+
+## See Also
+- [Composer Fundamentals and WebOps Workflows](/docs/composer)
+- [Pantheon YAML Configuration Files](/docs/pantheon-yml)

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -142,7 +142,7 @@ remote: Version '2' is not a valid pantheon.yml version!
 remote: Valid versions are: 1
 ```
 
-While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax.
+While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax, or try running the contents of your `pantheon.yml` file through a [YAML linter](http://www.yamllint.com/).
 
 ### Deploying Configuration Changes to Multidev
 Changes made to `pantheon.yml` file on a branch **are not** detected when creating the Multidev environment for that branch. As a workaround, make some modification to `pantheon.yml` file and re-commit to the Multidev environment. You will then receive a notice indicating configuration changes have been detected and applied to the Multidev environment:


### PR DESCRIPTION
Closes #4881
https://pantheon.io/docs/guides/drupal-8-composer-no-ci

## Effect
PR includes the following changes:
- Add a link to a YAML linting tool on the pantheon.yml troubleshooting section
- Link to the pantheon.yml page from the Composer-No-CI page

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
