### PR TITLE
move HSTS link to more relevant placement

### DIFF
--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -24,11 +24,9 @@ This redirect is considered best practice and recommended as part of the going l
 
 ### Set HSTS with Pantheon.yml
 
-This is the preferred method of setting HTTPS, HSTS, and the primary domain for your site.
+This is the preferred method of setting HTTPS, HSTS, and the primary domain for your site. See [Enforce HTTPS + HSTS](/pantheon-yml#enforce-https--hsts) in the Pantheon.yml doc to set the HSTS header and redirect all traffic to HTTPS.
 
 <Partial file="primary-domain.md" />
-
-See [Enforce HTTPS + HSTS](/pantheon-yml#enforce-https--hsts) in the Pantheon.yml doc to set the HSTS header and redirect all traffic to HTTPS.
 
 ### Redirect with PHP
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Based on discussion in channel, moved the link to the HSTS section of the pantheon.yml doc to a more relevant location.

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report (I'm very *meh* on this one)
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)