### PR TITLE
note files != db

### DIFF
--- a/source/content/rsync-and-sftp.md
+++ b/source/content/rsync-and-sftp.md
@@ -8,13 +8,15 @@ If you have more than 500 MB of content to be transferred to your `/files` direc
 
 This allows you to transfer unlimited data "server-to-server", which is much faster than transferring from your workstation. Files can be transferred to and from any Pantheon site environment (Dev, Test, and Live).
 
-There are two mechanisms for transferring files: SFTP and rsync.
+<Alert title="Notes" type="info">
 
-<Alert title="Note" type="info">
+ - This document covers copying [files](/files/), excluding database files. You cannot directly access the database files. See [Use the Pantheon WebOps Workflow](/pantheon-workflow/) for more information on how code moves up and content moves down.
 
-You will not be able to use SFTP or rsync to add any file or directory listed in a `.gitignore` file to your Git repository. Any file uploaded in this way cannot be committed and will not be available for deployment.
+ - You will not be able to use SFTP or rsync to add any file or directory listed in a `.gitignore` file to your Git repository. Any file uploaded in this way cannot be committed and will not be available for deployment.
 
 </Alert>
+
+There are two mechanisms for transferring files: SFTP and rsync.
 
 <Partial file="auth.md" />
 


### PR DESCRIPTION
Closes #5187

## Effect
PR includes the following changes:
- Notes at the start of rsynd and SFTP that you can't move DB files directly using SFTP or rsync
- Links to WebOps Workflow doc.

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)