### PR TITLE
Pass Page Tile to Segment

### DIFF
--- a/gatsby/gatsby-browser.js
+++ b/gatsby/gatsby-browser.js
@@ -27,6 +27,8 @@ export const onRouteUpdate = () => {
   window.previousPath = locations[locations.length - 2];
   window.analytics && window.analytics.page({
     url: window.location.href,
-    referrer: window.previousPath
+    referrer: window.previousPath,
+    title: document.title
   })
+  //console.log("Title: ", document.title) //For debugging
 }

--- a/gatsby/src/layout/seo.js
+++ b/gatsby/src/layout/seo.js
@@ -61,6 +61,8 @@ function SEO({ description, lang, meta, keywords, title, authors, image, categor
 
       {...titleProps}
 
+      defer={false}
+
       meta={[
         {...tagValues},
         {


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Sets `defer={false} in the Helmet component, to provide the page title faster.
- With `document.title` now accessible at `onRouteUpdate`, we pass it to Segment.

## Remaining Work
- [x] Technical review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Trigger a recrawl in Addsearch
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
