### PR TITLE
fix: content using relative urls

### DIFF
--- a/source/changelogs/2019-07-01-July.md
+++ b/source/changelogs/2019-07-01-July.md
@@ -6,7 +6,7 @@ description: July changelog updates.
 
 ## Platform Improvements
 ## General Availability for New Regions
-Now when you create a new site on Pantheon, you can select from one of four regions across the globe, including Australia, Canada, and the European Union. For more info see [Pantheon Site Regions and Data Residency](https://pantheon.io/docs/regions).
+Now when you create a new site on Pantheon, you can select from one of four regions across the globe, including Australia, Canada, and the European Union. For more info see [Pantheon Site Regions and Data Residency](/regions).
 
 ## DNS Recommendations Update
 


### PR DESCRIPTION
Closes #

## Effect
PR includes the following changes:
- fix: content using relative url

Currently using full path URLs:
![image](https://user-images.githubusercontent.com/366275/64378735-2f9eb700-cfe2-11e9-8cd0-8a8eafb74ffd.png)

After using relative URL path:
![image](https://user-images.githubusercontent.com/366275/64378782-4ba25880-cfe2-11e9-9d77-be441aaaad7b.png)


## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
