### PR TITLE
highlight cache age

### DIFF
--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -63,7 +63,7 @@ Two of the headers listed above are Drupal-specific. By default, WordPress does 
   accept-ranges: bytes
   date: Mon, 16 Apr 2018 16:30:18 GMT
   via: 1.1 varnish
-  age: 44742
+  age: 44742 //highlight-line
   x-served-by: cache-mdw17344-MDW, cache-jfk8146-JFK
   x-cache: HIT, HIT
   x-cache-hits: 1, 1


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes #4166

## Effect
PR includes the following changes:
- Highlights the age line in `curl` output.
- This plus #5288 resolves #4166

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)