### PR TITLE
Document Thrive Theme Builder needs FS_METHOD fix

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -68,6 +68,7 @@ Plugins and Themes with issues resolved by this include:
 - [Divi WordPress Theme & Visual Page Builder](https://www.elegantthemes.com/gallery/divi/)
 - [Event Espresso](https://eventespresso.com/)
 - [SmartCrawl Pro](https://premium.wpmudev.org/project/smartcrawl-wordpress-seo/)
+- [Thrive Theme Builder](https://thrivethemes.com/themebuilder/)
 - [Visual Composer: Website Builder](https://visualcomposer.io/)
 - [WPBakery: Page Builder](https://wpbakery.com/)
 - [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)


### PR DESCRIPTION
Closes: #5672 

## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues#define-fs_method)** - Added Thrive Theme Builder to the list of plugins requiringthe  `FS_METHOD` fix.yet-completed work).

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
