### PR TITLE
add CSS widths for larger screen sizes

### DIFF
--- a/gatsby/src/styles/main.css
+++ b/gatsby/src/styles/main.css
@@ -968,6 +968,35 @@ span#changelog-rsaquo {
 .guide-content-well {
 	/*border-bottom: .1em solid #eef2f3;*/
 }
+
+@media (min-width: 1300px) {
+	.doc-content-well {
+		width: 1270px;
+		padding-right: 0px;
+	}
+}
+
+@media (min-width: 1400px) {
+	.doc-content-well {
+		width: 1380px;
+		padding-right: 0px;
+	}
+}
+
+@media (min-width: 1700px) {
+	.doc-content-well {
+		width: 1680px;
+		padding-right: 0px;
+	}
+}
+
+@media (min-width: 2000px) {
+	.doc-content-well {
+		width: 1980px;
+		padding-right: 0px;
+	}
+}
+
 .doc-content-well {
 	padding-bottom: 50px;
 }


### PR DESCRIPTION
As a reader with a large screen resolution, I want the content to better expand to use the space I give it when I resize my browser window.

##  Effect
PR includes the following changes:
- Adds CSS to expand the doc-content-well class when the screen size reaches larger intervals.

## Remaining Work
- [ ] Technical review (@carolyn-shannon ?)
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
