### PR TITLE
Add DNS Providers Index Page

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -4,5 +4,5 @@
     "MD023": false,
     "MD024": false,
     "MD029": false,
-    "MD033": {"allowed_elements": ["Alert",  "Accordion", "dd", "dl", "Download", "DrushChangelog", "dt", "Enablement", "ExternalLink", "LocaldevChangelog", "Partial", "Partial", "Popover", "ReviewDate", "Span", "Tab", "TabList"]}
+    "MD033": {"allowed_elements": ["Alert",  "Accordion", "dd", "dl", "Download", "DrushChangelog", "dt", "Enablement", "ExternalLink", "LocaldevChangelog", "Partial", "Partial", "Popover", "ReviewDate", "Span", "Tab", "TabList", "DNSProviderDocs"]}
 }

--- a/source/content/dns-providers/enom.md
+++ b/source/content/dns-providers/enom.md
@@ -1,8 +1,8 @@
 ---
-title: eNom Domain Configuration
-provider: eNom
+title: Enom Domain Configuration
+provider: Enom
 dnsprovider: true
-description: Learn how to point your eNom domain to a Pantheon site.
+description: Learn how to point your Enom domain to a Pantheon site.
 tags: [providers]
 permalink: docs/:basename/
 editpath: dns-providers/enom.md/
@@ -10,11 +10,11 @@ editpath: dns-providers/enom.md/
 ## Before You Begin
 Be sure that you have a:
 
-- Registered domain name using eNom to host DNS
+- Registered domain name using Enom to host DNS
 - [Paid Pantheon plan](/guides/launch/plans)
 - [Domain connected](/guides/launch/domains) to the target Pantheon environment (typically Live)
 
-## Configure DNS Records on eNom
+## Configure DNS Records on Enom
 
 ### A Record
 1. Navigate to **Domains** > **My Domains**.
@@ -35,9 +35,9 @@ An A record is required to configure a subdomain (e.g., `www.example.com`).
 2. Enter **www** in the **Host Name** field, select **A** for the **Record Type** then enter the A record value provided by Pantheon (e.g. `23.185.0.2`) in the **Address** field.
 4. Click **Save**.
 
-## eNom Docs
+## Enom Docs
 
-[Change Host Records - Forward, Redirect or Point Your Domain/Sub-Domain](https://www.enom.com/kb/kb/kb_0002_change-host-records.htm)
+[Change Host Records - Forward, Redirect or Point Your Domain/Sub-Domain](https://www.Enom.com/kb/kb/kb_0002_change-host-records.htm)
 
 ## Next Steps
 

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -23,7 +23,7 @@ We offer DNS provider-specific instructions for several common DNS hosts:
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [eNom Domain Configuration](/enom)
+ - [Enom Domain Configuration](/Enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -17,19 +17,7 @@ While Pantheon does not offer DNS management services, we can help you to unders
 
 We offer DNS provider-specific instructions for several common DNS hosts:
 
-
- - [1&1 Domain Configuration](/1-and-1)
- - [Cloudflare Domain Configuration](/cloudflare)
- - [DNS Made Easy Domain Configurationi](/dns-made-easy)
- - [DreamHost Domain Configuration](/dreamhost)
- - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/enom)
- - [Gandi Domain Configuration](/gandi)
- - [GoDaddy Domain Configuration](/godaddy)
- - [Google Domain Configuration](/google)
- - [Namecheap Domain Configuration](/namecheap)
- - [Network Solutions Domain Configuration](/network-solutions)
- - [Amazon Route 53 Domain Configuration](/route53)
+<DNSProviderDocs />
 
 ## DNS Terminology
 

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -23,7 +23,7 @@ We offer DNS provider-specific instructions for several common DNS hosts:
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/Enom)
+ - [Enom Domain Configuration](/enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -40,7 +40,7 @@ If you don't already own a domain name, register one with a third-party provider
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [eNom Domain Configuration](/enom)
+ - [Enom Domain Configuration](/Enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -35,18 +35,7 @@ If you don't already own a domain name, register one with a third-party provider
 
 <Accordion title="DNS Host-Specific Instructions" id="host-specific2" icon="info-sign">
 
- - [1&1 Domain Configuration](/1-and-1)
- - [Cloudflare Domain Configuration](/cloudflare)
- - [DNS Made Easy Domain Configurationi](/dns-made-easy)
- - [DreamHost Domain Configuration](/dreamhost)
- - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/enom)
- - [Gandi Domain Configuration](/gandi)
- - [GoDaddy Domain Configuration](/godaddy)
- - [Google Domain Configuration](/google)
- - [Namecheap Domain Configuration](/namecheap)
- - [Network Solutions Domain Configuration](/network-solutions)
- - [Amazon Route 53 Domain Configuration](/route53)
+<DNSProviderDocs />
 
 </Accordion>
 

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -40,7 +40,7 @@ If you don't already own a domain name, register one with a third-party provider
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/Enom)
+ - [Enom Domain Configuration](/enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -37,18 +37,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 <Accordion title=" DNS Host-Specific Instructions" id="host-specific2" icon="info-sign">
 
- - [1&1 Domain Configuration](/1-and-1)
- - [Cloudflare Domain Configuration](/cloudflare)
- - [DNS Made Easy Domain Configuration](/dns-made-easy)
- - [DreamHost Domain Configuration](/dreamhost)
- - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/enom)
- - [Gandi Domain Configuration](/gandi)
- - [GoDaddy Domain Configuration](/godaddy)
- - [Google Domain Configuration](/google)
- - [Namecheap Domain Configuration](/namecheap)
- - [Network Solutions Domain Configuration](/network-solutions)
- - [Amazon Route 53 Domain Configuration](/route53)
+<DNSProviderDocs />
 
 </Accordion>
 

--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -42,7 +42,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
  - [DNS Made Easy Domain Configuration](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [eNom Domain Configuration](/enom)
+ - [Enom Domain Configuration](/Enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -42,7 +42,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
  - [DNS Made Easy Domain Configuration](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/Enom)
+ - [Enom Domain Configuration](/enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -33,7 +33,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [eNom Domain Configuration](/enom)
+ - [Enom Domain Configuration](/Enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -33,7 +33,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
  - [DNS Made Easy Domain Configurationi](/dns-made-easy)
  - [DreamHost Domain Configuration](/dreamhost)
  - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/Enom)
+ - [Enom Domain Configuration](/enom)
  - [Gandi Domain Configuration](/gandi)
  - [GoDaddy Domain Configuration](/godaddy)
  - [Google Domain Configuration](/google)

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -28,18 +28,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 <Accordion title="DNS Host-Specific Instructions" id="host-specific2" icon="info-sign">
 
- - [1&1 Domain Configuration](/1-and-1)
- - [Cloudflare Domain Configuration](/cloudflare)
- - [DNS Made Easy Domain Configurationi](/dns-made-easy)
- - [DreamHost Domain Configuration](/dreamhost)
- - [Dyn Domain Configuration](/dyn)
- - [Enom Domain Configuration](/enom)
- - [Gandi Domain Configuration](/gandi)
- - [GoDaddy Domain Configuration](/godaddy)
- - [Google Domain Configuration](/google)
- - [Namecheap Domain Configuration](/namecheap)
- - [Network Solutions Domain Configuration](/network-solutions)
- - [Amazon Route 53 Domain Configuration](/route53)
+<DNSProviderDocs />
 
 </Accordion>
 

--- a/src/components/dns-provider-docs.js
+++ b/src/components/dns-provider-docs.js
@@ -1,0 +1,42 @@
+import React from "react"
+import { Link, useStaticQuery, graphql } from "gatsby"
+
+const DNSProviderDocs = () => {
+  const pages = useStaticQuery(
+    graphql`
+      {
+        allMdx(
+          filter: { fileInfo: { absolutePath: { regex: "/.dns-providers./" } } }
+          sort: { fields: frontmatter___title, order: ASC }
+        ) {
+          nodes {
+            fields {
+              slug
+            }
+            frontmatter {
+              provider
+            }
+          }
+        }
+      }
+    `
+  )
+
+  return (
+    <>
+      <ul>
+        {pages.allMdx.nodes.map((page, i) => {
+          return (
+              <li key={i}>
+                <Link to={page.fields.slug} title={page.frontmatter.provider}>
+                  {page.frontmatter.provider}
+                </Link>
+              </li>
+          )
+        })}
+      </ul>
+    </>
+  )
+}
+
+export default DNSProviderDocs

--- a/src/pages/dns-providers.js
+++ b/src/pages/dns-providers.js
@@ -1,0 +1,73 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+import Layout from "../layout/layout"
+import SEO from "../layout/seo"
+
+{
+  /* @TODO Convert to a React Component */
+}
+const previewFlexPanelItem = {
+  flex: "1 46%",
+  margin: "0px 0px 15px 15px",
+  color: "#333",
+}
+
+class dnsProviders extends React.Component {
+  render() {
+    const data = this.props.data.allMdx
+    //console.log("data: ", data) // FOR DEBUGGING
+    //console.log ("data.nodes: ", data.nodes) //DEBUGGING
+    return (
+      <>
+        <SEO title="DNS Providers" />
+        <Layout>
+          <div style={{ marginTop: "-20px" }} className="container">
+            <div className="container doc-content-well">
+              <div className="row">
+                <h1 className="title">DNS Providers</h1>
+              </div>
+              <div className="row mb-70">
+                <ul>
+                  {data.nodes.map((page, i) => {
+                    return (
+                      <>
+                        <li key={`index-${i}`}>
+                          <Link
+                            to={page.fields.slug}
+                            title={page.frontmatter.provider}
+                          >
+                            {page.frontmatter.provider}
+                          </Link>
+                        </li>
+                      </>
+                    )
+                  })}
+                </ul>
+              </div>
+            </div>
+          </div>
+        </Layout>
+      </>
+    )
+  }
+}
+
+export default dnsProviders
+
+export const pageQuery = graphql`
+  {
+    allMdx(
+      filter: { fileInfo: { absolutePath: { regex: "/.dns-providers./" } } }
+      sort: { fields: frontmatter___title, order: ASC }
+    ) {
+      nodes {
+        fields {
+          slug
+        }
+        frontmatter {
+          provider
+        }
+      }
+    }
+  }
+`

--- a/src/pages/dns-providers.js
+++ b/src/pages/dns-providers.js
@@ -2,6 +2,7 @@ import React from "react"
 import { Link, graphql } from "gatsby"
 import Layout from "../layout/layout"
 import SEO from "../layout/seo"
+import DNSProviderDocs from "../components/dns-provider-docs"
 
 {
   /* @TODO Convert to a React Component */
@@ -14,9 +15,6 @@ const previewFlexPanelItem = {
 
 class dnsProviders extends React.Component {
   render() {
-    const data = this.props.data.allMdx
-    //console.log("data: ", data) // FOR DEBUGGING
-    //console.log ("data.nodes: ", data.nodes) //DEBUGGING
     return (
       <>
         <SEO title="DNS Providers" />
@@ -27,22 +25,7 @@ class dnsProviders extends React.Component {
                 <h1 className="title">DNS Providers</h1>
               </div>
               <div className="row mb-70">
-                <ul>
-                  {data.nodes.map((page, i) => {
-                    return (
-                      <>
-                        <li key={`index-${i}`}>
-                          <Link
-                            to={page.fields.slug}
-                            title={page.frontmatter.provider}
-                          >
-                            {page.frontmatter.provider}
-                          </Link>
-                        </li>
-                      </>
-                    )
-                  })}
-                </ul>
+                <DNSProviderDocs />
               </div>
             </div>
           </div>
@@ -53,21 +36,3 @@ class dnsProviders extends React.Component {
 }
 
 export default dnsProviders
-
-export const pageQuery = graphql`
-  {
-    allMdx(
-      filter: { fileInfo: { absolutePath: { regex: "/.dns-providers./" } } }
-      sort: { fields: frontmatter___title, order: ASC }
-    ) {
-      nodes {
-        fields {
-          slug
-        }
-        frontmatter {
-          provider
-        }
-      }
-    }
-  }
-`

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -31,6 +31,7 @@ import DrushChangelog from "../components/drushChangelog"
 import ReviewDate from "../components/reviewDate"
 import Youtube from "../components/youtube"
 import ResourceSelector from "../components/resourceSelector"
+import DNSProviderDocs from "../components/dns-provider-docs.js"
 
 const shortcodes = {
   Callout,
@@ -55,6 +56,7 @@ const shortcodes = {
   ReviewDate,
   Youtube,
   ResourceSelector,
+  DNSProviderDocs,
 }
 
 class DocTemplate extends React.Component {

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -34,6 +34,7 @@ import ChecklistItem from "../components/checklistItem"
 import ReviewDate from "../components/reviewDate"
 import Youtube from "../components/youtube"
 import ResourceSelector from "../components/resourceSelector"
+import DNSProviderDocs from "../components/dns-provider-docs.js"
 
 const shortcodes = {
   Callout,
@@ -59,6 +60,7 @@ const shortcodes = {
   ReviewDate,
   Youtube,
   ResourceSelector,
+  DNSProviderDocs,
 }
 
 class GuideTemplate extends React.Component {


### PR DESCRIPTION
## Summary

**[DNS Providers](https://pantheon.io/docs/dns-providers)** - A standalone page listing all available DNS provider docs. All instances of the list of DNS providers are now a component, so they'll always be up to date everywhere. [PR 5645](https://github.com/pantheon-systems/documentation/pull/5645)

## Effect

The following changes are already committed:

- fixes caps for enom
- adds index of dns providers

## Remaining Work

The following changes still need to be completed:

- [ ] tech review / more eyes

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
