### PR TITLE
Manual site audit into own section, update tags

### DIFF
--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -1,8 +1,10 @@
 ---
 title: Launch Check - Drupal Performance and Configuration Analysis
-description: Detailed information on Launch Check, Drupal Performance and Configuration Analysis.
-tags: [status]
-categories: [drupal7,performance,go-live]
+description: Detailed information on Launch Check, Pantheon's automated checks for Drupal performance and configuration
+tags: [performance, modules]
+categories: [go-live]
+cms: Drupal
+
 ---
 Pantheon provides static site analysis as a service for Drupal sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab and are accessible by site team members.
 
@@ -34,9 +36,18 @@ In short, you get a fast, repeatable report that can help detect common problems
 
 To generate the reports, Pantheon uses [Site Audit](https://drupal.org/project/site_audit), an open-source collection of Drush commands. Site Audit is developed and maintained by Pantheon, but is not limited to the Pantheon platform. Any Pantheon specific support is wrapped in a vendor option.
 
+## Run Site Audit Manually
+
+You can execute a full report encoded in JSON format to your terminal using [Terminus](/terminus):
+
+```bash
+terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon
+```
+
 ## Frequently Asked Questions
 
 ### Deprecated Configuration for the Temporary Files Path Warning on Drupal 8.8.0
+
 The release of Drupal 8.8.0 introduced a change in the temporary files path, which prompts the following warning:
 
 ```
@@ -46,21 +57,15 @@ You are using deprecated configuration for the temporary files path. Remove the 
 You can safely ignore this warning.
 
 ### Trusted Host Setting for Drupal 8
+
 A warning within `/admin/reports/status` will appear when the `trusted_host_patterns` setting is not configured. This setting protects sites from HTTP Host header attacks. However, sites running on Pantheon are not vulnerable to this specific attack and the warning can be safely ignored. For more details, see [Configuring settings.php](/settings-php/#trusted-host-setting).
 
 ### Why does site audit have more reports than what's shown in the Dashboard?
 
 The Dashboard integration is intended to provide developers with the most actionable items; some reports are purely informational and have been omitted. Additionally, some reports are more system intensive, so it makes more sense to allow them to be run on-demand, rather than automatically.
 
-### How can I manually run site audit on my site?
-
-You can also execute a full report encoded in JSON format to your terminal:
-
-```bash
-terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon
-```
-
 ### Are there plans to support Drupal 6 sites?
+
 At this time, there are no plans to support Drupal 6 with this tool.
 
 ### Can I opt out of a specific recommendation?

--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -4,7 +4,7 @@ description: Detailed information on Launch Check, Pantheon's automated checks f
 tags: [performance, modules]
 categories: [go-live]
 cms: Drupal
-
+reviewed: "2020-05-27"
 ---
 Pantheon provides static site analysis as a service for Drupal sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab and are accessible by site team members.
 
@@ -40,7 +40,7 @@ To generate the reports, Pantheon uses [Site Audit](https://drupal.org/project/
 
 You can execute a full report encoded in JSON format to your terminal using [Terminus](/terminus):
 
-```bash
+```bash{promptUser: user}
 terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon
 ```
 
@@ -50,9 +50,7 @@ terminus remote:drush <site>.<env> -- aa --skip=insights --detail --vendor=panth
 
 The release of Drupal 8.8.0 introduced a change in the temporary files path, which prompts the following warning:
 
-```
-You are using deprecated configuration for the temporary files path. Remove the configuration and add the following to settings.php. $settings["file_temp_path"] = "/srv/bindings/.../tmp"
-```
+> You are using deprecated configuration for the temporary files path. Remove the configuration and add the following to settings.php. $settings["file_temp_path"] = "/srv/bindings/.../tmp"
 
 You can safely ignore this warning.
 
@@ -73,15 +71,16 @@ At this time, there are no plans to support Drupal 6 with this tool.
 If you want to permanently opt out of a check, you can set configuration options in `settings.php`. Individual check names can be specified with a combination of the report name and check name. Note that the configuration array is `$conf` in Drupal 7 and `$config` in Drupal 8.
 
 #### Examples
+
 Drupal 7 — permanently opt out of the PageCompression check in the Cache report:
 
-```php
+```php:title=settings.php
 $conf['site_audit']['opt_out']['CachePageCompression'] = TRUE;
 ```
 
 Drupal 8 — permanently opt out of the check for Development modules:
 
-```php
+```php:title=settings.php
 $config['site_audit']['opt_out']['ExtensionsDev'] = TRUE;
 ```
 
@@ -99,11 +98,12 @@ Use the [Site Audit Issue Queue](https://drupal.org/project/issues/site_audit) t
 
 If your site's Launch Check is showing recent update information about Database or Redis usage, but older information for the Site Audit checks, and clicking "run the checks now" doesn't update the status, there may be an application error interrupting its complete operation. In order to debug what might be causing an error, you can run the [Terminus](/terminus) command to execute Site Audit directly on your Pantheon site:
 
-```bash
+```bash{promptUser: user}
 terminus drush <site>.<env> -- aa --skip=insights --detail --vendor=pantheon --strict=0
 ```
 
 If Site Audit isn't running, there may be a fatal PHP error in your application; debugging these problems are crucial for your site's continuing operation and performance.
 
 ## See Also
+
 If you have a WordPress site, see [Launch Check - WordPress Performance and Configuration Analysis](/wordpress-launch-check).

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -1,11 +1,12 @@
 ---
----
 title: Launch Check - WordPress Performance and Configuration Analysis
 description: Learn more about the checks we automatically run on your Pantheon WordPress site.
 tags: [performance, wp-cli, plugins]
 categories: [go-live]
 cms: WordPress
+reviewed: "2020-05-27"
 ---
+
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab, and are accessible by site team members.
 
 ![status tab on live environment](../images/dashboard/status-tab.png)
@@ -28,12 +29,13 @@ To manually perform a site audit using WP Launch Check from the command line, ru
 
 For more information about WP-CLI, visit their [GitHub page](https://github.com/wp-cli/wp-cli). For more information on WordPress Launch Check, go to the [GitHub repo](https://github.com/pantheon-systems/wp_launch_check/).
 
-
 ## What Does Launch Check Evaluate?
 
 ### Cron
 
-This check verifies that Cron is enabled and what jobs are scheduled. It is enabled by default, but it if has been disabled you'll receive the following message: "Cron appears to be disabled, make sure DISABLE_WP_CRON is not defined in your wp-config.php."
+This check verifies that Cron is enabled and what jobs are scheduled. It is enabled by default, but it if has been disabled you'll receive the following message:
+
+> Cron appears to be disabled, make sure DISABLE_WP_CRON is not defined in your wp-config.php.
 
 ### Database
 
@@ -42,7 +44,7 @@ This displays database stats such as the number of rows in the options table, op
 #### What issues will I experience if I don't use InnoDB?
 
 InnoDB has row level locking; MYISAM has table level locking. If a query is being performed on a table with MYISAM storage engine, no other query can modify the data until the first has given up its lock, which can result in tremendous performance issues for web applications.
-To learn how to move your tables to InnoDB, see  [Moving MySQL tables from MyISAM to InnoDB](/myisam-to-innodb).
+To learn how to move your tables to InnoDB, see [Moving MySQL tables from MyISAM to InnoDB](/myisam-to-innodb).
 
 ### Probable Exploits
 
@@ -54,10 +56,9 @@ This tells you if Object Caching and Redis are enabled.
 
 If you receive an error similar to the following, you'll need to move the `object-cache.php` from the plugin directory to `wp-content/object-cache.php`. For more information, see [Installing Redis on Drupal or WordPress](/redis).
 
-```
-Cannot redeclare class WP_Object_Cache in
+> Cannot redeclare class WP_Object_Cache in
 /srv/bindings/0fef773f42984256a4f6feec2556a5ed/code/wp-content/plugins/wp-redis/object-cache.php
-```
+
 ### Plugins
 
 This check lists all your enabled plugins and alerts you when they need to be updated. It also checks for any vulnerabilities.

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -1,8 +1,9 @@
 ---
+---
 title: Launch Check - WordPress Performance and Configuration Analysis
 description: Learn more about the checks we automatically run on your Pantheon WordPress site.
-tags: [status]
-categories: [wordpress,performance,go-live]
+tags: [performance, wp-cli, plugins]
+categories: [go-live]
 cms: WordPress
 ---
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab, and are accessible by site team members.
@@ -18,9 +19,12 @@ This mechanism does not actually perform requests on your site, and in doing so 
 In short, you get a fast, repeatable report that can help detect common problems and provide introspection into your site.
 
 ## How Does it Work?
-WP Launch Check is an extension for WP-CLI designed for Pantheon customers. While designed initially for the Pantheon Dashboard it is intended to be fully usable outside of Pantheon.
 
-To use WP Launch Check from the command line, run: `wp launchcheck <subcommand>`.
+WP Launch Check is a site audit extension for WP-CLI designed for Pantheon customers. While designed initially for the Pantheon Dashboard it is intended to be fully usable outside of Pantheon.
+
+## Run Launch Check Manually
+
+To manually perform a site audit using WP Launch Check from the command line, run: `wp launchcheck <subcommand>`.
 
 For more information about WP-CLI, visit their [GitHub page](https://github.com/wp-cli/wp-cli). For more information on WordPress Launch Check, go to the [GitHub repo](https://github.com/pantheon-systems/wp_launch_check/).
 
@@ -36,13 +40,16 @@ This check verifies that Cron is enabled and what jobs are scheduled. It is enab
 This displays database stats such as the number of rows in the options table, options being auto-loaded, tables using InnoDB storage engine (suggests a query to run if not), transients, and expired transients.
 
 #### What issues will I experience if I don't use InnoDB?
+
 InnoDB has row level locking; MYISAM has table level locking. If a query is being performed on a table with MYISAM storage engine, no other query can modify the data until the first has given up its lock, which can result in tremendous performance issues for web applications.
 To learn how to move your tables to InnoDB, see  [Moving MySQL tables from MyISAM to InnoDB](/myisam-to-innodb).
 
 ### Probable Exploits
+
 This check will display a list of exploited patterns in code, the file name that has the exploit, line number, and match.
 
 ### Object Cache
+
 This tells you if Object Caching and Redis are enabled.
 
 If you receive an error similar to the following, you'll need to move the `object-cache.php` from the plugin directory to `wp-content/object-cache.php`. For more information, see [Installing Redis on Drupal or WordPress](/redis).
@@ -52,6 +59,7 @@ Cannot redeclare class WP_Object_Cache in
 /srv/bindings/0fef773f42984256a4f6feec2556a5ed/code/wp-content/plugins/wp-redis/object-cache.php
 ```
 ### Plugins
+
 This check lists all your enabled plugins and alerts you when they need to be updated. It also checks for any vulnerabilities.
 
 - **Green:** All of your plugins are up-to-date
@@ -59,15 +67,19 @@ This check lists all your enabled plugins and alerts you when they need to be up
 - **Red:** Displays all vulnerabilities and unsupported plugins
 
 #### Unsupported Plugins
+
 - [WP Super Cache](https://wordpress.org/plugins/wp-super-cache/)
 - [W3 Total Cache](https://wordpress.org/plugins/w3-total-cache/)
 - [batcache](https://wordpress.org/plugins/batcache/)
 
 ### PHP Sessions
+
 Displays the files that references sessions. If any are found, you'll be prompted to install the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin.
 
 ## Support
+
 If you have a feature request, message enhancements, or found a bug, please look at the [project's issues](https://github.com/pantheon-systems/wp_launch_check/issues) and submit a new issue if someone else has not already posted it. Pull requests are always welcome!
 
 ## See Also
+
 If you have a Drupal site, see [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check).

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -25,7 +25,11 @@ WP Launch Check is a site audit extension for WP-CLI designed for Pantheon custo
 
 ## Run Launch Check Manually
 
-To manually perform a site audit using WP Launch Check from the command line, run: `wp launchcheck <subcommand>`.
+To manually perform a site audit using WP Launch Check from the command line (using [Terminus](/terminus)), run:
+
+```bash{promptUser: user}
+terminus wp <site>.<env> -- launchcheck <subcommand>
+```
 
 For more information about WP-CLI, visit their [GitHub page](https://github.com/wp-cli/wp-cli). For more information on WordPress Launch Check, go to the [GitHub repo](https://github.com/pantheon-systems/wp_launch_check/).
 


### PR DESCRIPTION
## Summary

**[Drupal Launch Check](https://pantheon.io/docs/drupal-launch-check)** - Separates manual site audit instructions into its own section.
**[WordPress Launch Check](https://pantheon.io/docs/wordpress-launch-check)** - Separates manual site audit instructions into its own section.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
