### PR TITLE
rename dns provider instruction index to be more technically correct...

### DIFF
--- a/source/content/dns-providers.md
+++ b/source/content/dns-providers.md
@@ -1,5 +1,5 @@
 ---
-title: Registrar-specific DNS Instructions
+title: DNS Host-specific DNS Instructions
 description: A list of docs to help you connect your Pantheon site to your domain
 categories: [go-live]
 tags: [dns, domains]


### PR DESCRIPTION
Amends: #5645  

## Summary

Changes the title to DNS Host-specific Instructions

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Re-index page in Addsearch
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
