### PR TITLE
Note lack of external image libs

### DIFF
--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -99,11 +99,13 @@ Once you have downloaded and enabled the Imagemagick module, you'll need to conf
 
 When creating a new preset, if the "Division by Zero" warning appears, add the [`image_allow_insecure_derivatives`](https://www.drupal.org/project/image_allow_insecure_derivatives) conf variable to your `settings.php` file.
 
-Some modules (like [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)) require the explicit path to the ImageMagick library. Use the path `/usr/bin/convert`. [ImageAPI Optimize's support for 3rd party services (like advpng and OptiPNG)](https://www.drupal.org/node/773342) are not available at this time.
+Some modules (like [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)) require the explicit path to the ImageMagick library. Use the path `/usr/bin/convert`.
+
+ImageAPI Optimize's [support for 3rd party services](https://www.drupal.org/node/773342) (like advpng and OptiPNG) are not available at this time.
 
 ## Troubleshooting and FAQs
-#### How do I request the addition of a new library or a newer version of an existing library?
+### How do I request the addition of a new library or a newer version of an existing library?
 Please [contact support](/support/) with a description of your use case and a link to the library's webpage. We welcome new requests, but please bear in mind they are not guaranteed and it is possible the feature request may be denied. As a result, we recommend you set aside enough time for alternative solutions.
 
-#### Will you setup and configure the module/plugin for me?
+### Will you setup and configure the module/plugin for me?
 No. This is not within our [scope of support](/support/#scope-of-support). It is important to be aware of how a Drupal module or WordPress plugin is setup and how it functions. This will prove invaluable in cases where you need to plan and build your site.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -99,7 +99,7 @@ Once you have downloaded and enabled the Imagemagick module, you'll need to conf
 
 When creating a new preset, if the "Division by Zero" warning appears, add the [`image_allow_insecure_derivatives`](https://www.drupal.org/project/image_allow_insecure_derivatives) conf variable to your `settings.php` file.
 
-Some modules (like [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)) require the explicit path to the ImageMagick library. Use the path `/usr/bin/convert`.
+Some modules (like [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)) require the explicit path to the ImageMagick library. Use the path `/usr/bin/convert`. [ImageAPI Optimize's support for 3rd party services (like advpng and OptiPNG)](https://www.drupal.org/node/773342) are not available at this time.
 
 ## Troubleshooting and FAQs
 #### How do I request the addition of a new library or a newer version of an existing library?

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -139,7 +139,7 @@ Alternatively, [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/7.59/
 ### [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)
 **Issue**: ImageAPI Optimize supports 3rd party libraries such as advpng, OptiPNG, PNGCRUSH, jpegtran, jfifremove, advdef, pngout, jpegoptim. These libraries have to be installed on the server. At this time, they are not supported.
 
-**Solution**: [Use a 3rd-party module like reSmush.It](https://www.drupal.org/project/resmushit) or [a local application like ImageOptim.](https://imageoptim.com)
+**Solution**: Use a 3rd-party module like [reSmush.It](https://www.drupal.org/project/resmushit) or a local application like [ImageOptim.](https://imageoptim.com) or [OptiPNG](http://optipng.sourceforge.net/).
 
 <hr />
 

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -136,6 +136,13 @@ Alternatively, [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/7.59/
 
 <hr />
 
+### [ImageAPI Optimize](https://www.drupal.org/project/imageapi_optimize)
+**Issue**: ImageAPI Optimize supports 3rd party libraries such as advpng, OptiPNG, PNGCRUSH, jpegtran, jfifremove, advdef, pngout, jpegoptim. These libraries have to be installed on the server. At this time, they are not supported.
+
+**Solution**: [Use a 3rd-party module like reSmush.It](https://www.drupal.org/project/resmushit) or [a local application like ImageOptim.](https://imageoptim.com)
+
+<hr />
+
 ### [IMCE 6.x](https://www.drupal.org/node/251024) and [IMCE 7.x](https://www.drupal.org/project/imce/releases/7.x-1.11)
 **Issue**: Operations on directories containing an inordinate amount of files will likely hit the load balancer timeout threshold (30 seconds).
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -259,7 +259,7 @@ This will convert the database tables in the existing installation to the proper
 
 ## Image Optimization Tools
 
-Image optimization libraries such as advpng, OptiPNG, PNGCRUSH, jpegtran, jfifremove, advdef, pngout, jpegoptim have to be installed on the server. At this time, they are not supported. For more information see [Modules and Plugins with Known Issues.](https://pantheon.io/docs/modules-plugins-known-issues#imageapi-optimization)
+Image optimization libraries such as advpng, OptiPNG, PNGCRUSH, jpegtran, jfifremove, advdef, pngout, jpegoptim have to be installed on the server. At this time, they are not supported. For more information see [Modules and Plugins with Known Issues.](/modules-plugins-known-issues#imageapi-optimize)
 
 ## Terminus Support
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -257,6 +257,9 @@ terminus drush <site>.<env> -- utf8mb4-convert-databases
 
 This will convert the database tables in the existing installation to the proper encoding to support emoji characters. After making the conversion, test it out by placing an emoji in the site text.
 
+## Image Optimization Tools
+
+Image optimization libraries such as advpng, OptiPNG, PNGCRUSH, jpegtran, jfifremove, advdef, pngout, jpegoptim have to be installed on the server. At this time, they are not supported. For more information see [Modules and Plugins with Known Issues.](https://pantheon.io/docs/modules-plugins-known-issues#imageapi-optimization)
 
 ## Terminus Support
 


### PR DESCRIPTION
Closes #5166
Replaces #5231

## Effect
PR includes the following changes:
- Notes where appropriate that external image libraries are not provided on the platform.

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)