### PR TITLE
clarify where to put files for terminus

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -5,5 +5,5 @@
     "MD023": false,
     "MD024": false,
     "MD029": false,
-    "MD033": {"allowed_elements": ["Alert", "Span", "Accordion", "Partial"]}
+    "MD033": {"allowed_elements": ["Alert", "Span", "Accordion", "Partial", "Enablement"]}
 }

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -117,8 +117,9 @@ terminus backup:get <site>.<env> --element=files
 This will create and get a backup of the site's files.
 
 Move the resulting backup to the proper directory on your local file system:
-    - **Drupal**: `sites/default/files`
-    - **WordPress**: `wp-content/uploads`
+
+- **Drupal**: `sites/default/files`
+- **WordPress**: `wp-content/uploads`
 
 ### Via SFTP CLI
 

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -25,8 +25,8 @@ Pantheon cannot troubleshoot or support local development solutions; however, we
 Be sure you have:
 
 - A local stack capable of running Drupal or WordPress. [Lando](https://github.com/lando/lando) integrates with the Pantheon platform. Tools such as [MAMP](https://www.mamp.info/en/), [WAMP](http://www.wampserver.com/), and [XAMPP](https://www.apachefriends.org/index.html) all work.
-    - Pantheon uses a [particular architecture to maximize performance and availability](/application-containers/), but it's possible to run the same code on a variety of different configurations. As long as the solution supports a minimum of PHP 5.3 and MySQL, you should be fine.
-    - Ensure that your local stack's PHP version matches the [PHP version set for the target site on Pantheon](/php-versions/#verify-current-php-versions).
+  - Pantheon uses a [particular architecture to maximize performance and availability](/application-containers/), but it's possible to run the same code on a variety of different configurations. As long as the solution supports a minimum of PHP 5.3 and MySQL, you should be fine.
+  - Ensure that your local stack's PHP version matches the [PHP version set for the target site on Pantheon](/php-versions/#verify-current-php-versions).
 - Git client for tracking code changes
 - SFTP client, such as [FileZilla](https://filezilla-project.org/ "FileZilla, a Cross-platform GUI SFTP client."), for transferring files OR rsync
 - [Terminus](/terminus/)
@@ -34,7 +34,7 @@ Be sure you have:
 
 To save time, clear the target site environment's cache. This can be done from the Pantheon Dashboard, from the application itself, or by running the following Terminus command:
 
-```bash
+```bash{promptUser: user}
 terminus env:clear-cache <site>.<env>
 ```
 
@@ -58,12 +58,13 @@ The first step is to get a `git clone` of your code from Pantheon to your local 
 
 3. On your local environment, go to where you want the code to reside. Git will create a directory as part of the clone, so you don't need to create one. Run the command you copied in step 2:
 
-    ```
+    ```bash{promptUser: user}
     git clone ssh://codeserver.dev.xxx@codeserver.dev.xxx.drush.in:2222/~/repository.git my-site
     ```
+
     If everything worked correctly, you will see Git fetching the data:
 
-    ![Git Clone During](../images/git_clone.png)<br />
+    ![Git Clone During](../images/git_clone.png)
 
     If you run into permission problems, check your [SSH key](/ssh-keys/) setup. If the clone starts but can't complete, check your network to see if you have a current version of Git.
 
@@ -74,13 +75,14 @@ From within the Site Dashboard:
 
 1. Create an on-demand backup by selecting **Database / Files** > **Export** > **Export Database**.
 
-2. Download the scheduled or on-demand backup by selecting **Backups** > **Backup Log** > **Database download link**.
+1. Download the scheduled or on-demand backup by selecting **Backups** > **Backup Log** > **Database download link**.
 
-3. Import the database into your local environment using a MySQL client:
+1. Import the database into your local environment using a MySQL client:
 
-  ```sql
-  $ gunzip < database.sql.gz | mysql -uUSER -pPASSWORD DATABASENAME
+  ```bash{promptUser: user}
+  gunzip < database.sql.gz | mysql -uUSER -pPASSWORD DATABASENAME
   ```
+
   <Alert title="Note" type="info">
 
   Replace `database.sql.gz` with the name of the database archive downloaded from Pantheon.
@@ -91,29 +93,29 @@ From within the Site Dashboard:
 
 1. Create and get the database with Terminus commands:
 
-    ```
+    ```bash{promptUser: user}
     terminus backup:create <site>.<env> --element=db
     terminus backup:get <site>.<env> --element=db
     ```
 
+1. Import the archive into your local MySQL database using the following command:
 
-2. Import the archive into your local MySQL database using the following command:
-
-    ````sql
-    $ gunzip < database.sql.gz | mysql -uUSER -pPASSWORD DATABASENAME
-    ````
+    ```bash{promptUser: user}
+    gunzip < database.sql.gz | mysql -uUSER -pPASSWORD DATABASENAME
+    ```
 
 ## Get the Files
 
 For an overview of ways to transfer files, see [SFTP and rsync on Pantheon](/rsync-and-sftp/).
 
 ### Via Terminus
-
 Run the following Terminus commands:
-```
+
+```bash{promptUser: user}
 terminus backup:create <site>.<env> --element=files
 terminus backup:get <site>.<env> --element=files
 ```
+
 This will create and get a backup of the site's files.
 
 Move the resulting backup to the proper directory on your local file system:
@@ -125,12 +127,16 @@ Move the resulting backup to the proper directory on your local file system:
 
 SFTP is slower, but easier for some to use:
 
-- Get your SFTP login credentials by clicking **Connection Info**. You will see your connection credentials and a link to connect directly with your preferred client.
-- From the terminal, navigate to the proper directory on your local file system:
+1. Get your SFTP login credentials by clicking **Connection Info**. You will see your connection credentials and a link to connect directly with your preferred client.
+
+1. From the terminal, navigate to the proper directory on your local file system:
+
     - **Drupal**: `sites/default`
     - **WordPress**: `wp-content/uploads`
-- Paste the CLI command copied from your Dashboard.
-- Run `get -r *` to transfer the files down to your local environment.
+
+1. Paste the CLI command copied from your Dashboard.
+
+1. Run `get -r *` to transfer the files down to your local environment.
 
 ## Submit Changes to Pantheon
 
@@ -138,44 +144,49 @@ SFTP is slower, but easier for some to use:
 
 Test your changes, then [commit locally and push to Pantheon](/git/#push-changes-to-pantheon):
 
-```bash
+```bash{promptUser: user}
 git commit -am "enter a summary of the changes"
 ```
+
 Next, push the changes:
 
-```bash
+```bash{promptUser: user}
 git push origin master
 ```
 
 ### Send the Database
 
 Create an archive using the MySQL utility mysqldump:
-```sql
+
+```bash{promptUser: user}
 mysqldump -uUSERNAME -pPASSWORD DATABASENAME | gzip > database.sql.gz
 ```
+
 Upload and import the file by going to your Pantheon Dashboard and selecting **Database / Files** > **Import**.
 
 ### Send the Files
 
-**Drupal: Via Drush**
+#### Upload files to Drupal Via Drush
 
 Drush and rsync is by far the easiest way to send files for Drupal sites:
 
-````
+```bash{promptUser: user}
 drush -r . rsync --temp-dir=../tmp/ @self:sites/default/files/ @pantheon.SITENAME.ENV:%files
-````
+```
 
-**WordPress or Drupal: Via SFTP**
+#### Upload Files to WordPress or Drupal Via SFTP
 
 Send files using SFTP:
 
-- [Copy the SFTP CLI command](/sftp#sftp-connection-information)
-- From terminal, navigate to the proper directory on your local file system:
+1. [Copy the SFTP CLI command](/sftp#sftp-connection-information)
+1. From the terminal, navigate to the proper directory on your local file system:
+
     - **Drupal**: `sites/default/files`
     - **WordPress**: `wp-content/uploads`
-- Paste the CLI command copied from your Dashboard
-- Navigate to the correct remote directory by running `cd files`
-- Run `put -r ./*` to transfer the files up
+
+1. Paste the CLI command copied from your Dashboard
+1. Navigate to the correct remote directory by running `cd files`
+1. Run `put -r ./*` to transfer the files up
 
 You can also transfer a single file or a single directory at a time instead of transferring every file, every time.
 
@@ -195,7 +206,7 @@ This file is ignored by the `.gitignore` file  in [WordPress](https://github.com
 
 The following can be used as a starting point for the `wp-config-local.php` file which needs to be saved in the same location as your `wp-config.php` file. You will need to replace the database values with the values from your local environment, and the key/salt values with your unique phrase (generated from [WordPress.org](https://api.wordpress.org/secret-key$)).
 
-```php
+```php:title=wp-config-local.php
 <?php
 define('DB_NAME',     'database_name_here');
 define('DB_USER',     'username_here');
@@ -227,7 +238,7 @@ define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
 
 1. Drupal 7 users will need to create a local settings file (e.g.`settings.local.php`) and include it within their `settings.php` file:
 
-    ```php
+    ```php:title=setting.php
     /**
      * Include a local settings file if it exists. D7 only
      */
@@ -239,6 +250,6 @@ define('WP_SITEURL', 'http://' . $_SERVER['HTTP_HOST']);
 
 2. You will also need to exclude the local configuration file from git, by adding the following to `.gitignore`:
 
-    ```
+    ```git:title=.gitignore
     sites/*/settings.local.php
     ```

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -1,8 +1,8 @@
 ---
 title: Local Development
 description: Suggestions and solutions for working locally on your Pantheon Drupal or WordPress site.
-tags: [local]
-categories: []
+tags: [local development, sftp, Lando, workflow]
+categories: [develop]
 ---
 
 <Alert title="Pantheon Localdev" type="success" icon="star">
@@ -115,6 +115,10 @@ terminus backup:create <site>.<env> --element=files
 terminus backup:get <site>.<env> --element=files
 ```
 This will create and get a backup of the site's files.
+
+Move the resulting backup to the proper directory on your local file system:
+    - **Drupal**: `sites/default/files`
+    - **WordPress**: `wp-content/uploads`
 
 ### Via SFTP CLI
 


### PR DESCRIPTION

## Effect
PR includes the following changes:
- clarify where to put files for terminus

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
