### PR TITLE
modify external link CTAs

### DIFF
--- a/gatsby/src/components/externalLink.js
+++ b/gatsby/src/components/externalLink.js
@@ -2,13 +2,13 @@ import React from "react"
 
 const ExternalLink = ({ text, link }) => {
   var classes = "external"
-  if (link === "https://pantheon.io/contact-us" ||
-      link === "https://pantheon.io/pantheon-top-edu" ||
-      link === "https://pantheon.io/agencies/partner-program" ||
-      link === "https://pantheon.io/register" ||
-      link === "https://pantheon.io/edu" ||
-      link === "https://pantheon.io/plans/elite" ||
-      link === "https://pantheon.io/essential-developer-training" )
+  if (link == "https://pantheon.io/contact-us" ||
+      link == "https://pantheon.io/pantheon-top-edu" ||
+      link == "https://pantheon.io/agencies/partner-program" ||
+      link == "https://pantheon.io/register" ||
+      link == "https://pantheon.io/edu" ||
+      link == "https://pantheon.io/plans/elite" ||
+      link == "https://pantheon.io/essential-developer-training" )
     {
       classes = "external cta docs-cta"
       link = link + "?docs"


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Modifies externalLink.js CTA comparisons to permit Docs attribution from Docs CTA links.

## Remaining Work
- [ ] Technical review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
