### PR TITLE
Terminus formatting

### DIFF
--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -133,7 +133,7 @@ class TerminusTemplate extends React.Component {
     const node = this.props.data.mdx
     const contentCols = node.frontmatter.showtoc ? 9 : 12
     const isoDate = this.props.data.date
-    const ifCommandsDate = node.fields.slug == "/terminus/commands" ? this.props.data.releasesJson.published_at : node.frontmatter.reviewed
+    const ifCommandsDate = node.fields.slug == "/terminus/commands" ? this.props.data.terminusReleasesJson.published_at : node.frontmatter.reviewed
     const ifCommandsISO = node.fields.slug == "/terminus/commands" ? this.props.data.jsonISO.published_at : isoDate.frontmatter.reviewed
 
     return (
@@ -228,10 +228,10 @@ export const pageQuery = graphql`
         reviewed
       }
     }
-    releasesJson {
+    terminusReleasesJson {
       published_at(formatString: "MMMM DD, YYYY")
     }
-    jsonISO: releasesJson {
+    jsonISO: terminusReleasesJson {
       published_at(formatString: "YYYY-MM-DD")
     }
   }

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -144,8 +144,8 @@ class TerminusTemplate extends React.Component {
           reviewed={isoDate.frontmatter.reviewed}
         />
         <div className="">
-          <div className="container">
-            <div className="row col-md-12 guide-nav manual-guide-toc-well">
+          <div className="container-fluid">
+            <div className="row col-md-10 guide-nav manual-guide-toc-well">
               <Navbar
                 title={node.frontmatter.title}
                 items={items}

--- a/gatsby/src/templates/terminuspage.js
+++ b/gatsby/src/templates/terminuspage.js
@@ -133,6 +133,8 @@ class TerminusTemplate extends React.Component {
     const node = this.props.data.mdx
     const contentCols = node.frontmatter.showtoc ? 9 : 12
     const isoDate = this.props.data.date
+    const ifCommandsDate = node.fields.slug == "/terminus/commands" ? this.props.data.releasesJson.published_at : node.frontmatter.reviewed
+    const ifCommandsISO = node.fields.slug == "/terminus/commands" ? this.props.data.jsonISO.published_at : isoDate.frontmatter.reviewed
 
     return (
       <Layout>
@@ -141,7 +143,7 @@ class TerminusTemplate extends React.Component {
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
           image={"/assets/images/terminus-thumbLarge.png"}
-          reviewed={isoDate.frontmatter.reviewed}
+          reviewed={ifCommandsISO}   
         />
         <div className="">
           <div className="container-fluid">
@@ -164,8 +166,8 @@ class TerminusTemplate extends React.Component {
                       contributors={node.frontmatter.contributors}
                       featured={node.frontmatter.featuredcontributor}
                       editPath={node.fields.editPath}
-                      reviewDate={node.frontmatter.reviewed}
-                      isoDate={isoDate.frontmatter.reviewed}
+                      reviewDate={ifCommandsDate}
+                      isoDate={ifCommandsISO}
                     />
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.body}</MDXRenderer>
@@ -225,6 +227,12 @@ export const pageQuery = graphql`
       frontmatter {
         reviewed
       }
+    }
+    releasesJson {
+      published_at(formatString: "MMMM DD, YYYY")
+    }
+    jsonISO: releasesJson {
+      published_at(formatString: "YYYY-MM-DD")
     }
   }
 `


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Makes the Terminus guide fluid, to use browser window size better.
- Adds review dates to Some Terminus pages
- Sets the review data for the Commands reference page to match the release date of the version of Terminus whose data creates that page (Should always be the latest version).

## Remaining Work
- [x] Pull 2 of these commits out of #5478 
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
