### PR TITLE
Link to PHP UA blocking from Bots and Indexing

### DIFF
--- a/source/content/bots-and-indexing.md
+++ b/source/content/bots-and-indexing.md
@@ -71,7 +71,7 @@ To support pre-launch SEO and site search testing, we allow the following bots a
 - [SEMrush](https://www.semrush.com/bot/)
 - [RogerBot](https://moz.com/help/guides/moz-procedures/what-is-rogerbot) by Moz
 - [Dotbot](https://moz.com/help/guides/moz-procedures/dotbot) by Moz
-- [PowerMapper](https://www.powermapper.com/products/mapper/){external}
+- [PowerMapper](https://www.powermapper.com/products/mapper/)
 - [Swiftbot](https://swiftype.com/swiftbot) by Swiftype
 
 Some tools (like [Siteimprove](https://siteimprove.com/) or [ScreamingFrog](https://www.screamingfrog.co.uk/seo-spider/)) can be set to ignore `robots.txt` when scanning. If you're testing links or SEO with other tools, you may request the addition of the tool to our `robots.txt` file by [contacting support](/support#can-i-request-a-feature-be-added-to-the-platform) to create a feature request. Otherwise, you can connect a custom domain (like `seo.example.com`) to the Live environment and test your links following the alternative domain.

--- a/source/content/bots-and-indexing.md
+++ b/source/content/bots-and-indexing.md
@@ -48,12 +48,13 @@ It is important to note that each of your site environments have a `robots.txt` 
 User-agent: *
 Disallow: /
 
+User-agent: dotbot
+User-agent: PetalBot
+User-agent: PowerMapper
 User-agent: RavenCrawler
 User-agent: rogerbot
-User-agent: dotbot
 User-agent: SemrushBot
 User-agent: SemrushBot-SA
-User-agent: PowerMapper
 User-agent: Swiftbot
 Allow: /
 ```

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -176,6 +176,9 @@ Remember to replace the example user agent (`UglyBot`):
 ```php:title=wp-config.php%20or%20settings.php
 if (stripos($_SERVER['HTTP_USER_AGENT'], 'UglyBot') !== FALSE) {
   header('HTTP/1.0 403 Forbidden');
+} else {
+if (stripos($_SERVER['HTTP_USER_AGENT'], 'PetalBot') !== FALSE) {
+  header('HTTP/1.0 403 Forbidden');
   exit;
 }
 ```

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -174,12 +174,18 @@ The `stripos` function implements a case-insensitive match which can be helpful 
 Remember to replace the example user agent (`UglyBot`):
 
 ```php:title=wp-config.php%20or%20settings.php
+// Either check a single bot.
 if (stripos($_SERVER['HTTP_USER_AGENT'], 'UglyBot') !== FALSE) {
   header('HTTP/1.0 403 Forbidden');
-} else {
-if (stripos($_SERVER['HTTP_USER_AGENT'], 'PetalBot') !== FALSE) {
-  header('HTTP/1.0 403 Forbidden');
-  exit;
+}
+
+// Or check against a list of bots.
+$bots = ['UglyBot', 'PetalBot'];
+foreach ($bots as $bot) {
+  if (stripos($_SERVER['HTTP_USER_AGENT'], $bot) !== FALSE) {
+    header('HTTP/1.0 403 Forbidden');
+    exit;
+  }
 }
 ```
 


### PR DESCRIPTION
## Summary

**[Bots and Indexing](https://pantheon.io/docs/bots-and-indexing#indexing-your-pantheon-site)** - Adds note about disrespectful bots and crawlers that don't abide by robots.txt, points to [Optimize Site Traffic](https://pantheon.io/docs/optimize-site-traffic#block-user-agents-in-drupal-or-wordpress) for CMS-level option. [PR 5739](https://github.com/pantheon-systems/documentation/pull/5739)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- link bots and indexing to optimize site traffic doc, remind users that not all bots care about house rules
- add petalbot to robots example

## Remaining Work

The following changes still need to be completed:

- [x] confirm PHP "or"

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
