### PR TITLE
WPML - Correction

### DIFF
--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -977,7 +977,7 @@ For more details, see WPML's documentation on troubleshooting .mo files generati
 1. In `wp-config.php`, add the following after the `define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');` line:
 
   ```php:title=wp-config.php
-  ( 'WP_LANG_DIR', $_SERVER['HOME'] .'/files/languages' );
+  define('WP_LANG_DIR', $_SERVER['HOME'] .'/files/languages');
   ```
 
 2. Create the `languages` directory inside `/files` for each environment.


### PR DESCRIPTION
Changed ( 'WP_LANG_DIR', $_SERVER['HOME'] .'/files/languages' );
to 
define('WP_LANG_DIR', $_SERVER['HOME'] .'/files/languages');

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- Correction to WPML Issue 3
-

## Remaining Work
- [ ] List any outstanding work here
- [ ] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
