### PR TITLE
Multidev for Gold Support and higher - Reverts 5638

### DIFF
--- a/source/content/crisis-response-upstream.md
+++ b/source/content/crisis-response-upstream.md
@@ -14,7 +14,7 @@ The **Pantheon Crisis Response WordPress Upstream** is a specialized WordPress [
 
 ![Crisis Response WP home page](../images/covid-response-home.png)
 
-If you are a government, medical, or educational institution with a crisis communications website, or a non-profit organization directly providing relief, we will [provide the full service of our WebOps platform](https://pantheon.io/resources-navigate-covid-19) at no charge through December 31, 2020. We want you to deliver vital information to the public without worrying about traffic cost or site availability.
+If you are a government, medical, or educational institution with a crisis communications website, or a non-profit organization directly providing relief, we will [provide the full service of our WebOps platform](https://pantheon.io/resources-navigate-covid-19) at no charge. We want you to deliver vital information to the public without worrying about traffic cost or site availability.
 
 ## Features
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -10,11 +10,13 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through December 31, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) for more information (note: this offer has been extended since the post was published).
+Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
+
+We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
 
 </Alert>
 
-Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~ through December 31, 2020. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
+Multidev is available to all accounts with [Gold support](/support/#support-features-and-response-times) and above. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
 
 Visit the [Partner Program Page](https://pantheon.io/plans/partner-program?docs) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
@@ -54,9 +56,11 @@ Branch names can contain any ASCII letter and number (a through z, 0 through 9) 
 Yes, you can; your Git repository is not restricted. If you do not use Multidev, then the interface will not show the branches, allow creation of an environment for a branch, and so forth.
 
 ## Can I create a new environment for my local branch?
+
 Yes. Push a new branch from your local (e.g., `git push origin example-br`) then navigate to **Multidev** > **Git Branches** from your Site Dashboard and select **Create Environment** next to the branch name.
 
 ## Is there a limit on the number of branches or environments?
+
 There is no limit on the number of branches you can have in your Git repository. The limit on Multidev environments is 10 per site.
 
 ## Can I associate a domain with a branch environment?
@@ -84,4 +88,5 @@ Yes, you can backup and restore a branch environment. However, if you restore an
 If the organization changes to a plan that doesn't feature Multidev, you will still be able to access existing Multidev environments, but will not be able to create new ones.
 
 ## Creating a Multidev Failed - Specified Key Was Too Long
+
 Users encounter this error with sites that use the MyISAM engine with a varchar index that exceeds 767 bytes. To resolve, [convert MyISAM tables to InnoDB](/myisam-to-innodb).

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -8,13 +8,7 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 ## Who has access to Multidev?
 
-<Alert title="Note" type="info" >
-
-Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
-
-We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
-
-</Alert>
+<Partial file="covid-offer.md" />
 
 Multidev is available to all accounts with [Gold support](/support/#support-features-and-response-times) and above. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -22,9 +22,7 @@ Visit the [Partner Program Page](https://pantheon.io/plans/partner-program?docs)
 
 ### Should I have access to Multidev?
 
-Yes! Multidev is available to all users until through December 31, 2020.
-
-After that, users will have access to Multidev if they:
+Users have access to Multidev if they:
 
 - Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs)).
 - Are a Direct Online customer with Gold support or above.

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -17,7 +17,9 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through December 31, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) (note: this offer has been extended since the post was published).
+Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
+
+We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
 
 </Alert>
 
@@ -74,7 +76,7 @@ Independent infrastructure for a site, including code, database, and files.
 
 <dd>
 
-To divide in branches, copying source code&nbsp;to start independent development. At Pantheon, we are also copying content (files and database) when forking.
+To divide in branches, copying source code to start independent development. At Pantheon, we are also copying content (files and database) when forking.
 
 </dd>
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -15,13 +15,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 </Enablement>
 
-<Alert title="Note" type="info" >
-
-Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
-
-We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
-
-</Alert>
+<Partial file="covid-offer.md" />
 
 ## Benefits of Multidev
 

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -18,7 +18,9 @@ Creating a Multidev environment creates an application container with a database
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through December 31, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: this offer has been extended since the post was published).
+Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
+
+We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
 
 </Alert>
 
@@ -29,9 +31,11 @@ Multidev is one of the highlight features of the Pantheon Partner Program. Visit
 From within the [Organization Dashboard](/organization-dashboard), you can assign [organization](/organizations) members one of three roles: Administrator, Team Member, and Developer. Developers in an organization can commit code to Multidev and Development environments, but cannot deploy code or clone databases and files into Test or Live environments.
 
 ### Can I Restrict Access to a Specific Site with the Developer Role?
+
 Only sites owned by Enterprise and EDU+ can assign the developer role to specific users. Partner Organizations cannot specify which members have access to specific sites.
 
 ### How is site ownership determined?
+
 The person who creates the site owns it until someone else starts paying for it. The user or Enterprise Organization who pays for the site is the owner thereafter.
 
 ### Where can I learn more about these roles?
@@ -45,6 +49,7 @@ When you or the administrators, team members, or developers in your agency [crea
 ## Support
 
 ### Why do login attempts fail for all users across my organization simultaneously?
+
 Any large agency that has multiple developers who login frequently via username/password will trigger failed logins for everyone else who works on the site. This occurs despite everyone using the right password and even when one user logins in and out successfully 3 times.
 
 As a workaround, we recommend following development best practice workflows by [authenticating via SSH key for password-less access](/ssh-keys).
@@ -53,13 +58,16 @@ As a workaround, we recommend following development best practice workflows by [
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through December 31, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: this offer has been extended since the post was published).
+Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
+
+We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
 
 </Alert>
 
 Only organizational team members and administrators of a Supporting Organization with Multidev will be able to use this feature. Site team members who are associated with the site but not the agency can access Multidev environments via the unique URL, but will not be able to commit code to them.
 
 ### Why can't my Agency Organization own a site?
+
 Enterprise, Reseller, OEM, and EDU+ organizations own sites. Registered Agencies, Pantheon Partners, Premier Pantheon Partners, Strategic Pantheon Partners, and EDU organizations support sites. This is because an agency's role is to develop, service, and maintain a site on behalf of its owner. Read more about owning and supporting sites in our [Organizations](/organizations/#organization-site-association) doc.
 
 ### Can I add my own Agency as a Supporting Organization to a client's site?
@@ -67,18 +75,23 @@ Enterprise, Reseller, OEM, and EDU+ organizations own sites. Registered Agencies
 No. Only the owner of the site can add an agency as a Supporting Organization. This action grants all members of the organization access to the site. You should ask site owners to add your agency as a Supporting Organization if you are providing services to the site.
 
 ### What privileges and roles are granted when adding a Supporting Organization?
+
 All organization members have access to the site, with permissions determined by their roles at the organization level.
 
 ### Can the site owner override privileges and access for organizational team members of a Supporting Organization?
+
 Yes, but only for sites owned by Enterprise or EDU+ organizations. Roles designated on the Site Team modal will override any roles assigned within the organization.
 
 ### Do you have a status page?
+
 Yes. Please follow [@pantheonstatus](https://twitter.com/pantheonstatus) on Twitter and bookmark [status.pantheon.io](https://status.pantheon.io/).
 
 ### How do I submit a support request when the Dashboard is down?
+
 If you need to submit a support request and can’t access the Dashboard, send an email to helpdesk@pantheon.io.
 
 ### As a Partner, do I get enhanced support?
+
 Your support level increases along with your Partner Program level. Refer to the [Pantheon Partner Portal](https://pantheon.io/plans/partner-portal) for more information.
 
 ### As an Agency, how many sandbox sites do members of an organization receive?
@@ -88,4 +101,5 @@ Each member of an organization can create up to 10 Sandbox sites. When the limit
 ## Unsupported
 
 ### Can we run our Joomla, Magento, Laravel, or (insert other PHP framework here)?
+
 No, we don’t support them.

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -16,13 +16,7 @@ Creating a Multidev environment creates an application container with a database
 
 ### How can my Organization get Multidev and how much does it cost?
 
-<Alert title="Note" type="info" >
-
-Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
-
-We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
-
-</Alert>
+<Partial file="covid-offer.md" />
 
 Multidev is one of the highlight features of the Pantheon Partner Program. Visit the [Partner Program Page](https://pantheon.io/plans/partner-program) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
@@ -56,13 +50,7 @@ As a workaround, we recommend following development best practice workflows by [
 
 ### Why can't I access Multidev on my site when the Supporting Organization can use it?
 
-<Alert title="Note" type="info" >
-
-Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
-
-We launched this initiative at the beginning of COVID-19 to support organizations responding to the pandemic or delivering vital information to the public. This evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
-
-</Alert>
+<Partial file="covid-offer.md" />
 
 Only organizational team members and administrators of a Supporting Organization with Multidev will be able to use this feature. Site team members who are associated with the site but not the agency can access Multidev environments via the unique URL, but will not be able to commit code to them.
 

--- a/source/partials/covid-offer.md
+++ b/source/partials/covid-offer.md
@@ -1,0 +1,7 @@
+<Alert title="Note" type="info" >
+
+Pantheon is extending our [COVID WebOps offer](http://pantheon.io/blog/supporting-orgs-on-covid-19-front-line?docs) to qualified government, medical, or educational institutions with a crisis communications website, and to non-profit organizations directly providing relief.
+
+We launched this initiative at the beginning of the COVID-19 pandemic to support organizations responding to the pandemic or delivering vital information to the public. It's since evolved to include a pre-built response site to allow organizations on the COVID-19 front lines to deploy rapidly and deliver emergency communications.
+
+</Alert>


### PR DESCRIPTION
Revert: #5638  and #5966 

## Summary

**[Multidev FAQ](https://pantheon.io/docs/multidev-faq)** and others - Multidev returns to its regularly scheduled availability: Orgs and Online Gold Support and higher.

## Effect

The following changes are already committed:

- removes notes that advertise the temporary free Multidev for all

## Remaining Work

The following changes still need to be completed:

- [ ] merge by Dec 31

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
