### PR TITLE
AMP for WP - Mobile Redirection breaks cache

### DIFF
--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -362,6 +362,11 @@ Plugins and Themes with issues resolved by this include:
 - [WPBakery: Page Builder](https://wpbakery.com/)
 - [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)
 
+### [AMP for WP – Accelerated Mobile Pages](https://wordpress.org/plugins/accelerated-mobile-pages/)
+**Issue**: Enabling the Mobile Redirection feature within AMP for WP sends a session cookie which conflicts with platform-level page caching.
+
+**Solution**: Disable the option for Mobile Redirection within the AMP for WP options page. See the  [WordPress support forum](https://wordpress.org/support/topic/varnish-compatibility-issue-with-session-keys/) for details.
+
 ### [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/)
 **Issue**: Full site backups are exported to the `wp-content/ai1wm-backups` directory, which is tracked in Git. Large backup files tracked in Git can cause problems with platform backups, deploys and other workflows.
 

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -3,6 +3,7 @@ title: Modules and Plugins with Known Issues
 description: A list of Drupal modules and WordPress plugins that are not supported and/or require workarounds.
 tags: [debugcode, siteintegrations]
 categories: []
+contributors: [amkorolyov]
 ---
 This page lists modules and plugins that may not function as expected or are currently problematic on the Pantheon platform. This is not a comprehensive list (see [other issues](#other-issues)). We continually update it as problems are reported and/or solved. If you are aware of any modules or plugins that do not work as expected, please [contact support](/support/).
 
@@ -363,9 +364,40 @@ Plugins and Themes with issues resolved by this include:
 - [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)
 
 ### [AMP for WP – Accelerated Mobile Pages](https://wordpress.org/plugins/accelerated-mobile-pages/)
-**Issue**: Enabling the Mobile Redirection feature within AMP for WP sends a session cookie which conflicts with platform-level page caching.
+**Issue**: Enabling the Mobile Redirection feature within AMP for WP sends a session cookie which conflicts with platform-level page caching. See the  [WordPress support forum](https://wordpress.org/support/topic/varnish-compatibility-issue-with-session-keys/) for details.
 
-**Solution**: Disable the option for Mobile Redirection within the AMP for WP options page. See the  [WordPress support forum](https://wordpress.org/support/topic/varnish-compatibility-issue-with-session-keys/) for details.
+**Solution**: Disable the option for Mobile Redirection within the AMP for WP options page. Then handle mobile redirection via PHP within `wp-config.php`, for example:
+
+```php:title=wp-config.php
+if ((is_mobile())&&(strrpos($_SERVER['REQUEST_URI'],'amp') == false)) {
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] .'/amp');
+
+  // Name transaction "redirect" in New Relic for improved reporting (optional).
+  if (extension_loaded('newrelic')) {
+    newrelic_name_transaction("redirect");
+  }
+  exit();
+}
+function is_mobile() {
+  if ( empty($_SERVER['HTTP_USER_AGENT']) ) {
+          $is_mobile = false;
+  }
+  elseif ( strpos($_SERVER['HTTP_USER_AGENT'], 'Mobile') !== false // many mobile devices (all iPhone, iPad, etc.)
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'Android') !== false
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'Silk/') !== false
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'Kindle') !== false
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'BlackBerry') !== false
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'Opera Mini') !== false
+          || strpos($_SERVER['HTTP_USER_AGENT'], 'Opera Mobi') !== false ) {
+                  $is_mobile = true;
+  }
+  else {
+          $is_mobile = false;
+  }
+  return $is_mobile;
+}```
+
 
 ### [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/)
 **Issue**: Full site backups are exported to the `wp-content/ai1wm-backups` directory, which is tracked in Git. Large backup files tracked in Git can cause problems with platform backups, deploys and other workflows.

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -3,7 +3,7 @@ title: Modules and Plugins with Known Issues
 description: A list of Drupal modules and WordPress plugins that are not supported and/or require workarounds.
 tags: [debugcode, siteintegrations]
 categories: []
-contributors: [amkorolyov]
+contributors: [aleksandrkorolyov]
 ---
 This page lists modules and plugins that may not function as expected or are currently problematic on the Pantheon platform. This is not a comprehensive list (see [other issues](#other-issues)). We continually update it as problems are reported and/or solved. If you are aware of any modules or plugins that do not work as expected, please [contact support](/support/).
 

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -396,8 +396,8 @@ function is_mobile() {
           $is_mobile = false;
   }
   return $is_mobile;
-}```
-
+}
+```
 
 ### [All-in-One WP Migration](https://wordpress.org/plugins/all-in-one-wp-migration/)
 **Issue**: Full site backups are exported to the `wp-content/ai1wm-backups` directory, which is tracked in Git. Large backup files tracked in Git can cause problems with platform backups, deploys and other workflows.

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -340,3 +340,8 @@
   github: //github.com/szipfel
   twitter: https://twitter.com/szipfel
   bio: Technical Engagement Manager
+- id: amkorolyov
+  name: Aleksandr Korolyov
+  avatar: //abs.twimg.com/sticky/default_profile_images/default_profile_400x400.png
+  twitter: //twitter.com/amkorolyov
+  bio: Software Engineer | DrupalSquad

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -340,8 +340,10 @@
   github: //github.com/szipfel
   twitter: https://twitter.com/szipfel
   bio: Technical Engagement Manager
-- id: amkorolyov
+- id: aleksandrkorolyov
   name: Aleksandr Korolyov
-  avatar: //abs.twimg.com/sticky/default_profile_images/default_profile_400x400.png
-  twitter: //twitter.com/amkorolyov
+  avatar: //media.licdn.com/dms/image/C4D03AQH1LPNKcQgTMg/profile-displayphoto-shrink_200_200/0?e=1580947200&v=beta&t=UEzVTSsuCofURxJ2kLeuYro3qTGynPrktJYwtbmQEdA
+  github: //github.com/alexandrkorolyov128
+  linkedin: //www.linkedin.com/in/aleksandr-korolev-575045148
+  drupal: //www.drupal.org/u/aleksandrkorolyov
   bio: Software Engineer | DrupalSquad


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- Add AMP for WP to the list of known problematic plugins, specifically when "Mobile Redirection" is enabled 

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
