### PR TITLE
Addition to the No CI workflow doc

### DIFF
--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -168,7 +168,7 @@ Normally the next step would go through the standard Drupal installation. But si
    git push --force
    ```
 
-   **Note:** the `vendor` directory is being committed to Pantheon. This is because Pantheon needs the full site artifact. If you prefer to ignore the `vendor` directory then take a look at [our Build Tools guide](/guides/build-tools/) for documentation on the more advanced automated workflow with a build step.
+   **Note:** the `vendor` directory is being committed to Pantheon. This is because Pantheon needs the full site artifact. If you prefer to ignore the `vendor` directory then take a look at [our Build Tools guide](/guides/build-tools/) for documentation on the more advanced automated workflow with a build step. With Build Tools, you can also use `terminus build:env:push` for this step. 
 
 ### Installing Drupal
 

--- a/source/content/guides/drupal-8-composer-no-ci.md
+++ b/source/content/guides/drupal-8-composer-no-ci.md
@@ -168,7 +168,13 @@ Normally the next step would go through the standard Drupal installation. But si
    git push --force
    ```
 
-   **Note:** the `vendor` directory is being committed to Pantheon. This is because Pantheon needs the full site artifact. If you prefer to ignore the `vendor` directory then take a look at [our Build Tools guide](/guides/build-tools/) for documentation on the more advanced automated workflow with a build step. With Build Tools, you can also use `terminus build:env:push` for this step. 
+  <Alert type="info" title="Note">
+  
+  The `vendor` directory is being committed to Pantheon. This is because Pantheon needs the full site artifact. If you prefer to ignore the `vendor` directory then take a look at [our Build Tools guide](/guides/build-tools/) for documentation on the more advanced automated workflow with a build step.
+  
+  With Build Tools, you can also use `terminus build:env:push` for this step.
+
+  </Alert>
 
 ### Installing Drupal
 

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -351,6 +351,6 @@
   name: Fatima Sarah Khalid
   avatar: https://avatars2.githubusercontent.com/u/6685950
   github: //github.com/sugaroverflow
-  twitter: sugaroverflow
+  twitter: https://twitter.com/sugaroverflow
   drupal: //www.drupal.org/u/sugaroverflow
   bio: Developer Programs Engineer

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -347,3 +347,10 @@
   linkedin: //www.linkedin.com/in/aleksandr-korolev-575045148
   drupal: //www.drupal.org/u/aleksandrkorolyov
   bio: Software Engineer | DrupalSquad
+- id: sugaroverflow
+  name: Fatima Sarah Khalid
+  avatar: https://avatars2.githubusercontent.com/u/6685950
+  github: //github.com/sugaroverflow
+  twitter: sugaroverflow
+  drupal: //www.drupal.org/u/sugaroverflow
+  bio: Developer Programs Engineer


### PR DESCRIPTION
Inspired by a [composer workflow discussion](https://github.com/pantheon-systems/example-drops-8-composer/pull/319#issuecomment-566786747). 

If users using the No CI Workflow have Build Tools installed, they can use `terminus build:env:push` since it uses `--force` with both the `git add` and `git push` steps. I wasn't sure whether to add a new note to the step, but since Build Tools was already being mentioned,  I added it to the existing one. 

## Effect
PR includes the following changes:
- Adding a note to step 7 of Downloading Drupal Dependencies with Composer
- Adding myself to the contributors list 

## Remaining Work
- [ ] Technical Review @greg-1-anderson 
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)