### PR TITLE
[OTTO-253] Proposal: describe "retired" versions of PHP

### DIFF
--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -1,18 +1,21 @@
 ---
 title: Upgrade PHP Versions
 description: Learn how to upgrade PHP versions to resolve  compatibility issues.
-categories: [platform]
-tags: [libraries, updates]
+tags: [pantheonyml, services]
+categories: [workflow,platform]
+reviewed: "2020-05-05"
 ---
 Upgrading your site's PHP version will improve the security, performance, and supportability of your site. See our blog post for an [example of 62% performance gains after upgrading](https://pantheon.io/blog/php-7-now-available-all-sites-pantheon).
 
 ## Before You Begin
+
 Older software is more likely to contain code that is incompatible with recent PHP versions. Before you change your PHP version:
 
 - Update core to the latest release. For details, see [WordPress and Drupal Core Updates](/core-updates).
 - Update themes, plugins, and modules. For details, see [Working in the WordPress Dashboard and Drupal Admin Interface](/cms-admin).
 
 ## Verify Current PHP Versions
+
 Verify current PHP settings from the Site Dashboard by clicking **Settings** > **PHP version**.
 
 <Alert title="Note" type="info">
@@ -22,6 +25,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 </Alert>
 
 ### Available PHP Versions
+
 The recommended PHP versions available on Pantheon are:
 
 - [7.4](https://v74-php-info.pantheonsite.io/)
@@ -31,23 +35,26 @@ The recommended PHP versions available on Pantheon are:
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
 ### EOL PHP Versions
+
 Pantheon also makes PHP [7.1](https://v71-php-info.pantheonsite.io/), PHP [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), and [5.5](https://v55-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary. 
 
 ### PHP Versions Being Retired
+
 PHP [5.3](https://v53-php-info.pantheonsite.io/) is being retired from the platform. Sites using PHP 5.3 will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development site.
 
 <Alert title="Note" type="info">
 
 Before changing your PHP version, confirm that your CMS is compatible:
 
-* [WordPress Requirements](https://wordpress.org/about/requirements/)
-* [Drupal 8 PHP versions supported](https://www.drupal.org/docs/8/system-requirements/php-requirements#php_required)
-* [Drupal 7 PHP versions supported](https://www.drupal.org/docs/7/system-requirements/drupal-7-php-requirements#php_required)
-* As of Drupal 6.45, Drupal 6 is [compatible with PHP 7.2](https://www.mydropwizard.com/blog/announcing-drupal-645-and-selected-contrib-php-72). Older versions of Drupal 6 require PHP 5.4 and below.
+- [WordPress Requirements](https://wordpress.org/about/requirements/)
+- [Drupal 8 PHP versions supported](https://www.drupal.org/docs/8/system-requirements/php-requirements#php_required)
+- [Drupal 7 PHP versions supported](https://www.drupal.org/docs/7/system-requirements/drupal-7-php-requirements#php_required)
+- As of Drupal 6.45, Drupal 6 is [compatible with PHP 7.2](https://www.mydropwizard.com/blog/announcing-drupal-645-and-selected-contrib-php-72). Older versions of Drupal 6 require PHP 5.4 and below.
 
 </Alert>
 
 ## Configure PHP Version
+
 Manage PHP versions by committing a `pantheon.yml` configuration file to the root of your site's code repository. If you have a local git clone of your site, this is the project root. When looking at the site over an SFTP connection, look in the `code` directory. If the `pantheon.yml` file is not present, create one to look like the following:
 
 ```yaml
@@ -68,7 +75,7 @@ The next time you [push your changes](/git#push-changes-to-pantheon) back to Pan
 
 The first place to determine if your changes have been successful is the output from your `git push` command. A correct implementation will return:
 
-```
+```none
 remote: PANTHEON NOTICE:
 remote:
 remote: Changes to `pantheon.yml` detected.
@@ -76,11 +83,9 @@ remote:
 remote: Successfully applied `pantheon.yml` to the 'dev' environment.
 ```
 
-<br />
-
 If you have an invalid `pantheon.yml` file, the `git push` operation will fail and your commit will be rejected. In this example, we've set an unavailable PHP version:
 
-```
+```none
 remote: PANTHEON ERROR:
 remote:
 remote: Changes to `pantheon.yml` detected, but there was an error while processing it:
@@ -118,15 +123,13 @@ We recommend working with theme, module, or plugin maintainers to resolve any is
 
 If you see errors on the Pantheon Dashboard when trying to auto-run `update.php`, for example, upgrading Drush should resolve the issue. For more information, see [Manage Drush Versions on Pantheon](https://pantheon.io/docs/drush-versions/#configure-drush-version).
 
-
-
 ## See Also
 
-* [PHP Supported Versions](https://secure.php.net/supported-versions.php)
-* [Drupal specific version notes on PHP requirements](https://www.drupal.org/requirements/php#drupalversions) and [WordPress Requirements](https://wordpress.org/about/requirements/)
-* [Log Files on Pantheon](/logs)
-* [PHP Errors and Exceptions](/php-errors)
-* [The pantheon.yml Configuration File](/pantheon-yml)
-* [Securely Working with phpinfo](/phpinfo)
-* [php.net - Backward Incompatible Changes](https://secure.php.net/manual/en/migration70.incompatible.php)
-* [Debug Intermittent PHP 7 Notices](/deprecated-constructor-notices)
+- [PHP Supported Versions](https://secure.php.net/supported-versions.php)
+- [Drupal specific version notes on PHP requirements](https://www.drupal.org/requirements/php#drupalversions) and [WordPress Requirements](https://wordpress.org/about/requirements/)
+- [Log Files on Pantheon](/logs)
+- [PHP Errors and Exceptions](/php-errors)
+- [The pantheon.yml Configuration File](/pantheon-yml)
+- [Securely Working with phpinfo](/phpinfo)
+- [php.net - Backward Incompatible Changes](https://secure.php.net/manual/en/migration70.incompatible.php)
+- [Debug Intermittent PHP 7 Notices](/deprecated-constructor-notices)

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -24,7 +24,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 
 </Alert>
 
-### Available PHP Versions
+### Recommended PHP Versions
 
 The recommended PHP versions available on Pantheon are:
 
@@ -34,13 +34,38 @@ The recommended PHP versions available on Pantheon are:
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
-### EOL PHP Versions
+### All PHP Versions
 
-Pantheon also makes PHP [7.1](https://v71-php-info.pantheonsite.io/), PHP [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), and [5.5](https://v55-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary. 
+| Version                                      | Recommended | Status |
+| --------------------------------------------:| ----------- | ------ |
+| [7.3](https://v73-php-info.pantheonsite.io/) | <span style="color:green">✔</span> | Active |
+| [7.2](https://v72-php-info.pantheonsite.io/) | <span style="color:green">✔</span> | Active |
+| [7.1](https://v71-php-info.pantheonsite.io/) | ❌           | EOL     |
+| [7.0](https://v70-php-info.pantheonsite.io/) | ❌           | EOL     |
+| [5.6](https://v56-php-info.pantheonsite.io/) | ❌           | EOL     |
+| [5.5](https://v55-php-info.pantheonsite.io/) | ❌           | EOL     |
+| [5.3](https://v53-php-info.pantheonsite.io/) | ❌           | Retired |
 
-### PHP Versions Being Retired
+<dl>
 
-PHP [5.3](https://v53-php-info.pantheonsite.io/) is being retired from the platform. Sites using PHP 5.3 will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development site.
+<dt>EOL</dt>
+
+<dd>
+
+End-of-life (**EOL**) versions are available on the platform but no longer under active development, and should not be used unless absolutely necessary.
+
+</dd>
+
+<dt>Retired</dt>
+
+<dd>
+
+Sites using retired versions of PHP will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development site.
+
+</dd>
+
+</dl>
+
 
 <Alert title="Note" type="info">
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -31,7 +31,10 @@ The recommended PHP versions available on Pantheon are:
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
 ### EOL PHP Versions
-Pantheon also makes PHP [7.1](https://v71-php-info.pantheonsite.io/), [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), [5.5](https://v55-php-info.pantheonsite.io/), and [5.3](https://v53-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary.
+Pantheon also makes PHP [7.1](https://v71-php-info.pantheonsite.io/), PHP [7.0](https://v70-php-info.pantheonsite.io/), [5.6](https://v56-php-info.pantheonsite.io/), and [5.5](https://v55-php-info.pantheonsite.io/) available on the platform, although these are end-of-life (**EOL**), and should not be used unless absolutely necessary. 
+
+### PHP Versions Being Retired
+PHP [5.3](https://v53-php-info.pantheonsite.io/) is being retired from the platform. Sites using PHP 5.3 will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development site.
 
 <Alert title="Note" type="info">
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -1,8 +1,8 @@
 ---
 title: Upgrade PHP Versions
 description: Learn how to upgrade PHP versions to resolve  compatibility issues.
-tags: [pantheonyml, services]
-categories: [workflow,platform]
+tags: [libraries, updates]
+categories: [platform]
 reviewed: "2020-05-05"
 ---
 Upgrading your site's PHP version will improve the security, performance, and supportability of your site. See our blog post for an [example of 62% performance gains after upgrading](https://pantheon.io/blog/php-7-now-available-all-sites-pantheon).

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -60,7 +60,7 @@ End-of-life (**EOL**) versions are available on the platform but no longer under
 
 <dd>
 
-Sites using retired versions of PHP will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development site.
+Sites using retired versions of PHP will continue to serve pages, but new development cannot be done. To resume development on a site using a retired version of PHP, first upgrade the PHP version on the development environment.
 
 </dd>
 


### PR DESCRIPTION
Closes #n/a

## Effect
This PR is a *proposal* for a new policy on PHP versions.

The new version of wp-cli deployed to the platform (2.4.0) does not work with PHP version 5.3. This causes problems for WordPress sites running on old versions of PHP. See [OTTO-253](https://getpantheon.atlassian.net/browse/OTTO-253) for details.

One possible solution is proposed here: we could declare PHP 5.3 as "under retirement" and require old sites to upgrade before doing any further development on the site. These sites would still continue to serve pages using the older version of PHP.

## Remaining Work
- [x] Policy review by Product
- [x] Technical review
- [ ] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
