### PR TITLE
extent output timeout for deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,6 +105,7 @@ jobs:
          name: Deploy Multidev environment
          command: |
            bash ./scripts/deploy-multidev.sh
+         no_output_timeout: 15m
       - deploy:
           command: |
             if [ "${CIRCLE_BRANCH}" == "master" ]; then


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Sets a 15 minute timeout for the deployment script job.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
