### PR TITLE
Revise "Provided host name" docs

### DIFF
--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -228,6 +228,10 @@ To resolve, add a default or empty `sites/default/settings.php` to your site's c
 
 This error comes from a feature in Drupal 8 designed to protect against [HTTP HOST Header attacks](https://www.drupal.org/node/1992030). Drupal 8 allows you to specify "trusted host patterns," which specify a set of domains that incoming requests must match.
 
-If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array. By default, Pantheon is configured in the backend to not allow any non-trusted hosts. You should typically have this snippet in your `settings.pantheon.php` file: [see here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184).
+If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array.
+
+By default, Pantheon's environment is configured to not allow any non-trusted hosts. Trusted hosts are added via the `PANTHEON_ENVIRONMENT` variable in `settings.php` [here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184):
+
+GITHUB-EMBED https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php php 184-190 GITHUB-EMBED
 
 

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -228,5 +228,7 @@ To resolve, add a default or empty `sites/default/settings.php` to your site's c
 
 This error comes from a feature in Drupal 8 designed to protect against [HTTP HOST Header attacks](https://www.drupal.org/node/1992030). Drupal 8 allows you to specify "trusted host patterns," which specify a set of domains that incoming requests must match.
 
-If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array.
+If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array. By default, Pantheon is configured in the backend to not allow any non-trusted hosts. You should typically have this snippet in your `settings.pantheon.php` file: [see here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184), which allows 
+
+
 

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -228,7 +228,6 @@ To resolve, add a default or empty `sites/default/settings.php` to your site's c
 
 This error comes from a feature in Drupal 8 designed to protect against [HTTP HOST Header attacks](https://www.drupal.org/node/1992030). Drupal 8 allows you to specify "trusted host patterns," which specify a set of domains that incoming requests must match.
 
-If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array. By default, Pantheon is configured in the backend to not allow any non-trusted hosts. You should typically have this snippet in your `settings.pantheon.php` file: [see here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184), which allows 
-
+If you see this error, you need to update your [trusted host patterns](#trusted-host-setting) in `settings.php` and add your new domain(s) to the `$settings['trusted_host_patterns']` array. By default, Pantheon is configured in the backend to not allow any non-trusted hosts. You should typically have this snippet in your `settings.pantheon.php` file: [see here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184).
 
 


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

## Effect
PR includes the following changes:
- It appears this snippet is somewhat inaccurate when relating to the Pantheon platform - we provide a "safety net", so the trust hosts don't matter on the platform. I just took a quick pass at it, so please revise wording as needed, am happy to clarify my thoughts on this!

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
