### PR TITLE
Add info about disabling Redis per-plugin

### DIFF
--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -415,7 +415,7 @@ A page load with 2,000 Redis calls can be 2 full seonds of object cache transact
 wp_cache_add_non_persistent_groups( array( 'bad-actor' ) );
 ```
 
-This declaration means use of wp_cache_set( 'foo', 'bar', 'bad-actor' ); and wp_cache_get( 'foo', 'bad-actor' ); will not use Redis, and instead fall back to WordPress' default runtime object cache.
+This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `wp_cache_get( 'foo', 'bad-actor' );` will not use Redis, and instead fall back to WordPress' default runtime object cache.
 
 ## Frequently Asked Questions
 

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -407,6 +407,16 @@ You have requested a non-existent service "cache.backend.redis".
 
 Install and enable the module to resolve.
 
+### Heavy Redis transactions tracing back to a specific plugin (WordPress)
+
+A page load with 2,000 Redis calls can be 2 full seonds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistency for the plugin's group:
+
+```php
+wp_cache_add_non_persistent_groups( array( 'bad-actor' ) );
+```
+
+This declaration means use of wp_cache_set( 'foo', 'bar', 'bad-actor' ); and wp_cache_get( 'foo', 'bad-actor' ); will not use Redis, and instead fall back to WordPress' default runtime object cache.
+
 ## Frequently Asked Questions
 
 ### How much Redis cache is available for each plan level?

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -409,7 +409,7 @@ Install and enable the module to resolve.
 
 ### Heavy Redis transactions tracing back to a specific plugin (WordPress)
 
-A page load with 2,000 Redis calls can be 2 full seonds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistency for the plugin's group:
+A page load with 2,000 Redis calls can be 2 full seonds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistency for the plugin's group in your theme's `function.php` file, or an [MU-plugin](/mu-plugin):
 
 ```php
 wp_cache_add_non_persistent_groups( array( 'bad-actor' ) );


### PR DESCRIPTION
## Effect
PR includes the following changes:
- Copies over "bad actor" troubleshooting info from our Redis plugin[ README file](https://github.com/pantheon-systems/wp-redis#how-do-i-disable-the-persistent-object-cache-for-a-bad-actor). This is a very common issue in WP.

## Remaining Work
- [x] Copy Review

## Post Launch
**Do not remove** - To be completed by the docs team upon merge:
- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
