### PR TITLE
Image Fix in Build Tools Page

### DIFF
--- a/source/content/guides/build-tools/04-configure.md
+++ b/source/content/guides/build-tools/04-configure.md
@@ -57,10 +57,10 @@ After making configuration changes in the Admin interface, settings are updated 
 
 Whenever you commit changes from the Pantheon dashboard, the commit will be reduced to contain only those files that belong in the source repository, and this commit will be pushed back to the canonical repository on GitHub:
 
-<p class="text-center" >![Sync commit from Pantheon to GitHub](../../../images/pr-workflow/pantheon-circle-github.png)</p>
+![Sync commit from Pantheon to GitHub](../../../images/pr-workflow/pantheon-circle-github.png)
 
 GitHub will then start a new CircleCI build, and the build results will once again be pushed to the existing Multidev environment that was created for this branch:
 
-<p class="text-center" >![Sync commit from GitHub to Pantheon Multidev](../../../images/pr-workflow/github-circle-multidev.png)</p>
+![Sync commit from GitHub to Pantheon Multidev](../../../images/pr-workflow/github-circle-multidev.png)
 
 You may continue working in this environment, making multiple changes, and committing updates whenever you would like your tests to run again.


### PR DESCRIPTION
Closes #5227

## Effect
PR includes the following changes:
- Removes leftover HTML breaking markdown rendering of images.

## Remaining Work
- [x] Confirm with CircleCi preview
- [ ] merge
- [ ] Turn off work computer because it's almost 6:30 PM and I'm never gonna get to play Borderlands 3 if I don't finish the presequel soon.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)