### PR TITLE
Update services.yml doc with information about directory permissions

### DIFF
--- a/source/content/services-yml.md
+++ b/source/content/services-yml.md
@@ -23,7 +23,10 @@ The table below illustrates which services file is used in which Pantheon enviro
 
 ## Create and Modify services.yml
 1.  Before you begin, make sure that you have updated your Drupal site to version 8.2.0 or greater.
-2.  From within the `sites/default` directory, create a new `services` file. Name it based on which environment you wish to configure settings for:
+2.  If Drupal has already been installed, permissions on the `sites/default` directory may need to be temporarily changed to allow write access.
+      * [`How to change directory permissions`](https://www.pluralsight.com/blog/it-ops/linux-file-permissions)
+      * Once the .yml has been created and edited, __change permissions__ back to lock down the `sites/default` directory.
+3.  From within the `sites/default` directory, create a new `services` file. Name it based on which environment you wish to configure settings for:
 
     - **All environments:** `services.yml`
     - **Production environment:** `services.pantheon.production.yml`


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Creating a services.yml File for Drupal 8](https://pantheon.io/docs/services-yml)** - Update services.yml documentation with information about changing sites/default directory permissions

## Effect

The following changes are already commited:

- Add information about possibly needing to change directory permissions
- Add external link to site describing how to change directory permissions

## Remaining Work

The following changes still need to be completed:

- [ ] No remaining work

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
