### PR TITLE
Move GoAccess troubleshooting to relevant section

### DIFF
--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -71,9 +71,14 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
   ```
 
 ### Troubleshooting "goaccess.conf Not Found"
-In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands.
+In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found by the binary. To resolve:
 
-1. Display the path of the default config file by typing `goaccess --dcf`.
+1. Display the default config path:
+
+  ```bash{promptUser: user}
+  goaccess --dcf
+  ```
+
 1. Move `goaccess.conf` from `/usr/local/Cellar/goaccess/[VERSION]/conf/etc/goaccess` to `/usr/local/Cellar/goaccess/[VERSION]/conf/etc`:
 
   ```bash{promptUser: user}

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -74,10 +74,10 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands.
 
 1. Display the path of the default config file by typing `goaccess --dcf`.
-1. Move `goaccess.conf` from `\Cellar\goaccess\[version]\conf\etc\goaccess` to `\Cellar\goaccess\[version]\conf\etc`:
+1. Move `goaccess.conf` from `/usr/local/Cellar/goaccess/[VERSION]/conf/etc/goaccess` to `/usr/local/Cellar/goaccess/[VERSION]/conf/etc`:
 
   ```bash{promptUser: user}
-  mv /Cellar/goaccess/[version]/conf/etc/goaccess /Cellar/goaccess/[version]/conf/etc
+  mv /usr/local/Cellar/goaccess/[VERSION]/conf/etc/goaccess /usr/local/Cellar/goaccess/[VERSION]/conf/etc
   ```
 
 ## Automate GoAccess Reports

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -80,6 +80,8 @@ In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goacce
   mv /usr/local/Cellar/goaccess/[VERSION]/conf/etc/goaccess /usr/local/Cellar/goaccess/[VERSION]/conf/etc
   ```
 
+An [issue has been filed](https://github.com/allinurl/goaccess/issues/1640) on the GoAccess repo.
+
 ## Automate GoAccess Reports
 
 1. Copy the general log retrieval script from [Automate Downloading Logs](/logs#automate-downloading-logs), and use this to download logs from all application containers on the desired environment.

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -4,7 +4,7 @@ description: Learn how to parse the nginx-access.log file with GoAccess to gathe
 tags: [logs, nginx, goacess]
 categories: [performance]
 contributors: [albertcausing, sarahg]
-reviewed: "2019-12-30"
+reviewed: "2020-01-09"
 ---
 Pantheon runs nginx web servers for optimal performance. Your site's nginx access logs record web server events and activities that can help you identify potential issues and gather information about users.
 
@@ -43,7 +43,7 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
 
 ## Create a report
 
-1. [Download your nginx log files](/logs) from Pantheon via SFTP.
+1. [Download your nginx log files](/logs/) from Pantheon via SFTP.
 1. From the directory containing your `nginx-access.log` file, run GoAccess:
 
   ```bash{promptUser: user}
@@ -70,6 +70,16 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
   xdg-open report.html
   ```
 
+### Troubleshooting "goaccess.conf Not Found"
+In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands.
+
+1. Display the path of the default config file by typing `goaccess --dcf`.
+1. Move `goaccess.conf` from `\Cellar\goaccess\[version]\conf\etc\goaccess` to `\Cellar\goaccess\[version]\conf\etc`:
+
+  ```bash{promptUser: user}
+  mv /Cellar/goaccess/[version]/conf/etc/goaccess /Cellar/goaccess/[version]/conf/etc
+  ```
+
 ## Automate GoAccess Reports
 
 1. Copy the general log retrieval script from [Automate Downloading Logs](/logs#automate-downloading-logs), and use this to download logs from all application containers on the desired environment.
@@ -83,12 +93,6 @@ log-format %h - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%^"
   # Create a GoAccess report and open it in a browser.
   goaccess */nginx-access.log* > goaccess.html && open goaccess.html # Or xdg-open for Linux
   ```
-
-## Troubleshooting
-### goaccess.conf Not Found
-In certain MacOS [Homebrew](https://brew.sh/) installations of GoAccess, `goaccess.conf` is not found when running `goaccess` commands. (Display the path of the default config file by typing `goaccess --dcf`.)
-
-Moving `goaccess.conf` from `\Cellar\goaccess\[version]\conf\etc\goaccess` into `\Cellar\goaccess\[version]\conf\etc` resolves the issue. 
 
 ## See Also
 


### PR DESCRIPTION
## Effect
PR includes the following changes:
- As suggested by @CFin86 , the troubleshooting section is easy to miss when it's at the bottom, bringing it up to the Mac section may save people some searching
- changed the term commands to `/` from `\` and to the homebrew dir
- Linked to the issue @carolyn-shannon filed with GoAccess as well

## Remaining Work
- [x] Technical review / Copy Review
- [ ] Set a reminder to check on the issue in x amount of time

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
