### PR TITLE
Note Solr module version EOL

### DIFF
--- a/source/content/solr-drupal-8.md
+++ b/source/content/solr-drupal-8.md
@@ -15,7 +15,7 @@ contributors: [peter-pantheon, cityofoaksdesign]
 
 If your search needs include geospatial search, emojis, or multilingual search, consider [OpenSolr](/opensolr) or another alternative search.
 
-Pantheon Search supports [Search API Solr 8.x-1.x](https://www.drupal.org/project/search_api_solr), which is currently unsupported by Solr. Search API Solr 8.x-1.x should continue to work as long as the Search API Pantheon module is also being used, following the installation directions below.
+Pantheon Search supports [Search API Solr 8.x-1.x](https://www.drupal.org/project/search_api_solr), which will reach end-of-life in December 2020. Search API Solr 8.x-1.x should continue to work as long as the Search API Pantheon module is also being used, following the installation directions below.
 
 </Alert>
 


### PR DESCRIPTION
Closes: #5536

## Summary

**[Enabling Solr on Drupal 8](https://pantheon.io/docs/solr-drupal-8)** - Adjusted copy around EOL for the Drupal module that supports our old version of Solr.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
