### PR TITLE
PLAT-1318 updating documenation for log collection

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -3,6 +3,7 @@ title: Log Files on Pantheon
 description: Use log files to identify errors, track response times, analyze visitors and more on your WordPress or Drupal site.
 tags: [logs, services]
 categories: [performance,platform]
+reviewed: "2020-01-13"
 ---
 Log files track and record your site's activity to help you find, debug, and isolate current or potential problems on your site. Each environment (Multidev, Dev, Test, and Live) has their own respective log files, which can be obtained via SFTP. Application-level logs can be accessed through Drupal directly. In addition to logs, [New Relic Pro](/new-relic) is a great way to help diagnose and fix errors and performance bottlenecks.
 
@@ -10,17 +11,19 @@ The server timezone and all log timestamps are in UTC (Coordinated Universal Tim
 
 ## Available Logs
 
-| Log        | Retention Policy           | Comments                                                |
-|:---------- |:-------------------------- |:------------------------------------------------------- |
-| **newrelic.log**          |                       | New Relic log; check if an environment is not logging. |
-| **nginx-access.log**      | Up to 60 days of logs |  Webserver access log. **Do not consider canonical**, as this will be wiped if the application container is reset or rebuilt. See [Parsing nginx Access Logs with GoAccess](/nginx-access-log). |
-| **nginx-error.log**       | 1MB of log data       | Webserver error log. |
+| Log                   | Retention Policy           | Comments                                                |
+|:--------------------- |:--------------------- |:------------------------------------------------------- |
+| **newrelic.log**          |                       | New Relic log; check if an environment is not logging.  |
+| **nginx-access.log**      | Up to 60 days of logs | Web server access log. **Do not consider canonical**, as this will be wiped if the application container is reset or rebuilt. See [Parsing nginx Access Logs with GoAccess](/nginx-access-log). |
+| **nginx-error.log**       | 1MB of log data       | Web server error log.                                   |
 | **php-error.log** <Popover content="Fatal errors from PHP error log are provided in each environment on the **Errors** tab of the Site Dashboard. Lower priority PHP errors are only in the PHP error log or in the application logs (watchdog on Drupal, WP_DEBUG for WordPress). For details, see [PHP Errors and Exceptions](/php-errors)" />  | 1MB of log data       | PHP [fatal error log](https://secure.php.net/manual/en/book.errorfunc.php); will not contain stack overflows. Fatal errors from this log are also shown in the Dashboard. |
 | **php-fpm-error.log**     | 1MB of log data       | PHP-FPM generated collection of stack traces of slow executions, similar to MySQL's slow query log. See [PHP Slow Log](/php-slow-log) |
 | **mysqld-slow-query.log** | 10MB of log data      | Log of MySQL queries that took more than 120 seconds to execute. Located in the database's `logs/` directory. |
 | **mysqld.log**            | 1MB of log data       | Log of established MySQL client connections and statements received from clients. Also Located in the database's `logs/` directory. |
 
-Rotated log files are archived within the `/logs` directory on application containers and database servers. You may find this directory contains sub-directories for each service that runs (ie NGINX and php) (e.g. `/logs/nginx/nginx-access.log-20160617.gz` or `/logs/php/php-error.log-20160617.gz` or `/logs/mysqld-slow-query.log-20160606`).
+Rotated log files are archived within the `/logs` directory on application containers and database servers.
+
+You may find that this directory contains sub-directories for services like Nginx and PHP (e.g. `/logs/nginx/nginx-access.log-20160617.gz` or `/logs/php/php-error.log-20160617.gz`) or log files directly in `logs` (e.g. `/logs/mysqld-slow-query.log-20160606`).
 
 <Alert title="Note" type="info">
 
@@ -33,7 +36,7 @@ Logs are stored within application containers that house your site's codebase an
 
 In the Connection Information section of the dashboard, we can see a pattern about the hostnames:
 
-```
+```none
 <env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in
 ```
 
@@ -51,12 +54,13 @@ In the Connection Information section of the dashboard, we can see a pattern abo
 3. Open a terminal window and paste the SFTP connection command.
 4. Run the following SFTP command in terminal:
 
-   ```
+   ```none
    get -r logs
    ```
 
 You now have a local copy of the logs directory, which contains the following:
-```
+
+```none
 ├── logs
     └──php
         └──newrelic.log
@@ -68,9 +72,9 @@ You now have a local copy of the logs directory, which contains the following:
         └──nginx-error.log
 ```
 
-You may still see the logs in this structure as well:
+You may still see log files in this structure as well:
 
-```
+```none
 ├── logs
     └──newrelic.log
     └──nginx-access.log
@@ -86,23 +90,26 @@ You may still see the logs in this structure as well:
 3. Edit and execute the command by replacing `appserver` with `dbserver`:
 
  From:
- ```
+
+ ```bash
  sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@appserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
  ```
 
  To:
- ```
+
+ ```bash
  sftp -o Port=2222 dev.de305d54-75b4-431b-adb2-eb6b9e546014@dbserver.dev.de305d54-75b4-431b-adb2-eb6b9e546014.drush.in`
  ```
 
 4. Run the following SFTP command in terminal:
 
- ```
+ ```bash
  get -r logs
  ```
 
 You now have a local copy of the logs directory, which contains the following:
-```
+
+```none
 ├── logs
     └──mysqld-slow-query.log
     └──mysqld.log
@@ -122,7 +129,8 @@ cd $HOME/site-logs
 
 Using your favorite text editor, create a file within the `site-logs` directory called `collect-logs.sh` and include the following:
 
-```bash
+```bash:title=collect-logs.sh
+#!/bin/bash
 # Site UUID from Dashboard URL, eg 12345678-1234-1234-abcd-0123456789ab
 SITE_UUID=xxxxxxxxxxx
 ENV=live
@@ -145,8 +153,8 @@ For densely populated directories, using `*` can cause failures. If the script f
 ### Collect Logs
 Download logs by executing the script from within the `site-logs` directory:
 
-```
-sh collect-logs.sh
+```bash{promptUser:user}
+bash collect-logs.sh
 ```
 
 You can now access the logs from within the `site-log` directory. More than one directory is generated for sites that use multiple application containers.
@@ -205,17 +213,11 @@ By default, Drupal logs events using the Database Logging module (dblog). PHP fa
  terminus drush <site>.<env> -- watchdog-show
  ```
 
- * Terminus can invoke Drush commands to "watch" events in real-time; `--tail` can be used to continuously show new watchdog messages until  interrupted (Control+C).
+* Terminus can invoke Drush commands to "watch" events in real-time; `--tail` can be used to continuously show new watchdog messages until  interrupted (Control+C).
 
-  ```bash
-  terminus drush <site>.<env> -- watchdog-show --tail
-  ```
-
-  <Alert title="Note" type="info">
-
-  At this time, `terminus drush "watchdog-show --tail"` is supported in 0.13.x versions and below, and not yet supported in  Terminus 1.x.
-
-  </Alert>
+ ```bash
+ terminus drush <site>.<env> -- watchdog-show --tail
+ ```
 
 ### My Drupal database logs are huge. Should I disable dblog?
 

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -20,7 +20,7 @@ The server timezone and all log timestamps are in UTC (Coordinated Universal Tim
 | **mysqld-slow-query.log** | 10MB of log data      | Log of MySQL queries that took more than 120 seconds to execute. Located in the database's `logs/` directory. |
 | **mysqld.log**            | 1MB of log data       | Log of established MySQL client connections and statements received from clients. Also Located in the database's `logs/` directory. |
 
-Rotated log files are archived within the `/logs` directory on application containers and database servers (e.g. `/logs/nginx-access.log-20160617.gz` or `/logs/mysqld-slow-query.log-20160606`).
+Rotated log files are archived within the `/logs` directory on application containers and database servers. You may find this directory contains sub-directories for each service that runs (ie NGINX and php) (e.g. `/logs/nginx/nginx-access.log-20160617.gz` or `/logs/php/php-error.log-20160617.gz` or `/logs/mysqld-slow-query.log-20160606`).
 
 <Alert title="Note" type="info">
 
@@ -64,14 +64,26 @@ In the Connection Information section of the dashboard, we can see a pattern abo
 You now have a local copy of the logs directory, which contains the following:
 ```
 ├── logs
+    └──php
+        └──newrelic.log
+        └──php-error.log
+        └──php-fpm-error.log
+        └──php-slow.log
+    └──nginx
+        └──nginx-access.log
+        └──nginx-error.log
+```
+
+You may still see the logs in this structure as well:
+
+```
+├── logs
     └──newrelic.log
     └──nginx-access.log
     └──nginx-error.log
     └──php-error.log
     └──php-fpm-error.log
     └──php-slow.log
-    └──pyinotify.log
-    └──watcher.log
 ```
 
 ### Database Log Files

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -44,12 +44,6 @@ In the Connection Information section of the dashboard, we can see a pattern abo
 
 ## Downloading Logs
 
-<Accordion title="Watch: Download Appserver and Database Log Files" id="logs-video" icon="facetime-video">
-
-`youtube: https://youtu.be/t3cyL5h5vTI`
-
-</Accordion>
-
 ### Application Log Files
 
 1. Access the Site Dashboard and desired environment (Multidev, Dev, Test, or Live).

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -20,7 +20,7 @@ Requests served by the [Pantheon Global CDN](/global-cdn) will not hit the nginx
 
 Be sure that you have:
 
-* [Terminus](/terminus)
+* [Terminus](/terminus/)
 * [GoAccess](https://goaccess.io/download)
   * **Mac OS X**: Install via [Homebrew](https://brew.sh/) (`brew install goaccess`)
   * **Windows**: Use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)

--- a/source/content/php-slow-log.md
+++ b/source/content/php-slow-log.md
@@ -3,6 +3,7 @@ title: PHP Slow Log
 description: Improve the stability of your Drupal or WordPress site using PHP Slow Log and PHP FPM Error Log to identify serious performance issues.
 tags: [logs]
 categories: [performance]
+reviewed: "2020-01-13"
 ---
 One of the key ways to find issues on your website is to check your PHP logs. This article instructs you on how to use your PHP slow log and PHP FPM error logs to find performance issues and PHP errors on Pantheon sites.
 
@@ -15,114 +16,124 @@ Make sure that you have:
 
 ## Download the PHP Slow Log and PHP FPM Error Log via SFTP
 
-1.  Add yourself to the site's team membership.
-2.  Get the SFTP connection information for the environment (Test, Dev, Live, or a Multidev) from the site's Dashboard.
-3.  Open a command line prompt and paste the SFTP connection information.
-4.  Navigate to the Logs directory, and use a `get` command to download the PHP slow log to your local machine for analysis.
+1. Add yourself to the site's team membership.
+1. Get the SFTP connection information for the environment (Test, Dev, Live, or a Multidev) from the site's Dashboard.
+1. Open a command line prompt and paste the SFTP connection information.
+1. Navigate to the Logs directory, and use a `get` command to download the PHP slow log to your local machine for analysis.
 
-    ```php
-    > $ sftp -o Port=2222 live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in
-    > live.91fd3bea-d11b-401a-85e0-0@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in's password:
-    > live.91fd3bea-d11b-401a-85e0-0@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in's password:
-    > Connected to appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in.
-    > sftp> cd logs/php
-    > sftp> ls -l
-    > -rw-r--r--    1 16193    16193      153146 Dec 15 22:34 newrelic.log
-    > -rw-r--r--    1 16193    16193        3499 Dec 15 22:46 nginx-error.log
-    > -rw-r--r--    1 16193    16193     1126685 Dec 14 08:07 nginx-error.log-20141214
-    > -rw-r--r--    1 16193    16193        5017 Dec 15 11:52 php-error.log
-    > -rw-------    1 16193    16193      642388 Dec 15 22:55 php-fpm-error.log
-    > -rw-------    1 16193    16193     1067358 Dec 12 20:07 php-fpm-error.log-20141212
-    > -rw-------    1 16193    16193     7209576 Dec 15 22:55 php-slow.log
-    > sftp> get php-slow.log
-    > Fetching /logs/php-slow.log to php-slow.log
-    > /logs/php-slow.log 100% 7041KB 370.6KB/s   00:19
-    > sftp> get php-fpm-error.log
-    > Fetching /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log to php-fpm-error.log
-    > /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log                                                                              100%  717KB 238.9KB/s   00:03
-    > sftp> exit
-    > $
-    ```
+  ```bash{outputLines:2-20}
+  sftp -o Port=2222 live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in
+  live.91fd3bea-d11b-401a-85e0-0@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in's password:
+  Connected to appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in.
+  sftp> cd logs/php
+  sftp> ls -l
+  -rw-r--r--    1 16193    16193      153146 Dec 15 22:34 newrelic.log
+  -rw-r--r--    1 16193    16193        3499 Dec 15 22:46 nginx-error.log
+  -rw-r--r--    1 16193    16193     1126685 Dec 14 08:07 nginx-error.log-20141214
+  -rw-r--r--    1 16193    16193        5017 Dec 15 11:52 php-error.log
+  -rw-------    1 16193    16193      642388 Dec 15 22:55 php-fpm-error.log
+  -rw-------    1 16193    16193     1067358 Dec 12 20:07 php-fpm-error.log-20141212
+  -rw-------    1 16193    16193     7209576 Dec 15 22:55 php-slow.log
+  sftp> get php-slow.log
+  Fetching /logs/php-slow.log to php-slow.log
+  /logs/php-slow.log 100% 7041KB 370.6KB/s   00:19
+  sftp> get php-fpm-error.log
+  Fetching /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log to php-fpm-error.log
+  /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log                                                                              100%  717KB 238.9KB/s   00:03
+  sftp> exit
+  ```
 
-You may still only need to change the directory to `/logs`. In that case `cd logs` enters the directory and that directory will have all of the logs contained inside.
+  **Note:** If there is no `php/` directory in `logs/`, the files will be directly within `logs`.
 
 ## Analyze the PHP Slow Log
 
-Look for custom modules or theme files (template.php file, &ast;.tpl.php files, etc.). This trace has both a custom Feature module (/sites/all/modules/features/tdm_community.module, field_get_items() function) and a .tpl file (/sites/all/themes/themename/templates/page.tpl.php, render() function). The script filenames may have a different path such as `/srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php`.
+1. Look for custom modules or theme files (`template.php` file, `*.tpl.php` files, etc.). This trace has both a custom Feature module (`/sites/all/modules/features/tdm_community.module, field_get_items()` function) and a `.tpl` file (`/sites/all/themes/themename/templates/page.tpl.php`, render() function).
 
-```php
-> 08-Dec-2014 19:04:01]  [pool www] pid 47289
-> script_filename = /code/index.php
-> [0x000000000328e9e8] field_valid_language() /code/modules/field/field.multilingual.inc:269
-> [0x000000000328e7d0] field_language() /code/modules/field/field.module:925
-> [0x000000000328e080] field_get_items() /code/sites/all/modules/features/tdm_community/tdm_community.module:19
-> [0x000000000328c260] tdm_community_preprocess_node() /code/includes/theme.inc:1125
-> [0x000000000328b310] theme() /code/includes/common.inc:5952
-> [0x000000000328a3c8] drupal_render() /code/includes/common.inc:5959
-> [0x0000000003289480] drupal_render() /code/includes/common.inc:5959
-> [0x0000000003288db0] drupal_render() /code/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module:717
-> [0x0000000003286f98] theme_ds_field_minimal() /code/includes/theme.inc:1161
-> [0x0000000003286048] theme() /code/includes/common.inc:5952
-> [0x0000000003285100] drupal_render() /code/includes/common.inc:5959
-> [0x00000000032841b8] drupal_render() /code/includes/common.inc:5959
-> [0x0000000003280f48] drupal_render() /code/sites/all/modules/contrib/ds/ds.module:747
-> [0x000000000327f128] ds_entity_variables() /code/includes/theme.inc:1125
-> [0x000000000327e1d8] theme() /code/includes/common.inc:5952
-> [0x000000000327d290] drupal_render() /code/includes/common.inc:5959
-> [0x000000000327c348] drupal_render() /code/includes/common.inc:5959
-> [0x000000000327b400] drupal_render() /code/includes/common.inc:5959
-> [0x000000000327b2d0] drupal_render() /code/includes/common.inc:6053
-> [0x000000000327a240] render() /code/sites/all/themes/themename/templates/page.tpl.php:113
-```
-Next, search for contributed modules or plug-ins that may be detrimental to the site. stream_wrappers.inc is showing twice at the exact same timestamp (08-Dec-2014 16:56:48) and is used to bring in external streaming media. This is often the cause of significant performance issues on sites.
+  The script filenames may have a different path such as `/srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php`.
 
-```php
-> [08-Dec-2014 16:56:48]  [pool www] pid 3863
-> script_filename = /code/index.php
-> [0x0000000005fbc2d0] realpath() /code/includes/stream_wrappers.inc:377
-> [0x0000000005fbbdd0] getLocalPath()   /code/includes/stream_wrappers.inc:695
-> [0x00007ffff7ee1700] url_stat() unknown:0
-> [0x0000000005fbbb60] file_exists() /code/includes/common.inc:4945
-> [0x0000000005fbb058] drupal_aggregated_file_exists() /code/includes/common.inc:4994
-> [0x0000000005fb92c0] drupal_build_js_cache() /code/includes/common.inc:4429
-> [0x0000000005fb8d80] drupal_get_js() /code/includes/theme.inc:2703
-> [0x0000000005fb6f60] template_process_html() /code/includes/theme.inc:1125
-> [0x0000000005fb6010] theme() /code/includes/common.inc:5967
-> [0x0000000005fb5af0] drupal_render() /code/includes/common.inc:5814
-> [0x0000000005fb49b8] drupal_render_page() /code/includes/common.inc:2701
-> [0x0000000005fb4600] drupal_deliver_html_page() /code/includes/common.inc:2589
-> [0x0000000005fb3f50] drupal_deliver_page() /code/includes/menu.inc:532
-> [0x0000000005fb3d70] menu_execute_active_handler() /code/index.php:21
+  ```php
+  08-Dec-2014 19:04:01]  [pool www] pid 47289
+  script_filename = /code/index.php
+  [0x000000000328e9e8] field_valid_language() /code/modules/field/field.multilingual.inc:269
+  [0x000000000328e7d0] field_language() /code/modules/field/field.module:925
+  [0x000000000328e080] field_get_items() /code/sites/all/modules/features/tdm_community/tdm_community.module:19
+  [0x000000000328c260] tdm_community_preprocess_node() /code/includes/theme.inc:1125
+  [0x000000000328b310] theme() /code/includes/common.inc:5952
+  [0x000000000328a3c8] drupal_render() /code/includes/common.inc:5959
+  [0x0000000003289480] drupal_render() /code/includes/common.inc:5959
+  [0x0000000003288db0] drupal_render() /code/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module:717
+  [0x0000000003286f98] theme_ds_field_minimal() /code/includes/theme.inc:1161
+  [0x0000000003286048] theme() /code/includes/common.inc:5952
+  [0x0000000003285100] drupal_render() /code/includes/common.inc:5959
+  [0x00000000032841b8] drupal_render() /code/includes/common.inc:5959
+  [0x0000000003280f48] drupal_render() /code/sites/all/modules/contrib/ds/ds.module:747
+  [0x000000000327f128] ds_entity_variables() /code/includes/theme.inc:1125
+  [0x000000000327e1d8] theme() /code/includes/common.inc:5952
+  [0x000000000327d290] drupal_render() /code/includes/common.inc:5959
+  [0x000000000327c348] drupal_render() /code/includes/common.inc:5959
+  [0x000000000327b400] drupal_render() /code/includes/common.inc:5959
+  [0x000000000327b2d0] drupal_render() /code/includes/common.inc:6053
+  [0x000000000327a240] render() /code/sites/all/themes/themename/templates/page.tpl.php:113
+  ```
 
-> [08-Dec-2014 16:56:48]  [pool www] pid 3883
-script_filename = /code/index.php
-> [0x00000000027b95a0] realpath() /code/includes/stream_wrappers.inc:377
-[0x00000000027b90a0] getLocalPath() /code/includes/stream_wrappers.inc:695
-> [0x00007ffff7ee1700] url_stat() unknown:0
-> [0x00000000027b8e30] file_exists() /code/includes/common.inc:4945
-> [0x00000000027b8328] drupal_aggregated_file_exists() /code/includes/common.inc:4994
-> [0x00000000027b6590] drupal_build_js_cache() /code/includes/common.inc:4429
-> [0x00000000027b6050] drupal_get_js() /code/includes/theme.inc:2703
-> [0x00000000027b4230] template_process_html() /code/includes/theme.inc:1125
-> [0x00000000027b32e0] theme() /code/includes/common.inc:5967
-> [0x00000000027b2dc0] drupal_render() /code/includes/common.inc:5814
-> [0x00000000027b1c88] drupal_render_page() /code/includes/common.inc:2701
-> [0x00000000027b18d0] drupal_deliver_html_page() /code/includes/common.inc:2589
-> [0x00000000027b1220] drupal_deliver_page() /code/includes/menu.inc:532
-> [0x00000000027b1040] menu_execute_active_handler() /code/index.php:21
-```
-To get a count of how many times any given file is called in a PHP slow log, use a `grep` command. Examples:
+2. Next, search for contributed modules or plug-ins that may be detrimental to the site. stream_wrappers.inc is showing twice at the exact same timestamp (08-Dec-2014 16:56:48) and is used to bring in external streaming media. This is often the cause of significant performance issues on sites.
 
-```php
-> $ grep -o 'stream_wrappers.inc' php-slow.log | wc -l
-56
-> $ grep -o 'page.tpl' php-slow.log | wc -l
-48
-> $ grep -o '.tpl' php-slow.log | wc -l
-73
-> $ grep -o 'tdm_'.&ast;.'module' php-slow.log | wc -l
-1995
-> $
-```
+  ```php
+  [08-Dec-2014 16:56:48]  [pool www] pid 3863
+  script_filename = /code/index.php
+  [0x0000000005fbc2d0] realpath() /code/includes/stream_wrappers.inc:377
+  [0x0000000005fbbdd0] getLocalPath()   /code/includes/stream_wrappers.inc:695
+  [0x00007ffff7ee1700] url_stat() unknown:0
+  [0x0000000005fbbb60] file_exists() /code/includes/common.inc:4945
+  [0x0000000005fbb058] drupal_aggregated_file_exists() /code/includes/common.inc:4994
+  [0x0000000005fb92c0] drupal_build_js_cache() /code/includes/common.inc:4429
+  [0x0000000005fb8d80] drupal_get_js() /code/includes/theme.inc:2703
+  [0x0000000005fb6f60] template_process_html() /code/includes/theme.inc:1125
+  [0x0000000005fb6010] theme() /code/includes/common.inc:5967
+  [0x0000000005fb5af0] drupal_render() /code/includes/common.inc:5814
+  [0x0000000005fb49b8] drupal_render_page() /code/includes/common.inc:2701
+  [0x0000000005fb4600] drupal_deliver_html_page() /code/includes/common.inc:2589
+  [0x0000000005fb3f50] drupal_deliver_page() /code/includes/menu.inc:532
+  [0x0000000005fb3d70] menu_execute_active_handler() /code/index.php:21
+  
+  [08-Dec-2014 16:56:48]  [pool www] pid 3883
+  script_filename = /code/index.php
+  [0x00000000027b95a0] realpath() /code/includes/stream_wrappers.inc:377
+  [0x00000000027b90a0] getLocalPath() /code/includes/stream_wrappers.inc:695
+  [0x00007ffff7ee1700] url_stat() unknown:0
+  [0x00000000027b8e30] file_exists() /code/includes/common.inc:4945
+  [0x00000000027b8328] drupal_aggregated_file_exists() /code/includes/common.inc:4994
+  [0x00000000027b6590] drupal_build_js_cache() /code/includes/common.inc:4429
+  [0x00000000027b6050] drupal_get_js() /code/includes/theme.inc:2703
+  [0x00000000027b4230] template_process_html() /code/includes/theme.inc:1125
+  [0x00000000027b32e0] theme() /code/includes/common.inc:5967
+  [0x00000000027b2dc0] drupal_render() /code/includes/common.inc:5814
+  [0x00000000027b1c88] drupal_render_page() /code/includes/common.inc:2701
+  [0x00000000027b18d0] drupal_deliver_html_page() /code/includes/common.inc:2589
+  [0x00000000027b1220] drupal_deliver_page() /code/includes/menu.inc:532
+  [0x00000000027b1040] menu_execute_active_handler() /code/index.php:21
+  ```
+
+3. To get a count of how many times any given file is called in a PHP slow log, use a `grep` command. Examples:
+
+  ```bash{outputLines:2}
+  grep -o 'stream_wrappers.inc' php-slow.log | wc -l
+  56
+  ```
+
+  ```bash{outputLines:2}
+  grep -o 'page.tpl' php-slow.log | wc -l
+  48
+  ```
+
+  ```bash{outputLines:2}
+  grep -o '.tpl' php-slow.log | wc -l
+  73
+  ```
+
+  ```bash{outputLines:2}
+  grep -o 'tdm_'.&ast;.'module' php-slow.log | wc -l
+  1995
+  ```
 
 By using these methods and files to find your PHP errors and performance issues, you will be able to greatly improve the stability of your website.

--- a/source/content/php-slow-log.md
+++ b/source/content/php-slow-log.md
@@ -24,111 +24,105 @@ Make sure that you have:
     > $ sftp -o Port=2222 live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in
     > live.91fd3bea-d11b-401a-85e0-0@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in's password:
     > live.91fd3bea-d11b-401a-85e0-0@appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in's password:
-    > Connected to appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in.  
-    > sftp> cd logs  
-    > sftp> ls -l  
-    > -rw-r--r--    1 16193    16193      153146 Dec 15 22:34 newrelic.log  
-    > -rw-r--r--    1 16193    16193    55123460 Dec 15 22:59 nginx-access.log  
-    > -rw-r--r--    1 16193    16193     3479688 Dec 09 08:07 nginx-access.log-20141209.gz  
-    > -rw-r--r--    1 16193    16193     5524355 Dec 10 08:07 nginx-access.log-20141210.gz  
-    > -rw-r--r--    1 16193    16193     5602638 Dec 11 08:06 nginx-access.log-20141211.gz  
-    > -rw-r--r--    1 16193    16193     6033991 Dec 12 08:07 nginx-access.log-20141212.gz  
-    > -rw-r--r--    1 16193    16193     5793730 Dec 13 08:07 nginx-access.log-20141213.gz  
-    > -rw-r--r--    1 16193    16193     4688934 Dec 14 08:07 nginx-access.log-20141214.gz  
-    > -rw-r--r--    1 16193    16193     5867636 Dec 15 08:07 nginx-access.log-20141215.gz  
-    > -rw-r--r--    1 16193    16193        3499 Dec 15 22:46 nginx-error.log  
-    > -rw-r--r--    1 16193    16193     1126685 Dec 14 08:07 nginx-error.log-20141214  
-    > -rw-r--r--    1 16193    16193        5017 Dec 15 11:52 php-error.log  
-    > -rw-------    1 16193    16193      642388 Dec 15 22:55 php-fpm-error.log  
-    > -rw-------    1 16193    16193     1067358 Dec 12 20:07 php-fpm-error.log-20141212  
-    > -rw-------    1 16193    16193     7209576 Dec 15 22:55 php-slow.log  
-    > sftp> get php-slow.log  
-    > Fetching /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/logs/php-slow.log to php-slow.log  
-    > /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/logs/php-slow.log 100% 7041KB 370.6KB/s   00:19  
-    > sftp> get php-fpm-error.log  
-    > Fetching /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log to php-fpm-error.log  
-    > /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log                                                                              100%  717KB 238.9KB/s   00:03  
-    > sftp> exit  
+    > Connected to appserver.live.91f33beg-d11b-4020a-0005e0-07ca0f4ce7bz.drush.in.
+    > sftp> cd logs/php
+    > sftp> ls -l
+    > -rw-r--r--    1 16193    16193      153146 Dec 15 22:34 newrelic.log
+    > -rw-r--r--    1 16193    16193        3499 Dec 15 22:46 nginx-error.log
+    > -rw-r--r--    1 16193    16193     1126685 Dec 14 08:07 nginx-error.log-20141214
+    > -rw-r--r--    1 16193    16193        5017 Dec 15 11:52 php-error.log
+    > -rw-------    1 16193    16193      642388 Dec 15 22:55 php-fpm-error.log
+    > -rw-------    1 16193    16193     1067358 Dec 12 20:07 php-fpm-error.log-20141212
+    > -rw-------    1 16193    16193     7209576 Dec 15 22:55 php-slow.log
+    > sftp> get php-slow.log
+    > Fetching /logs/php-slow.log to php-slow.log
+    > /logs/php-slow.log 100% 7041KB 370.6KB/s   00:19
+    > sftp> get php-fpm-error.log
+    > Fetching /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log to php-fpm-error.log
+    > /srv/bindings/b6126cf3069a4ba5983f3e9eaf35d627/logs/php-fpm-error.log                                                                              100%  717KB 238.9KB/s   00:03
+    > sftp> exit
     > $
     ```
 
+You may still only need to change the directory to `/logs`. In that case `cd logs` enters the directory and that directory will have all of the logs contained inside.
+
 ## Analyze the PHP Slow Log
 
-Look for custom modules or theme files (template.php file, &ast;.tpl.php files, etc.). This trace has both a custom Feature module (/sites/all/modules/features/tdm_community.module, field_get_items() function) and a .tpl file (/sites/all/themes/themename/templates/page.tpl.php, render() function).
+Look for custom modules or theme files (template.php file, &ast;.tpl.php files, etc.). This trace has both a custom Feature module (/sites/all/modules/features/tdm_community.module, field_get_items() function) and a .tpl file (/sites/all/themes/themename/templates/page.tpl.php, render() function). The script filenames may have a different path such as `/srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php`.
 
 ```php
-> 08-Dec-2014 19:04:01]  [pool www] pid 47289  
-> script_filename = /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php
-> [0x000000000328e9e8] field_valid_language() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/modules/field/field.multilingual.inc:269  
-> [0x000000000328e7d0] field_language() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/modules/field/field.module:925
-> [0x000000000328e080] field_get_items() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/sites/all/modules/features/tdm_community/tdm_community.module:19  
-> [0x000000000328c260] tdm_community_preprocess_node() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:1125  
-> [0x000000000328b310] theme() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5952  
-> [0x000000000328a3c8] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x0000000003289480] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x0000000003288db0] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module:717  
-> [0x0000000003286f98] theme_ds_field_minimal() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:1161  
-> [0x0000000003286048] theme() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5952  
-> [0x0000000003285100] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x00000000032841b8] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x0000000003280f48] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/sites/all/modules/contrib/ds/ds.module:747  
-> [0x000000000327f128] ds_entity_variables() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:1125  
-> [0x000000000327e1d8] theme() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5952  
-> [0x000000000327d290] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x000000000327c348] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x000000000327b400] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5959  
-> [0x000000000327b2d0] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:6053  
-> [0x000000000327a240] render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/sites/all/themes/themename/templates/page.tpl.php:113  
+> 08-Dec-2014 19:04:01]  [pool www] pid 47289
+> script_filename = /code/index.php
+> [0x000000000328e9e8] field_valid_language() /code/modules/field/field.multilingual.inc:269
+> [0x000000000328e7d0] field_language() /code/modules/field/field.module:925
+> [0x000000000328e080] field_get_items() /code/sites/all/modules/features/tdm_community/tdm_community.module:19
+> [0x000000000328c260] tdm_community_preprocess_node() /code/includes/theme.inc:1125
+> [0x000000000328b310] theme() /code/includes/common.inc:5952
+> [0x000000000328a3c8] drupal_render() /code/includes/common.inc:5959
+> [0x0000000003289480] drupal_render() /code/includes/common.inc:5959
+> [0x0000000003288db0] drupal_render() /code/sites/all/modules/contrib/ds/modules/ds_extras/ds_extras.module:717
+> [0x0000000003286f98] theme_ds_field_minimal() /code/includes/theme.inc:1161
+> [0x0000000003286048] theme() /code/includes/common.inc:5952
+> [0x0000000003285100] drupal_render() /code/includes/common.inc:5959
+> [0x00000000032841b8] drupal_render() /code/includes/common.inc:5959
+> [0x0000000003280f48] drupal_render() /code/sites/all/modules/contrib/ds/ds.module:747
+> [0x000000000327f128] ds_entity_variables() /code/includes/theme.inc:1125
+> [0x000000000327e1d8] theme() /code/includes/common.inc:5952
+> [0x000000000327d290] drupal_render() /code/includes/common.inc:5959
+> [0x000000000327c348] drupal_render() /code/includes/common.inc:5959
+> [0x000000000327b400] drupal_render() /code/includes/common.inc:5959
+> [0x000000000327b2d0] drupal_render() /code/includes/common.inc:6053
+> [0x000000000327a240] render() /code/sites/all/themes/themename/templates/page.tpl.php:113
 ```
 Next, search for contributed modules or plug-ins that may be detrimental to the site. stream_wrappers.inc is showing twice at the exact same timestamp (08-Dec-2014 16:56:48) and is used to bring in external streaming media. This is often the cause of significant performance issues on sites.
 
 ```php
-> [08-Dec-2014 16:56:48]  [pool www] pid 3863  
-> script_filename = /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php
-> [0x0000000005fbc2d0] realpath() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/stream_wrappers.inc:377
-> [0x0000000005fbbdd0] getLocalPath()   /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/stream_wrappers.inc:695
-> [0x00007ffff7ee1700] url_stat() unknown:0  
-> [0x0000000005fbbb60] file_exists() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4945  
-> [0x0000000005fbb058] drupal_aggregated_file_exists() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4994  
-> [0x0000000005fb92c0] drupal_build_js_cache() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4429  
-> [0x0000000005fb8d80] drupal_get_js() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:2703  
-> [0x0000000005fb6f60] template_process_html() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:1125  
-> [0x0000000005fb6010] theme() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5967  
-> [0x0000000005fb5af0] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5814  
-> [0x0000000005fb49b8] drupal_render_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:2701  
-> [0x0000000005fb4600] drupal_deliver_html_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:2589  
-> [0x0000000005fb3f50] drupal_deliver_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/menu.inc:532  
-> [0x0000000005fb3d70] menu_execute_active_handler() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php:21  
+> [08-Dec-2014 16:56:48]  [pool www] pid 3863
+> script_filename = /code/index.php
+> [0x0000000005fbc2d0] realpath() /code/includes/stream_wrappers.inc:377
+> [0x0000000005fbbdd0] getLocalPath()   /code/includes/stream_wrappers.inc:695
+> [0x00007ffff7ee1700] url_stat() unknown:0
+> [0x0000000005fbbb60] file_exists() /code/includes/common.inc:4945
+> [0x0000000005fbb058] drupal_aggregated_file_exists() /code/includes/common.inc:4994
+> [0x0000000005fb92c0] drupal_build_js_cache() /code/includes/common.inc:4429
+> [0x0000000005fb8d80] drupal_get_js() /code/includes/theme.inc:2703
+> [0x0000000005fb6f60] template_process_html() /code/includes/theme.inc:1125
+> [0x0000000005fb6010] theme() /code/includes/common.inc:5967
+> [0x0000000005fb5af0] drupal_render() /code/includes/common.inc:5814
+> [0x0000000005fb49b8] drupal_render_page() /code/includes/common.inc:2701
+> [0x0000000005fb4600] drupal_deliver_html_page() /code/includes/common.inc:2589
+> [0x0000000005fb3f50] drupal_deliver_page() /code/includes/menu.inc:532
+> [0x0000000005fb3d70] menu_execute_active_handler() /code/index.php:21
 
-> [08-Dec-2014 16:56:48]  [pool www] pid 3883  
-script_filename = /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php  
-> [0x00000000027b95a0] realpath() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/stream_wrappers.inc:377  
-[0x00000000027b90a0] getLocalPath() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/stream_wrappers.inc:695  
-> [0x00007ffff7ee1700] url_stat() unknown:0  
-> [0x00000000027b8e30] file_exists() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4945  
-> [0x00000000027b8328] drupal_aggregated_file_exists() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4994  
-> [0x00000000027b6590] drupal_build_js_cache() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:4429  
-> [0x00000000027b6050] drupal_get_js() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:2703  
-> [0x00000000027b4230] template_process_html() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/theme.inc:1125  
-> [0x00000000027b32e0] theme() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5967  
-> [0x00000000027b2dc0] drupal_render() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:5814  
-> [0x00000000027b1c88] drupal_render_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:2701  
-> [0x00000000027b18d0] drupal_deliver_html_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/common.inc:2589  
-> [0x00000000027b1220] drupal_deliver_page() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/includes/menu.inc:532  
-> [0x00000000027b1040] menu_execute_active_handler() /srv/bindings/d142301948514750b2ff39988as6f4b9158e5/code/index.php:21  
+> [08-Dec-2014 16:56:48]  [pool www] pid 3883
+script_filename = /code/index.php
+> [0x00000000027b95a0] realpath() /code/includes/stream_wrappers.inc:377
+[0x00000000027b90a0] getLocalPath() /code/includes/stream_wrappers.inc:695
+> [0x00007ffff7ee1700] url_stat() unknown:0
+> [0x00000000027b8e30] file_exists() /code/includes/common.inc:4945
+> [0x00000000027b8328] drupal_aggregated_file_exists() /code/includes/common.inc:4994
+> [0x00000000027b6590] drupal_build_js_cache() /code/includes/common.inc:4429
+> [0x00000000027b6050] drupal_get_js() /code/includes/theme.inc:2703
+> [0x00000000027b4230] template_process_html() /code/includes/theme.inc:1125
+> [0x00000000027b32e0] theme() /code/includes/common.inc:5967
+> [0x00000000027b2dc0] drupal_render() /code/includes/common.inc:5814
+> [0x00000000027b1c88] drupal_render_page() /code/includes/common.inc:2701
+> [0x00000000027b18d0] drupal_deliver_html_page() /code/includes/common.inc:2589
+> [0x00000000027b1220] drupal_deliver_page() /code/includes/menu.inc:532
+> [0x00000000027b1040] menu_execute_active_handler() /code/index.php:21
 ```
 To get a count of how many times any given file is called in a PHP slow log, use a `grep` command. Examples:
 
 ```php
-> $ grep -o 'stream_wrappers.inc' php-slow.log | wc -l  
-56  
-> $ grep -o 'page.tpl' php-slow.log | wc -l  
-48  
-> $ grep -o '.tpl' php-slow.log | wc -l  
-73  
-> $ grep -o 'tdm_'.&ast;.'module' php-slow.log | wc -l  
-1995  
-> $  
+> $ grep -o 'stream_wrappers.inc' php-slow.log | wc -l
+56
+> $ grep -o 'page.tpl' php-slow.log | wc -l
+48
+> $ grep -o '.tpl' php-slow.log | wc -l
+73
+> $ grep -o 'tdm_'.&ast;.'module' php-slow.log | wc -l
+1995
+> $
 ```
 
 By using these methods and files to find your PHP errors and performance issues, you will be able to greatly improve the stability of your website.

--- a/source/content/php-slow-log.md
+++ b/source/content/php-slow-log.md
@@ -76,7 +76,7 @@ Make sure that you have:
   [0x000000000327a240] render() /code/sites/all/themes/themename/templates/page.tpl.php:113
   ```
 
-2. Next, search for contributed modules or plug-ins that may be detrimental to the site. stream_wrappers.inc is showing twice at the exact same timestamp (08-Dec-2014 16:56:48) and is used to bring in external streaming media. This is often the cause of significant performance issues on sites.
+1. Next, search for contributed modules or plug-ins that may be detrimental to the site. stream_wrappers.inc is showing twice at the exact same timestamp (08-Dec-2014 16:56:48) and is used to bring in external streaming media. This is often the cause of significant performance issues on sites.
 
   ```php
   [08-Dec-2014 16:56:48]  [pool www] pid 3863
@@ -114,7 +114,7 @@ Make sure that you have:
   [0x00000000027b1040] menu_execute_active_handler() /code/index.php:21
   ```
 
-3. To get a count of how many times any given file is called in a PHP slow log, use a `grep` command. Examples:
+1. To get a count of how many times any given file is called in a PHP slow log, use a `grep` command. Examples:
 
   ```bash{outputLines:2}
   grep -o 'stream_wrappers.inc' php-slow.log | wc -l

--- a/source/scripts/access_getlogs.sh.txt
+++ b/source/scripts/access_getlogs.sh.txt
@@ -64,7 +64,11 @@ echo "[+] SAVING LOGS TO: ${TARGET}"
 
 for app_server in `dig +short appserver.$ENV.$SITEID.drush.in`;
 do
-    rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITEID@appserver.$ENV.$SITEID.drush.in:logs/nginx-access* $TARGET/as_$app_server/
+    if [ -d "/logs/nginx/" ]; then
+      rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITEID@appserver.$ENV.$SITEID.drush.in:/logs/nginx/nginx-access* $TARGET/as_$app_server/
+    else
+      rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITEID@appserver.$ENV.$SITEID.drush.in:logs/nginx-access* $TARGET/as_$app_server/
+    fi
 done
 
 echo "[+] DECOMPRESS GZ FILES"


### PR DESCRIPTION
We are changing where logs live for php and nginx on the platform. This affects how customers retrieve and look at their php and nginx logs.

Old:
```
├── logs
        └──newrelic.log
        └──php-error.log
        └──php-fpm-error.log
        └──php-slow.log
        └──nginx-access.log
        └──nginx-error.log
```
New:
```
├── logs
    └──php
        └──newrelic.log
        └──php-error.log
        └──php-fpm-error.log
        └──php-slow.log
    └──nginx
        └──nginx-access.log
        └──nginx-error.log
```


Closes #PLAT-1318

## Effect
PR includes the following changes:
- updates example scripts for new log directory structure
- updates documentation of logs and directory organizations for php and nginx
- removes video of fetching logs for now till it can be updated
- cleans up references to watcher and ipynotify logs as this system does not exist anymore

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
