### PR TITLE
adds callout to temp free multidev

### DIFF
--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -14,16 +14,18 @@ To support the large number of web teams whose day-to-day operations are disrupt
 
 </Alert>
 
-Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
+Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~ until July 1, 2020. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
 
 Visit the [Partner Program Page](https://pantheon.io/plans/partner-program?docs) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
 ### Should I have access to Multidev?
 
-Yes! Multidev is available until July 1, 2020 ~~if you:~~
+Yes! Multidev is available until July 1, 2020.
 
- - ~~Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs))~~.
- - ~~Are a Direct Online customer with Gold support or above.~~
+After that, users will have access to Multidev if they:
+
+ - Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs)).
+ - Are a Direct Online customer with Gold support or above.
 
 If you fully meet either of these conditions and still don't have access to Multidev, please [contact support](https://dashboard.pantheon.io/#support).
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -2,7 +2,7 @@
 title: Multidev FAQ
 description: A quick reference to answer some of the most frequently asked questions about Multidev.
 tags: [tools, workflow]
-categories: [manage,develop]
+categories: [develop]
 ---
 For information about what Multidev is and how to use it, see our full guide on [Multidev](/multidev).
 
@@ -10,7 +10,7 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 <Alert title="Note" type="info" >
 
-In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
 
 </Alert>
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -8,16 +8,22 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 ## Who has access to Multidev?
 
-Multidev is available to all **accounts with [Gold support](/support/#support-features-and-response-times) and above**. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
+<Alert title="Note" type="info" >
+
+In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+
+</Alert>
+
+Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
 
 Visit the [Partner Program Page](https://pantheon.io/plans/partner-program?docs) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
 ### Should I have access to Multidev?
 
-Multidev is available if you:
+Yes! Multidev is available until July 1, 2020 ~~if you:~~
 
- - Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs)).
- - Are a Direct Online customer with Gold support or above.
+ - ~~Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs))~~.
+ - ~~Are a Direct Online customer with Gold support or above.~~
 
 If you fully meet either of these conditions and still don't have access to Multidev, please [contact support](https://dashboard.pantheon.io/#support).
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -16,7 +16,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
 
 </Alert>
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -16,7 +16,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
 
 </Alert>
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -14,6 +14,12 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 </Enablement>
 
+<Alert title="Note" type="info" >
+
+In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+
+</Alert>
+
 ## Benefits of Multidev
 
 **Easy workflow.** Developers on your team can use a standardized best-practice development workflow in the cloud through their Dashboard.

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -18,7 +18,7 @@ Creating a Multidev environment creates an application container with a database
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
 
 </Alert>
 
@@ -53,7 +53,7 @@ As a workaround, we recommend following development best practice workflows by [
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
 
 </Alert>
 

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -16,6 +16,12 @@ Creating a Multidev environment creates an application container with a database
 
 ### How can my Organization get Multidev and how much does it cost?
 
+<Alert title="Note" type="info" >
+
+In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+
+</Alert>
+
 Multidev is one of the highlight features of the Pantheon Partner Program. Visit the [Partner Program Page](https://pantheon.io/plans/partner-program) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
 ## Change Management
@@ -44,6 +50,13 @@ Any large agency that has multiple developers who login frequently via username/
 As a workaround, we recommend following development best practice workflows by [authenticating via SSH key for password-less access](/ssh-keys).
 
 ### Why can't I access Multidev on my site when the Supporting Organization can use it?
+
+<Alert title="Note" type="info" >
+
+In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+
+</Alert>
+
 Only organizational team members and administrators of a Supporting Organization with Multidev will be able to use this feature. Site team members who are associated with the site but not the agency can access Multidev environments via the unique URL, but will not be able to commit code to them.
 
 ### Why can't my Agency Organization own a site?

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -18,7 +18,7 @@ Creating a Multidev environment creates an application container with a database
 
 <Alert title="Note" type="info" >
 
-In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
 
 </Alert>
 
@@ -53,7 +53,7 @@ As a workaround, we recommend following development best practice workflows by [
 
 <Alert title="Note" type="info" >
 
-In light of the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blogpost for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
 
 </Alert>
 


### PR DESCRIPTION
## Summary

**[Multidev FAQ](https://pantheon.io/docs/multidev-faq) (and others)** - To help web teams during times of Covid, Pantheon has made Multidev available to everyone for free through July 1.

## Effect

The following changes are already committed:

- adds callouts to `multidev-faq`, `multidev`, and `organization-faq`

## Remaining Work

The following changes still need to be completed:

- [x] I used a strikethrough to indicate that some information has been temporarily changed. Soliciting feedback about that style choice
- [ ] Create an undo PR

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
