### PR TITLE
Fix UTM redirection example

### DIFF
--- a/source/content/pantheon_stripped.md
+++ b/source/content/pantheon_stripped.md
@@ -25,7 +25,7 @@ If you redirect a request that contains `utm_` parameters, Pantheon's edge shoul
 You can see this for yourself by testing how Pantheon's own public facing website behaves. Try requesting the homepage over http with a `utm_campaign` parameter:
 
 ```
-curl -I https://pantheon.io/?utm_campaign=documentation_example
+curl -I http://pantheon.io/?utm_campaign=documentation_example
 HTTP/1.1 301 Moved Permanently
 Cache-Control: max-age=3600
 Content-Type: text/html


### PR DESCRIPTION
https://pantheon.io/docs/pantheon_stripped

# Effect
PR includes the following changes:
- Change example URL from HTTPS -> HTTP. We're illustrating that the redirect from HTTP -> HTTPS does not strip the UTM parameters, so we need to curl the HTTP address to show this.

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
