### PR TITLE
Update GoAccess documentation

### DIFF
--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -1,10 +1,9 @@
 ---
-title: Parsing NGINX Access Logs with GoAccess
+title: Parsing Nginx Access Logs with GoAccess
 description: Learn how to parse the nginx-access.log file with GoAccess to gather information on your visitors and referral traffic.
 tags: [logs]
 categories: [performance]
-goaccess: true
-contributors: [albertcausing]
+contributors: [albertcausing, sarahg]
 ---
 Pantheon runs nginx web servers for optimal performance. Your site's nginx access logs record web server events and activities that can help you identify potential issues and gather information about users.
 
@@ -25,13 +24,13 @@ Be sure that you have:
   * **Mac OS X**: Install via [Homebrew](https://brew.sh/) (`brew install goaccess`)
   * **Windows**: Use [Cygwin](https://cygwin.com/install.html)
   
-This guide is written for the latest stable release of GoAccess as of this writing, which is 1.3 ([release notes](https://goaccess.io/release-notes#release-1.3)).
+This guide is written for the latest stable release of GoAccess as of this writing, which is version 1.3 ([release notes](https://goaccess.io/release-notes#release-1.3)).
 
 ## Edit GoAccess Configuration
 
 To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats.
 
-The configuration file is located under `~/.goaccessrc` or `%sysconfdir%/goaccess.conf` where `%sysconfdir%` is either `/etc/`, `/usr/etc/` or `/usr/local/etc/` [read more](https://goaccess.io/faq#configuration).
+The configuration file is located under `~/.goaccessrc` or `%sysconfdir%/goaccess.conf` where `%sysconfdir%` is either `/etc/`, `/usr/etc/` or `/usr/local/etc/` ([read more](https://goaccess.io/faq#configuration)).
 
 Add the following lines to the `goaccess.conf` file, located in either `/etc/`, `/usr/etc/` or `/usr/local/etc/` depending on your installation method. You can also read from a `goaccess.conf` file in your home directory.
 
@@ -62,7 +61,7 @@ Alternatively, you can generate an HTML report with this command:
 goaccess nginx-access.log > report.html
 ```
 
-Then view that report in your browser:
+View that report in your browser:
 
 ```bash
 open report.html
@@ -89,3 +88,4 @@ goaccess */nginx-access.log* > goaccess.html && open goaccess.html
 - [PHP Slow Log](/php-slow-log/)
 - [PHP Errors and Exceptions](/php-errors/)
 - [Bots and Indexing](/bots-and-indexing/)
+- [Traffic Limits and Overages](/traffic-limits/)

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -48,11 +48,6 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 ```bash
 goaccess nginx-access.log
 ```
-
-This should return a report that looks something like this:
-
-(insert screenshot)
-
 You can use the arrow keys on your keyboard to scroll down to view more of the report, or hit `q` to exit.
 
 Alternatively, you can generate an HTML report with this command:
@@ -84,8 +79,5 @@ goaccess */nginx-access.log* > goaccess.html && open goaccess.html
 
 ## See Also
 - [Log Files on Pantheon](/logs)
-- [MySQL Slow Log](/mysql-slow-log/)
-- [PHP Slow Log](/php-slow-log/)
-- [PHP Errors and Exceptions](/php-errors/)
 - [Bots and Indexing](/bots-and-indexing/)
 - [Traffic Limits and Overages](/traffic-limits/)

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -1,40 +1,71 @@
 ---
-title: Parsing nginx Access Logs with GoAccess
+title: Parsing NGINX Access Logs with GoAccess
 description: Learn how to parse the nginx-access.log file with GoAccess to gather information on your visitors and referral traffic.
 tags: [logs]
 categories: [performance]
 goaccess: true
 contributors: [albertcausing]
 ---
-Pantheon uses nginx web servers for optimal performance. Log files record the web server events and activities and can help you identify potential issues and gather information about users.
+Pantheon runs NGINX web servers for optimal performance. Your site's NGINX access logs record web server events and activities that can help you identify potential issues and gather information about users.
 
 <Alert title="Note" type="info">
 
-Requests served by the [Pantheon Global CDN](/global-cdn) will not hit the nginx webserver and will not be logged in `nginx-access.log`.
+Requests served by the [Pantheon Global CDN](/global-cdn) will not hit the NGINX webserver and will not be logged in `nginx-access.log`.
 
 </Alert>
 
-[GoAccess](https://goaccess.io/) is a free, open source utility that creates on the fly server reports by parsing the `nginx-access.log` file. Use it to quickly identify the most used browsers and operating systems, or to debug failed requests—all from the command line.
+[GoAccess](https://goaccess.io/) is a free, open source utility that creates reports by parsing `nginx-access.log` files. Use it to quickly identify the most used browsers and operating systems, visitor IPs, or most frequent 404s — all from the command line.
 
 ## Before You Begin
 
 Be sure that you have:
 
-- [Terminus](/terminus)
-- [GoAccess](https://goaccess.io/download)
- - **Mac OS X**: Install via [Homebrew](https://brew.sh/)
- - **Windows**: Use [Cygwin](https://cygwin.com/install.html)
+* [Terminus](/terminus)
+* [GoAccess](https://goaccess.io/download)
+  * **Mac OS X**: Install via [Homebrew](https://brew.sh/) (`brew install goaccess`)
+  * **Windows**: Use [Cygwin](https://cygwin.com/install.html)
+  
+This guide is written for the latest stable release of GoAccess as of this writing, which is 1.3 ([release notes](https://goaccess.io/release-notes#release-1.3)).
 
 ## Edit GoAccess Configuration
 
-To parse the Pantheon `nginx-access.log` file with GoAccess, you'll need to specify the unique log formats.
+To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats.
 
-Add the following lines to the `goaccess.conf` file, located in either `/etc/`, `/usr/etc/` or `/usr/local/etc/` depending on your installation method:
+The configuration file is located under `~/.goaccessrc` or `%sysconfdir%/goaccess.conf` where `%sysconfdir%` is either `/etc/`, `/usr/etc/` or `/usr/local/etc/` [read more](https://goaccess.io/faq#configuration).
+
+Add the following lines to the `goaccess.conf` file, located in either `/etc/`, `/usr/etc/` or `/usr/local/etc/` depending on your installation method. You can also read from a `goaccess.conf` file in your home directory.
 
 ```
-time-format %H:%M:%S
+time-format %T
 date-format %d/%b/%Y
-log-format %^ - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T ~h{," }
+log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
+```
+
+## Create a report
+
+1. [Download your NGINX log files](/logs) from Pantheon via SFTP.
+2. From the directory containing your `nginx-access.log` file, run GoAccess:
+
+```bash
+goaccess nginx-access.log
+```
+
+This should return a report that looks something like this:
+
+(insert screenshot)
+
+You can use the arrow keys on your keyboard to scroll down to view more of the report, or hit `q` to exit.
+
+Alternatively, you can generate an HTML report with this command:
+
+```bash
+goaccess nginx-access.log > report.html
+```
+
+Then view that report in your browser:
+
+```bash
+open report.html
 ```
 
 ## Automate GoAccess Reports

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -85,7 +85,7 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 
 ## Troubleshooting
 ### goaccess.conf Not Found
-In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands. (Display the path of the default config file by typing `goaccess -dcf`.)
+In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands. (Display the path of the default config file by typing `goaccess --dcf`.)
 
 Moving `goaccess.conf` from `\Cellar\goaccess\[version]\conf\etc\goaccess` into `\Cellar\goaccess\[version]\conf\etc` resolves the issue. 
 

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -1,7 +1,7 @@
 ---
 title: Parsing Nginx Access Logs with GoAccess
 description: Learn how to parse the nginx-access.log file with GoAccess to gather information on your visitors and referral traffic.
-tags: [logs]
+tags: [logs, nginx, goacess]
 categories: [performance]
 contributors: [albertcausing, sarahg]
 ---
@@ -86,6 +86,8 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 ## Troubleshooting
 ### goaccess.conf Not Found
 In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands. (Display the path of the default config file by typing `goaccess -dcf`.)
+
+Moving `goaccess.conf` from `\Cellar\goaccess\[version]\conf\etc\goaccess` into `\Cellar\goaccess\[version]\conf\etc` resolves the issue. 
 
 ## See Also
 

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -6,11 +6,11 @@ categories: [performance]
 goaccess: true
 contributors: [albertcausing]
 ---
-Pantheon runs NGINX web servers for optimal performance. Your site's NGINX access logs record web server events and activities that can help you identify potential issues and gather information about users.
+Pantheon runs nginx web servers for optimal performance. Your site's nginx access logs record web server events and activities that can help you identify potential issues and gather information about users.
 
 <Alert title="Note" type="info">
 
-Requests served by the [Pantheon Global CDN](/global-cdn) will not hit the NGINX webserver and will not be logged in `nginx-access.log`.
+Requests served by the [Pantheon Global CDN](/global-cdn) will not hit the nginx webserver and will not be logged in `nginx-access.log`.
 
 </Alert>
 
@@ -43,7 +43,7 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 
 ## Create a report
 
-1. [Download your NGINX log files](/logs) from Pantheon via SFTP.
+1. [Download your nginx log files](/logs) from Pantheon via SFTP.
 2. From the directory containing your `nginx-access.log` file, run GoAccess:
 
 ```bash
@@ -70,30 +70,17 @@ open report.html
 
 ## Automate GoAccess Reports
 
-Copy the following script to quickly pull a site's nginx log file and create an HTML report using GoAccess. You can use <i class="fa fa-code"> View Raw</i> to open the file in a new window or tab:
+1. Copy the general log retrieval script from [Automate Downloading Logs](logs#automate-downloading-logs), and use this to download logs from all application containers on the desired environment.
 
-<Download file="access_getlogs.sh" />
-
-GITHUB-EMBED https://github.com/pantheon-systems/documentation/tree/master/source/scripts/access_getlogs.sh.txt bash GITHUB-EMBED
-
-Make the script executable:
+2. Add the following to either `collect-logs.sh` or a separate file:
 
 ```bash
-chmod +x ~/Downloads/access_getlogs.sh
+# Unpack archived log files (optional).
+gunzip */nginx-access.log-*
+
+# Create a GoAccess report and open it in a browser.
+goaccess */nginx-access.log* > goaccess.html && open goaccess.html
 ```
-
-Move the script to `/usr/local/bin/`:
-
-```bash
-sudo mv ~/Downloads/access_getlogs.sh /usr/local/bin/access_getlogs
-```
-
-Generate a report for a given site and environment:
-
-```bash
-access_getlogs --site=<site> --env=<env>
-```
-
 
 
 ## See Also

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -22,7 +22,7 @@ Be sure that you have:
 * [Terminus](/terminus)
 * [GoAccess](https://goaccess.io/download)
   * **Mac OS X**: Install via [Homebrew](https://brew.sh/) (`brew install goaccess`)
-  * **Windows**: Use [Cygwin](https://cygwin.com/install.html)
+  * **Windows**: Use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
   
 This guide is written for the latest stable release of GoAccess as of this writing, which is version 1.3 ([release notes](https://goaccess.io/release-notes#release-1.3)).
 
@@ -32,9 +32,9 @@ To parse your `nginx-access.log` files with GoAccess, you'll need to configure G
 
 The configuration file is located under `~/.goaccessrc` or `%sysconfdir%/goaccess.conf` where `%sysconfdir%` is either `/etc/`, `/usr/etc/` or `/usr/local/etc/` ([read more](https://goaccess.io/faq#configuration)).
 
-Add the following lines to the `goaccess.conf` file, located in either `/etc/`, `/usr/etc/` or `/usr/local/etc/` depending on your installation method. You can also read from a `goaccess.conf` file in your home directory.
+Add the following lines to the `goaccess.conf` file:
 
-```
+```conf:title=goaccess.conf
 time-format %T
 date-format %d/%b/%Y
 log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
@@ -43,41 +43,52 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 ## Create a report
 
 1. [Download your nginx log files](/logs) from Pantheon via SFTP.
-2. From the directory containing your `nginx-access.log` file, run GoAccess:
+1. From the directory containing your `nginx-access.log` file, run GoAccess:
 
-```bash
-goaccess nginx-access.log
-```
-You can use the arrow keys on your keyboard to scroll down to view more of the report, or hit `q` to exit.
+  ```bash{promptUser: user}
+  goaccess nginx-access.log
+  ```
 
-Alternatively, you can generate an HTML report with this command:
+  You can use the arrow keys on your keyboard to scroll down to view more of the report, or hit `q` to exit.
 
-```bash
-goaccess nginx-access.log > report.html
-```
+  Alternatively, you can generate an HTML report:
 
-View that report in your browser:
+  ```bash{promptUser: user}
+  goaccess nginx-access.log > report.html
+  ```
 
-```bash
-open report.html
-```
+1. View the report in your browser by opening `report.html`. For MacOS:
+
+  ```bash{promptUser: user}
+  open report.html
+  ```
+
+  For Linux:
+
+  ```bash{promptUser: user}
+  xdg-open report.html
+  ```
 
 ## Automate GoAccess Reports
 
-1. Copy the general log retrieval script from [Automate Downloading Logs](logs#automate-downloading-logs), and use this to download logs from all application containers on the desired environment.
+1. Copy the general log retrieval script from [Automate Downloading Logs](/logs#automate-downloading-logs), and use this to download logs from all application containers on the desired environment.
 
 2. Add the following to either `collect-logs.sh` or a separate file:
 
-```bash
-# Unpack archived log files (optional).
-gunzip */nginx-access.log-*
+  ```bash
+  # Unpack archived log files (optional).
+  gunzip */nginx-access.log-*
 
-# Create a GoAccess report and open it in a browser.
-goaccess */nginx-access.log* > goaccess.html && open goaccess.html
-```
+  # Create a GoAccess report and open it in a browser.
+  goaccess */nginx-access.log* > goaccess.html && open goaccess.html # Or xdg-open for Linux
+  ```
 
+## Troubleshooting
+### goaccess.conf Not Found
+In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands. (Display the path of the default config file by typing `goaccess -dcf`.)
 
 ## See Also
-- [Log Files on Pantheon](/logs)
-- [Bots and Indexing](/bots-and-indexing/)
-- [Traffic Limits and Overages](/traffic-limits/)
+
+* [Log Files on Pantheon](/logs)
+* [Bots and Indexing](/bots-and-indexing/)
+* [Traffic Limits and Overages](/traffic-limits/)


### PR DESCRIPTION
Updates https://pantheon.io/docs/nginx-access-log

## Effect
PR includes the following changes:
Refreshes the GoAccess doc. The existing doc doesn't seem to work with the latest release of GoAccess (seems like a log format issue), and we could provide clearer directions about how to actually run and utilize these reports.

## Remaining Work
- [x] Review/update the automation script
- [x] Technical review (also testing on Windows if possible — no idea if the suggestion to use Cygwin works)
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
