### PR TITLE
Dec Changelog - add one-click update note

### DIFF
--- a/source/changelogs/2019-12-01-December.md
+++ b/source/changelogs/2019-12-01-December.md
@@ -13,7 +13,7 @@ Updated to PHP [7.2.25](https://www.php.net/ChangeLog-7.php#7.2.25), and [7.3.12
 Update to [Drupal 8.7.10](https://www.drupal.org/project/drupal/releases/8.7.10) is available to [apply as a 1-click update](/core-updates/) on Pantheon site dashboards.
 
 ### WordPress 5.3
-Update to WordPress 5.3. For more information, see https://wordpress.org/support/wordpress-version/version-5-3/ 
+Update to WordPress 5.3 is available to [apply as a 1-click update](/core-updates/) on Pantheon site dashboards. For more information, see https://wordpress.org/support/wordpress-version/version-5-3/ 
 
 ## Documentation
 ### [Configuring Opensolr for Pantheon sites](/opensolr/)


### PR DESCRIPTION
## Effect
PR includes the following changes:
- add one-click update note to WP core updates

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
