### PR TITLE
Updated Authy URL

### DIFF
--- a/source/content/guides/two-factor-authentication.md
+++ b/source/content/guides/two-factor-authentication.md
@@ -56,7 +56,7 @@ For a single site, there are a few [different Drupal modules](https://groups.dru
 
 1. Install and enable the [Two-factor Authentication (TFA)](https://www.drupal.org/project/tfa) module and the [TFA Basic plugins](https://www.drupal.org/project/tfa_basic) module on your Drupal site.
 
-2. Download and set up a Time-based One-time Password Algorithm (TOTP) app such as [Authy](https://www.authy.com/users) for either iOS or Android.
+2. Download and set up a Time-based One-time Password Algorithm (TOTP) app such as [Authy](https://www.authy.com/download) for either iOS or Android.
 
 3. Configure the TFA module `admin/config/people/tfa` to **Enable TFA**; set **TOTP** as the default validation plugin; add **Recovery Codes** as a fallback plugin; and allow **Trusted Browsers** for your domain.
 


### PR DESCRIPTION
## Summary

Updated a URL returning a 404 - https://www.authy.com/users
The download page has been updated to https://www.authy.com/download

## Effect

The following changes are already commited:

## Remaining Work

The following changes still need to be completed:



## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
