### PR TITLE
update Terminus and related instructions for WSL

### DIFF
--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -24,6 +24,7 @@ import Releases from "../components/releases"
 import TerminusVersion from "../components/terminusVersion"
 import Download from "../components/download"
 import Commands from "../components/commands"
+import ReviewDate from "../components/reviewDate"
 
 const shortcodes = {
   Callout,
@@ -40,6 +41,7 @@ const shortcodes = {
   TerminusVersion,
   Download,
   Commands,
+  ReviewDate
 }
 
 // @TODO relocate this list
@@ -128,6 +130,7 @@ class TerminusTemplate extends React.Component {
   render() {
     const node = this.props.data.mdx
     const contentCols = node.frontmatter.showtoc ? 9 : 12
+    const isoDate = this.props.data.date
 
     return (
       <Layout>
@@ -136,6 +139,7 @@ class TerminusTemplate extends React.Component {
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
           image={"/assets/images/terminus-thumbLarge.png"}
+          reviewed={isoDate.frontmatter.reviewed}
         />
         <div className="">
           <div className="container">
@@ -158,6 +162,8 @@ class TerminusTemplate extends React.Component {
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
                       editPath={node.fields.editPath}
+                      reviewDate={node.frontmatter.reviewed}
+                      isoDate={isoDate.frontmatter.reviewed}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.body}</MDXRenderer>
@@ -212,8 +218,14 @@ export const pageQuery = graphql`
           name
           twitter
         }
+        reviewed(formatString: "MMMM DD, YYYY")
       }
       fileAbsolutePath
+    }
+    date: mdx(fields: { slug: { eq: $slug } }) {
+      frontmatter {
+        reviewed
+      }
     }
   }
 `

--- a/source/content/cygwin-windows.md
+++ b/source/content/cygwin-windows.md
@@ -6,13 +6,25 @@ categories: [develop]
 deprecated: true
 deprecatednote: Terminus is no longer supported on Windows, and this document is unmaintained. See the [Terminus Support](/platform-considerations/#terminus-support) section of Platform Considerations for more information.
 ---
+
+<Alert title="Warning" type="danger" >
+
+This guide is unmaintained. For Windows 10 users, we recommend using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+
+</Alert>
+
 If you do not have access to a Mac or Linux environment, you can install [Cygwin](https://cygwin.com/) to perform tasks typically not possible in Windows, such as:
 
 * Installing and using [Terminus, the Pantheon command line interface (CLI)](https://github.com/pantheon-systems/cli)
 
 ## Install Cygwin
+
 1. Download the [Cygwin](https://cygwin.com/install.html) installer and run `setup.exe`.
-2. Click **Next** through the defaults and select **mirror** for downloading packages.
-3. Search for each package, open the appropriate category (Net or PHP), and click **Skip** next to each package to select it for installation. Required packages: `curl`, `openssh`, `openssl` (Net), `php`, `php-curl`, `php-json`, `php-phar` (PHP)
-![Select openSSL package](../images/cygwin-select-packages.png)
-4. Complete the set up. Repeat this process when updating Cygwin or adding more packages.
+
+1. Click **Next** through the defaults and select **mirror** for downloading packages.
+
+1. Search for each package, open the appropriate category (Net or PHP), and click **Skip** next to each package to select it for installation. Required packages: `curl`, `openssh`, `openssl` (Net), `php`, `php-curl`, `php-json`, `php-phar` (PHP)
+
+  ![Select openSSL package](../images/cygwin-select-packages.png)
+
+1. Complete the set up. Repeat this process when updating Cygwin or adding more packages.

--- a/source/content/cygwin-windows.md
+++ b/source/content/cygwin-windows.md
@@ -3,6 +3,7 @@ title: Install Cygwin on Windows
 description: Learn how to install and configure Cygwin on Windows computers for Pantheon sites.
 tags: [local]
 categories: [develop]
+reviewed: "2020-02-05"
 ---
 
 <Alert title="Warning" type="danger" >

--- a/source/content/cygwin-windows.md
+++ b/source/content/cygwin-windows.md
@@ -3,13 +3,11 @@ title: Install Cygwin on Windows
 description: Learn how to install and configure Cygwin on Windows computers for Pantheon sites.
 tags: [local]
 categories: [develop]
-deprecated: true
-deprecatednote: Terminus is no longer supported on Windows, and this document is unmaintained. See the [Terminus Support](/platform-considerations/#terminus-support) section of Platform Considerations for more information.
 ---
 
 <Alert title="Warning" type="danger" >
 
-This guide is unmaintained. For Windows 10 users, we recommend using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10).
+This guide is unmaintained. For Windows 10 users, we recommend using the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10) to create a Linux environment on Windows. Once you've installed the Subsystem, follow the instructions in the [Terminus Manual](/terminus/install/).
 
 </Alert>
 

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -15,7 +15,7 @@ searchboost: 200
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then follow the instructions in the [Terminus Manual](/terminus/install/). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy/).
+[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy/).
 
 <Enablement title="Command Line Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 
@@ -45,6 +45,7 @@ If you are a plugin author, you will need to update your plugin for Terminus 2. 
 Terminus is open source! View the project on [GitHub](https://github.com/pantheon-systems/terminus) to contribute, file issues, and submit feature requests.
 
 ## Support
+
 Terminus is open source. Community submitted bugs and feature requests can be found [in the Terminus GitHub issues queue](https://github.com/pantheon-systems/terminus/issues). Don't see your bug or feedback listed? Create an issue on [Terminus' GitHub page](https://github.com/pantheon-systems/terminus/issues/new).
 
 Need help with Terminus? [Contact Support](https://dashboard.pantheon.io/#support/support/all).

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -10,6 +10,7 @@ categories: [workflow,develop]
 permalink: docs/:basename/
 nexturl: terminus/install/
 image: terminus-thumbLarge
+reviewed: "2020-02-05"
 searchboost: 200
 ---
 

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -15,7 +15,7 @@ searchboost: 200
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-[Install Terminus](/terminus/install) on Mac OS X or Linux. For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy).
+[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy).
 
 <Enablement title="Command Line Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -15,7 +15,7 @@ searchboost: 200
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy).
+[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then follow the instructions in the [Terminus Manual](/terminus/install/). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy/).
 
 <Enablement title="Command Line Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -16,7 +16,7 @@ searchboost: 200
 
 Our command line interface, Terminus, provides advanced interaction with Pantheon. Terminus enables you to do almost everything in a terminal that you can do in the Dashboard, and much more.
 
-[Install Terminus](/terminus/install) on Mac OS X or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy/).
+Install Terminus on macOS or Linux. Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10). For details on legacy versions of Terminus, see [Legacy Terminus Versions](/terminus/get-started/legacy/).
 
 <Enablement title="Command Line Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 
@@ -26,20 +26,20 @@ Increase your developers' confidence on Terminus and generate ideas for writing 
 
 ## Usage
 
-Use Terminus to perform these and [other operations](/terminus/commands):
+Use Terminus to perform these and [other operations](/terminus/commands/):
 
 - Create a new site
 - Create and delete Multidev environments
 - Clone one environment to another
 - Check for and apply upstream updates
 - Deploy code from one environment to another
-- Run [Drush](/drush) and [WP-CLI](/wp-cli) commands
+- Run [Drush](/drush/) and [WP-CLI](/wp-cli/) commands
 
 ## Contribute
 
 <Alert title="Note" type="info">
 
-If you are a plugin author, you will need to update your plugin for Terminus 2. See [what's new in Terminus 2.x](/terminus-2-0) to learn more.
+If you are a plugin author, you will need to update your plugin for Terminus 2. See [what's new in Terminus 2.x](/terminus-2-0/) to learn more.
 
 </Alert>
 

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -37,6 +37,21 @@ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/ma
 
 See [Troubleshooting](#troubleshooting) if your installation fails, or the [Installation](https://github.com/pantheon-systems/terminus#installation) section of the Terminus README file on GitHub for advanced installation methods.
 
+### Windows: Enable the terminus command
+
+If you encounter the following error after installation completes:
+
+```bash
+Terminus was installed, but the installer was not able to write to your bin dir. To enable the
+`terminus` command, add this alias to your .bash_profile (Mac) or .bashrc (Linux) file:
+```
+
+Use `alias` to have the `terminus` command call the application:
+
+```bash{promptUser: user}
+alias terminus=~/vendor/bin/terminus
+```
+
 ## Authenticate
 
 ### Machine Token
@@ -66,8 +81,8 @@ Commands that execute remote instructions to tools like Drush or WP-CLI require 
 If the installer throws an IOException at the end:
 
 ```bash
-  [Symfony\Component\Filesystem\Exception\IOException]
-  Failed to create symbolic link from "/path/to/current/dir/vendor/bin/terminus" to "/usr/local/bin/terminus".
+[Symfony\Component\Filesystem\Exception\IOException]
+Failed to create symbolic link from "/path/to/current/dir/vendor/bin/terminus" to "/usr/local/bin/terminus".
 ```
 
 You may need to remove an old installation from terminus from `/usr/local/bin/terminus`.
@@ -113,21 +128,12 @@ To resolve, save a copy of the [latest CA certificate](https://curl.haxx.se/docs
 
 The default Linux environment installed by the WSL may not have all of the requirements for Terminus installed. Using your distribution's package manager, install:
 
-- PHP (includeing `php-cli`, `php-curl`, and `php-xml`)
+- PHP (including `php-cli`, `php-curl`, and `php-xml`)
 - Curl (to download the installer)
 
-#### The Terminus install was successful, but the path was not set
-
-Terminus was installed, but the installer was not able to write to your bin dir.
-
-**Solution:** To enable the `terminus` command, add this alias to your [`.bash_profile` file](https://askubuntu.com/questions/969632/where-is-bash-profile-located-in-windows-subsystem-for-linux):
+On a subsystem with Ubuntu 18.04, since Curl is already installed, the commands to run all updates and install the PHP package look like this:
 
 ```bash{promptUser:user}
-alias terminus='terminus=/c/Users/User1/vendor/bin/terminus'
-```
-
-Or you can enable it by adding the directory the executable file is in to your path:
-
-```bash:title=.bashrc
-PATH="C:\Users\User1\vendor\bin:$PATH"
+sudo apt update && sudo apt upgrade -y
+sudo apt install php7.2-cli
 ```

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -16,7 +16,7 @@ searchboost: 100
 
 Terminus is available for Mac OS X and Linux.
 
-Some Windows users have installed Terminus using [Git BASH on Git for Windows](https://git-for-windows.github.io/), or the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), but this is unsupported.
+Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then install Terminus in the Linux shell.
 
 Because some Terminus commands use SSH authentication, consider [generating and adding SSH keys](/ssh-keys) to your account before you continue.
 
@@ -29,10 +29,10 @@ Because some Terminus commands use SSH authentication, consider [generating and 
 
 ## Install
 
-Install the most recent release of Terminus with the following command within a directory where you have permission to write files. If in doubt, you can create a <code>terminus</code> directory in your <code>\$HOME</code> and install there:
+Install the most recent release of Terminus with the following command within a directory where you have permission to write files. If in doubt, you can create a `terminus` directory in your `$HOME` and install there:
 
-```bash
-  curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
+```bash{promptUser: user}
+curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
 ```
 
 See [Troubleshooting](#troubleshooting) if your installation fails, or the [Installation](https://github.com/pantheon-systems/terminus#installation) section of the Terminus README file on GitHub for advanced installation methods.
@@ -47,12 +47,12 @@ First, [create a Machine Token](https://dashboard.pantheon.io/login?destination=
 
 Once the token has been created, use it to authenticate Terminus by running the following command:
 
-```bash
-  terminus auth:login --machine-token=‹machine-token›
+```bash{promptUser: user}
+terminus auth:login --machine-token=‹machine-token›
 ```
 
-```bash
-  terminus auth:login --email=dev@example.com
+```bash{promptUser: user}
+terminus auth:login --email=dev@example.com
 ```
 
 ### SSH Authentication
@@ -82,9 +82,9 @@ curl: (23) Failed writing body (0 != 1928)
 
 You should relocate your installation to a directory where you have permission to write files. If in doubt, you can create a `terminus` diretory in your `$HOME` and go there:
 
-```bash
-  cd $HOME/terminus
-  curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install</code></pre></figure>
+```bash{promptUser: user}
+cd $HOME/terminus
+curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
 ```
 
 ### PHP Fatal error: Uncaught exception 'ReflectionException'
@@ -109,38 +109,25 @@ To resolve, save a copy of the [latest CA certificate](https://curl.haxx.se/docs
 
 ### Windows 10 Installation issues
 
-**Problem:** PHP is not installed.
+#### Prerequisites are not installed
 
-**Solution:** Install PHP. Consider using a package such as [XAMMP](https://www.apachefriends.org/index.html), which provides a simple installation process.
+The default Linux environment installed by the WSL may not have all of the requirements for Terminus installed. Using your distribution's package manager, install:
 
-**Problem:** Composer is not installed.
+- PHP (includeing `php-cli`, `php-curl`, and `php-xml`)
+- Curl (to download the installer)
 
-**Solution:** Install composer using the [.exe installer](https://getcomposer.org/doc/00-intro.md#installation-windows)
-
-**Problem:** `curl: command not found`
-
-Installation fails because curl cannot be found:
-
-```bash
-User1@DESKTOP-UBJ92JO  /usr/bin
-$ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/master/builds/installer.phar && php installer.phar install
-bash: curl: command not found
-```
-
-**Solution:** [Install curl](https://stackoverflow.com/questions/9507353/how-do-i-install-set-up-and-use-curl-on-windows)
-
-**Problem:** The Terminus install was successful, but the path was not set.
+#### The Terminus install was successful, but the path was not set
 
 Terminus was installed, but the installer was not able to write to your bin dir.
 
 **Solution:** To enable the `terminus` command, add this alias to your [`.bash_profile` file](https://askubuntu.com/questions/969632/where-is-bash-profile-located-in-windows-subsystem-for-linux):
 
-```bash
-alias terminus=terminus=/c/Users/User1/vendor/bin/terminus
+```bash{promptUser:user}
+alias terminus='terminus=/c/Users/User1/vendor/bin/terminus'
 ```
 
 Or you can enable it by adding the directory the executable file is in to your path:
 
-```bash
+```bash:title=.bashrc
 PATH="C:\Users\User1\vendor\bin:$PATH"
 ```

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -11,6 +11,7 @@ permalink: docs/terminus/:basename/
 nexturl: terminus/examples/
 previousurl: terminus/
 image: terminus-thumbLarge
+reviewed: "2020-02-05"
 searchboost: 100
 ---
 

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -27,7 +27,40 @@ Because some Terminus commands use SSH authentication, consider [generating and 
 - [PHP-CURL](https://secure.php.net/manual/en/curl.setup.php)
 - [Composer](https://getcomposer.org/download/)
 
-## Install
+## Install Terminus
+
+There are several ways to install Terminus, depending on your use case:
+
+- For a self-contained Terminus executable, [install terminus.phar](#standalone-terminus).
+- For a composer-managed version of Terminus that is _not_ part of your other composer-managed project(s) and doesn't utilize global composer installations, use the [Terminus installer PHAR](#terminus-installer-phar).
+- If you want to contribute to the Terminus project, [download and install](https://github.com/pantheon-systems/terminus#installing-with-git) from the git repository.
+- To add Terminus as a dependency of your composer-based project, [install with Composer](#install-terminus-as-a-project-dependency).
+
+### Standalone Terminus
+
+1. Download the latest `terminus.phar` from the [Releases](https://github.com/pantheon-systems/terminus/releases) page. In the example below, we're directing the file to `$HOME/bin/` and renaming the file to `terminus`:
+
+  ```bash{promptUser: user}
+  wget https://github.com/pantheon-systems/terminus/releases/download/2.3.0/terminus.phar -O ~/.bin/terminus
+  ```
+
+  Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above vermatim.
+
+  Your installation directory must be in or added to your `$PATH` environment variable in order to call `terminus` from any working directory.
+
+1. Make the Terminus file exectable. The example below assumes the same installation path as above:
+
+  ```bash{promptUser: user}
+  chmod +X ~/.bin/terminus
+  ```
+
+<Alert type="info" title="Note">
+
+There is an unofficial third party installer script which will download `terminus.phar` and attempt to update the appropriate rc files, available [here](https://github.com/alexfornuto/terminus-installer). Note that this script is *not* supported directly by Pantheon.
+
+</Alert>
+
+### Terminus Installer PHAR
 
 Install the most recent release of Terminus with the following command within a directory where you have permission to write files. If in doubt, you can create a `terminus` directory in your `$HOME` and install there:
 
@@ -37,19 +70,12 @@ curl -O https://raw.githubusercontent.com/pantheon-systems/terminus-installer/ma
 
 See [Troubleshooting](#troubleshooting) if your installation fails, or the [Installation](https://github.com/pantheon-systems/terminus#installation) section of the Terminus README file on GitHub for advanced installation methods.
 
-### Windows: Enable the terminus command
+### Install Terminus as a Project Dependency
 
-If you encounter the following error after installation completes:
-
-```bash
-Terminus was installed, but the installer was not able to write to your bin dir. To enable the
-`terminus` command, add this alias to your .bash_profile (Mac) or .bashrc (Linux) file:
-```
-
-Use `alias` to have the `terminus` command call the application:
+To add Terminus to a composer-managed project:
 
 ```bash{promptUser: user}
-alias terminus=~/vendor/bin/terminus
+composer install pantheon-systems/terminus
 ```
 
 ## Authenticate
@@ -121,6 +147,21 @@ curl: (60) SSL certificate problem: unable to get local issuer certificate
 ```
 
 To resolve, save a copy of the [latest CA certificate](https://curl.haxx.se/docs/caextract.html) to a new file named `cacert.pem` then add `curl.cainfo = "[path_to_file]\cacert.pem"` to your `php.ini` file. If you're running XAMPP, you can add the `cacert.pem` file within the `xampp\php\extras\ssl` directory.
+
+### Enable the terminus command
+
+If you encounter the following error after installation completes:
+
+```bash
+Terminus was installed, but the installer was not able to write to your bin dir. To enable the
+`terminus` command, add this alias to your .bash_profile (Mac) or .bashrc (Linux) file:
+```
+
+Use `alias` to have the `terminus` command call the application:
+
+```bash{promptUser: user}
+alias terminus=~/vendor/bin/terminus
+```
 
 ### Windows 10 Installation issues
 

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -15,11 +15,11 @@ reviewed: "2020-02-05"
 searchboost: 100
 ---
 
-Terminus is available for Mac OS X and Linux.
+Terminus is available for macOS and Linux.
 
 Windows 10 users can install the [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10), then install Terminus in the Linux shell.
 
-Because some Terminus commands use SSH authentication, consider [generating and adding SSH keys](/ssh-keys) to your account before you continue.
+Because some Terminus commands use SSH authentication, consider [generating and adding SSH keys](/ssh-keys/) to your account before you continue.
 
 ## Requirements
 
@@ -45,11 +45,11 @@ There are several ways to install Terminus, depending on your use case:
   wget https://github.com/pantheon-systems/terminus/releases/download/2.3.0/terminus.phar -O ~/.bin/terminus
   ```
 
-  Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above vermatim.
+  Remember to get the latest version of Terminus from the [Releases](https://github.com/pantheon-systems/terminus/releases) page, don't copy the command above verbatim.
 
   Your installation directory must be in or added to your `$PATH` environment variable in order to call `terminus` from any working directory.
 
-1. Make the Terminus file exectable. The example below assumes the same installation path as above:
+1. Make the Terminus file executable. The example below assumes the same installation path as above:
 
   ```bash{promptUser: user}
   chmod +X ~/.bin/terminus
@@ -57,7 +57,7 @@ There are several ways to install Terminus, depending on your use case:
 
 <Alert type="info" title="Note">
 
-There is an unofficial third party installer script which will download `terminus.phar` and attempt to update the appropriate rc files, available [here](https://github.com/alexfornuto/terminus-installer). Note that this script is *not* supported directly by Pantheon.
+There is an unofficial third-party installer script which will download `terminus.phar` and attempt to update the appropriate `rc` files, available [on GitHub](https://github.com/alexfornuto/terminus-installer). Note that this script is *not* supported directly by Pantheon.
 
 </Alert>
 
@@ -83,7 +83,7 @@ composer install pantheon-systems/terminus
 
 ### Machine Token
 
-Once Terminus is installed, login with a machine token, which is used to securely authenticate your machine. Machine tokens provide the same access as your username and password, and do not expire. For more information, see [Machine Tokens](/machine-tokens).
+Once Terminus is installed, login with a machine token, which is used to securely authenticate your machine. Machine tokens provide the same access as your username and password, and do not expire. For more information, see [Machine Tokens](/machine-tokens/).
 
 First, [create a Machine Token](https://dashboard.pantheon.io/login?destination=%2Fuser#account/tokens/create/terminus/) from **User Dashboard** > **Account** > **Machine Tokens**.
 
@@ -99,7 +99,7 @@ terminus auth:login --email=dev@example.com
 
 ### SSH Authentication
 
-Commands that execute remote instructions to tools like Drush or WP-CLI require SSH authentication. See [Generate and Add SSH Keys](/ssh-keys) to prevent password requests when executing these commands.
+Commands that execute remote instructions to tools like Drush or WP-CLI require SSH authentication. See [Generate and Add SSH Keys](/ssh-keys/) to prevent password requests when executing these commands.
 
 ## Troubleshooting
 
@@ -122,7 +122,7 @@ file installer.phar: Permission denied
 curl: (23) Failed writing body (0 != 1928)
 ```
 
-You should relocate your installation to a directory where you have permission to write files. If in doubt, you can create a `terminus` diretory in your `$HOME` and go there:
+You should relocate your installation to a directory where you have permission to write files. If in doubt, you can create a `terminus` directory in your `$HOME` and go there:
 
 ```bash{promptUser: user}
 cd $HOME/terminus
@@ -149,7 +149,7 @@ curl: (60) SSL certificate problem: unable to get local issuer certificate
 
 To resolve, save a copy of the [latest CA certificate](https://curl.haxx.se/docs/caextract.html) to a new file named `cacert.pem` then add `curl.cainfo = "[path_to_file]\cacert.pem"` to your `php.ini` file. If you're running XAMPP, you can add the `cacert.pem` file within the `xampp\php\extras\ssl` directory.
 
-### Enable the terminus command
+### Enable the terminus Command
 
 If you encounter the following error after installation completes:
 
@@ -158,13 +158,13 @@ Terminus was installed, but the installer was not able to write to your bin dir.
 `terminus` command, add this alias to your .bash_profile (Mac) or .bashrc (Linux) file:
 ```
 
-Use `alias` to have the `terminus` command call the application:
+Use this command to create a `terminus` alias that calls the application:
 
 ```bash{promptUser: user}
-alias terminus=~/vendor/bin/terminus
+echo "alias terminus=~/vendor/bin/terminus" >> ~/.bashrc
 ```
 
-### Windows 10 Installation issues
+### Windows 10 Installation Issues
 
 #### Prerequisites are not installed
 


### PR DESCRIPTION
Closes #5468

## Effect
PR includes the following changes:
- Updates Terminus instructions to suggest the Windows Subsystem for Linux for Windows users.
- Warns readers of the Cygwin guide to do the same.
- Documents all Terminus installation methods and their use cases (related to https://github.com/pantheon-systems/terminus/pull/2058)
- ~Makes Terminus guide pages fluid.~ moved to #5505 

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)