### PR TITLE
Fix Regression: ToC Scroll

### DIFF
--- a/gatsby/src/components/toc/index.js
+++ b/gatsby/src/components/toc/index.js
@@ -29,7 +29,7 @@ const TOC = ({ title }) => {
   })
 
   return (
-    <nav aria-labelledby="toc-nav">
+    <nav aria-labelledby="toc-nav" className=" pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top">
     <div id="toc" className="tocbot">
       <h4 id="toc-nav">{title || "Table of Contents"}</h4>
       <div className="toc-placeholder" />

--- a/gatsby/src/templates/changelog.js
+++ b/gatsby/src/templates/changelog.js
@@ -80,6 +80,7 @@ class ChangelogTemplate extends React.Component {
         />
         <div className="">
           <div className="container doc-content-well">
+          <article className="doc article col-md-9 md-70">
             <div id="doc" className="doc article col-md-9 md-70">
               <h1 className="toc-ignore">Pantheon Changelog</h1>
               <h2 className="toc-ignore">{node.frontmatter.title}</h2>
@@ -96,12 +97,8 @@ class ChangelogTemplate extends React.Component {
                 </MDXProvider>
               </div>
             </div>
-            <div
-              className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
-              role="complementary"
-            >
-              <TOC title="Contents" />
-            </div>
+            </article>
+            <TOC title="Contents" />
           </div>
           <NavButtons
             prev={this.props.pageContext.previous}

--- a/gatsby/src/templates/changelog.js
+++ b/gatsby/src/templates/changelog.js
@@ -78,8 +78,7 @@ class ChangelogTemplate extends React.Component {
           authors={node.frontmatter.contributors}
           image={"/assets/images/default-thumb-doc.png"}
         />
-        <div className="">
-          <div className="container doc-content-well">
+        <div className="container doc-content-well">
           <article className="doc article col-md-9 md-70">
             <div id="doc" className="doc article col-md-9 md-70">
               <h1 className="toc-ignore">Pantheon Changelog</h1>
@@ -97,16 +96,15 @@ class ChangelogTemplate extends React.Component {
                 </MDXProvider>
               </div>
             </div>
-            </article>
-            <TOC title="Contents" />
-          </div>
-          <NavButtons
-            prev={this.props.pageContext.previous}
-            next={this.props.pageContext.next}
-            prevTitle="Older"
-            nextTitle="Newer"
-          />
+          </article>
+          <TOC title="Contents" />
         </div>
+        <NavButtons
+          prev={this.props.pageContext.previous}
+          next={this.props.pageContext.next}
+          prevTitle="Older"
+          nextTitle="Newer"
+        />
       </Layout>
     )
   }

--- a/gatsby/src/templates/changelogs.js
+++ b/gatsby/src/templates/changelogs.js
@@ -112,12 +112,7 @@ class ChangelogsTemplate extends React.Component {
                 ))}
               </div>
             </div>
-            <div
-              className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
-              role="complementary"
-            >
-              <TOC title="Contents" />
-            </div>
+            <TOC title="Contents" />
           </div>
           <NavButtons
             prev={this.props.pageContext.previous}


### PR DESCRIPTION
## Summary

**[Site Improvement](https://pantheon.io/docs)** - Fixes regression so ToC scrolls with reader.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
