### PR TITLE
Updated Launch Guide to remove outdated phrase

### DIFF
--- a/source/content/guides/launch/03-domains.md
+++ b/source/content/guides/launch/03-domains.md
@@ -34,7 +34,7 @@ The steps below will guide you through the process of migrating a site onto Pant
 ## Existing Sites
 
 ### Avoid HTTPS Interruption
-Sites that already have HTTPS working can pre-provision certificates and avoid HTTPS service interruption by verifying ownership of the domain.
+Sites can pre-provision certificates and avoid HTTPS service interruption by verifying ownership of the domain.
 
 To pre-provision HTTPS, CAA records must either:
 


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Connect A Domain](https://pantheon.io/docs/guides/launch/domains)** - Due to a recent change, any domain can pre-provision HTTPS, not just ones that already have HTTPS enabled on their old host.

## Effect
The following changes are already committed:

- Removed phrase that said it was only available for existing domains with HTTPS.
-

## Remaining Work
The following changes still need to be completed:

- [ ] Maybe better highlight in Docs that this can be skipped and that a valid HTTPS cert will be created after DNS change with a slight delay?

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
