### PR TITLE
Pantheon Plugins for WP: update frontmatter

### DIFF
--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -1,6 +1,6 @@
 ---
 title: Pantheon Plugins for WordPress
-description: WordPress plugins developed and maintained for the Pantheon WebOps Platform workflow.
+description: WordPress plugins developed and maintained for the Pantheon WebOps Platform.
 tags: [plugins, cache, saml, redis, solr]
 categories: [integrate]
 cms: WordPress

--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -1,8 +1,9 @@
 ---
-title: Pantheon Plugins
-description: Details on specific WordPress plugins developed and maintained for the Pantheon Website Management Platform workflow.
-tags: [WordPress, plugins, must-use, cache, SAML, Redis, Solr]
+title: Pantheon Plugins for WordPress
+description: WordPress plugins developed and maintained for the Pantheon WebOps Platform workflow.
+tags: [plugins, cache, saml, redis, solr]
 categories: [integrate]
+cms: [WordPress]
 reviewed: "2020-04-21"
 
 ---

--- a/source/content/plugins.md
+++ b/source/content/plugins.md
@@ -3,7 +3,7 @@ title: Pantheon Plugins for WordPress
 description: WordPress plugins developed and maintained for the Pantheon WebOps Platform workflow.
 tags: [plugins, cache, saml, redis, solr]
 categories: [integrate]
-cms: [WordPress]
+cms: WordPress
 reviewed: "2020-04-21"
 
 ---

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -3,7 +3,7 @@ title: WordPress Known Issues
 description: Learn the recommended solutions for known issues on the Pantheon Website Management Platform for WordPress sites.
 tags: [debugcode]
 categories: [wordpress,troubleshoot]
-cms: wordpress
+cms: WordPress
 ---
 This page tracks known issues and the recommended solution (if any) for running WordPress on the Pantheon website platform. Most sites work fine, but there are some common gotchas we are tracking and working to address.
 

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -3,7 +3,7 @@ title: Launch Check - WordPress Performance and Configuration Analysis
 description: Learn more about the checks we automatically run on your Pantheon WordPress site.
 tags: [status]
 categories: [wordpress,performance,go-live]
-cms: wordpress
+cms: WordPress
 ---
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab, and are accessible by site team members.
 


### PR DESCRIPTION
## Summary

**[Pantheon Plugins for WordPress](https://pantheon.io/docs/plugins)** - Updates page title to clarify topic, updates frontmatter tags.

## To Do
- [x] Copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
