### PR TITLE
toc-ignore H2s from changelog

### DIFF
--- a/gatsby/src/components/localdevChangelog.js
+++ b/gatsby/src/components/localdevChangelog.js
@@ -17,6 +17,9 @@ const LocaldevChangelog = ({ data }) => (
                 __html: localdev.changelog.replace(
                   /h3/g,
                   'h3 class="toc-ignore"'
+                ).replace(
+                  /h2/g,
+                  'h2 class="toc-ignore"'
                 ),
               }}
             />


### PR DESCRIPTION
## Summary

**[Use Pantheon Localdev to Develop Sites Locally](https://pantheon.io/docs/localdev)** - Adds `toc-ignore` class to the H2s they decided to use with reckless abandon in the Localdev changelog.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
