### PR TITLE
Attempt to use fileAbsolutePath for GitHub edit links

### DIFF
--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import './style.css';
 
-const Github = ({ pageTitle, path }) => {
+const Github = ({ pageTitle, path, editPath }) => {
   return (
     <div className="dropdown">
       <button
@@ -18,7 +18,7 @@ const Github = ({ pageTitle, path }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/source/content/${path}.md`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/${editPath}.md`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/components/headerBody/index.js
+++ b/gatsby/src/components/headerBody/index.js
@@ -7,7 +7,7 @@ import Slack from "../slack"
 import ContributorGuest from "../contributorGuest"
 import './style.css';
 
-const HeaderBody = ({ title, subtitle, description, slug, contributors, featured }) => {
+const HeaderBody = ({ title, subtitle, description, slug, contributors, featured, editPath }) => {
   const contributor = contributors ? contributors[0] : null;
   return (
     <>
@@ -31,6 +31,7 @@ const HeaderBody = ({ title, subtitle, description, slug, contributors, featured
         <Github
           pageTitle={title}
           path={slug}
+          editPath={editPath}
         />
         <Twitter
           pageTitle={title}

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -76,6 +76,7 @@ class DocTemplate extends React.Component {
                 slug={node.fields.slug}
                 contributors={node.frontmatter.contributors}
                 featured={node.frontmatter.featuredcontributor}
+                editPath={node.absoluteFilePath}
               />
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                 <MDXProvider components={shortcodes}>


### PR DESCRIPTION
Closes #5087 

## Effect
PR includes the following changes:
- Uses the `fileAbsolutePath` data from GraphQL to construct the link to edit pages. 

## Remaining Work
- [ ] get the data to be something other than `undefined`
- [ ] Update guide template to match changes in doc template.
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
