### PR TITLE
Remove cname details

### DIFF
--- a/source/partials/standard-dns-config.md
+++ b/source/partials/standard-dns-config.md
@@ -2,10 +2,7 @@
 
  Standard DNS configurations utilize the following:
 
-  - Bare Domain (`example.com` or `@`):
-      -  Two AAAA records pointing to unique IPv6 addresses
-      -  One A record pointing to an IPv4 address
-  -  Subdomain (`www`):
-      -  One CNAME record pointing to the Live environment's platform domain (e.g. `live-site-name.pantheonsite.io`)
+  -  Two AAAA records pointing to unique IPv6 addresses
+  -  One A record pointing to an IPv4 address
 
 </Accordion>

--- a/source/partials/standard-dns-config.md
+++ b/source/partials/standard-dns-config.md
@@ -1,8 +1,8 @@
 <Accordion title="Standard DNS Configurations" id="dns-config" icon="info-sign">
 
- Standard DNS configurations utilize the following:
+ Standard DNS configurations utilize the following configuration for both the bare domain (`example.com`) and any subdomains (like `www`):
 
-  -  Two AAAA records pointing to unique IPv6 addresses
-  -  One A record pointing to an IPv4 address
+  *  Two AAAA records pointing to unique IPv6 addresses
+  *  One A record pointing to an IPv4 address
 
 </Accordion>


### PR DESCRIPTION
Removes reference to CNAME configuration for subdomains that is no longer recommended in the "Details" page for any domains.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- Removes reference to no-longer-recommended CNAME use for subdomains

## Remaining Work
- [ ] List any outstanding work here
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
