### PR TITLE
Code Block Command Prompts

### DIFF
--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -1,6 +1,12 @@
 // custom typefaces
 require("prismjs/themes/prism-okaidia.css")
 
+// Code block line numbering
+require("prismjs/plugins/line-numbers/prism-line-numbers.css")
+
+// Code block shell prompt
+require("prismjs/plugins/command-line/prism-command-line.css")
+
 // Previous version scripts and styles
 // require("../source/docs/assets/js/main.js")
 

--- a/gatsby/src/components/styleExample/style.css
+++ b/gatsby/src/components/styleExample/style.css
@@ -25,3 +25,15 @@
 	font-size: 50px;
 	font-weight: 700;
 }
+
+.source-code::after  {
+    position: absolute;
+    font-size: 12px;
+    font-weight: 700;
+    color: #959595;
+    text-transform: uppercase;
+    letter-spacing: 1px;
+    content: "Source Code";
+    margin-top: 10px;
+}
+

--- a/gatsby/src/layout/layout/style.css
+++ b/gatsby/src/layout/layout/style.css
@@ -5,5 +5,5 @@
 @import '../../../../source/docs/assets/fonts/MyFontsWebfontsKit/MyFontsWebfontsKit.css';
 @import '../../../node_modules/bootstrap/dist/css/bootstrap.min.css';
 @import '../../styles/main.css';
-
+@import '../../styles/codeBlocks.css';
 

--- a/gatsby/src/styles/codeBlocks.css
+++ b/gatsby/src/styles/codeBlocks.css
@@ -1,0 +1,25 @@
+.command-line-prompt {
+	border-right: 0px solid #999;
+	display: block;
+	float: left;
+	font-size: 100%;
+	letter-spacing: -1px;
+	margin-right: 0em;
+	pointer-events: none;
+
+	-webkit-user-select: none;
+	-moz-user-select: none;
+	-ms-user-select: none;
+	user-select: none;
+}
+
+.command-line-prompt > span:before {
+    color: #999;
+    content: "";
+    display: block;
+    padding-right: 0.8em;
+  }
+  
+  .command-line-prompt > span[data-user]:before {
+	content: "$";
+}

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -72,7 +72,7 @@ terminus site:list
 ```
 
 ### Update the Code
-Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal set ready to go for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
+Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal site ready  for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
 
 ```bash{outputLines:2-7}
 terminus drush <site>.<env> -- site-install

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -12,7 +12,9 @@ date: 2/25/2015
 The latest version of Pantheon's CLI, [Terminus](/terminus/), incorporates not only Drush and WP-CLI, but also the vast majority of tasks available to you within the Pantheon Dashboard. You can create new sites, clone one environment to another, create branches, check for upstream updates, and more. By using Terminus, a site administrator can massively reduce the time spent on relatively simple tasks. In this guide, we will walk through the basics of creating a completely new Drupal site on Pantheon, installing some contrib modules, committing code, and cloning from one site environment to another&mdash;all through the Terminus CLI.
 
 <Alert title="Note" type="info">
+
 The following does **not** pertain to Composer managed sites. For information about using Composer to manage Drupal 8 sites, see [Build Tools Guide](/guides/build-tools/).
+
 </Alert>
 
 ## Installing Terminus
@@ -20,8 +22,8 @@ Installing Terminus is a fairly straight forward process. Just follow [these ins
 
 After you install Terminus, do a quick status check to make sure it works. Depending on your OS, the output may vary, but here's a sample:
 
-```
-$ terminus auth:login --email=<email> --machine-token=<machine_token>
+```bash{outputLines:2}
+terminus auth:login --email=<email> --machine-token=<machine_token>
  [notice] Logging in via machine token.
 ```
 
@@ -33,8 +35,8 @@ Excellent! You've installed Terminus and logged into your Pantheon account. For 
 
 Terminus can be used on any Pantheon hosted website you have, and it can also create new sites! Let's get a list of your current Pantheon sites:
 
-```
-$ terminus site:list
+```bash{outputLines:2-7}
+terminus site:list
 +--------------------------+-----------+---------------+--------------------------+
 | Site                     | Framework | Service Level | UUID                     |
 +--------------------------+-----------+---------------+--------------------------+
@@ -42,18 +44,23 @@ $ terminus site:list
 | git-import-example       | drupal    | free          | git-import-example       |
 +--------------------------+-----------+---------------+--------------------------+
 ```
+
 ### Create a Brand New Site
 
 Now let's create a new site:
 
+```bash{outputLines:2}
+terminus upstream:list | grep "Drupal 7" | grep "core"
+21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
 ```
-$ terminus upstream:list | grep "Drupal 7" | grep "core"
-  21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
-$ terminus site:create terminus-cli-create "Terminus CLI Create" 21e1fada-199c-492b-97bd-0b36b53a9da0
 
+```bash{outputLines:2-4}
+terminus site:create terminus-cli-create "Terminus CLI Create" 21e1fada-199c-492b-97bd-0b36b53a9da0
 [notice] Creating a new site...
+```
 
-$ terminus site:list
+```bash{outputLines:1-8}
+terminus site:list
 +--------------------------+-----------+---------------+--------------------------+
 | Site                     | Framework | Service Level | UUID                     |
 +--------------------------+-----------+---------------+--------------------------+
@@ -65,10 +72,9 @@ $ terminus site:list
 ```
 
 ### Update the Code
-
 Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal set ready to go for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.
 
-```bash
+```bash{outputLines:2-7}
 terminus drush <site>.<env> -- site-install
 Running drush site-install  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
@@ -82,7 +88,7 @@ If the command above fails with `exception 'Drush\Sql\SqlException' with message
 
 You should now be able to open a web browser and see your brand new Drupal site! On Mac, try using the `open` command to see an environment in your default browser:
 
-```bash
+```bash{promptUser: user}
 open https://dev-terminus-cli-create.pantheon.io
 ```
 
@@ -90,16 +96,16 @@ open https://dev-terminus-cli-create.pantheon.io
 
 There is also the `terminus dashboard <site>.<env> --print` command if, at any point in time, you want to open the site's Pantheon Dashboard.
 
-```
-$ terminus dashboard <site>.<env>
+```bash{promptUser: user}
+terminus dashboard <site>.<env>
 ```
 
 ![Dashboard in browser](../../images/dashboard/terminus-cli-open-dash.png)
 
 Also, the status of each of the environments within the site can be seen using a `terminus env:list` command.
 
-```
-$ terminus env:list <site>
+```bash{outputLines:2-8}
+terminus env:list <site>
 ------ --------------------- ------------------------------------ ----------------- -------- -------------
  ID     Created               Domain                               Connection Mode   Locked   Initialized
 ------ --------------------- ------------------------------------ ----------------- -------- -------------
@@ -112,8 +118,8 @@ $ terminus env:list <site>
 ### Install Contrib Modules and Themes
 While the site's Dev environment is still in SFTP mode, we can use Drush to download and install some Drupal contrib modules, such as Views and Administration Menu.
 
-```
-$ terminus drush <site>.<env> -- dl admin_menu
+```bash{outputLines:2-13}
+terminus drush <site>.<env> -- dl admin_menu
 Running drush dl admin_menu  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project admin_menu (7.x-3.0-rc5) downloaded to                         [success]
@@ -130,13 +136,12 @@ admin_menu_toolbar was enabled successfully.                                [ok]
 
 Not bad, eh? All this without a single GUI or web browser click! If you look at the site's Dashboard, the new code will be displayed there, waiting to be committed.
 
-
 ![The dashboard showing the code was deployed to the Dev environment](../../images/dashboard/terminus-cli-code-to-commit-dashboard.png)
 
 Let's commit it all into the Git repo with the `terminus env:commit` command:
 
-```
-$ terminus env:commit <site>.<env> --message="Initial Commit"
+```bash{outputLines:2-7}
+terminus env:commit <site>.<env> --message="Initial Commit"
 Success: Successfully committed.
 +---------------------+--------+--------+------------------------------------------+------------------+
 | Time                | Author | Labels | Hash                                     | Message          |
@@ -151,8 +156,8 @@ Open the Pantheon Dashboard, and you'll see the new files are shown in the Git c
 
 To see what a commit message looks like, let's download Bootstrap and then commit it as well.
 
-```
-$ terminus drush <site>.<env> -- dl bootstrap
+```bash{outputLines:2-13}
+terminus drush <site>.<env> -- dl bootstrap
 Running drush dl bootstrap  on terminus-cli-create-dev
 dev.a248f559-fab9-49cd-983c-f5@appserver.dev.a248f559-fab9-49cd-983c-f5c0d11a2464.drush.in's password:
 Project bootstrap (7.x-3.0) downloaded to                              [success]
@@ -171,8 +176,8 @@ Success: Successfully commited.
 
 And finally, let's initialize the Test environment to move the code, files, and DB from Dev onward in the Pantheon workflow using a `terminus env:deploy` command:
 
-```
-$ terminus env:deploy <site>.test --sync-content --cc --updatedb
+```bash{promptUser: user}
+terminus env:deploy <site>.test --sync-content --cc --updatedb
 ```
 
 ## Congratulations!

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -27,7 +27,7 @@ terminus auth:login --email=<email> --machine-token=<machine_token>
  [notice] Logging in via machine token.
 ```
 
-Excellent! You've installed Terminus and logged into your Pantheon account. For a full list of commands, [refer to this page](https://github.com/pantheon-systems/cli/wiki/Available-Commands).
+Excellent! You've installed Terminus and logged into your Pantheon account. For a full list of commands, [refer to this page](/terminus/commands).
 
 ## Using Terminus
 

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -256,6 +256,52 @@ require_once WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
 
 </Example>
 
+You can also define a single line code block as a command:
+
+<Example>
+
+```bash{promptUser: user}
+mkdir -p ~/repos/mdx-slug
+```
+
+<hr className="source-code" /> <br/>
+
+````markdown
+```bash{promptUser: user}
+mkdir -p ~/repos/mdx-slug
+```
+````
+
+</Example>
+
+Or define which lines are output:
+
+<Example>
+
+```bash{outputLines:2-6}
+ls  -1 ~/repos
+documentation
+i3lock-color
+i3lock-fancy
+j4-dmenu-desktop
+mdx-slug
+```
+
+<hr className="source-code" /> <br/>
+
+````markdown
+```bash{outputLines:2-6}
+ls  -1 ~/repos
+documentation
+i3lock-color
+i3lock-fancy
+j4-dmenu-desktop
+mdx-slug
+```
+````
+
+</Example>
+
 ### Variables
 
 When writing multi-step processes, repeated variables and constants should be defined before providing the first set of commands. If the doc has a "Before You Begin" section, define varables here. Provide them using the callout below, and follow common conventions (lowercase for variables, uppercase for constants).

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -35,7 +35,7 @@ Meta data for a doc or guide is created in a section referred to as frontmatter.
 
 </p>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 ---
@@ -63,7 +63,7 @@ Be sure that you have:
 - An account with [Amazon Web Services (AWS)](https://aws.amazon.com/s3/). Amazon offers [free access](https://aws.amazon.com/free/) to most of their services for the first year.
 - [Terminus](/terminus) installed on your local computer.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ## Before You Begin
@@ -95,7 +95,7 @@ Be kind. If you're writing a guide that will use one or more example variables t
 
 #### Section not listed on TOC
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 # Page Title
@@ -114,7 +114,7 @@ Bold is used for navigational elements within a given interface:
 
 Go to **Account** > **Security** > **Personal Access Tokens**.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 Go to **Account** > **Security** > **Personal Access Tokens**.
@@ -128,7 +128,7 @@ Bold is also used when defining new terms, in cases where the [Definition List](
 
 **Transport Layer Security** (TLS) refers to a set of cryptographic security protocols used to encrypt network traffic.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 **Transport Layer Security** (TLS) refers to a set of cryptographic security protocols used to encrypt network traffic.
@@ -142,7 +142,7 @@ Bold is also used when defining new terms, in cases where the [Definition List](
 
 Emphasis should *always* be stressed with italics, and *never* with bold.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 Emphasis should *always* be stressed with italics, and *never* with bold.
@@ -161,7 +161,7 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 <dd>Description of the new term.</dd>
 </dl>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 <dl>
@@ -189,7 +189,7 @@ Use relative paths when linking to other pages of the docs site.
 
 [Quick Start](/guides/quickstart/)
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 [Quick Start](/guides/quickstart/)
@@ -203,7 +203,7 @@ Use relative paths when linking to other pages of the docs site.
 
 [Wikipedia entry on Style guide](https://en.wikipedia.org/wiki/Style_guide)
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 [Wikipedia entry on Style guide](https://en.wikipedia.org/wiki/Style_guide)
@@ -219,7 +219,7 @@ Used for file names, variables, commands, and output, inline within paragraphs:
 
 Inline code styling using backticks, like `$EXAMPLE`.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 Inline code styling using backticks, like `$EXAMPLE`.
@@ -244,14 +244,15 @@ if (!function_exists('install_drupal')) {
 }
 ```
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
-<pre><code className="php">
+````markdown
 ```php
 # This is a Windows-friendly symlink
 require_once WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
 ```
-</code></pre>
+
+````
 
 </Example>
 
@@ -272,9 +273,10 @@ export env=dev
 
 </Alert>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
-<pre><code className="html"><Alert title="Exports" type="export">
+````markdown
+<Alert title="Exports" type="export">
 
 This process uses [Terminus](/terminus/) extensively. Before we begin, set the variables `$site` and `$env` in your terminal session to match your site name and the Dev environment:
 
@@ -283,7 +285,8 @@ export site=yoursitename
 export env=dev
 ```
 
-</Alert></code></pre>
+</Alert>
+````
 
 </Example>
 
@@ -300,7 +303,7 @@ Notes should identify important pieces of information the reader shouldn't miss.
 
 </Alert>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 <Alert title="Note"  type="info" >
@@ -322,7 +325,7 @@ Warnings cover information critical to the reader and highlight potential danger
 
 </Alert>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 <Alert title="Warning" type="danger" >
@@ -351,7 +354,7 @@ Success callouts are used infrequently, usually in guides with specific end resu
 
 </Alert>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 <Alert title="Incorrect DNS Configuration" type="danger" icon="remove">
@@ -424,7 +427,7 @@ Some code.
 
 </TabList>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
     <TabList>
     
@@ -488,7 +491,7 @@ Screenshots are used to reference GUI instructions:
 
 ![Alt text describing the image](../images/dashboard/terminus-cli-code-to-commit-dashboard.png)
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ![Alt text describing the image](../images/dashboard/terminus-cli-code-to-commit-dashboard.png)
@@ -503,7 +506,7 @@ Terminal screenshots should only be used to demonstrate intended output:
 
 ![Alt text describing the image](../images/pr-workflow/composer-require-pathauto.png)
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ![Alt text describing the image](../images/pr-workflow/composer-require-pathauto.png)
@@ -525,7 +528,7 @@ RedisException: Redis server went away in Redis->setOption() (line 28 of /srv/bi
 
 Enable Redis via the Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add** > **Redis**. It may take a few minutes to provision the service.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ### RedisException: Redis server went away
@@ -554,7 +557,7 @@ This Panel contains additional context, or advanced instructions.
 
 </Accordion>
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```html
 <Accordion title="Panel Title" id="example-panel" icon="wrench">
@@ -583,7 +586,7 @@ All plans except for a Basic plan can use Redis. Redis is available to Sandbox s
 | Performance   | <span style="color:green">✔</span> |
 | Elite         | <span style="color:green">✔</span> |
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ## Enable Redis
@@ -612,7 +615,7 @@ Given two new sites with slugs <Popover title="Slugs" content="Generally, Slugs 
 * Subdirectories: `example.com/first-site` and `example.com/second-site`.
 * Subdomains: `first-site.example.com` and `second-site.example.com`.
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 Given two new sites with slugs <Popover title="Slugs" content="Generally, are URL friendly descriptions for a post or a page in WordPress. In the context of WordPress Site Networks, a slug is a URL friendly description for a network site." /> `first-site` and `second-site`, each configuration will result in the following URLs:
@@ -633,7 +636,7 @@ This is the optimal place to provide links to external resources on the subject,
 - [An internal link](/guides/)
 - [An external link](https://pantheon.io/blog/)
 
-<hr className="source-code" />
+<hr className="source-code" /> <br/>
 
 ```markdown
 ## See Also


### PR DESCRIPTION
Closes #5172 

## Effect
PR includes the following changes:
- Fixes the markdown rendering on [Using Terminus to Create and Update Drupal Sites on Pantheon](https://pantheon.io/docs//guides/terminus-drupal-site-management)
- I also went ahead and set up command prompts for code blocks, no biggie.

## Remaining Work
- [x] Update Style Guide
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
