### PR TITLE
Expand note for composer-based sites

### DIFF
--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -18,7 +18,7 @@ If none of the above apply to your project, use the [standard migration procedur
 
 <Alert title="Note" type="info" >
 
-Site migrations are one of the services offered by our [Professional Services](/professional-services/#site-migrations) team.
+The steps outlined below do not work for Composer-based sites. If you have need help migrating a Composer-based site (or any site, for that matter), site migrations are one of the services offered by our [Professional Services](/professional-services/#site-migrations) team.
 
 </Alert>
 


### PR DESCRIPTION
Closes: #5652 

## Summary

**[Manually Migrate Sites to Pantheon](https://pantheon.io/docs/migrate-manual)** - Notes that composer-based sites don't work with the steps in this doc, and suggest Pro Services.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
