### PR TITLE
5688 logfiles rsync

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -136,12 +136,14 @@ SITE_UUID=xxxxxxxxxxx
 ENV=live
 for app_server in `dig +short appserver.$ENV.$SITE_UUID.drush.in`;
 do
-  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@appserver.$ENV.$SITE_UUID.drush.in:logs/* app_server_$app_server
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@$app_server:logs/* app_server_$app_server
 done
 
 # Include MySQL logs
-db_server=`dig dbserver.$ENV.$SITE_UUID.drush.in +short`
-rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@dbserver.$ENV.$SITE_UUID.drush.in:logs db_server_$db_server
+for db_server in `dig +short dbserver.$ENV.$SITE_UUID.drush.in`;
+do
+  rsync -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' $ENV.$SITE_UUID@$db_server:logs/* db_server_$db_server
+done
 ```
 
 <Alert title="Note" type="info">


### PR DESCRIPTION
copy of #5688 to Pantheon repo

## Summary

**[Log Files on Pantheon](https://pantheon.io/docs/logs#automate-downloading-logs)** - Although this script is currently fetching all the app container IPs, it then rsyncs from the domain instead of the IPs that dig found. This results in a random assortment of container logs being downloaded and placed into folders that are incorrectly labelled.

## Remaining Work

The following changes still need to be completed:

- [ ] tech review
   - [x] check against infra changes
- [ ] copy

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
