### PR TITLE
Relaunch - new site plan gets billed immediately

### DIFF
--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -46,6 +46,8 @@ If you need to assume site and billing ownership, the current Site Owner must [t
 
 To retain Preferred Pricing an updated [invitation to pay](/add-client-site/#send-an-invitation-to-pay-to-your-client) must be sent from the Supporting Organization for the new site.
 
+The new Site Plan will be billed immediately.
+
 </Alert>
 
 ## Relaunch Procedure


### PR DESCRIPTION
Closes #4922 

## Effect
PR includes the following changes:
- adds to note that site plan changes are billed immediately

## Remaining Work
- [x] Technical review / Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
