### PR TITLE
add newline aftre ul in CSS

### DIFF
--- a/gatsby/src/styles/global.scss
+++ b/gatsby/src/styles/global.scss
@@ -34,6 +34,7 @@ ul {
 	color: #44525e;
 	font-size: 18px;
 	line-height: 29px;
+  padding-bottom: 1em;
 }
 p {
 	margin: 0 0 20px;


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Uses CSS to pad UL elements.

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
