### PR TITLE
Update rsync command used to fetch logs

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -140,8 +140,10 @@ do
 done
 
 # Include MySQL logs
-db_server=`dig dbserver.$ENV.$SITE_UUID.drush.in +short`
-rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@dbserver.$ENV.$SITE_UUID.drush.in:logs db_server_$db_server
+for db_server in `dig +short dbserver.$ENV.$SITE_UUID.drush.in`;
+do
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@$db_server:logs/* db_server_$db_server
+done
 ```
 
 <Alert title="Note" type="info">

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -136,7 +136,7 @@ SITE_UUID=xxxxxxxxxxx
 ENV=live
 for app_server in `dig +short appserver.$ENV.$SITE_UUID.drush.in`;
 do
-  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:logs/* app_server_$app_server
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@$app_server:logs/* app_server_$app_server
 done
 
 # Include MySQL logs


### PR DESCRIPTION
## Summary

**[Log Files on Pantheon](https://pantheon.io/docs/logs#automate-downloading-logs)** - Although this script is currently fetching all the app container IPs, it then rsyncs from the domain instead of the IPs that dig found. This results in a random assortment of container logs being downloaded and placed into folders that are incorrectly labelled.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
