### PR TITLE
Fixing a Broken Link to Multidev for All Post

### DIFF
--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -16,7 +16,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st).
 
 </Alert>
 


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

A small fix to a blog link to Multidev for All

## Effect

The following changes are already committed:

- Fixing Multidev for All blog link

## Remaining Work

The following changes still need to be completed:

- None

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
