### PR TITLE
Instruct contributors to install Node dependencies with npm ci

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ git@github.com:pantheon-systems/documentation.git
 
 ```
 cd documentation/gatsby
-npm install
+npm ci
 ```
 #### GitHub Token
 We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet) to use files from GitHub in our docs. Before you can build a local development site, you need to provide a GitHub token to the environment:


### PR DESCRIPTION
## Effect
PR includes the following changes:
Contributors to this project who use `npm install` during local set up will have a modified `package-lock.json` file. Unless it is explicitly omitted, changes to `package-lock.json` will be reflected in their pull requests.

Updating the instructions to use [`npm ci`](https://docs.npmjs.com/cli/ci.html) instead will not have this issue as `npm ci`

> will never write to package.json or any of the package-locks: installs are essentially frozen

While meant for an automated environment, such as continuous integration, the command works well here so that updates to `package-lock.json` are more explicit. 

## Remaining Work
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
