### PR TITLE
Remove lcache from Pantheon Modules

### DIFF
--- a/source/content/modules.md
+++ b/source/content/modules.md
@@ -16,9 +16,6 @@ WordPress users, see [Pantheon Plugins](/plugins/) for details on WordPress plug
 ## [Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache)
 The Advanced Page Cache module attaches [Drupal's cache metadata](https://www.drupal.org/docs/8/api/cache-api/cache-api) to a response so that Pantheon's [Global CDN](/global-cdn/) edge service can granularly clear new content as it is saved. The Global CDN can detect when underlying data changes, such as nodes and taxonomy terms, then clear pages containing that entity. For details, see [this blog post](https://pantheon.io/blog/pantheon-advanced-page-cache-drupal-cache-metadata-global-cdn).
 
-## [LCache](https://www.drupal.org/project/lcache)
-LCache is a module that applies the tiered caching model of multi-core processors (with local L1 and central L2 caches) to web applications. This allows scaling cache read access independently of network throughput. The current production implementation uses APCu as L1 and the database as L2.
-
 ## [Site Audit](https://www.drupal.org/project/site_audit)
 Static site analysis as a service for Drupal sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the Status tab and are accessible by site team members. For more details, see [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check/).
 


### PR DESCRIPTION
Closes #5438

## Effect
PR includes the following changes:
- Removes Lcache listing. Module hasn't been updated in 4 years, and is reported as not working.
- Lcache was designed to solve a problem on old infra.

## Remaining Work
- [x] @davidstrauss to waive or exercise veto.

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)