### PR TITLE
Correct formula from minutes to seconds

### DIFF
--- a/source/content/load-and-performance-testing.md
+++ b/source/content/load-and-performance-testing.md
@@ -50,7 +50,7 @@ Ultimately, it doesn't matter what tool(s) you use as long as you test your site
 3. Determine how much load to apply.
 
   * **Performance Tests**: Smaller loads should suffice, as you should be able to see transactional bottlenecks with 10-20 concurrent users.
-  * **Load Tests**: Determine how many concurrent users the site is expected to serve based on historical analytics for the site. Identify the peak hourly sessions and average session duration, then do some math: `hourly_sessions / (60 / average_duration) = Concurrent Users`
+  * **Load Tests**: Determine how many concurrent users per second the site is expected to serve based on historical analytics for the site. Identify the peak hourly sessions and average session duration, then do some math: `Concurrent Users = ( hourly_sessions x average_duration ) / 3600`
 
 
 ## Running the Tests

--- a/source/content/load-and-performance-testing.md
+++ b/source/content/load-and-performance-testing.md
@@ -3,7 +3,9 @@ title: Load and Performance Testing
 description: Learn how to monitor internal execution performance of your Pantheon Drupal or WordPress site.
 tags: [newrelic]
 categories: [performance,go-live]
+reviewed: "2020-04-02"
 ---
+
 Load and performance tests are critical steps in going live procedures, as they help expose and identify potential performance killers. These tests provide insight for how a site will perform in the wild under peak traffic spikes.
 
 <Alert title="Note" type="info">
@@ -13,20 +15,23 @@ Load testing is one of the services offered by our [Professional Services](/prof
 </Alert>
 
 ## Load vs Performance Testing
+
 Before you start, it's important to understand the difference between load and performance testing and know when to use each.
+
 ### Performance Testing
+
 Performance testing is the process in which you measure an application's response time to proactively expose bottlenecks. In addition to regularly referring to your New Relic reports, you should consider regularly executing performance tests as part of routine maintenance to ensure performance isn't being degraded by code or configuration changes.  You should run these test before any load testing. If your application is not performing well, then you can be assured that the load test will not go well.  
 
 The scope of performance tests should be limited to the application itself on a development environment (Dev or [Multidev](/multidev)) without caching. This will give you an honest look into your application and show exactly how uncached requests will perform. You can bypass cache by [setting the `no-cache` HTTP headers](/cache-control) in responses.
 
-
-
 ### Load Testing
+
 Load testing is the process in which you apply requests to your site that will represent the most load that your site will face once it is live.  This test will ensure that the site can withstand the peak traffic spikes after launch. This test should be done on the Live environment before the site has launched, in advance of anticipated major-traffic events, or after major overhauls, remembering to provide enough time to fix any issues identified after performance testing.
 
 If your site is already live, then you should run load tests on the Test environment. For Live environments with mulitple application containers, keep in mind that the Test environment has two application containers. Run a proportionate amount of traffic based on the number of Live environment app containers you have. If you have four app containers in live, then test with half of your anticipated peak. You can see the number of app containers using [Pantheon's free New Relic offering](/new-relic). 
 
 ## Preparing for Tests
+
 The procedure for executing a load test and a performance test are similar:
 
 1. Enable [New Relic Pro](/new-relic) within the Site Dashboard on Pantheon to ensure you have clear reporting to monitor response times.
@@ -43,17 +48,17 @@ The procedure for executing a load test and a performance test are similar:
      * [Jmeter](https://jmeter.apache.org/)
      * [Locust](http://locust.io/)
 
-The Pantheon onboarding team uses Locust, an open source load testing tool. Locust makes it easy to build out test scripts, and it allows you to crawl the site instead of using predefined URLs. Crawling the site has the added benefit of loading every page that is linked to anywhere on the site. This exposes edge case performance bottlenecks that would have gone undetected under tests with predefined URLs.
+  The Pantheon onboarding team uses Locust, an open source load testing tool. Locust makes it easy to build out test scripts, and it allows you to crawl the site instead of using predefined URLs. Crawling the site has the added benefit of loading every page that is linked to anywhere on the site. This exposes edge case performance bottlenecks that would have gone undetected under tests with predefined URLs.
 
-Ultimately, it doesn't matter what tool(s) you use as long as you test your site against the anticipated traffic patterns of the site in terms of overall volume and the proportion of anonymous versus authenticated traffic. Note that load testing for anonymous visits is considerably easier than testing authenticated workflows, which will require more investment of time and skills.  
+  Ultimately, it doesn't matter what tool(s) you use as long as you test your site against the anticipated traffic patterns of the site in terms of overall volume and the proportion of anonymous versus authenticated traffic. Note that load testing for anonymous visits is considerably easier than testing authenticated workflows, which will require more investment of time and skills.  
 
 3. Determine how much load to apply.
 
-  * **Performance Tests**: Smaller loads should suffice, as you should be able to see transactional bottlenecks with 10-20 concurrent users.
-  * **Load Tests**: Determine how many concurrent users per second the site is expected to serve based on historical analytics for the site. Identify the peak hourly sessions and average session duration, then do some math: `Concurrent Users = ( hourly_sessions x average_duration ) / 3600`
-
+   * **Performance Tests**: Smaller loads should suffice, as you should be able to see transactional bottlenecks with 10-20 concurrent users.
+   * **Load Tests**: Determine how many concurrent users per second the site is expected to serve based on historical analytics for the site. Identify the peak hourly sessions and average session duration, then do some math: `Concurrent Users = ( hourly_sessions x average_duration ) / 3600`
 
 ## Running the Tests
+
 If this is a performance test, be sure to run the test on a development environment (Dev or [Multidev](/multidev)) without caching. Run load tests on the Live environment before launching the site. If the site is already launched, use the Test environment instead.
 
 <Alert title="Warning" type="danger">
@@ -73,6 +78,7 @@ Once the test is running, execute common tasks done by editors and administrator
 * Flush Redis cache (if Redis is running)
 
 ## Assess Results
+
 Now that the test is complete, examine the New Relic data. The **Overview** tab will give you an average response time for the duration of the test. Times above 750ms are good indicators of performance optimization opportunities.
 
 Next, review the **Transactions** tab in New Relic and sort by **Slowest average response time**. Click on the slowest transaction to pull up the transaction trace. Review the transaction trace to find the performance bottleneck.
@@ -80,9 +86,9 @@ Next, review the **Transactions** tab in New Relic and sort by **Slowest average
 Finally, review the **Error analytics** tab in New Relic. PHP errors often indicate huge performance bottlenecks. If you have errors, fix them.
 
 ### Calculating Load Capacity After Launch
+
 After launch, you can establish a baseline that `X` response time will let you handle `Y` traffic. If `X` degrades in Dev/Test, that will impact how much traffic Live can handle.
 
 ## See Also
 
 * [Load Testing Drupal and WordPress with BlazeMeter](/guides/load-testing-with-blazemeter)
-


### PR DESCRIPTION
The formula `hourly_sessions / (60 / average_duration) = Concurrent Users` results in concurrent users per minute rather than per second which is the unit of measure needed for the load test input. You could just divide the existing equation all by 60, but reduces to a cleaner  `( hourly_sessions x average_duration ) / 3600`.  -vvv would be "Multiply the peak hourly sessions times the average session duration, and then divide by 3600 (the number of second in an hour).

**Note:** Please fill out the PR Template to ensure proper processing.


## Summary

**[Load and Performance Testing: Preparing for Tests](https://pantheon.io/docs/load-and-performance-testing#preparing-for-tests)** - Updates and identifies the unit of measure needed for the load test concurrent users formula. 

## Effect

The following changes are already committed:

- Unit of measure in description
- Formula rewritten to include unit of measure and simplified

## Remaining Work
none

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
