### PR TITLE
Update migrate-wordpress-site-networks references

### DIFF
--- a/source/content/migrate-wordpress-site-networks.md
+++ b/source/content/migrate-wordpress-site-networks.md
@@ -1,8 +1,8 @@
 ---
 title: 'Migrate to Pantheon: WordPress Site Networks'
 description: Learn how to import a WordPress Site Network into Pantheon.
-tags: [migratemanual]
-categories: [get-started,wordpress]
+tags: [wordpress, migration, Site Network]
+categories: [get-started]
 ---
 
 <Alert title="Note" type="info">
@@ -191,4 +191,6 @@ When you re-import the database with current content (prior to going live on Pan
 
 ## See Also
 
-* [The Quickstart Guide to Migrating a WordPress Site](https://pantheon.io/resources/quickstart-guide-migrating-wordpress-site)
+* [Migrate Sites to Pantheon](/migrate)
+* [Guided WordPress Migrations (video)](/videos/migrate-wordpress)
+* [WordPress Launch Check](/wordpress-launch-check)


### PR DESCRIPTION
## Summary

**[Migrate WordPress Site Networks](https://pantheon.io/docs/migrate-wordpress-site-networks)** - Updated See Also section with more helpful references.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
