### PR TITLE
increase GetFeedback iframe height

### DIFF
--- a/src/components/getFeedback.js
+++ b/src/components/getFeedback.js
@@ -4,7 +4,7 @@ const GetFeedBack = ({ formId, page, topic }) => {
   return (
     <iframe
       title="GetFeedBack"
-      style={{ width: "100%", minHeight: "300px" }}
+      style={{ width: "100%", minHeight: "320px" }}
       frameBorder="0"
       src={`https://www.getfeedback.com/r/${formId}?page=${page}&topic=${topic}`}
     />


### PR DESCRIPTION
## Summary

**Site Update** - Adjusts the iframe height for the GetFeedback module to avoid scrollbars.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
