### PR TITLE
warn hsts plugin/module users

### DIFF
--- a/source/partials/hsts.md
+++ b/source/partials/hsts.md
@@ -2,7 +2,7 @@
 
 Before adjusting `enforce_https`, review and understand the configuration options and all considerations to avoid unintended consequences.
 
-If you decide to use a plugin or module to set your HSTS header, you _must_ disable `enforce_https` in `pantheon.yml` to avoid duplicate headers, which creates an invalid policy.
+If you use a plugin or module to set your HSTS header, it will create a duplicate header. Disable `enforce_https` in `pantheon.yml` to avoid an invalid policy.
 
 </Alert>
 

--- a/source/partials/hsts.md
+++ b/source/partials/hsts.md
@@ -2,6 +2,8 @@
 
 Before adjusting `enforce_https`, review and understand the configuration options and all considerations to avoid unintended consequences.
 
+If you decide to use a plugin or module to set your HSTS header, you _must_ disable `enforce_https` in `pantheon.yml` to avoid duplicate headers, which creates an invalid policy.
+
 </Alert>
 
 Use of the HSTS header is defined by the `enforce_https` directive, and takes five possible values which are handled by Pantheon as shown below:


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes #5278

## Effect
PR includes the following changes:
- Warns that `enfore_https` must be disabled when using modules or plugins to set HSTS headers.
-

## Remaining Work
- [x] Input from @rachelwhitton
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)