### PR TITLE
Updating order of items

### DIFF
--- a/source/content/guides/launch/07-next-steps.md
+++ b/source/content/guides/launch/07-next-steps.md
@@ -52,6 +52,10 @@ When you're ready to launch another site, use this best-practice checklist to es
 
 <ChecklistItem title="Configure DNS" link="/guides/launch/domains/" />
 
-<ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />  **OR** <ChecklistItem title="Drupal Launch Check" link="/drupal-launch-check/" />
+<ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />
+
+**OR**
+
+<ChecklistItem title="Drupal Launch Check" link="/drupal-launch-check/" />
 
 <ChecklistItem title="Review Status Report" link="/guides/launch/launch-check/" />

--- a/source/content/guides/launch/07-next-steps.md
+++ b/source/content/guides/launch/07-next-steps.md
@@ -28,34 +28,30 @@ When you're ready to launch another site, use this best-practice checklist to es
 
 <ChecklistItem title="Upgrade Site Plan" link="/guides/launch/plans/" />
 
-<ChecklistItem title="Activate New Relic Pro" link="/new-relic/#activate-new-relic-apm-pro" />
-
-<ChecklistItem title="Load and Performance Test" link="/load-and-performance-testing/" />
-
-<ChecklistItem title="Add Domains to the Live Environment" link="/guides/launch/domains/" />
-
-<ChecklistItem title="Configure DNS" link="/guides/launch/domains/" />
-
-<ChecklistItem title="Redirect to a Primary Domain" link="/guides/launch/redirects/" />
-
-<ChecklistItem title="Setup Availability Monitoring" link="/new-relic/#configure-ping-monitors-for-availability" />
-
 <ChecklistItem title="Enable and Schedule Weekly Backups" link="/guides/launch/launch-check/" />
-
-<ChecklistItem title="Set Up Outgoing Email" link="/email/" />
-
-<ChecklistItem title="Disable XML-RPC For WordPress" link="/wordpress-best-practices/#avoid-xml-rpc-attacks" />
-
-<ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />
-
- **OR** 
-
-<ChecklistItem title="Drupal Launch Check" link="/drupal-launch-check/" />
-
-<ChecklistItem title="Review Status Report" link="/guides/launch/launch-check/" />
 
 <ChecklistItem title="Enable Redis" link="/redis/#enable-redis" />
 
 <ChecklistItem title="Configure Caching" link="/global-cdn-caching/" />
 
 <ChecklistItem title="Test Cache" link="/test-global-cdn-caching/" />
+
+<ChecklistItem title="Disable XML-RPC For WordPress" link="/wordpress-best-practices/#avoid-xml-rpc-attacks" />
+
+<ChecklistItem title="Set Up Outgoing Email" link="/email/" />
+
+<ChecklistItem title="Activate New Relic Pro" link="/new-relic/#activate-new-relic-apm-pro" />
+
+<ChecklistItem title="Setup Availability Monitoring" link="/new-relic/#configure-ping-monitors-for-availability" />
+
+<ChecklistItem title="Load and Performance Test" link="/load-and-performance-testing/" />
+
+<ChecklistItem title="Add Domains to the Live Environment" link="/guides/launch/domains/" />
+
+<ChecklistItem title="Redirect to a Primary Domain" link="/guides/launch/redirects/" />
+
+<ChecklistItem title="Configure DNS" link="/guides/launch/domains/" />
+
+<ChecklistItem title="WordPress Launch Check" link="/wordpress-launch-check/" />  **OR** <ChecklistItem title="Drupal Launch Check" link="/drupal-launch-check/" />
+
+<ChecklistItem title="Review Status Report" link="/guides/launch/launch-check/" />


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Launch Guide - Final Checklist](https://pantheon.io/docs/guides/launch/next-steps)** - puts items in a more logical order. [PR 5742](https://github.com/pantheon-systems/documentation/pull/5742)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- make the launch checklist as warm-fuzzy as it used to be
-

## Remaining Work

The following changes still need to be completed:

- [x] I'm not convinced `<ChecklistItem title="Disable XML-RPC For WordPress" link="/wordpress-best-practices/#avoid-xml-rpc-attacks" />` belongs here - we don't list other known gotchyas - but leaving it for now

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
