### PR TITLE
Add possible solution for WP Import / Export all

### DIFF
--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -854,7 +854,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 
 **Issue 2**: Uploading large import files hits the 59 second [timeout](/timeouts/), or you're getting invalid file paths.
 
-**Solution**: You can upload the import file directly to the plugin's designated writable path `wp-content/uploads/wpallimport/files/`. When creating a new import using `existing file`, the file uploaded should appear there as an option .
+**Solution**: You can upload the import file directly to the plugin's designated writable path `wp-content/uploads/wpallimport/files/`. When creating a new import using `existing file`, the file uploaded should appear there as an option . There have been some cases where turning off the "Random folder name" option has resolved issues exporting large files.
 
 <br />
 


### PR DESCRIPTION
Based on this ticket: 270559, turning off the "Random Folder" resolved the large export that was otherwise failing.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
-
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
