### PR TITLE
Update localdev.md

### DIFF
--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -104,6 +104,10 @@ Localdev will use the existing `.lando` file only when the site is initially clo
 
 Note that if there are services specified in `.lando`, Localdev will return an error.
 
+### Can WordPress Site Networks be developed through Localdev?
+
+At this time, WordPress Site Networks (also known as WordPress Multisite) development is not supported through Localdev.
+
 ### Contact Support / File an Issue
 
 While Localdev is in beta, [support request best practices](/support/#best-practices) are especially important for our team to help you resolve the issue, or to report any potential issues in Localdev itself.

--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -106,7 +106,7 @@ Note that if there are services specified in `.lando`, Localdev will return an e
 
 ### Can WordPress Site Networks be developed through Localdev?
 
-At this time, WordPress Site Networks (also known as WordPress Multisite) development is not supported through Localdev.
+At this time, WordPress Site Network (also known as WordPress Multisite) development is not supported through Localdev.
 
 ### Contact Support / File an Issue
 


### PR DESCRIPTION
This is an upcoming feature, but not yet ready. I've ran into a few customers attempting this, and although it looks possible with a lot of local configurations. See https://github.com/lando/lando/pull/2015 and https://github.com/lando/lando/pull/2111

## Summary

**[Use Pantheon Localdev to Develop Sites Locally](https://pantheon.io/docs/localdev)** - Added to FAQ about issues with WP Site Networks. [PR 5741](https://github.com/pantheon-systems/documentation/pull/5741)

## Remaining Work
The following changes still need to be completed:

- [x] Content Review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
