### PR TITLE
fix: editPath from path and not slug

### DIFF
--- a/gatsby/gatsby-node.js
+++ b/gatsby/gatsby-node.js
@@ -69,6 +69,14 @@ exports.onCreateWebpackConfig = ({ actions }) => {
   })
 }
 
+exports.createSchemaCustomization = ({ actions }) => {
+  actions.createTypes(`
+    type Mdx implements Node {
+      fileInfo: File @link(from: "parent")
+    }
+  `)
+}
+
 exports.createPages = ({ graphql, actions }) => {
   const { createPage } = actions
 
@@ -296,8 +304,20 @@ exports.createPages = ({ graphql, actions }) => {
 
 exports.onCreateNode = ({ node, getNode, actions }) => {
   const { createNode, createNodeField } = actions
+
   // MDX content
   if (node.internal.type === `Mdx`) {
+    const sourceInstanceName = getNode(node.parent).sourceInstanceName;
+    if (sourceInstanceName === 'content') {
+      const editPath = `source/content/${getNode(node.parent).relativePath}`;
+       // Add editPath field
+      createNodeField({
+        name: `editPath`,
+        node,
+        value: editPath
+      })
+    }
+
     // Add slug field
     const slug = calculateSlug(node, getNode)
     createNodeField({

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -1,7 +1,7 @@
 import React from "react"
 import './style.css';
 
-const Github = ({ pageTitle, path }) => {
+const Github = ({ pageTitle, path, editPath }) => {
   return (
     <div className="dropdown">
       <button
@@ -18,7 +18,7 @@ const Github = ({ pageTitle, path }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/${path}`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/${editPath}`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/components/github/index.js
+++ b/gatsby/src/components/github/index.js
@@ -18,7 +18,7 @@ const Github = ({ pageTitle, path }) => {
       <ul className="dropdown-menu" aria-labelledby="dropdownMenu1">
         <li>
           <a
-            href={`https://github.com/pantheon-systems/documentation/edit/master/source/content/${path}.md`}
+            href={`https://github.com/pantheon-systems/documentation/edit/master/${path}`}
             target="blank"
           >
             Edit This Page

--- a/gatsby/src/components/headerBody/index.js
+++ b/gatsby/src/components/headerBody/index.js
@@ -7,7 +7,7 @@ import Slack from "../slack"
 import ContributorGuest from "../contributorGuest"
 import './style.css';
 
-const HeaderBody = ({ title, subtitle, description, slug, contributors, featured }) => {
+const HeaderBody = ({ title, subtitle, description, slug, contributors, featured, editPath }) => {
   const contributor = contributors ? contributors[0] : null;
   return (
     <>
@@ -30,7 +30,7 @@ const HeaderBody = ({ title, subtitle, description, slug, contributors, featured
 
         <Github
           pageTitle={title}
-          path={slug}
+          path={editPath}
         />
         <Twitter
           pageTitle={title}

--- a/gatsby/src/components/headerBody/index.js
+++ b/gatsby/src/components/headerBody/index.js
@@ -30,7 +30,8 @@ const HeaderBody = ({ title, subtitle, description, slug, contributors, featured
 
         <Github
           pageTitle={title}
-          path={editPath}
+          path={path}
+          editPath={editPath}
         />
         <Twitter
           pageTitle={title}

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -76,6 +76,7 @@ class DocTemplate extends React.Component {
                 slug={node.fields.slug}
                 contributors={node.frontmatter.contributors}
                 featured={node.frontmatter.featuredcontributor}
+                editPath={node.fields.editPath}
               />
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                 <MDXProvider components={shortcodes}>
@@ -118,6 +119,7 @@ export const pageQuery = graphql`
       }
       fields {
         slug
+        editPath
       }
       frontmatter {
         title

--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -101,6 +101,7 @@ class GuideTemplate extends React.Component {
                       slug={node.fields.slug}
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
+                      editPath={node.fields.editPath}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>
@@ -151,6 +152,7 @@ export const pageQuery = graphql`
       fields {
         slug
         guide_directory
+        editPath
       }
       frontmatter {
         title

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -137,6 +137,7 @@ class TerminusTemplate extends React.Component {
                       slug={node.fields.slug}
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
+                      editPath={node.fields.editPath}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.code.body}</MDXRenderer>
@@ -175,6 +176,7 @@ export const pageQuery = graphql`
       }
       fields {
         slug
+        editPath
       }
       frontmatter {
         title


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: editPath from path and not slug

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
