### PR TITLE
Fail After 3 Attempts

### DIFF
--- a/.circleci/scripts/deploy-multidev.sh
+++ b/.circleci/scripts/deploy-multidev.sh
@@ -57,17 +57,7 @@ cd $BUILD_PATH
 # Export preview build to the multidev environment.
 printf "Copying docs to $docs_url \n"
 touch ./multidev-log.txt
-while true
-do
-    if ! rsync --delete-delay -chrltzv --ipv4 -e 'ssh -p 2222 -oStrictHostKeyChecking=no' public/ --temp-dir=../../tmp/ $MULTIDEV_NAME.$DOCS_PREVIEW_UUID@appserver.$MULTIDEV_NAME.$DOCS_PREVIEW_UUID.drush.in:files/docs/ | tee multidev-log.txt;
-    then
-        echo "Failed, retrying..."
-        sleep 5
-    else
-        echo "Success: Deployed to $url"
-        break
-    fi
-done
+try3 rsync --delete-delay -chrltzv --ipv4 -e 'ssh -p 2222 -oStrictHostKeyChecking=no' public/ --temp-dir=../../tmp/ $MULTIDEV_NAME.$DOCS_PREVIEW_UUID@appserver.$MULTIDEV_NAME.$DOCS_PREVIEW_UUID.drush.in:files/docs/ | tee multidev-log.txt;
 
 
 printf "\n Commenting on GitHub... \n"

--- a/.circleci/scripts/functions.sh
+++ b/.circleci/scripts/functions.sh
@@ -64,3 +64,19 @@ skip-preview() {
         return 1
     fi
 }
+
+try3 () {
+  for ((n=1;n<4;n++)); do
+    if ! $@
+      then
+        echo "failed $n times..."
+        if [[ $n = 3 ]]
+          then exit 1
+        fi
+        sleep 1
+      else
+        echo "Completed after $n tries"
+        break
+      fi
+  done
+}

--- a/.circleci/scripts/functions.sh
+++ b/.circleci/scripts/functions.sh
@@ -67,7 +67,8 @@ skip-preview() {
 
 try3 () {
   for ((n=1;n<4;n++)); do
-    if ! $@
+    echo "$@"
+    if ! "$@"
       then
         echo "failed $n times..."
         if [[ $n = 3 ]]


### PR DESCRIPTION
## Summary

**Stack Improvement** - Instead of endlessly trying to rsync to preview environments, we will fail after the third attempt.

## Effect

The following changes are already comited:

- Imports new function called `try3` which tries a command 3 times then fails.
- Uses `try3` in `deploy-multidev.sh`.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
