### PR TITLE
add disable XML-RPC to checklist

### DIFF
--- a/source/content/guides/launch/07-next-steps.md
+++ b/source/content/guides/launch/07-next-steps.md
@@ -44,6 +44,8 @@ When you're ready to launch another site, use this best-practice checklist to es
 
 <ChecklistItem title="Set Up Outgoing Email" link="/email/" />
 
+<ChecklistItem title="Disable XML-RPC For WordPress" link="wordpress-best-practices#avoid-xml-rpc-attacks" />
+
 <ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />
 
  **OR** 

--- a/source/content/guides/launch/07-next-steps.md
+++ b/source/content/guides/launch/07-next-steps.md
@@ -44,7 +44,7 @@ When you're ready to launch another site, use this best-practice checklist to es
 
 <ChecklistItem title="Set Up Outgoing Email" link="/email/" />
 
-<ChecklistItem title="Disable XML-RPC For WordPress" link="wordpress-best-practices#avoid-xml-rpc-attacks" />
+<ChecklistItem title="Disable XML-RPC For WordPress" link="/wordpress-best-practices/#avoid-xml-rpc-attacks" />
 
 <ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Add disable XML-RPC for WP to launch checklist

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
