### PR TITLE
improve keyboard-only navigation

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs:
           command: .circleci/scripts/set-env.sh && source $BASH_ENV
       - restore_cache:
           keys:
-            - v2.5.5-always-
-            - npm-v2.8.2-{{ checksum "gatsby/package-lock.json" }}
+            - v2.5.6-always-
+            - npm-v2.8.3-{{ checksum "gatsby/package-lock.json" }}
       - run:
           name: Install Terminus
           command: |
@@ -76,12 +76,12 @@ jobs:
           name: Test links
           command: .circleci/tests/link-checker.sh
       - save_cache:
-          key: npm-v2.8.2-{{ checksum "gatsby/package-lock.json" }}
+          key: npm-v2.8.3-{{ checksum "gatsby/package-lock.json" }}
           paths:
             - ~/build/gatsby/package-lock.json
             - ~/build/gatsby/node_modules
       - save_cache:
-          key: v2.5.5-always-{{ epoch }}
+          key: v2.5.6-always-{{ epoch }}
           paths:
             - ~/build/gatsby/public
             - ~/build/gatsby/.cache

--- a/gatsby/src/components/navbar/index.js
+++ b/gatsby/src/components/navbar/index.js
@@ -4,8 +4,7 @@ import './style.css';
 
 const Navbar = ({ title, items, activePage }) => {
   return (
-    <div className="col-md-3 manual-guide-toc" role="navigation">
-      <nav>
+      <nav className="col-md-3 manual-guide-toc" aria-labelledby="guide-nav">
       <button
         type="button"
         className="navbar-toggle"
@@ -18,7 +17,7 @@ const Navbar = ({ title, items, activePage }) => {
         <span className="sr-only">Toggle navigation</span>
         <i className="fa fa-bars" />
       </button>
-      <h3>{title}</h3>
+      <h3 id="guide-nav">{title}</h3>
       <div className="collapse navbar-collapse" id="guide-collapse">
         {items && (
           <ul id="manual-guide-toc" className="manual-guide-toc">
@@ -35,7 +34,6 @@ const Navbar = ({ title, items, activePage }) => {
         )}
       </div>
       </nav>
-    </div>
   )
 }
 

--- a/gatsby/src/components/navbar/style.css
+++ b/gatsby/src/components/navbar/style.css
@@ -1,12 +1,12 @@
 
-div.manual-guide-toc h3 {
+.manual-guide-toc h3 {
   font-size: 24px;
   margin-top: 40px;
   padding: 0px 0px 10px 40px;
 }
 
 @media (max-width: 500px) {
-  div.manual-guide-toc h3 {
+  .manual-guide-toc h3 {
     margin-top: 20px;
   }
 }
@@ -26,7 +26,7 @@ div.manual-guide-toc h3 {
   list-style-type: none;
   font-size: 16px !important;
 }
-div.col-md-3.manual-guide-toc {
+.col-md-3.manual-guide-toc {
   position: sticky;
   position: -webkit-sticky;
   position: -moz-sticky;
@@ -61,7 +61,7 @@ ul.manual-guide-toc > li > a:hover {
   padding: 10px 20px;
   margin-right: -18px;
 }
-div.manual-guide-toc.active-trail li > a:hover {
+.manual-guide-toc.active-trail li > a:hover {
   cursor: default !important;
   background-color: #fff !important;
 }
@@ -104,7 +104,7 @@ div.manual-guide-toc.active-trail li > a:hover {
 }
 
 @media (max-width: 994px) {
-  div.col-md-3.manual-guide-toc {
+  .col-md-3.manual-guide-toc {
     width: 100% !important;
     position: relative !important;
     top: 0;

--- a/gatsby/src/components/toc/index.js
+++ b/gatsby/src/components/toc/index.js
@@ -29,9 +29,9 @@ const TOC = ({ title }) => {
   })
 
   return (
-    <nav>
+    <nav aria-labelledby="toc-nav" className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top">
     <div id="toc" className="tocbot">
-      <h4>{title || "Table of Contents"}</h4>
+      <h4 id="toc-nav">{title || "Table of Contents"}</h4>
       <div className="toc-placeholder" />
     </div>
     </nav>

--- a/gatsby/src/components/toc/style.css
+++ b/gatsby/src/components/toc/style.css
@@ -23,7 +23,7 @@
 #terminus h2,
 #doc h3,
 #terminus h3 {
-  outline: none;
+  outline: darkred;
 }
 .tocify-item ul {
   display: none;

--- a/gatsby/src/layout/footer/index.js
+++ b/gatsby/src/layout/footer/index.js
@@ -199,6 +199,7 @@ const Footer = ({ data }) => {
                               title="Follow Pantheon on Facebook"
                             >
                               <i className="fa fa-facebook" aria-label="Facebook" role="img" focusable="false"/>
+                              <span class="sr-only">Facebook</span>
                             </a>
                           </li>
                           <li>
@@ -208,6 +209,7 @@ const Footer = ({ data }) => {
                               title="Pantheon on Twitter"
                             >
                               <i className="fa fa-twitter" aria-label="Twitter" role="img" focusable="false" />
+                              <span class="sr-only">Twitter</span>
                             </a>
                           </li>
                           <li>
@@ -217,6 +219,7 @@ const Footer = ({ data }) => {
                               title="Pantheon on LinkedIn"
                             >
                               <i className="fa fa-linkedin" aria-label="LinkedIn" role="img" focusable="false" />
+                              <span class="sr-only">LinkedIn</span>
                             </a>
                           </li>
                           <li>
@@ -225,7 +228,8 @@ const Footer = ({ data }) => {
                               href="https://www.youtube.com/user/GetPantheon"
                               title="Pantheon on YouTube"
                             >
-                              <i className="fa fa-youtube-play" />
+                              <i className="fa fa-youtube-play"  aria-label="YouTube" role="img" focusable="false" />
+                              <span class="sr-only">YouTube</span>
                             </a>
                           </li>
                           <li className="blog-link-li">

--- a/gatsby/src/layout/footer/style.css
+++ b/gatsby/src/layout/footer/style.css
@@ -582,6 +582,16 @@
   border-left: 1px solid #979797;
   height: 40px;
 }
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0,0,0,0);
+  border: 0;
+}
 .mktoForm .mktoFormRow {
   clear: none !important;
 }

--- a/gatsby/src/layout/header/index.js
+++ b/gatsby/src/layout/header/index.js
@@ -5,7 +5,8 @@ import AddSearch from "../../components/addSearch"
 
 const Header = ({ data }) => (
   <>
-    <div className="navbar navbar-fixed-top pio-docs-nav" role="navigation" id="header">
+    <nav className="navbar navbar-fixed-top pio-docs-nav" role="navigation" id="header">
+    <div id="skiptocontent"><a href="#doc">skip to main content</a></div>
       <div className="navbar-header">
         <button
           type="button"
@@ -156,6 +157,7 @@ const Header = ({ data }) => (
               <form
                 id="searchform"
                 action="/docs/search"
+                role="search"
                 acceptCharset="UTF-8"
                 encType="application/x-www-form-urlencoded"
                 title="Search Pantheon Documentation form"
@@ -177,7 +179,7 @@ const Header = ({ data }) => (
           </div>
         </div>
       </div>
-    </div>
+    </nav>
   </>
 )
 

--- a/gatsby/src/layout/header/style.css
+++ b/gatsby/src/layout/header/style.css
@@ -19,6 +19,30 @@
 .pio-docs-nav .navbar-nav {
   float: right;
 }
+#skiptocontent a {
+	padding:6px;
+	position: absolute;
+	top:-40px;
+	left:0px;
+	color:white;
+	border-right:1px solid white;
+	border-bottom:1px solid white;
+	border-bottom-right-radius:8px;
+	background:#BF1722;
+	-webkit-transition: top 1s ease-out;
+    transition: top 1s ease-out;
+    z-index: 100;
+}
+
+#skiptocontent a:focus {
+	position:absolute;
+	left:0px;
+	top:0px;
+	outline-color:transparent;	
+	-webkit-transition: top .1s ease-in;
+    transition: top .1s ease-in;
+}
+
 li.create-account {
 	padding-right: 20px !important;
 	padding-left: 20px !important;

--- a/gatsby/src/styles/global.scss
+++ b/gatsby/src/styles/global.scss
@@ -383,7 +383,6 @@ pre code, pre code .hljs, .hljs {
 .affix-top.pio-docs-sidebar {
 	top: 130px !important;
 	position: sticky;
-	position: -webkit-sticky;
 	position: -moz-sticky;
 	position: -ms-sticky;
 	position: -o-sticky;
@@ -577,70 +576,9 @@ h2 > .glyphicons {
 	}
 }
 
-/* Show and affix the side nav when space allows it */
-@media (min-width: 1500px) {
-	.pio-docs-sidebar.affix-bottom {
-		/*width: 250px !important;*/
-		/*margin-left: 50px;*/
-	}
-	.pio-docs-sidebar.affix-top {
-		/*width: 250px !important;*/
-		/*margin-left: 50px;*/
-	}
-	.pio-docs-sidebar.affix {
-		/*width: 250px !important;*/
-		/*margin-left: 50px;*/
-	}
-}
-
-@media (min-width: 1202px) and (max-width: 1499px) {
-	.pio-docs-sidebar.affix-bottom {
-		/*width: 250px !important;*/
-		/*margin-left: 40px;*/
-	}
-	.pio-docs-sidebar.affix-top {
-		/*width: 250px !important;*/
-		/*margin-left: 40px;*/
-	}
-	.pio-docs-sidebar.affix {
-		/*width: 250px !important;*/
-		/*margin-left: 40px;*/
-	}
-}
-@media (min-width: 992px) and (max-width: 1201px) {
-	.pio-docs-sidebar.affix-bottom {
-		/*width: 250px !important;*/
-	}
-	.pio-docs-sidebar.affix-top {
-		/*width: 250px !important;*/
-	}
-	.pio-docs-sidebar.affix {
-		/*width: 250px !important;*/
-	}
-}
-
 @media (max-width: 1200px) {
 	.container {
 	}
-}
-/* Widen the fixed sidebar */
-.pio-docs-sidebar.affix,
-.pio-docs-sidebar.affix-bottom {
-}
-.pio-docs-sidebar.affix {
-}
-.pio-docs-sidebar.affix-bottom {
-}
-.pio-docs-sidebar.affix {
-	/*position: fixed; /* Undo the static from mobile first approach */
-}
-.pio-docs-sidebar.affix-top {
-	/*width: 250px !important;*/
-}
-.pio-docs-sidebar.affix-bottom {
-}
-.pio-docs-sidebar.affix-bottom .pio-docs-sidenav,
-.pio-docs-sidebar.affix .pio-docs-sidenav {
 }
 
 @supports (-ms-ime-align: auto) {

--- a/gatsby/src/styles/global.scss
+++ b/gatsby/src/styles/global.scss
@@ -62,7 +62,10 @@ pre code {
 .pantheon-docs a:hover {
 	text-decoration: none;
 }
-
+.pantheon-docs a:focus {
+	outline: 5px auto #0a6bb5;
+	outline-offset: 0;
+}
 .pantheon-docs h1 {
 	margin-top: 35px;
 	font-family: "TabletGothic";

--- a/gatsby/src/styles/main.css
+++ b/gatsby/src/styles/main.css
@@ -2631,8 +2631,6 @@ a.ctaBtn.cta-black-on-yellow:after:hover {
 	display: -webkit-box !important;
 }
 a:focus {
-	outline: none;
-	outline-offset: inherit;
 	text-decoration: none;
 }
 

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -96,9 +96,9 @@ class DocTemplate extends React.Component {
           tags={node.frontmatter.tags}
           reviewed={isoDate.frontmatter.reviewed}
         />
-        <div className="">
+        <main id="doc">
           <div className="container doc-content-well">
-            <article id="doc" className="doc article col-md-9 md-70">
+            <article className="doc article col-md-9 md-70">
               <HeaderBody
                 title={node.frontmatter.title}
                 subtitle={node.frontmatter.subtitle}
@@ -118,8 +118,11 @@ class DocTemplate extends React.Component {
             </article>
             <TOC title="Contents" />
           </div>
-        </div>
-        <GetFeedback formId="tfYOGoE7" page={"/" + node.fields.slug} />
+        </main>
+          <GetFeedback
+            formId="tfYOGoE7"
+            page={"/" + node.fields.slug}
+          />
       </Layout>
     )
   }

--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -98,7 +98,7 @@ class DocTemplate extends React.Component {
         />
         <div className="">
           <div className="container doc-content-well">
-            <div id="doc" className="doc article col-md-9 md-70">
+            <article id="doc" className="doc article col-md-9 md-70">
               <HeaderBody
                 title={node.frontmatter.title}
                 subtitle={node.frontmatter.subtitle}
@@ -115,13 +115,8 @@ class DocTemplate extends React.Component {
                   <MDXRenderer>{node.body}</MDXRenderer>
                 </MDXProvider>
               </div>
-            </div>
-            <div
-              className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
-              role="complementary"
-            >
-              <TOC title="Contents" />
-            </div>
+            </article>
+            <TOC title="Contents" />
           </div>
         </div>
         <GetFeedback formId="tfYOGoE7" page={"/" + node.fields.slug} />

--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -105,7 +105,6 @@ class GuideTemplate extends React.Component {
           image={"/assets/images/terminus-thumbLarge.png"}
           reviewed={isoDate.frontmatter.reviewed}
         />
-        <div className="">
           <div className="container">
             <div className="row col-md-12 guide-nav manual-guide-toc-well">
               <Navbar
@@ -113,10 +112,10 @@ class GuideTemplate extends React.Component {
                 activePage={node.fields.slug}
                 items={items}
               />
-              <div id="terminus" className="terminus col-md-9 guide-doc-body">
+              <div className="col-md-9 guide-doc-body">
                 <div className="row guide-content-well">
-                  <div
-                    className={`col-xs-${contentCols} col-md-${contentCols}`}
+                  <article
+                    id="doc" className={`col-xs-${contentCols} col-md-${contentCols}`}
                   >
                     <HeaderBody
                       title={node.frontmatter.title}
@@ -132,7 +131,7 @@ class GuideTemplate extends React.Component {
                     <MDXProvider components={shortcodes}>
                       <MDXRenderer>{node.body}</MDXRenderer>
                     </MDXProvider>
-                  </div>
+                  </article>
                   {node.frontmatter.showtoc && (
                     <div
                       className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
@@ -160,7 +159,6 @@ class GuideTemplate extends React.Component {
               </div>
             </div>
           </div>
-        </div>
       </Layout>
     )
   }

--- a/gatsby/src/templates/guide.js
+++ b/gatsby/src/templates/guide.js
@@ -112,10 +112,10 @@ class GuideTemplate extends React.Component {
                 activePage={node.fields.slug}
                 items={items}
               />
-              <div className="col-md-9 guide-doc-body">
+              <main id="doc" className="col-md-9 guide-doc-body">
                 <div className="row guide-content-well">
                   <article
-                    id="doc" className={`col-xs-${contentCols} col-md-${contentCols}`}
+                    className={`col-xs-${contentCols} col-md-${contentCols}`}
                   >
                     <HeaderBody
                       title={node.frontmatter.title}
@@ -156,7 +156,7 @@ class GuideTemplate extends React.Component {
                   prev={this.props.pageContext.previous}
                   next={this.props.pageContext.next}
                 />
-              </div>
+              </main>
             </div>
           </div>
       </Layout>


### PR DESCRIPTION
## Summary
Modifies DOM elements and CSS in main content types to facilitate keyboard navigation.

## Remaining Work

The following changes still need to be completed:
- [ ] technical review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
