### PR TITLE
Free version of cookie-law-info breaks caching

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -344,14 +344,16 @@ ___
 
 **Issue:** This plugin sends two `set-cookie` headers in each response, which breaks caching on Pantheon's Global CDN. For example:
 
-```
-$ curl -I https://www.example.com
+```bash{outputLines: 2-20}
+curl -I https://www.example.com
 HTTP/2 200
 cache-control: public, max-age=600
 content-type: text/html; charset=UTF-8
 server: nginx
+//highlight-start
 set-cookie: cookielawinfo-checkbox-necessary=yes; expires=Thu, 20-Feb-2020 17:31:51 GMT; Max-Age=3600; path=/
 set-cookie: cookielawinfo-checkbox-non-necessary=yes; expires=Thu, 20-Feb-2020 17:31:51 GMT; Max-Age=3600; path=/
+//highlight-end
 x-pantheon-styx-hostname: styx-fe1-a-789d66bff9-tztp6
 x-styx-req-id: 7f93c166-53fe-11ea-803e-b26d7703e33f
 date: Thu, 20 Feb 2020 16:31:51 GMT

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -338,6 +338,37 @@ ___
 
 ___
 
+## [GDPR Cookie Consent](https://wordpress.org/plugins/cookie-law-info/)
+
+<ReviewDate date="2020-02-20" />
+
+**Issue:** This plugin sends two `set-cookie` headers in each response, which breaks caching on Pantheon's Global CDN. For example:
+
+```
+$ curl -I https://www.example.com
+HTTP/2 200
+cache-control: public, max-age=600
+content-type: text/html; charset=UTF-8
+server: nginx
+set-cookie: cookielawinfo-checkbox-necessary=yes; expires=Thu, 20-Feb-2020 17:31:51 GMT; Max-Age=3600; path=/
+set-cookie: cookielawinfo-checkbox-non-necessary=yes; expires=Thu, 20-Feb-2020 17:31:51 GMT; Max-Age=3600; path=/
+x-pantheon-styx-hostname: styx-fe1-a-789d66bff9-tztp6
+x-styx-req-id: 7f93c166-53fe-11ea-803e-b26d7703e33f
+date: Thu, 20 Feb 2020 16:31:51 GMT
+x-served-by: cache-mdw17379-MDW, cache-chi21146-CHI
+x-cache: MISS, MISS
+x-cache-hits: 0, 0
+x-timer: S1582216311.492451,VS0,VE204
+vary: Accept-Encoding, Cookie, Cookie
+age: 0
+accept-ranges: bytes
+via: 1.1 varnish
+```
+
+**Solution:** Several users have reported that [upgrading to the premium version of this plugin](https://www.webtoffee.com/product/gdpr-cookie-consent/) and disabling the included script blocker fixed the issue. For additional support, work with the plugin maintainers and review [related documentation for the premium version](https://www.webtoffee.com/cache-plugin-compatibility/).
+
+___
+
 ## [H5P](https://wordpress.org/plugins/h5p/)
 
 <Partial file="h5p-known-issues.md" />


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes #

## Effect
PR includes the following changes:
- Add free GDPR Cookie Consent plugin to the WP doc for plugins with known issues, it breaks caching
- Include solution that upgrading to premium version and disabling script blocker resolves 

Note: I've not directly configured the premium version myself, but have confirmed this solution on Pantheon via an active migration client 

@alexfornuto can you put that fancy highlighting on the curl response to call out the two `set-header:` lines? Please :) 

## Remaining Work
- [ ] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
