### PR TITLE
More webops messaging in workflow page

### DIFF
--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -21,6 +21,7 @@ Optimize your dev team and streamline WebOps workflows. Pantheon delivers custom
 
 ## Components of a Site
 One of the core concepts at the heart of the Pantheon WebOps workflow is the distinction between **code** and **content**.
+
 ### Code
 Code refers to anything version controlled by Git which includes core, custom and contributed modules or plugins, themes, and libraries.
 
@@ -37,7 +38,7 @@ The main process of the Pantheon WebOps workflow is to move code up from Dev to 
 
 #### Why does Pantheon do this?
 
-Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that it makes sense to separate the code and content because there is some level of separate between the people changing each. Generally speaking, the team members editing content expect to sign into a live environment, make changes, and immediately see the changes on that public site. Developers and designers changing code often prefer to make their changes on a non-live environment because the risk of breaking the site is too great. Changing code directly on a production environment is a practice we call "[Cowboy Coding](https://pantheon.io/blog/cowboy-coding-nostalgia)" and we greatly discourage it.
+Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that it makes sense to separate the code and content because there is some level of separation between the people changing each. Generally speaking, the team members editing content expect to sign into a live environment, make changes, and immediately see the changes on that public site. Developers and designers changing code often prefer to make their changes on a non-live environment because the risk of breaking the site is too great. Changing code directly on a production environment is a practice we call "[Cowboy Coding](https://pantheon.io/blog/cowboy-coding-nostalgia)" and we greatly discourage it.
 
 </Accordion>
 
@@ -79,7 +80,7 @@ It's also a good idea to review the Status tab and run **Launch Check**, and mak
 - [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check/)
 - [Launch Check - WordPress Performance and Configuration Analysis](/wordpress-launch-check/)
 
-Many teams have a standardized review procedure that they execute in the Test environment. That might mean manually checking important pages on the site or walking through content creation forms. If you have automated tests, you can trigger them upon deployment with our [platform hook system](/quicksilver).
+Many teams have a standardized review procedure that they execute in the Test environment. That might mean manually checking important pages on the site or walking through content creation forms. If you have automated tests, you can trigger them upon deployment with our [platform hook system](/quicksilver/).
 
 This entire process is designed around making sure that the Live environment is always stable and never at risk due to code updates.
 
@@ -147,7 +148,7 @@ The **Export** tool does not include a copy of the site's codebase and cannot be
 
 Typically, you'll create content in the Live environment. However, when deploying a newly-built site for the very first time, it is often necessary to push the content "up", which is the opposite of the normal content workflow. In this case, you may move the database and files (e.g. images) from Dev or Test to Live via the **Database/Files** > **Clone** area of the Dashboard.
 
-Moving content up to Live should almost never be done on a launched site. The only exception is if that site is 100% read-only, as pushing the database and files will overwrite all changes made in Live like comments or ecommerce orders from the public. Also note that overwriting the database of a Live environment may cause downtime.
+Moving content up to Live should almost never be done on a launched site. The only exception is if that site is 100% read-only, as pushing the database and files will overwrite all changes made in Live, like comments or ecommerce orders from the public. Also note that overwriting the database of a Live environment may cause downtime.
 
 If there are other workflows you would like to see, contact us. We're always looking for ways to improve the platform.
 

--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -37,7 +37,7 @@ The main process of the Pantheon WebOps workflow is to move code up from Dev to 
 
 #### Why does Pantheon do this?
 
-Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that it makes sense to separate the code and content because there is some level of separate between the people changing each. Generally speaking, the team members editing content expect to sign into a live site, make changes, and immediately see the changes on a public site. Developers and designers changing code often prefer to make their changes on a non-live environment because the risk of breaking the site is too great. Changing code directly on a Live site is a practice we call "[Cowboy Coding](https://pantheon.io/blog/cowboy-coding-nostalgia)" and we greatly discourage it.
+Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that it makes sense to separate the code and content because there is some level of separate between the people changing each. Generally speaking, the team members editing content expect to sign into a live environment, make changes, and immediately see the changes on that public site. Developers and designers changing code often prefer to make their changes on a non-live environment because the risk of breaking the site is too great. Changing code directly on a production environment is a practice we call "[Cowboy Coding](https://pantheon.io/blog/cowboy-coding-nostalgia)" and we greatly discourage it.
 
 </Accordion>
 
@@ -64,7 +64,7 @@ Once changes are pushed to Dev, the Deploys panel in the Test tab will prompt yo
 
  - Check the **Pull files and the database from the Live environment?** checkbox to pull the content from your Live environment to the Test environment.
 
- - Drupal site deploys can also run `update.php` which executes [update hooks](https://www.drupal.org/docs/8/api/update-api/introduction-to-update-api-for-drupal-8) for databse changes.
+ - Drupal site deployments can also run `update.php` which executes [update hooks](https://www.drupal.org/docs/8/api/update-api/introduction-to-update-api-for-drupal-8) for databse changes.
 
    On WordPress site dashboards, cloning the content will expose an option to convert URLs from the Live environment's pattern to the Test environment's, including the protocol from HTTPS to HTTP for encrypted live environments.
 
@@ -111,7 +111,7 @@ By design, code changes via SFTP are prevented in Test and Live. All code change
 
 1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard or Terminus as outlined above.
 
-2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm.  Pushing a [hotfix via Git tags](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
+2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm. Pushing a [hotfix via Git tags](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
 
 ## Managing Database and Files: Clone, Import, Export, Wipe
 
@@ -135,7 +135,7 @@ The [database clone operation](/sites/#database--files) excludes some tables by 
 * `accesslog`
 * `watchdog`
 
-You can clone databases from one environment to another at any point.  It does not need to only be within the deployment process.
+You can clone databases from one environment to another at any point. It does not need to only be within the deployment process.
 
 <Alert title="Note" type="info">
 
@@ -145,7 +145,7 @@ The **Export** tool does not include a copy of the site's codebase and cannot be
 
 ## Uncommon Workflows
 
-Typically, you'll create content in the Live environment. However, when deploying a newly-built site for the very first time, it is often necessary to push the content "up", which is the opposite of the normal content workflow. In this case, you may move the database and files (e.g. images) from Dev or Test to Live via the  **Database/Files** > **Clone** area of the Dashboard.
+Typically, you'll create content in the Live environment. However, when deploying a newly-built site for the very first time, it is often necessary to push the content "up", which is the opposite of the normal content workflow. In this case, you may move the database and files (e.g. images) from Dev or Test to Live via the **Database/Files** > **Clone** area of the Dashboard.
 
 Moving content up to Live should almost never be done on a launched site. The only exception is if that site is 100% read-only, as pushing the database and files will overwrite all changes made in Live like comments or ecommerce orders from the public. Also note that overwriting the database of a Live environment may cause downtime.
 

--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -11,11 +11,11 @@ This page offers a high level description of the intended usage of Pantheon's De
 
 </Alert>
 
-Every Pantheon site comes with three environments: Dev, Test, and Live. Each environment runs a version of the site on its own container. Separate Dev, Test, and Live environments allow you to develop and test your site without impacting the live site's availability to the world. Additional development environments are available with [Multidev](/multidev/).
+Every Pantheon site comes with three environments: Dev, Test, and Live. Each environment runs a version of the site on its own container. Separate Dev, Test, and Live environments allow you to develop and test your site without impacting the Live environment's availability to the world. Additional development environments are available with [Multidev](/multidev/).
 
 <Enablement title="Get WebOps Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 
-Optimize your dev team and streamline WebOps workflows. Pantheon delivers custom workshops to help development teams master our platform and improve their internal DevOps.
+Optimize your dev team and streamline WebOps workflows. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps practices.
 
 </Enablement>
 
@@ -24,10 +24,8 @@ One of the core concepts at the heart of the Pantheon WebOps workflow is the dis
 ### Code
 Code refers to anything version controlled by Git which includes core, custom and contributed modules or plugins, themes, and libraries.
 
-<Partial file="_code.md" />
-
 ### Content
-Content refers to your sites files and the database. In this context, files are static images and assets stored in the standard upload path `wp-content/uploads` for WordPress and `sites/default/files` for Drupal.
+Content refers to your site's files and the database. In this context, files are static images and assets stored in the standard upload path `wp-content/uploads` for WordPress and `sites/default/files` for Drupal.
 
 ## Code Moves Up, Content Moves Down
 
@@ -39,7 +37,7 @@ The main process of the Pantheon WebOps workflow is to move code up from Dev to 
 
 #### Why does Pantheon do this?
 
-Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that version control is a critical component when building and maintaining a website. We've built a platform tailored specifically to let you use version control to maintain all of your code, keep all of your files separate, and have all the test beds you need to make sure everything works before changes hit production.
+Pantheon is an "[opinionated platform](https://stackoverflow.com/questions/802050/what-is-opinionated-software)". Specifically, we're of the opinion that it makes sense to separate the code and content because there is some level of separate between the people changing each. Generally speaking, the team members editing content expect to sign into a live site, make changes, and immediately see the changes on a public site. Developers and designers changing code often prefer to make their changes on a non-live environment because the risk of breaking the site is too great. Changing code directly on a Live site is a practice we call "[Cowboy Coding](https://pantheon.io/blog/cowboy-coding-nostalgia)" and we greatly discourage it.
 
 </Accordion>
 
@@ -50,11 +48,11 @@ For more detailed information on developing directly in SFTP mode, please see th
 
 ### Combine Code from Dev and Content from Live in Test
 
-When you're ready to test a new set of changes, deploy your code from Dev.  At this point, you will be prompted to clone your content from the Live database.  This combines the code from Dev and the database values from Live in the Test environment to be absolutely certain that your deployment to Live will go as planned. Deploys are performed by adding a git tag to the last commit on the Test environment.
+When you're ready to test a new set of changes, deploy your code from Dev to Test. At this point, you will be prompted to clone your content down from the Live environment. This combines the code from Dev and the database and files from Live in the Test environment. It is a WebOps best practice to simulate your eventual deployment to Live as closely as possible. Under the hood, [each deployment generates a Git tag](/git-faq#what-are-the-git-tags).
 
 <Alert title="Note" type="info">
 
-While you are able to update Dev via Git, if you would like to deploy your changes to Test or Live from the command line, you'll need to use [Terminus](/terminus/).
+While you are able to update the Dev environment via Git, if you would like to deploy your changes to Test or Live from the command line, you'll need to use [Terminus](/terminus/).
 
 </Alert>
 
@@ -64,9 +62,9 @@ Once changes are pushed to Dev, the Deploys panel in the Test tab will prompt yo
 
  - The **Deploy Log** helps you group a batch of commits into a single deployment. Best practice is to keep logical groups of edits together and then summarize those groups with a single deployment message.
 
- - Check the **Pull files and the database from the Live environment?** Checkbox to pull the content from your Live site to the Test environment.
+ - Check the **Pull files and the database from the Live environment?** checkbox to pull the content from your Live environment to the Test environment.
 
- - Drupal site deploys come with the ability to run `update.php` after  code deploys. `hook update n` and any other necessary database updates will be made automatically on the Test environment.
+ - Drupal site deploys can also run `update.php` which executes [update hooks](https://www.drupal.org/docs/8/api/update-api/introduction-to-update-api-for-drupal-8) for databse changes.
 
    On WordPress site dashboards, cloning the content will expose an option to convert URLs from the Live environment's pattern to the Test environment's, including the protocol from HTTPS to HTTP for encrypted live environments.
 
@@ -81,16 +79,13 @@ It's also a good idea to review the Status tab and run **Launch Check**, and mak
 - [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check/)
 - [Launch Check - WordPress Performance and Configuration Analysis](/wordpress-launch-check/)
 
-If there are additional manual "go live" instructions, now is a good time to review them and make sure they work and are properly documented.
+Many teams have a standardized review procedure that they execute in the Test environment. That might mean manually checking important pages on the site or walking through content creation forms. If you have automated tests, you can trigger them upon deployment with our [platform hook system](/quicksilver).
 
-This may be a good time to run regression or smoke tests by stepping through your main workflows manually, or by running an automated test suite. Use Test to make sure that everything is working correctly before deploying to Live.
-
-This entire process is designed around making sure that the Live site is always stable and never at risk due to code updates.
-
+This entire process is designed around making sure that the Live environment is always stable and never at risk due to code updates.
 
 ### Deploy Code to Live
 
-After testing your changes you can take them live. Deploying code from Test to Live will immediately update your live website; however, static assets such as images and CSS may still be outdated. To update them, check the **Clear Caches** option when deploying changes to your Live environment. For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches/).
+After testing your changes in the Test environment you can move them to the Live environment. Deploying code from Test to Live will immediately update your public website; however, static assets such as images and CSS may still be outdated. To refresh them, check the **Clear Caches** option when deploying changes to your Live environment. For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches/).
 
 ![Site dashboard, live environment, workflow section](../images/dashboard/deploy-live.png)
 
@@ -100,14 +95,13 @@ Dealing with changes to your site's configuration, stored in the database, can b
 
 ### WordPress
 
-* [WP-CFM](https://wordpress.org/plugins/wp-cfm/) plugin: exports bundles of configuration to `.json` files in `wp-content/config`
+* [WP-CFM](https://wordpress.org/plugins/wp-cfm/) plugin: exports bundles of configuration to `.json` files in `wp-content/config`.
 * [Advanced custom fields can be exported to code](https://stevegrunwell.com/blog/exploring-the-wordpress-advanced-custom-fields-export-feature/).
 
 
 ### Drupal
 
-* [hook\_update\_N()](https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_update_N/7.x): Encapsulate changes into a custom module and apply them by running `update.php`. Great example of this approach: [Automate Drupal site updates with a deployment module](http://befused.com/drupal/site-deployment-module).
-* [Views: Export to code](https://www.chapterthree.com/blog/howto-best-practices-for-embedding-views-code)
+* [hook\_update\_N()](https://api.drupal.org/api/drupal/modules%21system%21system.api.php/function/hook_update_N/7.x): Encapsulate changes into a custom module and apply them by running `update.php`. Here is a great example of this approach: [Automate Drupal site updates with a deployment module](http://befused.com/drupal/site-deployment-module).
 * [Features](https://www.drupal.org/project/features) module: Export sets of configuration like content types and fields to code as modules. 
 * Drupal 8 tackles configuration management head on. For more information, see [Configuration Workflow for Drupal 8 Sites](/drupal-8-configuration-management/).
 
@@ -115,15 +109,33 @@ Dealing with changes to your site's configuration, stored in the database, can b
 
 By design, code changes via SFTP are prevented in Test and Live. All code changes should be done in Dev. There are two ways to update code in Test or Live:
 
-1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard as outlined above.
+1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard or Terminus as outlined above.
 
-2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm.  Pushing a [hotfix via Git](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
+2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm.  Pushing a [hotfix via Git tags](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
 
 ## Managing Database and Files: Clone, Import, Export, Wipe
 
 You may also clone, import, export, and wipe the database and files per environment. Wiping completely resets the database and files, but leaves the codebase intact. This means you will lose all data and will need to either re-import, or re-install to get your site back online.
 
-The [database clone operation](/sites/#database--files) excludes some tables by default. The excluded tables are: cache, cache_block, cache_bootstrap, cache_field, cache_filter, cache_form, cache_image, cache_menu, cache_page, cache_path, cache_update, cache_views, cache_views_data, accesslog, and watchdog.  You can clone databases from one environment to another at any point.  It does not need to only be within the deployment process.
+The [database clone operation](/sites/#database--files) excludes some tables by default. The excluded tables are:
+
+* `cache`
+* `cache_block`
+* `cache_bootstrap`
+* `cache_field`
+* `cache_filter`
+* `cache_form`
+* `cache_image`
+* `cache_menu`
+* `cache_page`
+* `cache_path`
+* `cache_update`
+* `cache_views`
+* `cache_views_data`
+* `accesslog`
+* `watchdog`
+
+You can clone databases from one environment to another at any point.  It does not need to only be within the deployment process.
 
 <Alert title="Note" type="info">
 
@@ -135,7 +147,7 @@ The **Export** tool does not include a copy of the site's codebase and cannot be
 
 Typically, you'll create content in the Live environment. However, when deploying a newly-built site for the very first time, it is often necessary to push the content "up", which is the opposite of the normal content workflow. In this case, you may move the database and files (e.g. images) from Dev or Test to Live via the  **Database/Files** > **Clone** area of the Dashboard.
 
-Moving content up to Live should almost never be done on a launched site. The only exception is if that site is 100% read-only, as pushing the database and files will overwrite all changes made. Also note that overwriting the database of a live site may cause downtime.
+Moving content up to Live should almost never be done on a launched site. The only exception is if that site is 100% read-only, as pushing the database and files will overwrite all changes made in Live like comments or ecommerce orders from the public. Also note that overwriting the database of a Live environment may cause downtime.
 
 If there are other workflows you would like to see, contact us. We're always looking for ways to improve the platform.
 


### PR DESCRIPTION
Closes #5205 

## Effect
PR includes the following changes:
- Add more mentions of WebOps teams to workflow page.
- Miscellaneous copy edits. I 

## Remaining Work
- [ ] ~Technical review~
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
