### PR TITLE
Getting host ip to replace hostname

### DIFF
--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -91,7 +91,16 @@ Error:            ssh_init: nodename nor servname provided, or not known
 Error:            Could not connect to server
 ```
 
-Double check settings and resolve typos to fix this issue.
+### Cannot sftp to environment with multiple appservers
+Previously can access sftp in test and live but now getting `Error: Directory /srv/bindings/c1f103b56xxxxxxxxxxxx/files: no such file or directory` error. Symptoms include users able to connect in dev or multidevs with single appserver.
+
+Getting any of the equivalent IP of the host appserver by using a `dig` command to replace the hostname lets you connect again by:
+
+```bash
+dig +short appserver.live.120330a1-xxxxxxxxxxxxxxxxx.drush.
+35.194.x.x
+35.222.x.x 
+```
 
 ### Site Manager
 Features offered in the FileZilla Site Manager (like [Synchronized Browsing](https://wiki.filezilla-project.org/Using#Synchronized_Browsing)) are not supported because the Pantheon platform sometimes migrates sites across appservers without warning and the non-static binding string will change. This means that while you can set up your site in the Site Manager, you will need to reconfigure the login information and file paths whenever the dev environment site binding changes.

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -66,6 +66,8 @@ Starting at the Performance Medium service level up to Elite plans, the Test and
 Error:            File transfer failed
 ```
 
+This error can also occur when the application container has been migrated, so first confirm the [host path](/sftp#sftp-connection-information).
+
 Resolve instances of transfer failures by reconfiguring FileZilla to limit the number of simultaneous connections:
 
 1. Under the **File** menu, click on **Site Manager**.
@@ -80,6 +82,15 @@ Resolve instances of transfer failures by reconfiguring FileZilla to limit the n
 
 See also, [this FAQ on our related SFTP doc](/sftp#i-am-receiving-errors-connecting-to-my-server-with-an-sftp-client).
 
+#### Fallback Solution
+If all else fails, you can connect directly to an application container via the IP address. Use Dig to find the IP address:
+
+```bash{outputLines:2-3}
+dig +short appserver.live.120330a1-xxxxxxxxxxxxxxxxx.drush.
+35.194.x.x
+35.222.x.x
+```
+
 ### Uploading to the Files Directory
 FileZilla does not correctly upload files when the target directory on Pantheon is `files`. We recommend setting the target directory to `code/sites/default/files`, which is a symlink to `files` on Pantheon. If you experience issues using FileZilla, try the task using an alternate program such as [Transmit](https://panic.com/transmit/) (Mac OS) or [WinSCP](/winscp) (Windows).
 
@@ -89,17 +100,6 @@ The following error is caused by an invalid hostname, most often the result of a
 ```bash
 Error:            ssh_init: nodename nor servname provided, or not known
 Error:            Could not connect to server
-```
-
-### Cannot sftp to environment with multiple appservers
-Previously can access sftp in test and live but now getting `Error: Directory /srv/bindings/c1f103b56xxxxxxxxxxxx/files: no such file or directory` error. Symptoms include users able to connect in dev or multidevs with single appserver.
-
-Getting any of the equivalent IP of the host appserver by using a `dig` command to replace the hostname lets you connect again by:
-
-```bash
-dig +short appserver.live.120330a1-xxxxxxxxxxxxxxxxx.drush.
-35.194.x.x
-35.222.x.x 
 ```
 
 ### Site Manager

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -87,8 +87,8 @@ If all else fails, you can connect directly to an application container via the 
 
 ```bash{outputLines:2-3}
 dig +short appserver.live.120330a1-xxxxxxxxxxxxxxxxx.drush.
-35.194.x.x
-35.222.x.x
+203.0.113.5
+203.0.113.47
 ```
 
 ### Uploading to the Files Directory

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -66,7 +66,7 @@ Starting at the Performance Medium service level up to Elite plans, the Test and
 Error:            File transfer failed
 ```
 
-This error can also occur when the application container has been migrated, so first confirm the [host path](/sftp#sftp-connection-information).
+This error can also occur when the application container has been migrated. Confirm that the [host path](/sftp#sftp-connection-information) is correct before continuing.
 
 Resolve instances of transfer failures by reconfiguring FileZilla to limit the number of simultaneous connections:
 
@@ -82,7 +82,7 @@ Resolve instances of transfer failures by reconfiguring FileZilla to limit the n
 
 See also, [this FAQ on our related SFTP doc](/sftp#i-am-receiving-errors-connecting-to-my-server-with-an-sftp-client).
 
-#### Fallback Solution
+#### Fallback solution when file transfer fails
 If all else fails, you can connect directly to an application container via the IP address. Use Dig to find the IP address:
 
 ```bash{outputLines:2-3}

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -82,7 +82,7 @@ Resolve instances of transfer failures by reconfiguring FileZilla to limit the n
 
 See also, [this FAQ on our related SFTP doc](/sftp#i-am-receiving-errors-connecting-to-my-server-with-an-sftp-client).
 
-#### Fallback solution when file transfer fails
+#### Fallback Solution if File Transfer Fails
 If all else fails, you can connect directly to an application container via the IP address. Use Dig to find the IP address:
 
 ```bash{outputLines:2-3}

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -82,7 +82,7 @@ Resolve instances of transfer failures by reconfiguring FileZilla to limit the n
 
 See also, [this FAQ on our related SFTP doc](/sftp#i-am-receiving-errors-connecting-to-my-server-with-an-sftp-client).
 
-#### Fallback Solution if File Transfer Fails
+#### Fallback Solution If File Transfer Fails
 If all else fails, you can connect directly to an application container via the IP address. Use Dig to find the IP address:
 
 ```bash{outputLines:2-3}


### PR DESCRIPTION
Closes #5245

## Effect
PR includes the following changes:
- Getting host ip to replace hostname using the dig command
-

## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Archive from **Done** in [Main Project](https://github.com/pantheon-systems/documentation/projects/14)
