### PR TITLE
`drush-script: drush9` does not work in COS/COE

### DIFF
--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -71,7 +71,7 @@ Drush 9 aliases are written one file per site to the directory `$HOME/.drush/sit
   host: appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in
   paths:
     files: files
-    drush-script: drush9
+    drush-script: drush
   uri: ${env-name}-example.pantheonsite.io
   user: ${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1
   ssh:


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Doc Title](https://pantheon.io/docs/doc-title)** - The script drush9 is no longer present in COS/COE environment

drush is compatible in both heirloom and COS/COE

## Effect

`Exit Code: 127(Command not found)` when using drush alias


## Remaining Work

The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
