### PR TITLE
Add clearer notes on drush ard deprecation

### DIFF
--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -72,12 +72,6 @@ The recommended way to migrate Drupal sites from another host is to use `drush a
 
   ![Drupal create archive](../images/dashboard/drupal-guided-migrate.png)
 
-  <Alert title="Note" type="info">
-
-  `drush ard` is only available on Drush 8 and earlier.
-
-  </Alert>
-
   The Dashboard instructs you to put the archive on your existing website, but you can put the site archive on Dropbox, S3, or any number of other places. The important thing is that you have a site archive that can be downloaded via a publicly accessible URL.
 
 9. Paste a publicly accessible URL to a download of your site archive. Change the end of Dropbox URLs from `dl=0` to `dl=1` so we can import your site archive properly.

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -56,7 +56,7 @@ The <a class="external" href="https://wordpress.org/plugins/wp-native-php-sessio
 
 <Tab title="Drupal" id="tab-2-id">
 
-The recommended way to migrate Drupal sites from another host is to use `drush ard` to create an archive that can be easily imported.
+The recommended way to migrate Drupal sites from another host is to use `drush ard` (Drush 8 or earlier) to create an archive that can be easily imported.
 
 1. Navigate to your User Dashboard and click the **Migrate Existing Site** button.
 
@@ -100,6 +100,7 @@ Manually migrate your site to Pantheon when any of the following apply:
 * **Plugin install unavailable on existing WordPress site**: For example, if your existing site is hosted on WordPress.com, you'll be unable to install the Pantheon Migrations plugin.
 * **Local WordPress Site**: If your WordPress site is only on your local machine and not yet live.
 * **Debug Failed Migration**: It can be helpful to migrate your code, database, and files separately to help debug edge-cases that are not supported through guided migration.
+* **Using Drush 9 or later**: `drush ard` is only available on Drush 8 and earlier.
 
 For more details, see [Manually Migrate Sites to Pantheon](/migrate-manual/).
 
@@ -291,7 +292,7 @@ When asked for your current site URL, enter `https://example.com` and continue t
 
 <Tab title="Drupal" id="tab-2-id">
 
-Drupal users can run the provided Drush command to generate an archive then upload it to a third party service (like [Dropbox](https://www.dropbox.com/) or [Google Drive](https://drive.google.com)) to continue the standard migration procedure. If the archive file size exceeds 500MB you must [manually migrate](/migrate-manual).
+Drupal users with access to Drush 8 or earlier can run the provided Drush command to generate an archive then upload it to a third party service (like [Dropbox](https://www.dropbox.com/) or [Google Drive](https://drive.google.com)) to continue the standard migration procedure. If Drush 8 is not available, or the archive file size exceeds 500MB you must [manually migrate](/migrate-manual).
 
 </Tab>
 


### PR DESCRIPTION
Clarify that Drush archive-based migration is only available when using Drush 8 or earlier.

## Effect
PR includes the following changes:
- added clearer notes to Drupal migration sections re need for Drush 8/earlier for archive-based migrations

## Remaining Work
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
