### PR TITLE
Adding another registration method for WPML in Pantheon

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -791,7 +791,13 @@ ___
 
 ![The Configure WMPL Button](../images/wpml-configure.png)
 
-You can also add the registration keys via `wp-config.php` as `define( 'OTGS_INSTALLER_SITE_KEY_WPML', 'your-site-key' );`. More details in the [WPML Guide](https://wpml.org/faq/install-wpml/#registration-using-php).
+You can also add the registration keys to `wp-config.php`:
+
+```php:title=wp-config.php
+define( 'OTGS_INSTALLER_SITE_KEY_WPML', 'your-site-key' );
+```
+
+Learn more in the [WPML Guide](https://wpml.org/faq/install-wpml/#registration-using-php).
 
 ___
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -791,6 +791,8 @@ ___
 
 ![The Configure WMPL Button](../images/wpml-configure.png)
 
+You can also add the registration keys via `wp-config.php` as `define( 'OTGS_INSTALLER_SITE_KEY_WPML', 'your-site-key' );`. More details in the [WPML Guide](https://wpml.org/faq/install-wpml/#registration-using-php).
+
 ___
 
 **Issue 3:** Upon activating WPML String Translation plugin, you may see this error:


### PR DESCRIPTION
~**Note:** Please fill out the PR Template to ensure proper processing.~ Filled out properly by Alex.

## Summary

**[WordPress Plugins and Themes with Known Issues - WPML](https://pantheon.io/docs/plugins-known-issues#wpml---the-wordpress-multilingual-plugin)** - Additional solution options for providing the WPML registration key.

This is relevant for users in Live where the option to add the registration code is disabled due to the file update capability is disabled

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
