### PR TITLE
Clean up primary domain and HSTS instructions

### DIFF
--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -93,14 +93,25 @@ Redirecting all traffic to a primary domain is a best practice for SEO since it 
 
 <Alert title="Note" type="info">
 
-Redirects must be managed via PHP, since `.htaccess` is ignored. For details, see [Configure Redirects](/redirects/#php-vs-htaccess).
+Redirects cannot be managed via `.htaccess`, which is ignored on our platform. For details, see [Configure Redirects](/redirects/#php-vs-htaccess).
 
 </Alert>
 
-### Redirect to HTTPS and the Primary Domain
-It's a best practice for SEO and security to standardize all traffic on HTTPS and choose a primary domain. Configure redirects to the primary domain with HTTPS in [`settings.php`](/settings-php/) or [`wp-config.php`](/wp-config-php/):
+### Redirect to the Primary Domain
+
+<Partial file="primary-domain.md" />
+
+### Redirect to HTTPS
+It's a best practice for SEO and security to standardize all traffic on HTTPS and choose a primary domain. Configure redirects to the primary domain with HTTPS in [pantheon.yml](/pantheon-yml#enforce-https--hsts)
+
+### Redirect with PHP
+If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects:
+
+<Accordion title="PHP Redirection" >
 
 <Partial file="_redirects.md" />
+
+</Accordion>
 
 For more redirect scenarios, see [Configure Redirects](/redirects).
 

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -22,15 +22,12 @@ Choose one of the following two options to configure the primary domain.
 
 ## Set Primary Domain with Terminus
 
-1. Install or upgrade to the [latest version of Terminus](/terminus/install).
-
-2. Use Terminus to add the primary domain. In this example, replace `my-site` with your site name, and `live` if you'd like to set it for a different environment, and `www.example.com` with your primary domain:
-
-```bash
-terminus domain:primary:add my-site.live www.example.com
-```
+<Partial file="primary-domain.md" />
 
 ## Set Primary Domain with PHP Snippet
+If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects:
+
+<Accordion title="PHP Redirection" >
 
 1. Navigate to **<span class="glyphicons glyphicons-embed-close"></span> Code** in the **<span class="glyphicons glyphicons-wrench"></span> Dev** tab of your Site Dashboard. Confirm your Connection Mode is set to **SFTP**.
 
@@ -60,7 +57,7 @@ terminus domain:primary:add my-site.live www.example.com
 
 1. Navigate to the **<span class="glyphicons glyphicons-cardio"></span> Live** environment and click **<span class="glyphicons glyphicons-new-window-alt"></span> Visit Live Site** to test the redirect logic.
 
-<Accordion title="Level Up: Configure Site Monitoring Services  (Optional)" id="host-specific1" icon="graduation-cap">
+</Accordion>
 
 ## Ready to launch like the pros?
 Now that you're redirecting requests to a single, primary domain, it's the perfect time to configure a long-duration HSTS header, or set up an availability monitoring service to watch over your site like an automated hawk.
@@ -68,7 +65,6 @@ Now that you're redirecting requests to a single, primary domain, it's the perfe
 ### [Send a Long-Duration HSTS Header for Increased Security](/pantheon-yml/#enforce-https--hsts)
 Prevent cookie hijacking and get an A+ rating from SSL Labs.
 
-### [Setup Availability Monitoring](/new-relic/#configure-ping-monitors-for-availability)
+### [Setup Availability Monitoring](/new-relic/#configure-ping-monitors-for-availability) (Optional)
 New Relic provides a free availability monitoring service that sends a request to designated URLs from configured locations at given intervals and alerts you via email if a response fails.
 
-</Accordion>

--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -45,7 +45,7 @@ If your site configuration prevents you from setting the primary domain from the
 ## Additional Redirects (Optional)
 Implement scenario specific redirects as required by the site. Depending on the needs of the site, you may only need one, some, or none of the following.
 
-Redirect logic should be added to `wp-config.php` for WordPress sites, and `settings.php` for Drupal sites.
+Redirect logic should be added to `wp-config.php` for WordPress sites, and `settings.php` for Drupal sites. Note that the platform-set primary domain will redirect all requests, not just the root domain
 
 ### Redirect to HTTPS
 The following configuration will redirect HTTP requests to HTTPS, such as `http://env-site-name.pantheonsite.io` to `https://env-site-name.pantheonsite.io` or `http://example.com` to `https://example.com`:
@@ -161,6 +161,13 @@ if ( (isset($redirect_targets[ $_SERVER['REQUEST_URI'] ] ) ) && (php_sapi_name()
 ```
 
 ### Redirect Multiple Subdomains
+
+<Alert type="info" title="Note">
+
+If you've configured your [primary domain at the platform level](#set-primary-domain-and-hsts-with-pantheonyml) and can [add these subdomains](/domains#custom-domains) to the same same environment, redirection will happen automatically.
+
+</Alert>
+
 The following configuration will redirect requests for `sub1.example.com`, `sub2.example.com`, `sub3.example.com`, and `sub4.example.com` to `https://new.example.com`:
 
 ```php

--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -24,7 +24,7 @@ This redirect is considered best practice and recommended as part of the going l
 
 ### Set Primary Domain and HSTS with Pantheon.yml
 
-This is the preferred method of setting HTTPS, HSTS, and the primary domain for your site. For details, see [Launch Essentials](/guides/launch/redirects).
+This is the preferred method of setting HTTPS, HSTS, and the primary domain for your site.
 
 To set the primary domain:
 

--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -20,16 +20,33 @@ Using `.htaccess` is generally not recommended - even for sites running  [Apache
 When using multiple snippets, be sure to step through the logic. This is particularly important when redirecting to a common domain while also incorporating redirects for specific pages. All `if` conditional statements need to be in the correct order. For example, a wholesale redirect executed *prior* to redirects for specific pages would likely prevent the second statement from being evaluated.
 
 ## Redirect to HTTPS and the Primary Domain
-This redirect is considered best practice and recommended as part of the going live procedure. Configure this redirect after connecting a custom domain in the Site Dashboard when you're ready to launch the site. For details, see [Launch Essentials](/guides/launch/). 
+This redirect is considered best practice and recommended as part of the going live procedure. Configure this redirect after connecting a custom domain in the Site Dashboard when you're ready to launch the site.
 
-The following configuration will redirect HTTP to HTTPS _and_ enforce use of a primary domain, such as `http://live-site-name.pantheonsite.io` to `https://www.example.com` or `http://example.com` to `https://www.example.com`:
+### Set Primary Domain and HSTS with Pantheon.yml
+
+This is the preferred method of setting HTTPS, HSTS, and the primary domain for your site. For details, see [Launch Essentials](/guides/launch/redirects).
+
+To set the primary domain:
+
+<Partial file="primary-domain.md" />
+
+See [Enforce HTTPS + HSTS](/pantheon-yml#enforce-https--hsts) in the Pantheon.yml doc to set the HSTS header and redirect all traffic to HTTPS.
+
+### Redirect with PHP
+
+If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects:
+
+<Accordion title="PHP Redirection" >
 
 <Partial file="_redirects.md" />
+
+</Accordion>
 
 ## Additional Redirects (Optional)
 Implement scenario specific redirects as required by the site. Depending on the needs of the site, you may only need one, some, or none of the following.
 
-As described [above](#redirect-to-https-and-the-primary-domain), redirect logic should be added to `wp-config.php` for WordPress sites, and `settings.php` for Drupal sites.
+Redirect logic should be added to `wp-config.php` for WordPress sites, and `settings.php` for Drupal sites.
+
 ### Redirect to HTTPS
 The following configuration will redirect HTTP requests to HTTPS, such as `http://env-site-name.pantheonsite.io` to `https://env-site-name.pantheonsite.io` or `http://example.com` to `https://example.com`:
 

--- a/source/partials/primary-domain.md
+++ b/source/partials/primary-domain.md
@@ -1,0 +1,8 @@
+1. Install or upgrade to the [latest version of Terminus](/terminus/install).
+
+1. Use Terminus to add the primary domain. In this example, replace `my-site` with your site name, and `live` if you'd like to set it for a different environment, and `www.example.com` with your primary domain:
+
+  ```bash
+  terminus domain:primary:add my-site.live www.example.com
+  ```
+


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Puts new primary domain instructions into a partial.
- Use that partial in the Launch guide and the Domains & Redirects docs.
- Collapses older PHP method into accordions.

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
