### PR TITLE
Fix date formatting

### DIFF
--- a/src/components/reviewDate/index.js
+++ b/src/components/reviewDate/index.js
@@ -2,7 +2,8 @@ import React from "react"
 import './style.css';
 
 const reviewDate = ({ date }) => {
-  var formattedDate = new Date(`${date} 08:00:00`)
+  var formattedDate = new Date(`${date}`)
+  formattedDate.setMinutes(formattedDate.getMinutes() + formattedDate.getTimezoneOffset() )
   return (
     <>
       <h4 className="review-date toc-ignore" >

--- a/src/components/reviewDate/index.js
+++ b/src/components/reviewDate/index.js
@@ -1,9 +1,8 @@
 import React from "react"
 import './style.css';
 
-
 const reviewDate = ({ date }) => {
-  var formattedDate = new Date(`${date} 01:00:00 GMT-05:00`)
+  var formattedDate = new Date(`${date} 08:00:00`)
   return (
     <>
       <h4 className="review-date toc-ignore" >


### PR DESCRIPTION
Closes: #5706 

## Summary

**[Multiple Pages]()** - Apparently Firefox and Safari don't like it when you specify a timezone in a JS Date, so instead I'm just manually adding 8 hours to the UTC dates to spring them forward a day.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
