### PR TITLE
Add link to VS Code doc from SFTP client list

### DIFF
--- a/source/content/sftp.md
+++ b/source/content/sftp.md
@@ -97,7 +97,7 @@ SFTP mode works with any standards-compliant SFTP client, including many GUI too
 - PHPStorm with [WordPress](/wordpress-phpstorm) and [Drupal](/drupal-phpstorm)
 - [FileZilla](/filezilla/)
 - [WinSCP](/winscp/)
-- [Visual Studio Code](/visual-studio-code)
+- [Visual Studio Code](/visual-studio-code/)
 
 ## Troubleshooting
 

--- a/source/content/sftp.md
+++ b/source/content/sftp.md
@@ -97,6 +97,7 @@ SFTP mode works with any standards-compliant SFTP client, including many GUI too
 - PHPStorm with [WordPress](/wordpress-phpstorm) and [Drupal](/drupal-phpstorm)
 - [FileZilla](/filezilla/)
 - [WinSCP](/winscp/)
+- [Visual Studio Code](/visual-studio-code)
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Link to the VS Code doc from our list of SFTP/IDE docs

## Remaining Work
None

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
