### PR TITLE
copy troubleshooting from plugin page

### DIFF
--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -47,6 +47,15 @@ For installation details, see [Configuring Environment Indicators](/environment-
 ## [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions)
 Resolve errors with code (themes, modules or plugins) that relies on PHP's default session manager. For more details, see [WordPress and PHP Sessions](/wordpress-sessions/#troubleshooting-session-errors).
 
+### Troubleshooting WP Native PHP Sessions
+If you see an error similar to:
+
+> Fatal error: session_start(): Failed to initialize storage module: user (path: ) in …/code/wp-content/plugins/plugin-that-uses-sessions/example.php on line 2
+
+The cause is likely a plugin in the [mu-plugins](/mu-plugin) directory that is instantiating a session prior to this plugin loading. To fix, deactivate the WP Native PHP Sessions plugin and instead load it via an mu-plugin that loads first.
+
+For example, create an mu-plugin called `00.php` and add a line in it to include the `wp-native-php-sessions/pantheon-sessions.php` file.
+
 ## [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/)
 Provides support for SAML Authentication. The plugin comes bundled with the OneLogin SAML library and [SimpleSAMLphp](https://simplesamlphp.org/). For an example use case, see [Using WP SAML Auth with Google Apps](/guides/wordpress-google-sso)
 

--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -51,7 +51,7 @@ Resolve errors with code (themes, modules or plugins) that relies on PHP's defau
 
 If you see an error similar to the following in the error logs:
 
-```
+```none
 Fatal error: session_start(): Failed to initialize storage module: user (path: ) in …/code/wp-content/plugins/plugin-that-uses-sessions/example.php on line 2
 ```
 

--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -48,9 +48,12 @@ For installation details, see [Configuring Environment Indicators](/environment-
 Resolve errors with code (themes, modules or plugins) that relies on PHP's default session manager. For more details, see [WordPress and PHP Sessions](/wordpress-sessions/#troubleshooting-session-errors).
 
 ### Troubleshooting WP Native PHP Sessions
-If you see an error similar to:
 
-> Fatal error: session_start(): Failed to initialize storage module: user (path: ) in …/code/wp-content/plugins/plugin-that-uses-sessions/example.php on line 2
+If you see an error similar to the following in the error logs:
+
+```
+Fatal error: session_start(): Failed to initialize storage module: user (path: ) in …/code/wp-content/plugins/plugin-that-uses-sessions/example.php on line 2
+```
 
 The cause is likely a plugin in the [mu-plugins](/mu-plugin) directory that is instantiating a session prior to this plugin loading. To fix, deactivate the WP Native PHP Sessions plugin and instead load it via an mu-plugin that loads first.
 


### PR DESCRIPTION
Closes: #5564

## Summary

**[Pantheon Plugins](https://pantheon.io/docs/plugins)** - Duplicate troubleshooting from the WP Native PHP Sessions page in WordPress plugin directory.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
