### PR TITLE
Restore example D7 snippet for managing cache configs in settings.php

### DIFF
--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -140,6 +140,58 @@ Depending on your use case, there are three possibilities:
 
  - For Actions that require access to protected services like Redis or the site database, you can use the `$_ENV` superglobal. Please review our guide on [Reading Pantheon Environment Configuration](/read-environment-config) for more information, or see our [Redis](/redis) guide for examples.
 
+As an example, here's how you can hard-code your Drupal 7 caching configuration and Google Analytics based on the environment. To learn more, see [Defining variables in a site's settings.php $conf array](https://www.drupal.org/node/1525472).
+
+```php:title=settings.php
+// All Pantheon Environments.
+if (defined('PANTHEON_ENVIRONMENT')) {
+// Drupal caching in development environments.
+if (!in_array(PANTHEON_ENVIRONMENT, array('test', 'live'))) {
+  // Anonymous caching.
+  $conf['cache'] = 0;
+  // Block caching - disabled.
+  $conf['block_cache'] = 0;
+  // Expiration of cached pages - none.
+  $conf['page_cache_maximum_age'] = 0;
+  // Aggregate and compress CSS files in Drupal - off.
+  $conf['preprocess_css'] = 0;
+  // Aggregate JavaScript files in Drupal - off.
+  $conf['preprocess_js'] = 0;
+}
+// Drupal caching in test and live environments.
+else {
+  // Anonymous caching - enabled.
+  $conf['cache'] = 1;
+  // Block caching - enabled.
+  $conf['block_cache'] = 1;
+  // Expiration of cached pages - 15 minutes.
+  $conf['page_cache_maximum_age'] = 900;
+  // Aggregate and compress CSS files in Drupal - on.
+  $conf['preprocess_css'] = 1;
+  // Aggregate JavaScript files in Drupal - on.
+  $conf['preprocess_js'] = 1;
+}
+// Minimum cache lifetime - always none.
+$conf['cache_lifetime'] = 0;
+// Cached page compression - always off.
+$conf['page_compression'] = 0;
+
+
+if (PANTHEON_ENVIRONMENT == 'dev') {
+  // Google Analytics.
+  $conf['googleanalytics_account'] = 'UA-XXXXXXXX-X';
+}
+else if (PANTHEON_ENVIRONMENT == 'test') {
+  // Google Analytics.
+  $conf['googleanalytics_account'] = 'UA-XXXXXXXX-Y';
+}
+else if (PANTHEON_ENVIRONMENT == 'live') {
+  // Google Analytics.
+  $conf['googleanalytics_account'] = 'UA-XXXXXXXX-Z';
+}
+}
+```
+
 ### Why does Drupal report that `settings.php` is not protected? I can't change the permissions on `settings.php`.
 
 If you do not have a `settings.php` file in your codebase, you'll see the following message on `/admin/reports/status`:


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.


## Summary

**[Configuring Settings.php](https://pantheon.io/docs/settings-php#how-can-i-write-logic-based-on-the-pantheon-server-environment)** - Restore example D7 snippet for managing cache configs in settings.php

## Effect

The following changes are already commited:

-

## Remaining Work

The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
