### PR TITLE
Supply missing cloned composer directory steps

### DIFF
--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -29,6 +29,7 @@ This guide uses the local command line environment, and there are several comman
 
 ```bash
 export site=yoursitename
+export site-composer=my-site-composer
 ```
 
 </Alert>
@@ -70,6 +71,7 @@ This will setup the multidev environment to receive and demo our changed code.
 
     ```bash
     composer create-project pantheon-systems/example-drops-8-composer $site-composer
+    cd $site-composer
     ```
 
 This will create a new directory based on the example project [pantheon-systems/example-drops-8-composer](https://github.com/pantheon-systems/example-drops-8-composer) in the `$site-composer` directory.


### PR DESCRIPTION
Closes #5377

## Effect
PR includes the following changes:
- supplies an instruction to export variable to match the `$site-composer`
- supplies a missing change directory step

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
