### PR TITLE
Custom Certificate users can skip validation

### DIFF
--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -15,7 +15,7 @@ If your site uses Legacy SSL, it's also on an outdated TLS configuration. The Gl
 If you just haven’t gotten around to upgrading, consider using our managed HTTPS, which includes automated certificate management, leveraging Let’s Encrypt certificates. As a convenience, when you upgrade to managed HTTPS you’ll never have to worry about an expired certificate again. As long as your domain is pointed to Pantheon, we will automatically renew the certificates required to keep your site secure. [Upgrade](/https/) to get best-in-class encryption and an A+ grade from SSL Labs.
 
 ### Option 2: Manually Managed Custom Certificates
-If you require a custom, dedicated certificate, you can now bring it the Global CDN. This is a paid service that our Sales Team can help you with. 
+If you require a custom, dedicated certificate, you can now bring it to the Global CDN. This is a paid service that our Sales Team can help you with. 
 
 1. Please [contact sales](https://pantheon.io/contact-us) if you are not a contract customer.
 

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -19,29 +19,11 @@ If you just haven’t gotten around to upgrading, consider using our managed HTT
 
 ### Option 2: Manually Managed Custom Certificates
 
-If you require a custom, dedicated certificate, you can now bring it the Global CDN. This is a paid service that our Sales Team can help you with. Please [contact sales](https://pantheon.io/contact-us) prior to going through the following steps if you are not a contract customer.
+If you require a custom, dedicated certificate, you can now bring it the Global CDN. This is a paid service that our Sales Team can help you with. 
 
-1. [Open a support ticket](/support/#ticket-support) with the certificate details required to request a **Certificate Signing Request** (CSR) from Pantheon. Use as few certificates as possible. Domains from multiple environments and sites can be combined, with up to 100 [**Subject Alternative Names**](https://en.wikipedia.org/wiki/Subject_Alternative_Name) (SANs) per certificate.
+1. Please [contact sales](https://pantheon.io/contact-us) if you are not a contract customer.
 
-    When requesting a CSR file, you must provide Pantheon Support with the following information:
-
-     - Common name (e.g. `example.com`)
-     - DNS names (e.g. `example.com`:`www.example.com`:`blog.example.com`:`dev.example.com`)
-     - Email addresses \[optional\] (e.g. `someone@example.com`:`admin@example.com`)
-     - Organization (e.g. `ACME, Inc.`)
-     - Organizational unit \[optional\] (e.g. `Engineering`)
-     - Country (e.g. `US`)
-     - Locality (e.g. `San Francisco`)
-     - State / Province (e.g. `California`)
-     - Technical contact email
-     - Technical contact first name
-     - Technical contact last name
-
-<br />
-
-2. Pantheon Support will provide you with the CSR file, to pass on to your **Certificate Authority** (CA). See [CA Limitations](#ca-limitations) below for more information.
-
-3. Once you have a set of certificates from the CA, send us:
+1. After a closed contract, Pantheon Professional Services will provide you with the CSR file, to pass on to your **Certificate Authority** (CA). See [CA Limitations](#ca-limitations) below for more information.
 
 
    - The end-client certificate
@@ -57,11 +39,11 @@ If you require a custom, dedicated certificate, you can now bring it the Global 
 
 4. Once the certificate is in place, you will see under **Details** for your domain(s) the following:
 
-    ![Custom Certificate Confirmation](../images/dashboard/custom-cert-confirm.png)
+  ![Custom Certificate Confirmation](../images/dashboard/custom-cert-confirm.png)
 
 5. [Test Before Going Live](#test-before-going-live) (optional, recommended)
 
-6.  [Disable Let's Encrypt by adding CAA DNS records](#disable-lets-encrypt-with-caa-records-required).
+1. [Disable Let's Encrypt by adding CAA DNS records](#disable-lets-encrypt-with-caa-records-required).
 
 7. Update `A` and `AAAA` records provided by Pantheon Support. Note that even for subdomains, `A` and `AAAA` records are required. Do not use a `CNAME` record.
 

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -4,27 +4,22 @@ description: For contract customers who require dedicated, custom TLS certificat
 ---
 
 ## Access
-
 A white glove concierge service is now available to contract customers, including Enterprise, EDU+, Pantheon One, Elite, and Resellers. For more information, please contact [Sales](https://pantheon.io/why-pantheon-enterprise).
 
 ## Upgrade to the Global CDN
-
 If your site is using our Legacy SSL service, it's on deprecated legacy infrastructure served from a single server in the central US. When you upgrade to the Global CDN you'll see faster performance, with content  delivered from almost 50 points of presence (POPs) around the world.
 
 If your site uses Legacy SSL, it's also on an outdated TLS configuration. The Global CDN is configured to only use TLS 1.2 and no weak 3DES cipher. On the legacy infrastructure, your site isn't as fast, secure, or as resilient as it could be.
 
 ### Option 1: Automated Certificate Management via Let's Encrypt
-
 If you just haven’t gotten around to upgrading, consider using our managed HTTPS, which includes automated certificate management, leveraging Let’s Encrypt certificates. As a convenience, when you upgrade to managed HTTPS you’ll never have to worry about an expired certificate again. As long as your domain is pointed to Pantheon, we will automatically renew the certificates required to keep your site secure. [Upgrade](/https/) to get best-in-class encryption and an A+ grade from SSL Labs.
 
 ### Option 2: Manually Managed Custom Certificates
-
 If you require a custom, dedicated certificate, you can now bring it the Global CDN. This is a paid service that our Sales Team can help you with. 
 
 1. Please [contact sales](https://pantheon.io/contact-us) if you are not a contract customer.
 
 1. After a closed contract, Pantheon Professional Services will provide you with the CSR file, to pass on to your **Certificate Authority** (CA). See [CA Limitations](#ca-limitations) below for more information.
-
 
    - The end-client certificate
    - Any intermediate certificates provided by the CA.
@@ -37,18 +32,17 @@ If you require a custom, dedicated certificate, you can now bring it the Global 
 
   </Alert>
 
-4. Once the certificate is in place, you will see under **Details** for your domain(s) the following:
+1. Once the certificate is in place, you will see under **Details** for your domain(s) the following:
 
   ![Custom Certificate Confirmation](../images/dashboard/custom-cert-confirm.png)
 
-5. [Test Before Going Live](#test-before-going-live) (optional, recommended)
+1. [Test Before Going Live](#test-before-going-live) (optional, recommended)
 
 1. [Disable Let's Encrypt by adding CAA DNS records](#disable-lets-encrypt-with-caa-records-required).
 
-7. Update `A` and `AAAA` records provided by Pantheon Support. Note that even for subdomains, `A` and `AAAA` records are required. Do not use a `CNAME` record.
+1. Update `A` and `AAAA` records provided by Pantheon Support. Note that even for subdomains, `A` and `AAAA` records are required. Do not use a `CNAME` record.
 
 ## Test Before Going Live
-
 Test production domain(s) before updating DNS by overriding DNS on your local computer from your local `hosts` file:
 
 <Partial file="_hosts-file.md" />
@@ -56,7 +50,6 @@ Test production domain(s) before updating DNS by overriding DNS on your local co
 For non-production domains, test on any environment (Dev, Test, Live or Multidev), just make sure to include the non-production domains on your certificate. We are happy to provide a new CSR if your original CSR and certificate did not initially non-production domains.
 
 ## Disable Let's Encrypt with CAA Records (Required)
-
 A **Certification Authority Authorization** (CAA) record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain. In order to ensure your custom certificate is served for all traffic, you must prevent Let’s Encrypt from issuing certificates. You have two options to prevent Let’s Encrypt from issuing certificates for domains on your custom certificate:
 
  - An empty CAA policy,
@@ -68,7 +61,6 @@ CAA records configured for the root domain (e.g., `example.com`) are inherited b
 
 
 ## Technical Specifications
-
 |                                                                       | Legacy                    | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
 |:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |:--------------------------------------|
 | **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt | Bring your own                        |
@@ -84,17 +76,13 @@ CAA records configured for the root domain (e.g., `example.com`) are inherited b
 \* The browser compatibility and SSL Labs scores are guaranteed for shared Let’s Encrypt certificates. The same results are typical for a custom certificate from a mainstream CA with mainstream attributes, but not guaranteed.  For custom certificates, compatibility and SSL Labs score depends on attributes of that certificate, such as number of SAN entries, CA and signing algorithm.
 
 ## Frequently Asked Questions
-
 ### Do I need a separate certificate for each site in my organization?
-
 Nope! You can use the a single certificate to cover multiple domains spread across various environments or sites. This capability is enabled because the Global CDN uses a technology called Server Name Indication (SNI), which automatically matches inbound requests with an appropriate certificate, including custom certificates.
 
 ### How long will it take to load my certificate into Pantheon?
-
 Please allow two business days to get a CSR and load the certificate.
 
 ### How do I renew or replace my custom certificate?
-
 45 days before your custom certificate expires, Pantheon will open a ticket with your team with a new CSR. You can send that CSR to the Certificate Authority to generate new certificates (as described above for [bringing a custom certificate](#option-2-manually-managed-custom-certificates)).
 
 To update a certificate with additional domains, [contact support](/support/) with the following details:
@@ -106,29 +94,21 @@ To update a certificate with additional domains, [contact support](/support/) wi
 It may take up to two business days to process the request.
 
 ### What about sites purchased online?
-
 Custom certificates are available for contract customers (e.g. Elite, Enterprise, EDU+) and we have no plans to offer it for Basic or Performance sites purchased online. If bringing your own certificate for non-contract site is a requirement, please see suggestions on [how to terminate TLS through a 3rd-party](/https/#can-i-bring-my-own-certificate).
 
 ### Will custom certificates be self-serve?
-
 We have no current plans to offer a self-serve option. The concierge service is designed to quickly guide you through the steps required to deliver HTTPS on the Global CDN using your custom certificate, and we may follow-up with a self-serve option in the future.
 
 ### Which certificates do I submit?
-
 Include the end-client certificate for your named domains, as well as the intermediate certificate, in separate files.
 
-
 ### What is the maximum number of SAN entries?
-
 For the broadest client compatibility we recommend limiting the number of Subject Alternate Names to 100.
 
-
 ### Are private keys available for export?
-
 Private keys are just that, private, and not available for export. They are stored securely, server side, and it’s a security best practice to not share private keys among different deployments. If you manage multiple domains, with some on Pantheon, and some outside of Pantheon, then we recommend using separate certificates, and we are happy to provide you with a new Certificate Signing Request (CSR) so we can deploy a certificate on Pantheon that only has the domains served on Pantheon.
 
 ### What are the Global CDN IP addresses?
-
 The Global CDN currently has 4 offsets. After certificate deployment, we will provide DNS information so you can upgrade. In the examples below, `X` will be replaced with a value of `1`, `2`, `3`, or `4`:
 
 A record: `23.185.0.X`
@@ -141,7 +121,6 @@ AAAA record 2:  `2620:12a:8001::X`
 CAA records are required  to [prohibit Let's Encrypt from issuing certificates](#disable-lets-encrypt-with-caa-records-required). If your DNS provider does not support CAA records, consider one that does. If using a DNS provider that supports CAA records is not possible, please inform your Engagement Manager, as our [Professional Services](/professional-services) team can help.
 
 ## Caveats / Known Issues
-
 ### Let's Encrypt Certificate Served Instead of Custom Certificate
 If a Let's Encrypt certificate was deployed to the Global CDN before adding CAA records to prevent Let's Encrypt from issuing certificates, then it will take 10 days for Pantheon to automatically remove the domain from the Let's Encrypt certificate.
 
@@ -149,7 +128,6 @@ If a Let's Encrypt certificate was deployed to the Global CDN before adding CAA 
 Your CA must accept the CSR Pantheon provides. If your CA fails to accept our CSR, you will not be able to use it to generate a certificate. The CA GlobalSign does not currently meet this requirement. The workaround is to simply use another CA.
 
 ### Downgrading a Site that uses a Custom Certificate
-
 Since all sites require an encryption certificate, to downgrade a site that uses a custom certificate, use Pantheon’s [Global CDN](/https/) to enable Let’s Encrypt. Alternatively, you can use another CDN like [Cloudflare](/cloudflare/).
 
 ## See also

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -43,10 +43,17 @@ If you require a custom, dedicated certificate, you can now bring it the Global 
 
 3. Once you have a set of certificates from the CA, send us:
 
-    - The end-client certificate
-    - Any intermediate certificates provided by the CA.<br /><br />
 
-    Be sure to send these as separate files, not a "chained cert".
+   - The end-client certificate
+   - Any intermediate certificates provided by the CA.
+
+  Be sure to send these as separate files, not a "chained cert".
+
+  <Alert type="info" title="Note">
+
+  When adding the domain to your environment, you may be presented with the option to **Verify your domain to provision HTTPS**. You can skip this step by clicking **Skip to updating DNS**.
+
+  </Alert>
 
 4. Once the certificate is in place, you will see under **Details** for your domain(s) the following:
 

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -21,6 +21,8 @@ If you require a custom, dedicated certificate, you can now bring it to the Glob
 
 1. After a closed contract, Pantheon Professional Services will provide you with the CSR file, to pass on to your **Certificate Authority** (CA). See [CA Limitations](#ca-limitations) below for more information.
 
+1. Once you have a set of certificates from the CA, send us:
+
    - The end-client certificate
    - Any intermediate certificates provided by the CA.
 

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -17,6 +17,12 @@ Get the most out of Global CDN with help from the experts at Pantheon. We delive
 
 <Partial file="configure-dns.md" />
 
+<Alert type="info" title="Note">
+
+When adding the domain to your environment, you may be presented with the option to **Verify your domain to provision HTTPS**. If you're using a manually managed [custom certificate](/custom-certificates#option-2-manually-managed-custom-certificates), skip this step by clicking **Skip to updating DNS**.
+
+</Alert>
+
 For more detailed instructions pertaining to your specific DNS host, click below:
 
 <Accordion title="DNS Host-Specific Instructions" id="host-specific2" icon="info-sign">


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds a note to custom-certificates and https docs that those with manually managed custom certs can skip domain validation in the Dashboard.
- CSS Improvement: implement new line after `ul` elements instead of manual `<br />` tags. 

## Remaining Work
- [x] Technical review (@ksenour)
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)