### PR TITLE
Warn against PHP geolocation

### DIFF
--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -1,16 +1,16 @@
 ---
 title: Getting the Client IP Address
 description: Getting the client IP address to set up geolocation capabilities on your Pantheon site.
-tags: [variables]
-categories: [drupal,develop]
+tags: [Drupal, geolocation]
+categories: [develop]
 reviewed: "2020-03-09"
 ---
 
 <Alert title="Warning" type="danger">
 
-This page was written before the [Pantheon Global CDN](/global-cdn) was launched for all customers. Now that all traffic runs through a CDN endpoint and is cached when possible, the methods below are now longer an accurate way to geolocate your traffic.
+This page was written before the [Pantheon Global CDN](/global-cdn) was launched for all customers. Now that all traffic runs through a CDN endpoint and is cached when possible, the methods below are no longer an accurate way to geolocate your traffic.
 
-If geolocation is a requirement for your site, consider an [Advanced Global CDN](/advanced-global-cdn) configuration, or a third party geo-aware edge, like Cloudflare
+If geolocation is a requirement for your site, consider an [Advanced Global CDN](/advanced-global-cdn) configuration, or a third party geo-aware edge, like Cloudflare.
 
 </Alert>
 

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -38,7 +38,12 @@ We offer various methods for you to interact with your Pantheon site, so it is i
 
 ### Cloudflare
 
-When using Cloudflare as a stacked CDN or proxy, use the variable `$_SERVER["HTTP_CF_CONNECTING_IP"]` instead of `$_SERVER["REMOTE_ADDR"]`.
+When using Cloudflare as a stacked CDN or proxy, use the variable `$_SERVER["HTTP_CF_CONNECTING_IP"]` instead of `$_SERVER["REMOTE_ADDR"]`. 
+
+### Geolocation with Cloudflare
+For geolocation, [enable geolocation](https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-Cloudflare-IP-Geolocation) on the Cloudflare dashboard. The country code value is passed along in the `CF-IPCountry` request header to the origin web server.
+
+Any PhP reading `CF-IPCountry` values should also add `Vary: CF-IPCountry` to responses to ensure Pantheon's Global CDN properly personalizes cache hits. This will ensure cache behavior is both correct (content returned for the user agent's actual location) and efficient (cache can hit for other requests coming from the same country)
 
 #### Drupal 7 Domain Access module with Cloudflare
 

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -6,6 +6,14 @@ categories: [drupal,develop]
 reviewed: "2020-03-09"
 ---
 
+<Alert title="Warning" type="danger">
+
+This page was written before the [Pantheon Global CDN](/global-cdn) was launched for all customers. Now that all traffic runs through a CDN endpoint and is cached when possible, the methods below are now longer an accurate way to geolocate your traffic.
+
+If geolocation is a requirement for your site, consider an [Advanced Global CDN](/advanced-global-cdn) configuration, or a third party geo-aware edge, like Cloudflare
+
+</Alert>
+
 There are two ways to get the client IP address if you are running Drupal on Pantheon:
 
 1. Use the system environment variable `$_SERVER["REMOTE_ADDR"]`. One benefit is that on Pantheon this takes into account if the `X-Forwarded-For` header is sent in cases when a request is filtered by a proxy.

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -40,7 +40,7 @@ We offer various methods for you to interact with your Pantheon site, so it is i
 
 When using Cloudflare as a stacked CDN or proxy, use the variable `$_SERVER["HTTP_CF_CONNECTING_IP"]` instead of `$_SERVER["REMOTE_ADDR"]`. 
 
-### Geolocation with Cloudflare
+#### Geolocation with Cloudflare
 For geolocation, [enable geolocation](https://support.cloudflare.com/hc/en-us/articles/200168236-Configuring-Cloudflare-IP-Geolocation) on the Cloudflare dashboard. The country code value is passed along in the `CF-IPCountry` request header to the origin web server.
 
 Any PhP reading `CF-IPCountry` values should also add `Vary: CF-IPCountry` to responses to ensure Pantheon's Global CDN properly personalizes cache hits. This will ensure cache behavior is both correct (content returned for the user agent's actual location) and efficient (cache can hit for other requests coming from the same country)

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -3,11 +3,14 @@ title: Getting the Client IP Address
 description: Getting the client IP address to set up geolocation capabilities on your Pantheon site.
 tags: [variables]
 categories: [drupal,develop]
+reviewed: "2020-03-09"
 ---
+
 There are two ways to get the client IP address if you are running Drupal on Pantheon:
 
 1. Use the system environment variable `$_SERVER["REMOTE_ADDR"]`. One benefit is that on Pantheon this takes into account if the `X-Forwarded-For` header is sent in cases when a request is filtered by a proxy.
-2. Use Drupal’s `ip_address()` function. The function leverages the `$_SERVER["REMOTE_ADDR"]` variable to get the client IP, as well as parse other meta information like the remote proxy IP (if available), trim the forwarded IPs if they contain any additional commas or spaces, and filter out any untrusted IPs.
+
+1. Use Drupal’s `ip_address()` function. The function leverages the `$_SERVER["REMOTE_ADDR"]` variable to get the client IP, as well as parse other meta information like the remote proxy IP (if available), trim the forwarded IPs if they contain any additional commas or spaces, and filter out any untrusted IPs.
 
 <Alert title="Note" type="info">
 
@@ -33,7 +36,7 @@ When using Cloudflare as a stacked CDN or proxy, use the variable `$_SERVER["HTT
 
 When using Cloudflare in combination with the Domain Access module on Drupal 7, the user's IP address will get cached by the `ip_address()` function incorrectly, early during the bootstrap process. To correct this you can add the following code block to your `settings.php` file, above where you include the Domain Access module's `settings.inc` file:
 
-```php
+```php:title=settings.php
 if (!empty($_SERVER['HTTP_CF_CONNECTING_IP'])) {
   $_SERVER['REMOTE_ADDR'] = $_SERVER['HTTP_CF_CONNECTING_IP'];
   $_SERVER['HTTP_X_FORWARDED_FOR'] = ", {$_SERVER['REMOTE_ADDR']}";


### PR DESCRIPTION
Closes #5566
## Summary
[Getting the Client IP Address](https://pantheon.io/docs/client-ip): adds a warning about IP geo-location post Global CDN

## Effect
PR includes the following changes:
- Adds a warning to `client-ip.md` about IP geo-location post global CDN
- Formatting improvements

## Remaining Work
- [ ] Input from @davidstrauss 
- [x] Technical review
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
