### PR TITLE
add web team agility assessment link

### DIFF
--- a/source/content/custom-upstream.md
+++ b/source/content/custom-upstream.md
@@ -2,16 +2,16 @@
 title: Introduction to Custom Upstreams
 description: Learn how to use Custom Upstreams to free up developer time.
 tags: [tools, workflow]
-categories: []
+categories: [platform]
 ---
 
 `youtube: https://youtu.be/b1lNrZL0xxM`
 
 If you are a digital agency servicing clients, or a reseller of Pantheon as part of a managed solution, visit the [Partner Program Page](https://pantheon.io/agencies/partner-program) to learn more about getting Custom Upstreams and some of the other benefits of becoming a Pantheon Partner.
 
-<Enablement title="Accelerate Your Workflow" link="https://pantheon.io/agencies/learn-pantheon?docs">
+<Enablement title="Web Team Agility Assessment" link="https://pantheon.io/web-team-agility-assessment?docs">
 
-Improve your agency's development efficiency with custom WebOps training from Pantheon experts.
+How mature is your web team? Take our Web Team Agility Assessment to find out.
 
 </Enablement>
 

--- a/source/content/git.md
+++ b/source/content/git.md
@@ -1,14 +1,14 @@
 ---
 title: Starting With Git
 description: Use Git version control to deploy code to your Drupal or WordPress site's development environment.
-categories: []
+categories: [develop]
 tags: [git]
 ---
 Git is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
 
-<Enablement title="Agency WebOps Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
+<Enablement title="Web Team Agility Assessment" link="https://pantheon.io/web-team-agility-assessment?docs">
 
-Dev/Test/Live, parallel feature development with Multidev, hotfix workflows, and more! Learn how Pantheon's WebOps training can accelerate your workflow.
+How mature is your web team? Take our Web Team Agility Assessment to find out.
 
 </Enablement>
 

--- a/source/content/guides/edt/01-essentialdevelopertraining.md
+++ b/source/content/guides/edt/01-essentialdevelopertraining.md
@@ -17,9 +17,9 @@ image: launchGuide-twitterLarge
 
 Welcome! This guide is an online version of our [Essential Developer Training](https://pantheon.io/essential-developer-training).
 
-<Enablement title="Getting Essential Developer Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
+<Enablement title="Web Team Agility Assessment" link="https://pantheon.io/web-team-agility-assessment?docs">
 
-Ramp up faster with an instructor-led version of this material, delivered by Pantheon's Developer Relations team.
+How mature is your web team? Take our Web Team Agility Assessment to find out.
 
 </Enablement>
 

--- a/source/content/guides/edt/01-essentialdevelopertraining.md
+++ b/source/content/guides/edt/01-essentialdevelopertraining.md
@@ -17,9 +17,9 @@ image: launchGuide-twitterLarge
 
 Welcome! This guide is an online version of our [Essential Developer Training](https://pantheon.io/essential-developer-training).
 
-<Enablement title="Web Team Agility Assessment" link="https://pantheon.io/web-team-agility-assessment?docs">
+<Enablement title="Get Instructor-Led Essential Developer Training" link="https://pantheon.io/learn-pantheon?docs">
 
-How mature is your web team? Take our Web Team Agility Assessment to find out.
+Ramp up faster with an instructor-led version of this material, delivered by Pantheon's Developer Relations team.
 
 </Enablement>
 

--- a/source/content/kill-mysql-queries.md
+++ b/source/content/kill-mysql-queries.md
@@ -2,13 +2,13 @@
 title: Identify and Kill Queries with MySQL Command-Line Tool
 description: Learn how to identify and kill long-running MySQL queries on your WordPress or Drupal site in a few commands.
 tags: [debugdb]
-categories: []
+categories: [develop]
 ---
 Long-running MySQL queries keep other transactions from accessing the necessary tables to execute a request, leaving your users on hold. To kill these queries, you'll need to [access the environment's MySQL Database](/mysql-access).
 
-<Enablement title="Agency WebOps Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
+<Enablement title="Web Team Agility Assessment" link="https://pantheon.io/web-team-agility-assessment?docs">
 
-Tune your site (or sites!) for optimal performance with help from the experts at Pantheon. We deliver custom workshops to help development teams master the platform and build awesome websites.
+How mature is your web team? Take our Web Team Agility Assessment to find out.
 
 </Enablement>
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- web team agility assessment enablement

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
