### PR TITLE
Updated link on Relaunch page

### DIFF
--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -78,7 +78,7 @@ In order to retain Preferred Pricing an updated [invitation to pay](/add-client-
 
 6. Test and confirm that the new site is accessible via the custom domain over HTTPS (e.g., `https://www.example.com/`).
 7. Repeat steps 2-6 above for each affected domain. Keep in mind that `www.example.com` and `example.com` are different domains.
-8. In the new Site Dashboard, [standardize traffic for the primary domain](/domains/#redirect-to-https-and-the-primary-domain).
+8. In the new Site Dashboard, [standardize traffic for the primary domain](/domains#primary-domain).
 9. In the old Site Dashboard, [downgrade the site from a paid plan to Sandbox](/site-plan/#cancel-current-plan).
 10. In the old Site Dashboard, [remove the existing card as a payment method for the site](/site-billing/#do-not-bill-this-site-to-a-card). If you're a contract customer, you can skip this step.
 


### PR DESCRIPTION
The link in Step 8 was pointing to the right page, but the anchor changed its name.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [x] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
