### PR TITLE
Adding links to the new workshops on landing pages

### DIFF
--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -85,6 +85,10 @@
     title: 'Quick Start Guide'
     subtitle: 'New to our platform? Check out our step-by-step guide to learn all the basics.'
     url: '/guides/quickstart'
+  cta_alt:
+    title: 'Command Line Interface with Terminus'
+    subtitle: 'An introduction to Terminus: Pantheon's command line interface.'
+    url: 'https://pantheon.io/live-workshops/command-line-interface-terminus?docs'
   subtopics:
     - title: 'Command Line Interface'
       subtitle: 'Use Terminus to interact with the platform from the command line.'
@@ -363,6 +367,10 @@
     title: 'Launch Essentials Guide'
     subtitle: "Ready to launch like a pro? Check out our step-by-step guide to see how it's done."
     url: '/guides/launch'
+  cta_alt:
+    title: 'Going Live Best Practices'
+    subtitle: 'How do you take a website live on Pantheon?'
+    url: 'https://pantheon.io/live-workshops/going-live-best-practices?docs'
   topics-groups:
     - title: 'New Relic'
       subtitle: 'Use New Relic’s reporting to get end-to-end visibility into your website’s performance.'
@@ -540,6 +548,10 @@
     title: 'Terminus Manual'
     subtitle: 'Prefer working from the command line? Check out Terminus, the Pantheon CLI.'
     url: '/terminus'
+  cta_alt:
+    title: 'Integrate and Automate with Quicksilver'
+    subtitle: 'An introduction to Quicksilver: Pantheon's tool for integrating and automating with anything.'
+    url: 'https://pantheon.io/live-workshops/integrate-and-automate-quicksilver?docs'
   topics-groups:
     - title: ''
       subtitle: ''
@@ -687,6 +699,10 @@
     title: 'Front End Performance Guide'
     subtitle: "Ready to dive into Pantheon's Global CDN? Check out this guide to learn how to ace an online speed test."
     url: '/guides/frontend-performance'
+  cta_alt:
+    title: 'Website Performance with Varnish, Redis, and New Relic'
+    subtitle: 'How does Pantheon help your website be faster than other platforms?'
+    url: 'https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic?docs'
   topics-groups:
     - title: 'New Relic'
       subtitle: 'Use New Relic’s reporting to get end-to-end visibility into your website’s performance.'

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -87,7 +87,7 @@
     url: '/guides/quickstart'
   cta_alt:
     title: 'Command Line Interface with Terminus'
-    subtitle: 'An introduction to Terminus: Pantheon's command line interface.'
+    subtitle: "An introduction to Terminus: Pantheon's command line interface."
     url: 'https://pantheon.io/live-workshops/command-line-interface-terminus?docs'
   subtopics:
     - title: 'Command Line Interface'
@@ -550,7 +550,7 @@
     url: '/terminus'
   cta_alt:
     title: 'Integrate and Automate with Quicksilver'
-    subtitle: 'An introduction to Quicksilver: Pantheon's tool for integrating and automating with anything.'
+    subtitle: "An introduction to Quicksilver: Pantheon's tool for integrating and automating with anything."
     url: 'https://pantheon.io/live-workshops/integrate-and-automate-quicksilver?docs'
   topics-groups:
     - title: ''
@@ -701,7 +701,7 @@
     url: '/guides/frontend-performance'
   cta_alt:
     title: 'Website Performance with Varnish, Redis, and New Relic'
-    subtitle: 'How does Pantheon help your website be faster than other platforms?'
+    subtitle: 'How does Pantheon help your website run faster than other platforms?'
     url: 'https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic?docs'
   topics-groups:
     - title: 'New Relic'


### PR DESCRIPTION
Add secondary CTAs on landing pages that point to the new Live Workshops. This is a lift and shift from the workshop pages so a pass through to update the language would be nice.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

Add secondary CTAs on landing pages that point to the new Live Workshop signups. 

## Effect

The following changes are already committed:

- CTA's are added to 4 new landing pages

## Remaining Work

The following changes still need to be completed:

- [ ] A pass for language

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
