### PR TITLE
add note for wp-rocket

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1,8 +1,8 @@
 ---
 title: WordPress Plugins and Themes with Known Issues
 description: A list of WordPress plugins, themes, and functions that are not supported and/or require workarounds.
-tags: [debugcode, siteintegrations]
-categories: [troubleshoot, integrate]
+tags: [plugins,themes,debug]
+categories: [troubleshoot]
 contributors: [aleksandrkorolyov]
 ---
 
@@ -709,9 +709,10 @@ ___
 
 ## [WP-Rocket](https://wp-rocket.me/)
 
-<ReviewDate date="2020-03-20" />
+<ReviewDate date="2020-05-18" />
 
-**Issue 1:** As with other caching plugins, this conflicts with [Pantheon's Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/). The caching feature can be disabled so other features like file optimization, media, etc. can be used side-by-side.
+**Issue 1:** As with other caching plugins, this conflicts with [Pantheon's Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/). The caching feature can be disabled so other features like file optimization, media, etc. can be used side-by-side. Note that if not disabled, WP-Rocket will auto-create
+the `advanced-cache.php` file.
 
 **Solution:**
 


### PR DESCRIPTION
Closes: #5701 

## Summary

**[WordPress Plugins and Themes With Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Add note to WP Rocket plugin that the plugin will auto-create an `advanced-cache.php` file if not disabled. [PR 5716](https://github.com/pantheon-systems/documentation/pull/5716)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
