### PR TITLE
remove duplicate css declarations to nav

### DIFF
--- a/gatsby/src/components/toc/index.js
+++ b/gatsby/src/components/toc/index.js
@@ -29,7 +29,7 @@ const TOC = ({ title }) => {
   })
 
   return (
-    <nav aria-labelledby="toc-nav" className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top">
+    <nav aria-labelledby="toc-nav">
     <div id="toc" className="tocbot">
       <h4 id="toc-nav">{title || "Table of Contents"}</h4>
       <div className="toc-placeholder" />


### PR DESCRIPTION
## Effect
Remove duplicate css declarations in nav element.

## Post Launch
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
