### PR TITLE
[SimpleSAML] Change default log handler to errorlog

### DIFF
--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -144,7 +144,7 @@ Set up your SimpleSAMLphp `config.php` as follows:
   $config = array (
        'baseurlpath' => 'https://'. $host .':443/simplesaml/', // SAML should always connect via 443
        'certdir' => 'cert/',
-       'loggingdir' => $_ENV['HOME'] . '/files/private/log/',
+       'logging.handler' => 'errorlog',
        'datadir' => 'data/',
        'tempdir' => $_ENV['HOME'] . '/tmp/simplesaml',
        Your $config array continues for a while...
@@ -154,6 +154,7 @@ Set up your SimpleSAMLphp `config.php` as follows:
        'store.sql.username' => $db['username'],
        'store.sql.password' => $db['password'],
   ```
+  For persistent and centralised logging, a custom [`SimpleSAML/Logger/LoggingHandlerInterface`](https://github.com/pantheon-systems/documentation/issues/SimpleSAML/Logger/LoggingHandlerInterface) implementation is required.
 
   <Alert title="Note" type="info">
 

--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -154,7 +154,7 @@ Set up your SimpleSAMLphp `config.php` as follows:
        'store.sql.username' => $db['username'],
        'store.sql.password' => $db['password'],
   ```
-  For persistent and centralised logging, a custom [`SimpleSAML/Logger/LoggingHandlerInterface`](https://github.com/pantheon-systems/documentation/issues/SimpleSAML/Logger/LoggingHandlerInterface) implementation is required.
+  For persistent and centralised logging, a custom [`SimpleSAML/Logger/LoggingHandlerInterface`](https://github.com/simplesamlphp/simplesamlphp/blob/master/lib/SimpleSAML/Logger.php) implementation is required.
 
   <Alert title="Note" type="info">
 


### PR DESCRIPTION
Closes #5337 

## Effect
PR includes the following changes:
- Change default configuration of SimpleSAML log handler to errorlog 

## Remaining Work
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [x] Update Status Report
- [x] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
