### PR TITLE
update drupal-s3 subhead to not specify D7.

### DIFF
--- a/source/content/drupal-s3.md
+++ b/source/content/drupal-s3.md
@@ -1,6 +1,6 @@
 ---
 title: AWS S3 Setup for Drupal
-description: Add the ability to integrate with AWS S3 to a Drupal 7 site on Pantheon
+description: Add the ability to integrate AWS S3 with a Drupal site on Pantheon
 tags: [siteintegrations]
 categories: [drupal7, integrate]
 contributors: [peter-pantheon, alexfornuto]


### PR DESCRIPTION
Most people coming here now will be looking for D8 info and the details tab defaults to D8. Optionally change "with" to "into" if that version of "integrate" is preferred.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary
Update the subhead of the page to be more descriptive of the current state of the content.

**[Doc Title](https://pantheon.io/docs/doc-title)** - adjusted the subhead text to remove explicit reference to D7

## Effect

More accurately describes the page's content and helps to prevent people from turning away because they don't think it is relevant to D8.

The following changes are already committed:

-
-

## Remaining Work

The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
