### PR TITLE
Primary Domain exception for Platform Domain

### DIFF
--- a/source/content/advanced-redirects.md
+++ b/source/content/advanced-redirects.md
@@ -1,7 +1,7 @@
 ---
 title: Advanced Redirects and Restrictions
 description: Configure custom redirect logic for specific scenarios
-tags: [redirects, variables, dns]
+tags: [redirects, variables, dns, domains]
 categories: [go-live,develop]
 reviewed: "2020-02-12"
 ---
@@ -12,7 +12,7 @@ Redirect logic should be added to `wp-config.php` for [WordPress](/wp-config-php
 
 <Alert type="danger" title="Warning">
 
-With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain (or if set, [remove](/redirects#update-or-remove-primary-domain) the Primary Domain).
+With a Primary Domain set at the platform level, all other domains (except the [platform domain](/domains#platform-domains)) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain (or if set, [remove](/redirects#update-or-remove-primary-domain) the Primary Domain).
 
 </Alert>
 

--- a/source/content/advanced-redirects.md
+++ b/source/content/advanced-redirects.md
@@ -10,9 +10,9 @@ Basic domain and HTTPS redirection can be handled by the [Primary Domain](/redir
 
 Redirect logic should be added to `wp-config.php` for [WordPress](/wp-config-php) sites, and `settings.php` for [Drupal](/settings-php) sites.
 
-<Alert type="info" title="Note">
+<Alert type="danger" title="Warning">
 
-With a Primary Domain set at the platform level, all other domains will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set or [remove](/redirects#update-or-remove-primary-domain) the Primary Domain.
+With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
 
 </Alert>
 

--- a/source/content/advanced-redirects.md
+++ b/source/content/advanced-redirects.md
@@ -12,7 +12,7 @@ Redirect logic should be added to `wp-config.php` for [WordPress](/wp-config-php
 
 <Alert type="danger" title="Warning">
 
-With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
+With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain (or if set, [remove](/redirects#update-or-remove-primary-domain) the Primary Domain).
 
 </Alert>
 

--- a/source/partials/primary-domain.md
+++ b/source/partials/primary-domain.md
@@ -2,7 +2,7 @@
 
 <Alert type="danger" title="Warning">
 
-With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
+With a Primary Domain set at the platform level, all other domains (except the [platform domain](/domains#platform-domains)) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
 
 </Alert>
 

--- a/source/partials/primary-domain.md
+++ b/source/partials/primary-domain.md
@@ -2,7 +2,7 @@
 
 <Alert type="danger" title="Warning">
 
-With a Primary Domain set at the platform level, all other domains will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
+With a Primary Domain set at the platform level, all other domains (except the platform domain) will be pointed to your Primary domain _at the root level_. If you want to redirect secondary domains to specific pages on your site (for example, `olddomain.com` to `newdomain.com/old-landing-page`), do not set a Primary Domain. Instead use [PHP redirects](/redirects/#redirect-with-php).
 
 </Alert>
 


### PR DESCRIPTION
Closes: #5524

## Summary

**[Configure Redirects](https://pantheon.io/docs/redirects)** (and any other pages using the `primary-domain` partial) - Clarified that The Primary Domain does not automatically redirect from the Platform Domain.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
