### PR TITLE
Remove twig_extensions from the Known Issues list

### DIFF
--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -301,11 +301,7 @@ ___
 ## [Taxonomy CSV](https://www.drupal.org/project/taxonomy_csv)
 
 **Issue**:  This module requires the use of the `/tmp` directory. See [Using the tmp Directory](#using-the-tmp-directory) section below.
-___
 
-## [Twig Extensions](https://www.drupal.org/project/twig_extensions)
-
-**Issue**:  This module uses [`php-intl`]( https://secure.php.net/manual/en/intro.intl.php), which is not currently supported by Pantheon.
 ___
 
 ## [Varnish](https://www.drupal.org/project/varnish)


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Removes Twig Extensions from the Drupal modules with issues list

Our supported PHP versions (7.1+) all now include the intl extension, so this module now installs without errors. See https://pantheon.io/docs/changelog/2019/02#php-intl-extension-now-available.

## Remaining Work
- [ ] Technical review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
