### PR TITLE
update docs link in coe banner

### DIFF
--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -62,7 +62,7 @@ For enhanced security and a more intuitive experience:
 - The site's home directory is now the root directory.
 - Logs are now written to logs/php/ and logs/nginx/ for each respective service.
 
-For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe) documentation
+For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe)
 
 </Alert>
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -62,7 +62,7 @@ For enhanced security and a more intuitive experience:
 - The site's home directory is now the root directory.
 - Logs are now written to logs/php/ and logs/nginx/ for each respective service.
 
-For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe)
+For more information and an updated list of changes see the [Platform Considerations documentation](#compute-optimized-environments-coe)
 
 </Alert>
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -62,7 +62,7 @@ For enhanced security and a more intuitive experience:
 - The site's home directory is now the root directory.
 - Logs are now written to logs/php/ and logs/nginx/ for each respective service.
 
-For an updated example log collection script see [Documentation](/logs#automate-downloading-logs)
+For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe) documentation
 
 </Alert>
 

--- a/source/content/read-environment-config.md
+++ b/source/content/read-environment-config.md
@@ -100,7 +100,7 @@ For enhanced security and a more intuitive experience:
 - The site's home directory is now the root directory.
 - Logs are now written to logs/php/ and logs/nginx/ for each respective service.
 
-For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe) documentation
+For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe)
 
 </Alert>
 

--- a/source/content/read-environment-config.md
+++ b/source/content/read-environment-config.md
@@ -100,7 +100,7 @@ For enhanced security and a more intuitive experience:
 - The site's home directory is now the root directory.
 - Logs are now written to logs/php/ and logs/nginx/ for each respective service.
 
-For an updated example log collection script see [Documentation](/logs#automate-downloading-logs)
+For more information and an updated list of changes see the [Platform Considerations documentation](/platform-considerations#compute-optimized-environments-coe) documentation
 
 </Alert>
 


### PR DESCRIPTION
dependent on HERMES-2577

## Summary

**COE(S) Dashboard Banner** - The COE banner at the top of the Dashboard now links to the [COE section of Platform Considerations](https://pantheon.io/docs/platform-considerations#compute-optimized-environments-coe), where users can find more information. [PR](#)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- updates the documentation to match the COE banner

## Remaining Work

- [x] HERMES-2577 is merged

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
