### PR TITLE
Update drupal-8-composer-no-ci.md

### DIFF
--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -83,7 +83,6 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
 1.  Delete the following directories:
     - `scripts/github`
     - `scripts/gitlab`
-    - `.circleci`
     - `tests`
 
 1.  Modify `composer.json`:

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -80,10 +80,15 @@ Instead of setting up `composer.json` manually, it is easier to start with the [
 
 `example-drops-8-composer` was designed to run automated tests on a continuous integration server. Unless you plan on running automated tests it is safe to completely remove the automated testing functionality.
 
-1.  Delete the following directories:
+1.  Delete the following directories and files:
     - `scripts/github`
     - `scripts/gitlab`
+    - `.circleci`
+    - `.ci`
     - `tests`
+    - `bitbucket-pipelines.yml`
+    - `build-providers.json`
+    - `gitlab-ci.yml`
 
 1.  Modify `composer.json`:
     - Remove all dependencies in the `require-dev` section.


### PR DESCRIPTION
Removed line 86 as the .circleci directory does not exist
Additionally, I noticed that I have a 'bitbucket-pipelines.yml' and 'build-providers.json' files. Can those files be deleted? If so, please add to the doc changes.

Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
