### PR TITLE
Update to content under Application Log Files

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -72,7 +72,7 @@ You now have a local copy of the logs directory, which contains the following:
         └──nginx-error.log
 ```
 
-You may still see log files in this structure as well:
+You may still see log files in this structure if your site is still on the heirloom system:
 
 ```none
 ├── logs

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -60,7 +60,7 @@ In the Connection Information section of the dashboard, we can see a pattern abo
 
 You now have a local copy of the logs directory.
 
-For sites on [Compute Optimized Environments (COE)](platform-considerations#compute-optimized-environments-coe), the directory structure will resemble:
+For sites on [Compute Optimized Environments (COE)](/platform-considerations#compute-optimized-environments-coe), the directory structure will resemble:
 
 ```none
 ├── logs

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -58,7 +58,9 @@ In the Connection Information section of the dashboard, we can see a pattern abo
    get -r logs
    ```
 
-You now have a local copy of the logs directory, which contains the following:
+You now have a local copy of the logs directory.
+
+For sites on [Compute Optimized Environments (COE)](platform-considerations#compute-optimized-environments-coe), the directory structure will resemble:
 
 ```none
 ├── logs
@@ -72,7 +74,7 @@ You now have a local copy of the logs directory, which contains the following:
         └──nginx-error.log
 ```
 
-You may still see log files in this structure if your site is still on the heirloom system:
+For sites not on COE, the directory structure will be more like this:
 
 ```none
 ├── logs


### PR DESCRIPTION
Update to content under the Application Log Files section because a customer pointed out there is no context to explaining why the other log structure was being shared.  If that is not the best way to word it then please change it however you see fit.

## Summary

**[Log Files](https://pantheon.io/docs/logs#downloading-logs)** - Shows the difference in logs directory structure that users will see on COE. [PR 5721](https://github.com/pantheon-systems/documentation/pull/5721)

## Remaining Work

The following changes still need to be completed:

- [x] copy edit

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
