### PR TITLE
no more shared ssl certs

### DIFF
--- a/source/content/https.md
+++ b/source/content/https.md
@@ -35,7 +35,8 @@ For more detailed instructions pertaining to your specific DNS host, click below
 <Partial file="enable-https.md" />
 
 ## Let's Encrypt Certificates
-[Let's Encrypt](https://letsencrypt.org) is a free, automated, and open certificate authority that aims to make HTTPS the standard for all websites, a goal we share. Pantheon automatically adds your site's domains to a shared Let's Encrypt certificate, and always renews it automatically, with no additional cost. Let's Encrypt issued certs are valid for 90 days and we renew them at least 30 days before expiration.
+
+[Let's Encrypt](https://letsencrypt.org) is a free, automated, and open certificate authority that aims to make HTTPS the standard for all websites, a goal we share. Pantheon automatically provisions a Let's Encrypt certificate for your site, and always renews it automatically, for no additional cost. Let's Encrypt issued certs are valid for 90 days and we renew them at least 30 days before expiration.
 
 <Partial file="https-requirements.md" />
 
@@ -44,7 +45,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 |                                                                       | Legacy                    | Global CDN with Let's Encrypt   |
 |:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |
-| **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt |
+| **Certificate Type**                                                  | Bring your own            | Issued by Let's Encrypt         |
 | **Renewal**                                                           | Self-managed (up to you)  | Automatic                       |
 | **Inbound IP**                                                        | Static (unique)           | Static (shared)                 |
 | **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br /> Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> |
@@ -57,30 +58,37 @@ For more detailed instructions pertaining to your specific DNS host, click below
 ## Frequently Asked Questions
 
 ### How do I switch my site over to HTTPS from HTTP?
+
 To avoid mixed-content browser warnings and excessive redirects, follow the process described in [Switching Sites from HTTP to HTTPS](/http-to-https).
 
 ### How do I upgrade my existing Pantheon site?
+
 Make the switch on an existing Pantheon site by updating DNS for your domains. If your site doesn't have the new combined "Domains/HTTPS" tab, open a support chat to get the upgrade enabled
 
 ### What level of encryption is provided?
+
 High grade TLS 1.2 encryption with up-to-date ciphers. For a deep analysis of the HTTPS configuration on upgraded sites see [this A+ SSL Labs report for https://pantheon.io](https://www.ssllabs.com/ssltest/analyze.html?d=pantheon.io).
 
 ### How can I obtain an A+ SSL Labs rating?
+
 Upgrade your site to the Global CDN and then send the [HSTS header](/pantheon-yml/#enforce-https--hsts).
 
 ### Can I bring my own certificate?
+
 Yes. See our page on [custom certificates](https://pantheon.io/docs/custom-certificates/) for more information.
 
-But you shouldn't need to buy a dedicated certificate or worry about renewals in most cases. For example, wildcard certificates aren't necessary to secure communications for multiple domains, because we will automatically deploy certificates for all domains on your site. The certificates provided by Pantheon on the Global CDN provide end-to-end encryption. Even though certificates are shared, they are still secure. Concerns with shared certificates are cosmetic.
+But you shouldn't need to buy a custom certificate or worry about renewals in most cases. For example, wildcard certificates aren't necessary to secure communications for multiple domains, because we will automatically deploy certificates for all domains on your site. The certificates provided by Pantheon on the Global CDN provide end-to-end encryption.
 
 Some customers have purchased expensive certificates, often through an upsell from the certificate authority. Unfortunately, an expensive certificate does not mean increased security. If in doubt, we encourage you to test your site with SSL Labs, compare it to this [A+ report](https://www.ssllabs.com/ssltest/analyze.html?d=pantheon.io), and share it with your client.
 
 If bringing your own certificate is a hard requirement, then we recommend terminating HTTPS through a 3rd-party CDN service provider like Cloudflare, CloudFront, StackPath, etc. Configuration differs depending on provider, so please [contact support](https://pantheon.io/docs/support/) to discuss your case.
 
 ### Is HTTPS encryption end-to-end?
+
 Yes! HTTPS is terminated at the CDN edge and traffic is encrypted all the way to the individual application container. This is an improvement over our legacy system that terminated all encryption at the load balancer, and a huge upgrade over setups which use a "mixed mode" strategy of terminating HTTPS at the CDN and then back-ending to the origin over unencrypted clear text communication.
 
 ### Will HTTPS be available for my site throughout the upgrade process?
+
 Yes! As long as you are following the Dashboard DNS recommendations before starting the upgrade, you will see no interruption in HTTPS service. The process to provision certificates can take up to an hour, after which you can update DNS records without HTTPS interruption.
 
 Existing sites that are live over HTTPS which are not already hosted on Pantheon can [pre-provision HTTPS](/guides/launch/domains/#avoid-https-interruption) to avoid interruption. If you are unable to prove ownership as described, we recommend a maintenance window.
@@ -101,20 +109,25 @@ If you do not already have HTTPS, there's _no need_ to pre-provision.
 <Partial file="tables/custom-domains-limit.md" />
 
 ### Which browsers and operating systems are supported?
+
 All modern browsers and operating systems are supported. For details, see the **Handshake Simulation** portion of this [report](https://www.ssllabs.com/ssltest/analyze.html?d=pantheon.io).
 
 ### What about Cloudflare?
+
 Refer to [Cloudflare Domain Configuration](/cloudflare).
 
 ### For how long are Let's Encrypt certificates valid and what happens when they expire?
+
 Let's Encrypt certificates are valid for 90 days and are automatically updated on the platform before they expire.
 
 ## Known Issues
 
 ### HTTPS doesn't provision with incorrect AAAA configurations
+
 Pantheon cannot not begin provisioning HTTPS if the Site Dashboard detects incorrect values set on AAAA records. Once you update the records using the recommended values, HTTPS will start to provision automatically. The values for AAAA records look similar, but they are distinct.
 
 ### Certificate Mismatch Browser Warning
+
 If your DNS changes propagate before certificates are fully deployed across the CDN, it's possible to see a certificate mismatch. To avoid this situation, wait a full 60 minutes from starting the upgrade to updating DNS. If you see a certificate mismatch, you can simply wait it out (up to 60 minutes), though you may also be able to see the new service in action more quickly using a different browser or incognito window.
 
 ### HTTPS doesn't provision with Sucuri's default settings
@@ -122,9 +135,11 @@ If your DNS changes propagate before certificates are fully deployed across the 
 By default Sucuri blocks serving the challenges needed to verify domain ownership and issue Let's Encrypt certificates. Contact Sucuri support and request they enable the "Forward Certificate Validation" setting, which allows HTTPS provisioning to complete successfully. Note you'll want to keep this setting enabled, so the certificate will always renew automatically.
 
 ### Moz Pro 804 HTTPS SSL error
+
 Moz Pro is unable to crawl sites using Server Name Indication (SNI). For information on beta access to SNI support, see [Moz Pro, our web crawler, and sites that use SNI (804 HTTPS SSL) error](https://moz.com/community/q/moz-pro-our-web-crawler-and-sites-that-use-sni).
 
 ### 403 Permission Denied (Drupal)
+
 The text challenge to pre-provision HTTPS on Pantheon requires adding a `.well-known` directory to the root of your site. However, Drupal core has a line in the `.htaccess` file that disallows Apache from serving dot files and folders, which returns a 403 permission denied response. If you see this error while trying to  pre-provision HTTPS on Drupal sites, use the [Let's Encrypt Challenge](https://www.drupal.org/project/letsencrypt_challenge) contrib module as a workaround.
 
 
@@ -140,10 +155,12 @@ If you encounter rate limits, we recommend the following approaches:
 ## Glossary
 
 ### HTTPS
+
 HTTPS encrypts and decrypts requests. For more information, see [this Google resource](https://support.google.com/webmasters/answer/6073543?hl=en).
 
 ### TLS (Transport Layer Security)
 TLS (Transport Layer Security) is a protocol for secure HTTP connections. It replaces its less secure predecessor, the **SSL (Secure Socket Layer)** protocol, which we no longer support. Pantheon uses the term HTTPS to refer to secure HTTP connections.
 
 ### Server Name Indication (SNI)
+
 Server name indication (SNI) is the technology replacing the expensive, legacy load balancers and allows multiple secure (HTTPS) websites to be served off the same IP address, without requiring all those sites to use the same certificate.

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -36,7 +36,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 ## Let's Encrypt Certificates
 
-[Let's Encrypt](https://letsencrypt.org) is a free, automated, and open certificate authority that aims to make HTTPS the standard for all websites, a goal we share. Pantheon automatically provisions a Let's Encrypt certificate for your site, and always renews it automatically, for no additional cost. Let's Encrypt issued certs are valid for 90 days and we renew them at least 30 days before expiration.
+[Let's Encrypt](https://letsencrypt.org) is a free, automated, and open certificate authority that aims to make HTTPS the standard for all websites, a goal we share. Pantheon automatically provisions a Let's Encrypt certificate for your site, and always renews it automatically, for no additional cost. Let's Encrypt issued certs are valid for 90 days and we renew them 30 days before expiration.
 
 <Partial file="https-requirements.md" />
 

--- a/source/partials/enable-https.md
+++ b/source/partials/enable-https.md
@@ -1,4 +1,5 @@
 ## Provision HTTPS
+
 The process to provision certificates kicks off automatically after the domain has been successfully routed to Pantheon, indicated by the following notice:
 
 <blockquote class="block-info">
@@ -9,7 +10,6 @@ The process to provision certificates kicks off automatically after the domain h
 
 </blockquote>
 
-
 Both the bare domain and the `www` domain will be accessible over HTTPS once the HTTPS status turns green (which may take up to an hour):
 
 <blockquote class="block-success">
@@ -19,5 +19,3 @@ Both the bare domain and the `www` domain will be accessible over HTTPS once the
 <span class="glyphicons glyphicons-ok text-success"></span> Let’s Encrypt certificate deployed to Pantheon’s Global CDN. Certificate renews automatically with no additional cost.
 
 </blockquote>
-
-


### PR DESCRIPTION
Closes: #5757

## Summary

**[HTTPS](https://pantheon.io/docs/https)** - Removed mention of shared certificates. [PR](#)

## Remaining Work

- [x] confirm language and time to provision
- [x] copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
