### PR TITLE
Document HTTPS warnings for Custom Cert users to ignore.

### DIFF
--- a/gatsby/src/components/alert/style.css
+++ b/gatsby/src/components/alert/style.css
@@ -103,6 +103,29 @@
   font-family: "Open Sans", sans-serif;
 }
 
+.alert-dash-warning {
+  background-image: none !important;
+  border-color: #ddd;
+  background-color: white !important;
+  border-left-color: #d83f48;
+  border-top-left-radius: 4px;
+  border-left-width: 8px;
+  border-right-width: 1px;
+  border-top-width: 1px;
+  border-bottom-width: 1px;
+  border-bottom-left-radius: 4px;
+  font-size: 18px;
+  line-height: 29px;
+  font-family: "Open Sans", sans-serif;
+}
+.alert-dash-warning h4 {
+  font-size: 16px;
+  color: #000000;
+  font-weight: 600;
+  line-height: 1.6;
+  font-family: "Open Sans", sans-serif;
+}
+
 .alert-export {
   background-image: none !important;
   border-color: #efd01b;

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -78,6 +78,20 @@ To help generate CAA records, please see the free online tool: <https://sslmate.
 CAA records configured for the root domain (e.g., `example.com`) are inherited by subdomains (e.g., `www.example.com`, `blog.example.com`, etc.). Disabling Let's Encrypt for the root domain will disable subdomains.
 
 
+<Alert title="note" type="info">
+
+After Disabling Let's Encrypt, the **Domains / HTTPS** page will give the following error.
+
+  <Alert title="HTTPS" type="dash-warning">
+
+  Unable to provision HTTPS. Authorization failed for this domain. Please contact Pantheon support with error code 008.
+
+  </Alert>
+
+The platform will also issue a proactive ticket with the subject **Action Required**. Custom certificate users can ignore both the warning and ticket.
+
+</Alert>
+
 ## Technical Specifications
 
 |                                                                       | Legacy                    | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |


### PR DESCRIPTION
Closes #4486

## Effect
PR includes the following changes:
- Adds a style for the alert component to mimic dashboard warning messages
- Documents that custom cert users can ignore the dash warning and proactive ticket.

## Remaining Work
- [x] :+1: from @rachelwhitton
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)