### PR TITLE
add addsearch custom tags for categories

### DIFF
--- a/gatsby/src/layout/seo.js
+++ b/gatsby/src/layout/seo.js
@@ -31,6 +31,9 @@ function SEO({ description, lang, meta, keywords, title, authors, image, categor
   const metaDescription = description || site.siteMetadata.description
   const metaImage = image || "/assets/images/default-thumb-doc.png"
   const authorList = authors ? Array.from(authors) : []
+  const addSearchCategories = categories ? categories.map((value) =>
+    `category=${value}`
+  ).join(";") : `category=other`
 
   const titleProps = title ? {
     title: `${title}`,
@@ -39,7 +42,7 @@ function SEO({ description, lang, meta, keywords, title, authors, image, categor
     title: site.siteMetadata.title
   }
 
-  const tagValues = tags && tags.length ?         {
+  const tagValues = tags && tags.length ? {
     property: `og:article:tags`,
     content: `${tags}`
   } : {
@@ -60,6 +63,10 @@ function SEO({ description, lang, meta, keywords, title, authors, image, categor
 
       meta={[
         {...tagValues},
+        {
+          name: `addsearch-custom-field`,
+          content: addSearchCategories
+        },
         {
           itemprop: `name`,
           content: `${title} | ${site.siteMetadata.title}`,


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds an Addsearch custom meta tag containing the categories each doc is listed under.

## Remaining Work
- [x] Technical review (@carolyn-shannon )

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)