### PR TITLE
update Preview Dev env after deploy to prod

### DIFF
--- a/.circleci/scripts/deploy-live.sh
+++ b/.circleci/scripts/deploy-live.sh
@@ -21,7 +21,8 @@ else
 fi
 
 # Update Dev on Docs Preview site
-try3 rsync --delete-delay -chrltzv --ipv4 -e 'ssh -p 2222 -oStrictHostKeyChecking=no' public/ --temp-dir=../../tmp/ dev.$DOCS_PREVIEW_UUID@appserver.dev.$DOCS_PREVIEW_UUID.drush.in:files/docs/ | tee multidev-log.txt;
+touch ./dev-deployment-log.txt
+try3 rsync --delete-delay -chrltzv --ipv4 -e 'ssh -p 2222 -oStrictHostKeyChecking=no' public/ --temp-dir=../../tmp/ dev.$DOCS_PREVIEW_UUID@appserver.dev.$DOCS_PREVIEW_UUID.drush.in:files/docs/ | tee dev-deployment-log.txt;
 
 #=====================================================#
 # Delete Multidev environment from static-docs site   #

--- a/.circleci/scripts/deploy-live.sh
+++ b/.circleci/scripts/deploy-live.sh
@@ -20,6 +20,8 @@ else
     exit 1
 fi
 
+# Update Dev on Docs Preview site
+try3 rsync --delete-delay -chrltzv --ipv4 -e 'ssh -p 2222 -oStrictHostKeyChecking=no' public/ --temp-dir=../../tmp/ dev.$DOCS_PREVIEW_UUID@appserver.dev.$DOCS_PREVIEW_UUID.drush.in:files/docs/ | tee multidev-log.txt;
 
 #=====================================================#
 # Delete Multidev environment from static-docs site   #


### PR DESCRIPTION
## Summary

**Stack Improvement** - After deployment to production, deploys to the dev environment of the preview site. This should reduce rsync time on fresh multidevs, in conjunction with incremental gatsby builds.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
