### PR TITLE
Add YotuWP plugin and solution to known issues

### DIFF
--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -914,6 +914,18 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 
 <hr />
 
+### [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)
+
+**Issue**: The plugin asks for SFTP credentials after installation.
+
+**Solution**: This plugin is checking the `FS_METHOD` value. Add the following to `wp-config.php`, above the line `/* That's all, stop editing! Happy Pressing. */`:
+
+```php
+define('FS_METHOD', 'direct');
+```
+
+<hr />
+
 
 ## WordPress Themes
 


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Based on case 273354, the YotuWP plugin prompting for ftp credentials as it is trying to write with an incompatible fs method.

## Effect
PR includes the following changes:
- Adds solution for YotuWP to function properly.

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
