### PR TITLE
Report Pages without Category

### DIFF
--- a/source/content/videos/cache.md
+++ b/source/content/videos/cache.md
@@ -7,6 +7,7 @@ tags: [cacheedge]
 categories: [develop, cli,performance]
 layout: video
 searchboost: 50
+type: video
 ---
 
 <Youtube src="ecjZhtu41hs" title="Caching" />

--- a/source/content/videos/drush.md
+++ b/source/content/videos/drush.md
@@ -7,6 +7,7 @@ tags: [devdrush]
 categories: [develop,drupal,workflow]
 layout: video
 searchboost: 50
+type: video
 ---
 
 <Youtube src="wAL4LQwy8Ow" title="Drush" />

--- a/source/content/videos/git.md
+++ b/source/content/videos/git.md
@@ -7,6 +7,7 @@ tags: [git]
 categories: [develop, cli,develop]
 layout: video
 searchboost: 50
+type: video
 ---
 
 <Youtube src="LG7_wWQHtS4" title="Git" />

--- a/source/content/videos/local.md
+++ b/source/content/videos/local.md
@@ -7,6 +7,7 @@ tags: [local]
 categories: [develop]
 layout: video
 searchboost: 50
+type: video
 ---
 
 <Youtube src="z01vIuB3kRg" title="Local Development" />

--- a/source/content/videos/migrate-wordpress.md
+++ b/source/content/videos/migrate-wordpress.md
@@ -6,6 +6,7 @@ permalink:  docs/videos/:basename/
 tags: [migrateguided]
 categories: [get-started,develop, cli]
 layout: video
+type: video
 searchboost: 50
 ---
 

--- a/source/content/videos/pantheon-yml.md
+++ b/source/content/videos/pantheon-yml.md
@@ -6,6 +6,7 @@ permalink:  docs/videos/:basename/
 tags: [pantheonyml]
 categories: [develop, cli, workflow,platform]
 layout: video
+type: video
 searchboost: 50
 ---
 

--- a/source/content/videos/sftp.md
+++ b/source/content/videos/sftp.md
@@ -7,6 +7,7 @@ tags: [admin, sftpfiles]
 categories: [develop]
 searchboost: 50
 layout: video
+type: video
 ---
 
 <Youtube src="ktesh9SiHfc" title="On Server Development" />

--- a/source/content/videos/terminus.md
+++ b/source/content/videos/terminus.md
@@ -6,6 +6,7 @@ permalink:  docs/videos/:basename/
 categories: [develop,workflow]
 tags: [devterminus]
 layout: video
+type: video
 searchboost: 50
 ---
 

--- a/source/content/videos/wp-cli.md
+++ b/source/content/videos/wp-cli.md
@@ -7,6 +7,7 @@ tags: [devwpcli]
 categories: [wordpress,workflow]
 layout: video
 searchboost: 50
+type: video
 ---
 
 <Youtube src="2KphdFOaOeM" title="WP-CLI" />

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -3,6 +3,7 @@ title: WordPress Known Issues
 description: Learn the recommended solutions for known issues on the Pantheon Website Management Platform for WordPress sites.
 tags: [debugcode]
 categories: [wordpress,troubleshoot]
+cms: wordpress
 ---
 This page tracks known issues and the recommended solution (if any) for running WordPress on the Pantheon website platform. Most sites work fine, but there are some common gotchas we are tracking and working to address.
 

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -3,6 +3,7 @@ title: Launch Check - WordPress Performance and Configuration Analysis
 description: Learn more about the checks we automatically run on your Pantheon WordPress site.
 tags: [status]
 categories: [wordpress,performance,go-live]
+cms: wordpress
 ---
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab, and are accessible by site team members.
 

--- a/src/reports/reports.js
+++ b/src/reports/reports.js
@@ -88,8 +88,10 @@ class ReviewReport extends React.Component {
                   frontmatter {
                     title
                     categories
+                    cms
                     reviewed
                     tags
+                    type
                   }
                   fields {
                     slug
@@ -109,8 +111,10 @@ class ReviewReport extends React.Component {
                   frontmatter {
                     title
                     categories
+                    cms
                     reviewed
                     tags
+                    type
                   }
                   fields {
                     slug
@@ -409,9 +413,11 @@ class ReviewReport extends React.Component {
                       <tr>
                         <th width="5%">Create an Issue</th>
                         <th width="20%">Title</th>
-                        <th width="10%">Review Date</th>
-                        <th with="20%">Categories</th>
-                        <th>Tags</th>
+                        <th width="6%">Review Date</th>
+                        <th width="10%">CMS</th>
+                        <th with="10%">Categories</th>
+                        <th width="40%">Tags</th>
+                        <th>Type</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -449,6 +455,7 @@ class ReviewReport extends React.Component {
                                 </Link>
                               </td>
                               <td>{page.node.frontmatter.reviewed}</td>
+                              <td>{page.node.frontmatter.cms ? page.node.frontmatter.cms : null}</td>
                               <td>
                                 {page.node.frontmatter.categories.map(
                                   (category, i) => {
@@ -473,6 +480,7 @@ class ReviewReport extends React.Component {
                                     })
                                   : null}
                               </td>
+                              <td>{page.node.frontmatter.type ? page.node.frontmatter.type : "doc"}</td>
                             </tr>
                           )
                         })}
@@ -510,7 +518,9 @@ class ReviewReport extends React.Component {
                         <th width="5%">Create an Issue</th>
                         <th width="20%">Title</th>
                         <th width="10%">Review Date</th>
+                        <th width="10%">CMS</th>
                         <th>Tags</th>
+                        <th>Type</th>
                       </tr>
                     </thead>
                     <tbody>
@@ -543,6 +553,7 @@ class ReviewReport extends React.Component {
                                 </Link>
                               </td>
                               <td>{page.node.frontmatter.reviewed}</td>
+                              <td>{page.node.frontmatter.cms ? page.node.frontmatter.cms : null}</td>
                               <td>
                                 {page.node.frontmatter.tags
                                   ? page.node.frontmatter.tags.map((tag, i) => {
@@ -554,6 +565,7 @@ class ReviewReport extends React.Component {
                                     })
                                   : null}
                               </td>
+                              <td>{page.node.frontmatter.type ? page.node.frontmatter.type : "doc"}</td>
                             </tr>
                           )
                         })}


### PR DESCRIPTION
Closes: DOC-97

## Summary

Adds a table of pages without a category to the local reporting.

## Remaining Work

The following changes still need to be completed:

- [x] Add content type column

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
