### PR TITLE
Fix Feedback Links for Live Workshops

### DIFF
--- a/source/partials/additionalResources/lw3.md
+++ b/source/partials/additionalResources/lw3.md
@@ -1,6 +1,6 @@
 ## Congratulations on completing Automate and Integrate with Quicksilver! 🎉
 
-If you thought that was interesting you shoudld sign up for workshop #3: [Website Performance with Varnish, Redis, and New Relic](https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
+If you thought that was interesting you should sign up for workshop #4: [Website Performance with Varnish, Redis, and New Relic](https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 
 ### Your Feedback Helps
 

--- a/source/partials/additionalResources/null.md
+++ b/source/partials/additionalResources/null.md
@@ -1,3 +1,3 @@
 This page provides additional resources for those who've completed an Essential Developer Training course. If you're seeing this, the URL wasn't complete. Try again.
 
-You can also [click here](https://pantheon.io/live-workshops) to learn more about Pantheon's live workshops.
+You can also visit `https://pantheon.io/live-workshops` to learn more about Pantheon's live workshops.


### PR DESCRIPTION
## Summary

**[Live Workshop Resources](https://pantheon.io/docs/doc-title)** - Replaced markdown links with A tags, because markdown can't handle links with brackets in them.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
