### PR TITLE
Add link to Reducing Large Repos from Platform Considerations

### DIFF
--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -146,7 +146,7 @@ If you require this behavior, [Advanced CDN](/professional-services#advanced-cdn
 ## Large Code Repository
 When a code repo is larger than 2GB, it increases the possibility of Git errors when committing code on Pantheon. We suggest keeping multimedia assets out of the repo by moving them to a media file storage service such as [Amazon S3](https://aws.amazon.com/s3/), and using version control to track URLs. 
 
-If your repository has grown over 2GB and is causing problems (such as errors when cloning), consider [pruning and optimizing the repo](reducing-large-repos).
+If your repository has grown over 2GB and is causing problems (such as errors when cloning), consider [pruning and optimizing the repo](/reducing-large-repos/).
 
 ## Large Files
 Due to the configuration of the [Pantheon Filesystem](/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through WordPress or Drupal, and must be added by [SFTP or rsync](/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -144,7 +144,9 @@ For more information, see [Dynamic Outgoing IP Addresses](/outgoing-ips).
 If you require this behavior, [Advanced CDN](/professional-services#advanced-cdn) can provide IP-based whitelist/blacklist features, as well as IP-based routing. Please contact your Customer Success Manager (CSM) or [contact us](https://pantheon.io/contact-us?docs) for more information.
 
 ## Large Code Repository
-When a code repo is larger than 2GB, it increases the possibility of Git errors when committing code on Pantheon. We suggest keeping multimedia assets out of the repo by moving them to a media file storage service such as [Amazon S3](https://aws.amazon.com/s3/), and using version control to track URLs.
+When a code repo is larger than 2GB, it increases the possibility of Git errors when committing code on Pantheon. We suggest keeping multimedia assets out of the repo by moving them to a media file storage service such as [Amazon S3](https://aws.amazon.com/s3/), and using version control to track URLs. 
+
+If your repository has grown over 2GB and is causing problems (such as errors when cloning), consider [pruning and optimizing the repo](reducing-large-repos).
 
 ## Large Files
 Due to the configuration of the [Pantheon Filesystem](/files/), Pantheon's file serving infrastructure is not optimized to store and deliver very large files. Files over 100MB cannot be uploaded through WordPress or Drupal, and must be added by [SFTP or rsync](/rsync-and-sftp/). Files over 256MB will fail no matter how they are uploaded. Transfers with files over 50MB will experience noticeable degradation in performance.


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Adds link to [Reducing Large Repos](https://pantheon.io/docs/reducing-large-repos) from [Platform Considerations](https://pantheon.io/docs/platform-considerations#large-code-repository)

## Remaining Work
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [x] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
