### PR TITLE
Update AddSearch Tagging

### DIFF
--- a/src/layout/seo.js
+++ b/src/layout/seo.js
@@ -21,6 +21,7 @@ function SEO({
   categories,
   tags,
   reviewed,
+  type,
 }) {
   const { site } = useStaticQuery(
     graphql`
@@ -43,9 +44,9 @@ function SEO({
   const metaImage = image || "/assets/images/default-thumb-doc.png"
   const authorList = authors ? Array.from(authors) : []
   const addSearchCategories = categories
-    ? categories.map(value => `category=${value}`).join(";")
-    : `category=other`
-
+    ? categories.join("/")
+    : `other`
+  const addSearchType = type ? `type=${type}` : "type=doc"
   const titleProps = title
     ? {
         title: `${title}`,
@@ -81,6 +82,10 @@ function SEO({
         { ...tagValues },
         {
           name: `addsearch-custom-field`,
+          content: addSearchType,
+        },
+        {
+          name: `addsearch-custom-category`,
           content: addSearchCategories,
         },
         {

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -101,6 +101,7 @@ class DocTemplate extends React.Component {
           categories={node.frontmatter.categories}
           tags={node.frontmatter.tags}
           reviewed={isoDate.frontmatter.reviewed}
+          type={node.frontmatter.type}
         />
         <main id="doc">
           <div className="container doc-content-well">
@@ -161,6 +162,7 @@ export const pageQuery = graphql`
         featuredcontributor
         reviewed(formatString: "MMMM DD, YYYY")
         tags
+        type
       }
       fileAbsolutePath
     }

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -110,6 +110,7 @@ class GuideTemplate extends React.Component {
           authors={node.frontmatter.contributors}
           image={"/assets/images/terminus-thumbLarge.png"}
           reviewed={isoDate.frontmatter.reviewed}
+          type={node.frontmatter.type}
         />
           <div className="container">
             <div className="row col-md-12 guide-nav manual-guide-toc-well">
@@ -199,6 +200,7 @@ export const pageQuery = graphql`
         featuredcontributor
         reviewed(formatString: "MMMM DD, YYYY")
         getfeedbackform
+        type
       }
       fileAbsolutePath
     }

--- a/src/templates/resource.js
+++ b/src/templates/resource.js
@@ -97,6 +97,7 @@ class ResourceTemplate extends React.Component {
           categories={node.frontmatter.categories}
           tags={node.frontmatter.tags}
           reviewed={isoDate.frontmatter.reviewed}
+          type={node.frontmatter.type}
         />
         <div className="">
           <div className="container doc-content-well">
@@ -153,6 +154,7 @@ export const pageQuery = graphql`
         featuredcontributor
         reviewed(formatString: "MMMM DD, YYYY")
         tags
+        type
       }
       fileAbsolutePath
     }

--- a/src/templates/terminuspage.js
+++ b/src/templates/terminuspage.js
@@ -144,6 +144,7 @@ class TerminusTemplate extends React.Component {
           authors={node.frontmatter.contributors}
           image={"/assets/images/terminus-thumbLarge.png"}
           reviewed={ifCommandsISO}   
+          type={node.frontmatter.type}
         />
         <div className="">
           <div className="container-fluid">
@@ -220,6 +221,7 @@ export const pageQuery = graphql`
           twitter
         }
         reviewed(formatString: "MMMM DD, YYYY")
+        type
       }
       fileAbsolutePath
     }

--- a/src/templates/video.js
+++ b/src/templates/video.js
@@ -86,6 +86,7 @@ class VideoTemplate extends React.Component {
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
           image={"/assets/images/default-thumb-doc.png"}
+          type={node.frontmatter.type}
         />
         <div className="">
           <div className="container doc-content-well">
@@ -149,6 +150,7 @@ export const pageQuery = graphql`
           url
         }
         featuredcontributor
+        type
       }
       fileAbsolutePath
     }


### PR DESCRIPTION
## Summary

**Site Upgrade** - Updates the way we provide metadata to AddSearch

## Effect

The following changes are already committed:

- Instead of providing our category values as a custom field, we provide them as a custom category.
- We provide the content type (Doc, Guide, Video, Resource, etc) as a custom field called "type".

## Remaining Work

The following changes still need to be completed:

- [ ] ~Provide these values as tags Google uses.~ Already there.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] **Full site re-crawl in AddSearch**
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
