### PR TITLE
Add D8 and WordPress info for wkhtmltopdf usage [wip]

### DIFF
--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -13,8 +13,27 @@ There are some scenarios when an external library is required. Pantheon has inst
 
 WKHTMLtoPDF can be found on your application container at `/srv/bin/wkhtmltopdf`.
 
-### Drupal
-Download and enable the print module and extensions via drush:
+<TabList>
+
+<Tab title="WordPress" id="wp-example" active={true}>
+
+Download and enable the [Save Page to PDF plugin](https://wordpress.org/plugins/save-page-to-pdf/).
+
+</Tab>
+
+<Tab title="Drupal 8" id="d8-example">
+
+Download and enable the [wkhtmltopdf module](https://www.drupal.org/project/wkhtmltopdf).
+
+```bash
+composer require drupal/wkhtmltopdf
+```
+
+</Tab>
+
+<Tab title="Drupal 7" id="d7-example">
+
+Download and enable the [Print module](https://www.drupal.org/project/print) via Drush:
 
 ```bash
 drush @pantheon.{sitename}.{env} en print --y
@@ -30,8 +49,9 @@ git commit -m "Added WKHTMLtoPDF library"
 git push
 ```
 
-### WordPress
-Currently, there are no known plugins that implement WKHTMLtoPDF directly. However, you can use the converter by creating a custom plugin or by placing the code within your theme's `functions.php` file.
+</Tab>
+
+</TabList>
 
 ## PhantomJS
 In its own words, [PhantomJS](https://github.com/ariya/phantomjs/) is a headless WebKit with JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -3,6 +3,7 @@ title: External Libraries on Pantheon
 description: Learn to incorporate external libraries on the Pantheon Website Management Platform.
 tags: [services]
 categories: [platform]
+reviewed: "2020-01-29"
 ---
 
 There are some scenarios when an external library is required. Pantheon has installed a number of common libraries that are available on the platform.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -8,11 +8,11 @@ reviewed: "2020-01-29"
 
 There are some scenarios when an external library is required. Pantheon has installed a number of common libraries that are available on the platform.
 
-## WKHTMLtoPDF
+## wkhtmltopdf
 
-[WebKit HTML](https://wkhtmltopdf.org/) allows you to create a snapshot or capture the content of a web page easily in a PDF.
+[wkhtmltopdf](https://wkhtmltopdf.org/) allows you to create a snapshot or capture the content of a web page easily in a PDF.
 
-WKHTMLtoPDF can be found on your application container at `/srv/bin/wkhtmltopdf`. To use it, install or create a compatible plugin or module:
+wkhtmltopdf can be found on your application container at `/srv/bin/wkhtmltopdf`. To use it, install or create a compatible plugin or module:
 
 <TabList>
 
@@ -30,7 +30,7 @@ Create a symlink to the hosted library and your site's libraries directory [via 
 mkdir -p sites/all/libraries/wkhtmltopdf
 ln -s /srv/bin/wkhtmltopdf sites/all/libraries/wkhtmltopdf/wkhtmltopdf
 git add .
-git commit -m "Added WKHTMLtoPDF library"
+git commit -m "Added wkhtmltopdf library"
 git push
 ```
 
@@ -44,13 +44,13 @@ Download and enable the [Print module](https://www.drupal.org/project/print) fro
 terminus drush <site>.<env> -- en print --y
 ```
 
-Create a symlink to the hosted library and your site's libraries directory [via Git](/git/#clone-your-site-codebase):
+Create a symlink to the hosted library and your site's `libraries` directory [via Git](/git/#clone-your-site-codebase):
 
 ```bash{promptUser: user}
 mkdir -p sites/all/libraries/wkhtmltopdf
 ln -s /srv/bin/wkhtmltopdf sites/all/libraries/wkhtmltopdf/wkhtmltopdf
 git add .
-git commit -m "Added WKHTMLtoPDF library"
+git commit -m "Added wkhtmltopdf library"
 git push
 ```
 
@@ -58,7 +58,7 @@ git push
 
 <Tab title="WordPress" id="wp-example">
 
-Currently, there are no known plugins that implement WKHTMLtoPDF directly. However, you can use the converter by creating a custom plugin or by placing the code within your theme's `functions.php` file.
+Currently, there are no known plugins that implement wkhtmltopdf directly. However, you can use the converter by creating a custom plugin or by placing the code within your theme's `functions.php` file.
 
 If your WordPress site uses Composer, consider the [PHP WkHtmlToPdf](https://github.com/mikehaertl/phpwkhtmltopdf) PHP wrapper.
 
@@ -145,6 +145,6 @@ ImageAPI Optimize's [support for 3rd party services](https://www.drupal.org/node
 
 Please [contact support](/support/) with a description of your use case and a link to the library's webpage. We welcome new requests, but please bear in mind they are not guaranteed and it is possible the feature request may be denied. As a result, we recommend you set aside enough time for alternative solutions.
 
-### Will you setup and configure the module/plugin for me?
+### Will you set up and configure the module/plugin for me?
 
 No. This is not within our [scope of support](/support/#scope-of-support). It is important to be aware of how a Drupal module or WordPress plugin is setup and how it functions. This will prove invaluable in cases where you need to plan and build your site.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -66,6 +66,14 @@ If your WordPress site uses Composer, consider the [PHP WkHtmlToPdf](https://git
 
 </TabList>
 
+### Unable to Generate PDF File
+
+Due to a [known issue in wkhtmltopdf](https://github.com/wkhtmltopdf/wkhtmltopdf/issues/4242) and sites that use the CSS `quotes` property, some users may have issues with downloading a PDF created by wkhtmltopdf. In Live environments, creating a PDF fails silently. On Dev, you'll encounter the error `Unable to generate PDF file`.
+
+To confirm the source of the error, log in to the Drupal Admin and click **Reports** in the menu, then **Recent Log Messages** and look for `print_pdf` or `(returned 127): No stderr output available`.
+
+If you encounter this error, remove the offending `quotes` property from the CSS.
+
 ## PhantomJS
 
 In its own words, [PhantomJS](https://github.com/ariya/phantomjs/) is a headless WebKit with JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -54,12 +54,14 @@ git push
 </TabList>
 
 ## PhantomJS
+
 In its own words, [PhantomJS](https://github.com/ariya/phantomjs/) is a headless WebKit with JavaScript API. It has fast and native support for various web standards: DOM handling, CSS selector, JSON, Canvas, and SVG.
 
 - PhantomJS (1.7.0) is located at `/srv/bin/phantomjs` on your application container.
 - PhantomJS (2.1.1) is located at `/srv/bin/phantomjs-2.1.1` on your application container.
 
 ### Drupal PhantomJS Configuration
+
 Once you have downloaded and enabled the PhantomJS Capture module, you'll need to configure the image toolkit settings. Go to the image toolkit settings page at: `/admin/config/user-interface/phantomjs_capture` to specify the library path.
 
 ## Apache Tika
@@ -74,11 +76,11 @@ Once you have downloaded and installed the ApacheSolr Attachments module ([apach
 
 1. Go to the Tika settings page at: `/admin/config/search/apachesolr/attachments` and enter the following fields:
 
-   * **Extract Using:** Tika (local java application)
-   * **Tika Directory Path:** `/srv/bin`
-   * **Tika jar file:** `tika-app-1.18.jar`
+    - **Extract Using:** Tika (local java application)
+    - **Tika Directory Path:** `/srv/bin`
+    - **Tika jar file:** `tika-app-1.18.jar`
 
-2. Verify that your site is able to extract text from documents. Click **Test your Tika Attachments** under the Actions section.
+1. Verify that your site is able to extract text from documents. Click **Test your Tika Attachments** under the Actions section.
 
 If everything is working correctly, you will see the success message "Text can be successfully extracted".
 
@@ -88,22 +90,23 @@ Download and install the Search API Attachments module ([search_api_attachments]
 
 1. Go to the Search API Attachments settings page at: `/admin/config/search/search_api_attachments` and enter the following fields:
 
-   * **Extraction method:** Tika Extractor
-   * **Path to java executable:** `java`
-   * **Path to Tika .jar file:** `/srv/bin/tika-app-1.18.jar`
+   - **Extraction method:** Tika Extractor
+   - **Path to java executable:** `java`
+   - **Path to Tika .jar file:** `/srv/bin/tika-app-1.18.jar`
 
-2. Verify that your site is able to extract text from documents. Click **Submit and test extraction**.
+1. Verify that your site is able to extract text from documents. Click **Submit and test extraction**.
 
 If everything is working correctly, you will see the success message "Extracted data: Congratulations! The extraction seems working! Yay!".
 
 ### WordPress Tika Configuration
+
 There are no known plugins in the WordPress.org repository that will enable the use of Tika.
 
 ### Older Versions
 
 Pantheon also supplies the following older version of Tika:
 
- * `/srv/bin/tika-app-1.1.jar`
+- `/srv/bin/tika-app-1.1.jar`
 
 Sites that are using an old version of Tika should be upgraded to the supported path as soon as possible.
 
@@ -126,7 +129,9 @@ ImageAPI Optimize's [support for 3rd party services](https://www.drupal.org/node
 ## Troubleshooting and FAQs
 
 ### How do I request the addition of a new library or a newer version of an existing library?
-Please [contact support](/support) with a description of your use case and a link to the library's webpage. We welcome new requests, but please bear in mind they are not guaranteed and it is possible the feature request may be denied. As a result, we recommend you set aside enough time for alternative solutions.
+
+Please [contact support](/support/) with a description of your use case and a link to the library's webpage. We welcome new requests, but please bear in mind they are not guaranteed and it is possible the feature request may be denied. As a result, we recommend you set aside enough time for alternative solutions.
 
 ### Will you setup and configure the module/plugin for me?
+
 No. This is not within our [scope of support](/support/#scope-of-support). It is important to be aware of how a Drupal module or WordPress plugin is setup and how it functions. This will prove invaluable in cases where you need to plan and build your site.

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -11,43 +11,55 @@ There are some scenarios when an external library is required. Pantheon has inst
 
 [WebKit HTML](https://wkhtmltopdf.org/) allows you to create a snapshot or capture the content of a web page easily in a PDF.
 
-WKHTMLtoPDF can be found on your application container at `/srv/bin/wkhtmltopdf`.
+WKHTMLtoPDF can be found on your application container at `/srv/bin/wkhtmltopdf`. To use it, install or create a compatible plugin or module:
 
 <TabList>
 
-<Tab title="WordPress" id="wp-example" active={true}>
+<Tab title="Drupal 8" id="d8-example" active={true}>
 
-Download and enable the [Save Page to PDF plugin](https://wordpress.org/plugins/save-page-to-pdf/).
+Download and enable the [wkhtmltopdf module](https://www.drupal.org/project/wkhtmltopdf) from the Drupal Dashboard, or using Drush via [Terminus](/terminus/):
 
-</Tab>
-
-<Tab title="Drupal 8" id="d8-example">
-
-Download and enable the [wkhtmltopdf module](https://www.drupal.org/project/wkhtmltopdf).
-
-```bash
-composer require drupal/wkhtmltopdf
-```
-
-</Tab>
-
-<Tab title="Drupal 7" id="d7-example">
-
-Download and enable the [Print module](https://www.drupal.org/project/print) via Drush:
-
-```bash
-drush @pantheon.{sitename}.{env} en print --y
+```bash{promptUser: user}
+terminus drush <site>.<env> -- en wkhtmltopdf --y
 ```
 
 Create a symlink to the hosted library and your site's libraries directory [via Git](/git/#clone-your-site-codebase):
 
-```bash
+```bash{promptUser: user}
 mkdir -p sites/all/libraries/wkhtmltopdf
 ln -s /srv/bin/wkhtmltopdf sites/all/libraries/wkhtmltopdf/wkhtmltopdf
 git add .
 git commit -m "Added WKHTMLtoPDF library"
 git push
 ```
+
+</Tab>
+
+<Tab title="Drupal 7" id="d7-example">
+
+Download and enable the [Print module](https://www.drupal.org/project/print) from the Drupal Dashboard, or using Drush via [Terminus](/terminus/):
+
+```bash{promptUser: user}
+terminus drush <site>.<env> -- en print --y
+```
+
+Create a symlink to the hosted library and your site's libraries directory [via Git](/git/#clone-your-site-codebase):
+
+```bash{promptUser: user}
+mkdir -p sites/all/libraries/wkhtmltopdf
+ln -s /srv/bin/wkhtmltopdf sites/all/libraries/wkhtmltopdf/wkhtmltopdf
+git add .
+git commit -m "Added WKHTMLtoPDF library"
+git push
+```
+
+</Tab>
+
+<Tab title="WordPress" id="wp-example">
+
+Currently, there are no known plugins that implement WKHTMLtoPDF directly. However, you can use the converter by creating a custom plugin or by placing the code within your theme's `functions.php` file.
+
+If your WordPress site uses Composer, consider the [PHP WkHtmlToPdf](https://github.com/mikehaertl/phpwkhtmltopdf) PHP wrapper.
 
 </Tab>
 


### PR DESCRIPTION
Closes #5330 

## Effect
PR includes the following changes:
- Add D8 and WordPress info for wkhtmltopdf usage

## Remaining Work
- [ ] Test both D8 and WP options a bit more and add details on configuration for both
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
