### PR TITLE
update curl one-liner for non-PCRE grep systems

### DIFF
--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -48,7 +48,7 @@ The following commands will:
 
   ```bash{promptUser: user}
   mkdir ~/terminus && cd ~/terminus
-  curl -L https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | grep -Po '"tag_name": "\K.*?(?=")')/terminus.phar --output terminus
+  curl -L https://github.com/pantheon-systems/terminus/releases/download/$(curl --silent "https://api.github.com/repos/pantheon-systems/terminus/releases/latest" | perl -nle'print $& while m{"tag_name": "\K.*?(?=")}g')/terminus.phar --output terminus
   chmod +x terminus
   sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
   ```


### PR DESCRIPTION
## Summary

**[Terminus Manual - Install](https://pantheon.io/docs/terminus/install)** - Updates the new curl one-liner to use perl instead of perl style regex through grep, which isn't supported in freeBSD grep (which Mac uses).

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
