### PR TITLE
Fix GetFeedback display

### DIFF
--- a/gatsby/src/templates/doc.js
+++ b/gatsby/src/templates/doc.js
@@ -117,12 +117,12 @@ class DocTemplate extends React.Component {
               </div>
             </article>
             <TOC title="Contents" />
+            <GetFeedback
+              formId="tfYOGoE7"
+              page={"/" + node.fields.slug}
+            />
           </div>
         </main>
-          <GetFeedback
-            formId="tfYOGoE7"
-            page={"/" + node.fields.slug}
-          />
       </Layout>
     )
   }


### PR DESCRIPTION

## Summary

**[Doc Page Template](https://github.com/pantheon-systems/documentation/blob/master/gatsby/src/templates/doc.js)** - Moves the GetFeedback element in the Doc template to adjust the layout.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
