### PR TITLE
Add how to Secure wp-admin and wp-includes folder

### DIFF
--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -115,3 +115,7 @@ This method has the advantage of being toggleable without deploying code, by act
   ```
 
 1. Commit your work, deploy code changes then activate the plugin on Test and Live environments.
+
+### Secure wp-admin and wp-includes folder
+
+These are the common places where hackers try to probe your site for finding clues and disclosing your server paths, as best practice outlined here https://wordpress.org/support/article/hardening-wordpress/#securing-wp-admin, you can add `wp-admin` and `wp-includes` as a protected path in your pantheon.yml file as outlined [here](https://pantheon.io/docs/pantheon-yml#protected-web-paths).

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -118,4 +118,4 @@ This method has the advantage of being toggleable without deploying code, by act
 
 ### Secure wp-admin and wp-includes folder
 
-These are the common places where hackers try to probe your site for finding clues and disclosing your server paths, as best practice outlined here https://wordpress.org/support/article/hardening-wordpress/#securing-wp-admin, you can add `wp-admin` and `wp-includes` as a protected path in your pantheon.yml file as outlined [here](https://pantheon.io/docs/pantheon-yml#protected-web-paths).
+These are common places where hackers may try to probe your site to find clues and vulnerabilities. As part of best practices outlined at [WordPress.org](https://wordpress.org/support/article/hardening-wordpress/#securing-wp-admin), you can add `wp-admin` and `wp-includes` as a protected path in your [pantheon.yml file](/pantheon-yml#protected-web-paths).


### PR DESCRIPTION
Closes: #5702

## Summary
Shows how to secure wp-admin and wp-includes folder in the platform

## Effect

It will also help out mitigate `Class 'getid3_handler' not found` errors as opened up for discussion here https://core.trac.wordpress.org/ticket/49499#comment:4

## Remaining Work

The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
