### PR TITLE
ACDN link fix

### DIFF
--- a/source/content/advanced-global-cdn.md
+++ b/source/content/advanced-global-cdn.md
@@ -69,7 +69,7 @@ Yes. Unlike Global CDN, Advanced Global CDN can be configured to meet the unique
 - Custom/Comprehensive WAF services
 - Advanced bot detection & mitigation (Available as an add-on)
 
-[Get a full breakdown of the features](https://pantheon.io/advanced-global-cdn#pricing-matrix-wrapper) offered by our CDN services.
+[Get a full breakdown of the features](https://pantheon.io/product/advanced-global-cdn) offered by our CDN services.
 
 ## See Also
 

--- a/source/content/advanced-global-cdn.md
+++ b/source/content/advanced-global-cdn.md
@@ -69,7 +69,7 @@ Yes. Unlike Global CDN, Advanced Global CDN can be configured to meet the unique
 - Custom/Comprehensive WAF services
 - Advanced bot detection & mitigation (Available as an add-on)
 
-[Get a full breakdown of the features](https://pantheon.io/product/advanced-global-cdn) offered by our CDN services.
+[Get a full breakdown of the features](https://pantheon.io/product/advanced-global-cdn#pricing-matrix-wrapper) offered by our CDN services.
 
 ## See Also
 


### PR DESCRIPTION
Original path: https://pantheon.io/advanced-global-cdn#pricing-matrix-wrapper > https://pantheon.io/product/advanced-global-cdn
This update removes the intermediary stop. 

**Note:** Please fill out the PR Template to ensure proper processing.

## Summary

**[Advanced Global CDN](https://pantheon.io/docs/doc-title)** - Updates marketing link to match changes from the website.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
