### PR TITLE
update redirects page and snippet

### DIFF
--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -32,7 +32,11 @@ Make sure HTTPS has been successfully provisioned *before* adding any code (like
 
   If you run into issues, please refer to [this documentation](/sftp/#sftp-connection-information).
 
-4. Now open the `code` folder in your SFTP client, and download your site's `settings.php` (Drupal) or `wp-config.php` (WordPress) file.
+4. Open the `code` folder in your SFTP client.
+
+4. As part of best security practices, we suggest you [Require HTTPS with the HSTS Header](/pantheon-yml/#enforce-https--hsts). Download your site's `pantheon.yml` file and follow the recommendations for enforcing HTTPS on your site.
+
+4. Now download your site's `settings.php` (Drupal) or `wp-config.php` (WordPress) file.
 
 5. Edit your configuration file by adding the following snippet for the desired redirect (replace `example.com`):
 

--- a/source/partials/_redirects.md
+++ b/source/partials/_redirects.md
@@ -16,9 +16,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
-  if ($_SERVER['HTTP_HOST'] != $primary_domain
-      || !isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
-      || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON' ) {
+  if ($_SERVER['HTTP_HOST'] != $primary_domain) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {
@@ -53,9 +51,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
-  if ($_SERVER['HTTP_HOST'] != $primary_domain
-      || !isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
-      || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON' ) {
+  if ($_SERVER['HTTP_HOST'] != $primary_domain) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {
@@ -93,9 +89,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
-  if ($_SERVER['HTTP_HOST'] != $primary_domain
-      || !isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
-      || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON' ) {
+  if ($_SERVER['HTTP_HOST'] != $primary_domain) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {

--- a/source/partials/_redirects.md
+++ b/source/partials/_redirects.md
@@ -16,7 +16,20 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
+  $requires_redirect = false;
+  
+  // Ensure the site is being served from the primary domain.
   if ($_SERVER['HTTP_HOST'] != $primary_domain) {
+    $requires_redirect = true;
+  }
+
+  // If you're not using HSTS in the pantheon.yml file, uncomment this next block.
+  // if (!isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
+  //     || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+  //   $requires_redirect = true;
+  // }
+
+  if ($requires_redirect === true) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {
@@ -51,7 +64,21 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
+  $requires_redirect = FALSE;
+
+  // Ensure the site is being served from the primary domain.
   if ($_SERVER['HTTP_HOST'] != $primary_domain) {
+    $requires_redirect = TRUE;
+  }
+
+  // If you're not using HSTS in the pantheon.yml file, uncomment this next block.
+  // if (!isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
+  //     || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+  //   $requires_redirect = TRUE;
+  // }
+
+
+  if ($requires_redirect === TRUE) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {
@@ -89,7 +116,20 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
     $primary_domain = $_SERVER['HTTP_HOST'];
   }
 
+  $requires_redirect = false;
+  
+  // Ensure the site is being served from the primary domain.
   if ($_SERVER['HTTP_HOST'] != $primary_domain) {
+    $requires_redirect = true;
+  }
+
+  // If you're not using HSTS in the pantheon.yml file, uncomment this next block.
+  // if (!isset($_SERVER['HTTP_USER_AGENT_HTTPS'])
+  //     || $_SERVER['HTTP_USER_AGENT_HTTPS'] != 'ON') {
+  //   $requires_redirect = true;
+  // }
+
+  if ($requires_redirect === true) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).
     if (extension_loaded('newrelic')) {

--- a/source/partials/_redirects.md
+++ b/source/partials/_redirects.md
@@ -77,7 +77,6 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT']) && php_sapi_name() != 'cli') {
   //   $requires_redirect = TRUE;
   // }
 
-
   if ($requires_redirect === TRUE) {
 
     // Name transaction "redirect" in New Relic for improved reporting (optional).


### PR DESCRIPTION
Closes #5096 

## Effect
PR includes the following changes:
- Updates the redirect page to point visitors to the HSTS directions
- Updates the code snippet to exclude HTTPS checks

## Remaining Work
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
