### PR TITLE
update multipage guide title meta

### DIFF
--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -76,7 +76,7 @@ class GuideTemplate extends React.Component {
     return (
       <Layout>
         <SEO
-          title={node.frontmatter.title}
+          title={node.frontmatter.subtitle + " | " + node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
           image={"/assets/images/terminus-thumbLarge.png"}


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Titles should now be "$SUBTITLE | $TITLE | Pantheon Docs"

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report (debatable)
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
