### PR TITLE
Update on Certificate Served

### DIFF
--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -126,7 +126,7 @@ CAA records are required  to [prohibit Let's Encrypt from issuing certificates](
 ## Caveats / Known Issues
 
 ### Let's Encrypt Certificate Served Instead of Custom Certificate
-If a Let's Encrypt certificate was deployed to the Global CDN before adding CAA records to prevent Let's Encrypt from issuing certificates, then it will take 10 days for Pantheon to automatically remove the domain from the Let's Encrypt certificate.
+If a Let’s Encrypt certificate was deployed to the Global CDN before adding CAA records to prevent Let’s Encrypt from issuing certificates, then contact Pantheon support to assist in options to ensure the Custom Certificate is being served.  Please allow at least 3 business days for Pantheon to process your request.
 
 ### CA limitations
 Your CA must accept the CSR Pantheon provides. If your CA fails to accept our CSR, you will not be able to use it to generate a certificate. The CA GlobalSign does not currently meet this requirement. The workaround is to simply use another CA.

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -1,6 +1,7 @@
 ---
 title: 'Custom Certificates on The Pantheon Global CDN'
 description: For contract customers who require dedicated, custom TLS certificates
+reviewed: "2020-04-22"
 ---
 
 ## Access
@@ -60,7 +61,6 @@ A **Certification Authority Authorization** (CAA) record is used to specify whic
 To help generate CAA records, please see the free online tool: <https://sslmate.com/caa/>
 
 CAA records configured for the root domain (e.g., `example.com`) are inherited by subdomains (e.g., `www.example.com`, `blog.example.com`, etc.). Disabling Let's Encrypt for the root domain will disable subdomains.
-
 
 ## Technical Specifications
 |                                                                       | Legacy                    | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
@@ -126,7 +126,8 @@ CAA records are required  to [prohibit Let's Encrypt from issuing certificates](
 ## Caveats / Known Issues
 
 ### Let's Encrypt Certificate Served Instead of Custom Certificate
-If a Let’s Encrypt certificate was deployed to the Global CDN before adding CAA records to prevent Let’s Encrypt from issuing certificates, then contact Pantheon support to assist in options to ensure the Custom Certificate is being served.  Please allow at least 3 business days for Pantheon to process your request.
+
+If a Let's Encrypt Certificate is deployed before the CAA record preventing it, [contact Pantheon support](/support) for assistance. Please allow at least 3 business days for Pantheon to resolve the Let's Encrypt Certificate.
 
 ### CA limitations
 Your CA must accept the CSR Pantheon provides. If your CA fails to accept our CSR, you will not be able to use it to generate a certificate. The CA GlobalSign does not currently meet this requirement. The workaround is to simply use another CA.


### PR DESCRIPTION
 

Thank you.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Custom Certificates on The Pantheon Global CDN](https://pantheon.io/docs/custom-certificates)** - Updated the "Let's Encrypt Certificate Served Instead of Custom Certificate" section. 

@ari-gold Can act as SME for this update.  

@sarahg If updates using the Solutions as described on this wiki page 
(Link Removed) are required to remedy this issue for a customer is it Okay to suggest 3 business days to remedy. 

## Remaining Work

The following changes still need to be completed:

- [x] SME and CSE suggestions / approval

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
