### PR TITLE
Fix client IP example in nginx access log

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -154,7 +154,7 @@ See [Parsing nginx Access Logs with GoAccess](/nginx-access-log) for details.
 ### What is the first line in nginx-access.log?
 The first entry reflects an internal IP address of Pantheon's routing layer. The last entry provides a list of IPs used to serve the request, starting with the client IP and ending with internal IPs from the routing layer. For environments with HTTPS enabled, the loadbalancer IP address will be listed second, after the client IP.
 
-The client IP for the following example is `203.0.113.56`:
+The client IP for the following example is `122.248.101.126`:
 
 ```nginx
 203.0.113.56 - - [19/Feb/2016:02:00:00 +0000]  "GET /edu HTTP/1.1" 200 13142 "https://pantheon.io/agencies/pantheon-for-agencies" "Mozilla/5.0 (Windows NT 6.3; WOW64; rv:43.0) Gecko/20100101 Firefox/43.0" 0.399 "122.248.101.126, 50.57.202.75, 10.x.x.x, 10.x.x.x"


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Fixes the nginx access log client IP example to show the actual client IP, instead of the IP of our internal routing layer.

## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
