### PR TITLE
The 'search_api_solr_date_sort' module added.

### DIFF
--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -9,8 +9,7 @@ This page lists modules that may not function as expected or are currently probl
 
 We do not prevent you from installing and using these plugins/modules. However, we cannot provide support for incompatible modules, or if they are used against the guidance provided here.
 
-**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update%20&body=Re%3A%20%5BModules%20and%20Plugins%20with%20Known%20Issues%5D%28https%3A%2F%2Fpantheon.io/
-/modules-plugins-known-issues/%29%0A%0APriority%20%28Low%E2%80%9A%20Medium%E2%80%9A%20High%29%3A%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=fix%20content). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
+**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
 
 If your work is already updated but still listed here, let us know so we can remove it, or [submit a pull request](https://github.com/pantheon-systems/documentation/edit/master/source/_docs/modules-plugins-known-issues.md).
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -292,15 +292,15 @@ ___
 
 ## [Search Api Solr Date Sort](https://www.drupal.org/project/search_api_solr_date_sort)
 
-<ReviewDate date="2020-02-14" />
+<ReviewDate date="2020-03-12" />
 
-**Issue**: The module overrides a class from the [Pantheon Apache Solr module](https://pantheon.io/docs/solr-drupal-7) that is responsible for a correct connection to the Pantheon's Apache Solr service. As a result a Solr connection is lost.
+**Issue**: This module overrides a class from the [Pantheon Apache Solr module](https://pantheon.io/docs/solr-drupal-7) responsible for connecting to Pantheon's Apache Solr service. As a result, Solr connection is lost.
 
 **Solution**: Instead of patching the module, you can fix the issue with a custom module:
 
-1. Define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa).
+1. Define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa). See the [module source code](https://git.drupalcode.org/project/search_api_solr_date_sort/-/blob/7.x-1.x/includes/service.inc) for examples.
 
-1. Implement a `hook_search_api_service_info_alter()` (with a highest weight) and add your class into a configuration array.
+1. Implement a hook (`hook_search_api_service_info_alter()` for example) with a high weight, and add your class into a configuration array.
 
 ___
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -9,7 +9,7 @@ This page lists modules that may not function as expected or are currently probl
 
 We do not prevent you from installing and using these plugins/modules. However, we cannot provide support for incompatible modules, or if they are used against the guidance provided here.
 
-**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
+**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
 
 If your work is already updated but still listed here, let us know so we can remove it, or [submit a pull request](https://github.com/pantheon-systems/documentation/edit/master/source/_docs/modules-plugins-known-issues.md).
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -300,7 +300,7 @@ ___
 
 1. Define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa). See the [module source code](https://git.drupalcode.org/project/search_api_solr_date_sort/-/blob/7.x-1.x/includes/service.inc) for examples.
 
-1. Implement a hook (`hook_search_api_service_info_alter()` for example) with a high weight, and add your class into a configuration array.
+1. Implement a the `hook_search_api_service_info_alter()` function and add your class into a configuration array. Ensure that your [module's weight](https://www.drupal.org/docs/7/creating-custom-modules/howtos/how-to-update-a-modules-weight) is gereater than that of `search_api_solr_date` and `pantheon_apachesolr`.
 
 ___
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -292,12 +292,15 @@ ___
 
 ## [Search Api Solr Date Sort](https://www.drupal.org/project/search_api_solr_date_sort)
 
+<ReviewDate date="2020-02-14" />
+
 **Issue**: The module overrides a class from the [Pantheon Apache Solr module](https://pantheon.io/docs/solr-drupal-7) that is responsible for a correct connection to the Pantheon's Apache Solr service. As a result a Solr connection is lost.
 
-**Solution**: It's not required to patch the module. You can try to fix it in a custom module:
+**Solution**: Instead of patching the module, you can fix the issue with a custom module:
 
-- define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa)
-- implement a `hook_search_api_service_info_alter()` (with a highest weight) and add your class into a configuration array
+1. Define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa).
+
+1. Implement a `hook_search_api_service_info_alter()` (with a highest weight) and add your class into a configuration array.
 
 ___
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -1,7 +1,7 @@
 ---
 title: Drupal Modules with Known Issues
 description: A list of Drupal modules that are not supported and/or require workarounds.
-tags: [debugcode, siteintegrations]
+tags: [Drupal, modules]
 categories: [troubleshoot, integrate]
 ---
 
@@ -9,7 +9,8 @@ This page lists modules that may not function as expected or are currently probl
 
 We do not prevent you from installing and using these plugins/modules. However, we cannot provide support for incompatible modules, or if they are used against the guidance provided here.
 
-**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update%20&body=Re%3A%20%5BModules%20and%20Plugins%20with%20Known%20Issues%5D(https%3A%2F%2Fpantheon.io/docs/modules-plugins-known-issues/)%0A%0APriority%20(Low%E2%80%9A%20Medium%E2%80%9A%20High)%3A%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=fix%20content). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
+**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update%20&body=Re%3A%20%5BModules%20and%20Plugins%20with%20Known%20Issues%5D(https%3A%2F%2Fpantheon.io/
+/modules-plugins-known-issues/)%0A%0APriority%20(Low%E2%80%9A%20Medium%E2%80%9A%20High)%3A%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=fix%20content). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
 
 If your work is already updated but still listed here, let us know so we can remove it, or [submit a pull request](https://github.com/pantheon-systems/documentation/edit/master/source/_docs/modules-plugins-known-issues.md).
 
@@ -294,7 +295,7 @@ ___
 
 <ReviewDate date="2020-03-12" />
 
-**Issue**: This module overrides a class from the [Pantheon Apache Solr module](https://pantheon.io/docs/solr-drupal-7) responsible for connecting to Pantheon's Apache Solr service. As a result, Solr connection is lost.
+**Issue**: This module overrides a class from the [Pantheon Apache Solr module](/solr-drupal-7) responsible for connecting to Pantheon's Apache Solr service. As a result, Solr connection is lost.
 
 **Solution**: Instead of patching the module, you can fix the issue with a custom module:
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -301,7 +301,7 @@ ___
 
 1. Define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa). See the [module source code](https://git.drupalcode.org/project/search_api_solr_date_sort/-/blob/7.x-1.x/includes/service.inc) for examples.
 
-1. Implement a the `hook_search_api_service_info_alter()` function and add your class into a configuration array. Ensure that your [module's weight](https://www.drupal.org/docs/7/creating-custom-modules/howtos/how-to-update-a-modules-weight) is gereater than that of `search_api_solr_date` and `pantheon_apachesolr`.
+1. Implement the `hook_search_api_service_info_alter()` function in your custom module's `.module` file and add your class into a configuration array. See the [developer documentation](https://www.drupal.org/node/1999396) for details. Ensure that your [module's weight](https://www.drupal.org/docs/7/creating-custom-modules/howtos/how-to-update-a-modules-weight) is gereater than that of `search_api_solr_date` and `pantheon_apachesolr`.
 
 ___
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -9,8 +9,8 @@ This page lists modules that may not function as expected or are currently probl
 
 We do not prevent you from installing and using these plugins/modules. However, we cannot provide support for incompatible modules, or if they are used against the guidance provided here.
 
-**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update%20&body=Re%3A%20%5BModules%20and%20Plugins%20with%20Known%20Issues%5D(https%3A%2F%2Fpantheon.io/
-/modules-plugins-known-issues/)%0A%0APriority%20(Low%E2%80%9A%20Medium%E2%80%9A%20High)%3A%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=fix%20content). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
+**Module Maintainers:** If your work is listed here, please [reach out to us](https://github.com/pantheon-systems/documentation/issues/new?title=Modules%20and%20Plugins%20with%20Known%20Issues%20Doc%20Update%20&body=Re%3A%20%5BModules%20and%20Plugins%20with%20Known%20Issues%5D%28https%3A%2F%2Fpantheon.io/
+/modules-plugins-known-issues/%29%0A%0APriority%20%28Low%E2%80%9A%20Medium%E2%80%9A%20High%29%3A%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution%20&labels=fix%20content). We're happy to help provide information that can lead to conflict resolutions between your code and the platform.
 
 If your work is already updated but still listed here, let us know so we can remove it, or [submit a pull request](https://github.com/pantheon-systems/documentation/edit/master/source/_docs/modules-plugins-known-issues.md).
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -290,6 +290,17 @@ $conf[‘schema_suppress_type_warnings’] = TRUE;
 
 ___
 
+## [Search Api Solr Date Sort](https://www.drupal.org/project/search_api_solr_date_sort)
+
+**Issue**: The module overrides a class from the [Pantheon Apache Solr module](https://pantheon.io/docs/solr-drupal-7) that is responsible for a correct connection to the Pantheon's Apache Solr service. As a result a Solr connection is lost.
+
+**Solution**: It's not required to patch the module. You can try to fix it in a custom module:
+
+- define a new class that inherits from the `PantheonApachesolrSearchApiSolrService` and contains logic from the `SearchApiSolrDateSortSolrService` (or vice a versa)
+- implement a `hook_search_api_service_info_alter()` (with a highest weight) and add your class into a configuration array
+
+___
+
 ## [Simple OAuth / OAuth 2.0](https://www.drupal.org/project/simple_oauth)
 
 **Issue**: The module requires a very specific set of permissions for the folder and the keys to be uploaded. Using Private or non-standard filepaths won't work. It is not possible to change these in LIVE or TEST environment.


### PR DESCRIPTION
The update is based on a research from the ticket: https://pantheon.zendesk.com/agent/tickets/449203.

## Effect
PR includes the following changes:
- a new section about the  'search_api_solr_date_sort' module has been added to the `/docs/modules-known-issues` page

## Remaining Work
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
