### PR TITLE
clarifying who will get the https update

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -42,7 +42,7 @@ protected_web_paths:
 
 HTTPS adds a layer of encryption that prevents others from snooping on or tampering with traffic to your site. HTTP Strict Transport Security (**HSTS**) instructs browsers to only connect via HTTPS and helps protect websites against protocol downgrade attacks and cookie hijacking.
 
-Pantheon sites created or updated on or after September 30 2019 default to enforcing HTTPS via a redirect and a short, 5-minute duration, HSTS header. You can override the default with the `enforce_https` directive in a site-specific `pantheon.yml` file.
+Pantheon sites using the default Pantheon upstreams created or updated on or after September 30 2019 default to enforcing HTTPS via a redirect and a short, 5-minute duration, HSTS header. You can override the default with the `enforce_https` directive in a site-specific `pantheon.yml` file.
 
 <Partial file="hsts.md" />
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -42,7 +42,7 @@ protected_web_paths:
 
 HTTPS adds a layer of encryption that prevents others from snooping on or tampering with traffic to your site. HTTP Strict Transport Security (**HSTS**) instructs browsers to only connect via HTTPS and helps protect websites against protocol downgrade attacks and cookie hijacking.
 
-Pantheon sites using the default Pantheon upstreams created or updated on or after September 30 2019 default to enforcing HTTPS via a redirect and a short, 5-minute duration, HSTS header. You can override the default with the `enforce_https` directive in a site-specific `pantheon.yml` file.
+Pantheon sites (using the default Pantheon upstreams) created or updated on or after September 30 2019 default to enforcing HTTPS via a redirect and a short, 5-minute duration, HSTS header. You can override the default with the `enforce_https` directive in a site-specific `pantheon.yml` file.
 
 <Partial file="hsts.md" />
 


### PR DESCRIPTION
A migration customer noted that this only applies to sites created using the default Pantheon upstreams. I don't know if you'd rather just note that they have to have a pantheon.yml file in their codebase?

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- adds clarification 
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
