### PR TITLE
Change wording

### DIFF
--- a/source/content/errors-and-server-responses.md
+++ b/source/content/errors-and-server-responses.md
@@ -66,7 +66,7 @@ If you get a generic Service Unavailable and you're using AJAX when HTTP Basic 
 This error can be caused by sustained spikes in traffic (often caused by search engine crawlers) and by having PHP processes that run too slowly or have long waiting times for external resources which occupy the application container for long periods. If you have too much traffic for your site's resources, consider [upgrading your site plan](/site-plan/).
 
 ### Pantheon 504 Gateway Timeout
-"The application did not respond in time." There are two possibilities. Pantheon's routing and caching layer can only sustain open HTTP requests for so long. We do our best, but you may encounter this message if your application takes awhile to respond. The other option is that there was a server problem, typically php-fpm or MySQL timing out. See [Timeouts on Pantheon](/timeouts/) for more information.
+"The application did not respond in time." There are two possibilities. Pantheon's routing and caching layer can only sustain open HTTP requests for so long. We do our best, but you may encounter this message if your application takes awhile to respond. The other option is that there was an application problem, resulting to php-fpm or MySQL timing out. See [Timeouts on Pantheon](/timeouts/) for more information.
 
 Typically the request timeout is much shorter than the hard timeout for PHP. While you may be able to let an operation run for several minutes in your local development environment, this isn't possible on Pantheon. Luckily there are ways to solve the problem.
 

--- a/source/content/errors-and-server-responses.md
+++ b/source/content/errors-and-server-responses.md
@@ -66,7 +66,7 @@ If you get a generic Service Unavailable and you're using AJAX when HTTP Basic 
 This error can be caused by sustained spikes in traffic (often caused by search engine crawlers) and by having PHP processes that run too slowly or have long waiting times for external resources which occupy the application container for long periods. If you have too much traffic for your site's resources, consider [upgrading your site plan](/site-plan/).
 
 ### Pantheon 504 Gateway Timeout
-"The application did not respond in time." There are two possibilities. Pantheon's routing and caching layer can only sustain open HTTP requests for so long. We do our best, but you may encounter this message if your application takes awhile to respond. The other option is that there was an application problem, resulting to php-fpm or MySQL timing out. See [Timeouts on Pantheon](/timeouts/) for more information.
+"The application did not respond in time." There are two possibilities. Pantheon's routing and caching layer can only sustain open HTTP requests for so long. We do our best, but you may encounter this message if your application takes awhile to respond. The other option is that there was an application problem, resulting in php-fpm or MySQL timing out. See [Timeouts on Pantheon](/timeouts/) for more information.
 
 Typically the request timeout is much shorter than the hard timeout for PHP. While you may be able to let an operation run for several minutes in your local development environment, this isn't possible on Pantheon. Luckily there are ways to solve the problem.
 


### PR DESCRIPTION
Customer might expect that a 504 is a pantheon problem because of the mentioned word "server".

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- Change wording
The other option is that there was an application problem, resulting to php-fpm or MySQL timing out. 

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
