### PR TITLE
dig new site's A/AAAA earlier in relaunch

### DIFF
--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -12,11 +12,11 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 
 </Alert>
 
-## Before You Begin
-- Log in to the new Pantheon Site Dashboard
-- Open a second tab for the old Pantheon Site Dashboard
-- In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.)
-- Examine existing records pointing to Pantheon
+## Prepare for Relaunch
+1. Log in to the new Pantheon Site Dashboard
+1. Open a second tab for the old Pantheon Site Dashboard
+1. In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.)
+1. Examine existing records pointing to Pantheon
   <Partial file="standard-dns-config.md" />
 
   <Alert title="Note" type="info">
@@ -25,7 +25,7 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 
   </Alert>
 
-- Lower the TTL of existing DNS records to minimize the impact of upcoming DNS changes
+1. Lower the TTL of existing DNS records to minimize the impact of upcoming DNS changes
 
   <Accordion title="Learn More" id="ttl" icon="info-sign">
 
@@ -37,7 +37,7 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 
   </Accordion>
 
-- Use the terminal's `dig` command to obtain the new site's A and AAAA records:
+1. Use the terminal's `dig` command to obtain the new site's A and AAAA records:
 
   ```bash
   dig +short live-site-name.pantheonsite.io

--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -13,8 +13,8 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 </Alert>
 
 ## Before You Begin
-- Log in to the new Site Dashboard on Pantheon
-- Open a second tab for the old Site Dashboard on Pantheon
+- Log in to the new Pantheon Site Dashboard
+- Open a second tab for the old Pantheon Site Dashboard
 - In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.)
 - Examine existing records pointing to Pantheon
   <Partial file="standard-dns-config.md" />
@@ -36,6 +36,13 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
   When you make a change to the TTL of an existing record, you need to wait for the old TTL time to pass - that is, if it had been set to 86400, you would need to wait a full 24 hours for the new setting to begin propagating everywhere.
 
   </Accordion>
+
+- Use the terminal's `dig` command to obtain the new site's A and AAAA records:
+
+  ```bash
+  dig +short live-site-name.pantheonsite.io
+  dig +short AAAA live-site-name.pantheonsite.io
+  ```
 
 ### Roles & Permissions
 The permission to manage billing and plans is granted only to the role of **Site Owner** / **Organization Administrators**. Other roles do not have access as described on this page.

--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -13,10 +13,11 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 </Alert>
 
 ## Prepare for Relaunch
-1. Log in to the new Pantheon Site Dashboard
-1. Open a second tab for the old Pantheon Site Dashboard
-1. In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.)
-1. Examine existing records pointing to Pantheon
+1. Log in to the new Pantheon Site Dashboard.
+1. Open a second tab for the old Pantheon Site Dashboard.
+1. In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.).
+1. Examine existing records pointing to Pantheon.
+
   <Partial file="standard-dns-config.md" />
 
   <Alert title="Note" type="info">
@@ -37,12 +38,14 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 
   </Accordion>
 
-1. Use the terminal's `dig` command to obtain the new site's A and AAAA records:
+1. Use [`dig`](https://en.wikipedia.org/wiki/Dig_(command)) from your terminal to obtain the new site's A and AAAA records:
 
-  ```bash
+  ```bash{promptUser: user}
   dig +short live-site-name.pantheonsite.io
   dig +short AAAA live-site-name.pantheonsite.io
   ```
+
+  You can also use Google's [web implementstion](https://toolbox.googleapps.com/apps/dig/) of dig.
 
 ### Roles & Permissions
 The permission to manage billing and plans is granted only to the role of **Site Owner** / **Organization Administrators**. Other roles do not have access as described on this page.


### PR DESCRIPTION
Closes #5173

## Effect
PR includes the following changes:
- renames `Before You Begin` to `Prepare for Relaunch` - because 6 steps seems worth it
- adds `dig` command as suggested in #5173 to discover new A/AAAA earlier

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
