### PR TITLE
[OTTO-234] Report PHP 7.4 as a supported version

### DIFF
--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -24,14 +24,14 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 ### Available PHP Versions
 The recommended PHP versions available on Pantheon are:
 
+- [7.4](https://v74-php-info.pantheonsite.io/)
 - [7.3](https://v73-php-info.pantheonsite.io/)
 - [7.2](https://v72-php-info.pantheonsite.io/)
-- [7.1](https://v71-php-info.pantheonsite.io/)
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
 ### EOL PHP Versions
-Pantheon also makes PHP [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), [5.5](https://v55-php-info.pantheonsite.io/), and [5.3](https://v53-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary.
+Pantheon also makes PHP [7.1](https://v71-php-info.pantheonsite.io/), [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), [5.5](https://v55-php-info.pantheonsite.io/), and [5.3](https://v53-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary.
 
 <Alert title="Note" type="info">
 


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes # n/a

## Effect
- Marks PHP 7.4 as a supported version
- Notes that PHP 7.1 is now EOL

## Remaining Work
- [ ] Produce owner to confirm that PHP 7.4 has been launched on the platform (currently dark-deployed)
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
