### PR TITLE
Document Performance 2XL Plan

### DIFF
--- a/source/content/annual-billing.md
+++ b/source/content/annual-billing.md
@@ -19,7 +19,7 @@ The table below shows how much sites can save by switching to annual billing. Pe
 
 <dd>
 
-Set price for new sites created after late October that aren’t purchased via a qualified agency partner.
+Set price for new sites that aren't purchased via a qualified agency partner.
 
 </dd>
 

--- a/source/content/traffic-limits.md
+++ b/source/content/traffic-limits.md
@@ -28,6 +28,18 @@ For sites on Performance plans, we will notify you if your site exceeds the limi
 ### How will Pantheon let me know my site will automatically be bumped to the next level?
 You will receive a communication that you are over on month one, and again on month two when the plan level is changed.
 
+### What if my site's metrics exceed the limit of the Performance Extra Large Plan?
+The Performance Extra Large Plan allows for 300,000 monthly visits and 1.5 million monthly page views. High traffic sites should be moved to an Elite plan. To learn about moving to an Elite Plan, please [contact us](https://pantheon.io/contact-us).
+
+If you need time or are unable to commit to an annual contract, sites that exceed the Performance Extra Large limits will be upgraded to a Performance 2X Large Plan, which has a limit of 600,000 monthly visits and 3 million monthly page views. The 2X Large plan is not available for purchase via our dashboard, but can be applied by our Support team. Prices for the 2X Large plan are as follows:
+
+| Payment Type      |  Price   |
+|:----------------- |:-------- |
+| Preferred Monthly |  $1,100  |
+| Preferred Annual  |  $12,000 |
+| List Monthly      |  $1,500  |
+| List Annual       |  $16,500 |
+
 ### What is “sustained traffic”?
 Sustained traffic is two consecutive months of being over the site plan limit.
 

--- a/source/content/traffic-limits.md
+++ b/source/content/traffic-limits.md
@@ -33,12 +33,12 @@ The Performance Extra Large Plan allows for 300,000 monthly visits and 1.5 milli
 
 If you need time or are unable to commit to an annual contract, sites that exceed the Performance Extra Large limits will be upgraded to a Performance 2X Large Plan, which has a limit of 600,000 monthly visits and 3 million monthly page views. The 2X Large plan is not available for purchase via our dashboard, but can be applied by our Support team. Prices for the 2X Large plan are as follows:
 
-| Payment Type      |  Price   |
-|:----------------- |:-------- |
-| Preferred Monthly |  $1,100  |
-| Preferred Annual  |  $12,000 |
-| List Monthly      |  $1,500  |
-| List Annual       |  $16,500 |
+| Payment Type      | Price Per Month  |
+|:----------------- |:---------------- |
+| Preferred Monthly |  $1,100          |
+| Preferred Annual  |  $1,000          |
+| List Monthly      |  $1,500          |
+| List Annual       |  $1,375          |
 
 ### What is “sustained traffic”?
 Sustained traffic is two consecutive months of being over the site plan limit.


### PR DESCRIPTION
Closes #5266

## Effect
PR includes the following changes:
- Adds FAQ section on Performance 2XL to Traffic Limits page
- Fixes errant time reference left behind from the pricing change last year.

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)