### PR TITLE
5087 fix edit multipage

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -195,7 +195,6 @@ exports.createPages = ({ graphql, actions }) => {
         component: path.resolve(`./src/templates/${template}.js`),
         context: {
           slug: doc.node.fields.slug,
-          editPath: `/source/content/guides`+doc.node.fileName,
         },
       })
     })

--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -195,6 +195,7 @@ exports.createPages = ({ graphql, actions }) => {
         component: path.resolve(`./src/templates/${template}.js`),
         context: {
           slug: doc.node.fields.slug,
+          editPath: `/source/content/guides`+doc.node.fileName,
         },
       })
     })

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -18,7 +18,7 @@ const Github = ({ pageTitle, path, editPath }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/source/content/${path}.md`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/${editPath}`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import './style.css';
 
-const Github = ({ pageTitle, path }) => {
+const Github = ({ pageTitle, path, editPath }) => {
   return (
     <div className="dropdown">
       <button

--- a/gatsby/src/components/headerBody/index.js
+++ b/gatsby/src/components/headerBody/index.js
@@ -7,7 +7,7 @@ import Slack from "../slack"
 import ContributorGuest from "../contributorGuest"
 import './style.css';
 
-const HeaderBody = ({ title, subtitle, description, slug, contributors, featured }) => {
+const HeaderBody = ({ title, subtitle, description, slug, contributors, featured, editPath }) => {
   const contributor = contributors ? contributors[0] : null;
   return (
     <>
@@ -31,6 +31,7 @@ const HeaderBody = ({ title, subtitle, description, slug, contributors, featured
         <Github
           pageTitle={title}
           path={slug}
+          editPath={editPath}
         />
         <Twitter
           pageTitle={title}

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -58,6 +58,23 @@ class DocTemplate extends React.Component {
   render() {
     const node = this.props.data.mdx
 
+    let editPath
+    let guideMatch = /\/source\/content\/guides\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let subfolderMatch = /\/source\/content\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let docMatch = /\/source\/content\/.*\.md$/.exec(node.fileAbsolutePath)
+    if (guideMatch) {
+      //It is a guide.
+      editPath = guideMatch[0]
+    } else if (subfolderMatch) {
+      //If it is a doc in another subfolder
+      editPath = subfolderMatch[0]
+    } else if (docMatch) {
+      // If it is a regular old guide
+      editPath = docMatch[0]
+    } else {
+      // HALP there is no edit path!
+    }
+    
     return (
       <Layout>
         <SEO
@@ -76,6 +93,7 @@ class DocTemplate extends React.Component {
                 slug={node.fields.slug}
                 contributors={node.frontmatter.contributors}
                 featured={node.frontmatter.featuredcontributor}
+                editPath={editPath}
               />
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                 <MDXProvider components={shortcodes}>

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -62,6 +62,7 @@ class DocTemplate extends React.Component {
     let guideMatch = /\/source\/content\/guides\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
     let subfolderMatch = /\/source\/content\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
     let docMatch = /\/source\/content\/.*\.md$/.exec(node.fileAbsolutePath)
+
     if (guideMatch) {
       //It is a guide.
       editPath = guideMatch[0]

--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -73,6 +73,24 @@ class GuideTemplate extends React.Component {
       }
     })
 
+    let editPath
+    let guideMatch = /\/source\/content\/terminus\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let subfolderMatch = /\/source\/content\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let docMatch = /\/source\/content\/.*\.md$/.exec(node.fileAbsolutePath)
+
+    if (guideMatch) {
+      //It is a guide.
+      editPath = guideMatch[0]
+    } else if (subfolderMatch) {
+      //If it is a doc in another subfolder
+      editPath = subfolderMatch[0]
+    } else if (docMatch) {
+      // If it is a regular old guide
+      editPath = docMatch[0]
+    } else {
+      // HALP there is no edit path!
+    }
+
     return (
       <Layout>
         <SEO
@@ -101,6 +119,7 @@ class GuideTemplate extends React.Component {
                       slug={node.fields.slug}
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
+                      editPath={editPath}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -109,6 +109,24 @@ class TerminusTemplate extends React.Component {
     const node = this.props.data.mdx
     const contentCols = node.frontmatter.showtoc ? 9 : 12
 
+    let editPath
+    let guideMatch = /\/source\/content\/terminus\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let subfolderMatch = /\/source\/content\/[^/]+\/.*\.md$/.exec(node.fileAbsolutePath)
+    let docMatch = /\/source\/content\/.*\.md$/.exec(node.fileAbsolutePath)
+
+    if (guideMatch) {
+      //It is a guide.
+      editPath = guideMatch[0]
+    } else if (subfolderMatch) {
+      //If it is a doc in another subfolder
+      editPath = subfolderMatch[0]
+    } else if (docMatch) {
+      // If it is a regular old guide
+      editPath = docMatch[0]
+    } else {
+      // HALP there is no edit path!
+    }
+
     return (
       <Layout>
         <SEO
@@ -137,6 +155,7 @@ class TerminusTemplate extends React.Component {
                       slug={node.fields.slug}
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
+                      editPath={editPath}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>


### PR DESCRIPTION
Closes #5087 

## Effect
PR includes the following changes:
- Uses the `fileAbsolutePath` data from GraphQL to construct the link to edit pages. 

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
