### PR TITLE
Only run the deploy job on the master branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -143,6 +143,9 @@ workflows:
           requires:
             - build
       - deploy:
+          filters:
+            branches:
+              only: master
           requires:
             - test
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -140,6 +140,9 @@ workflows:
           requires:
             - build
       - preview:
+          filters:
+            branches:
+              ignore: master
           requires:
             - build
       - deploy:


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

## Effect
PR includes the following changes:
- In `.circleci/config.yml`, we adjust the workflow configuration by adding a filter for the `deploy` step, such that it's only run on the master branch.
- Also filters the `master` branch as an exclusion for the preview step, so Multidev deployments don't occur when running a job on master.

[CircleCI Documentation](https://circleci.com/docs/2.0/workflows/#branch-level-job-execution)

## Remaining Work
- [x] Technical review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
