### PR TITLE
Drupal 9 - add upgrade path

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -38,7 +38,7 @@ Test Drupal 9 with a fresh installation using either our Integrated Composer Ear
 | [**Integrated Composer**](#create-a-new-drupal-9-site-with-integrated-composer)        | • Composer automatically runs on Pantheon <br /> • Lean repository (vendor dir not in git) <br /> • Integrated 1-click Pantheon updates & Custom Upstreams | • Early Access only <br /> • Requires a unique site-name prefix                                                            |
 | [**Build Tools**](#create-a-drupal-9-site-with-continuous-integration-via-build-tools) | • Composer automatically runs via CI <br /> • Pull request-based workflow <br /> • Supports automated testing                                              | • Requires 3rd-party CI <br /> • Terminus required <br /> • Composer updates happen outside the 1-click Pantheon Dashboard |
 
-If you're not ready to create a new site yet, you can also [check an existing site's compatibility to upgrade](#test-an-existing-drupal-site-for-drupal-9-upgrade-compatibility).
+If you're not ready to create a new site yet, you can also [check an existing site's compatibility to upgrade](#test-an-existing-drupal-site-for-drupal-9-upgrade-compatibility). Once you're ready, [test upgrade an existing pantheon drupal 8 site to drupal 9](#test-upgrade-an-existing-pantheon-drupal-8-site-to-drupal-9).
 
 ## Create a New Drupal 9 Site with Integrated Composer
 
@@ -94,6 +94,47 @@ $node = Node::load(1);
 ```
 
 Since most of these changes are relatively minor, there are a number of [deprecation checking and correction tools](https://www.drupal.org/docs/9/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/deprecation-checking-and-correction-tools) available.
+
+## Test Upgrade an Existing Pantheon Drupal 8 Site to Drupal 9
+
+Already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Leverage the amazing power of our Multidev tooling to test Drupal 9 in a Git branch.
+
+1. Clone your Drupal 8 [site’s codebase to your computer](https://pantheon.io/docs/local-development#get-the-code). You can create a new Drupal 8 site or use an existing Drupal 8 site:
+
+  ```bash{promptUser: user}
+  git clone <url for site repo>
+  ```
+
+1. Use Terminus to create a [Multidev](/multidev) environment called `d9-beta` on your Drupal 8 site for testing:
+
+  ```bash{promptUser: user}
+  terminus multidev:create <site>.<env> d9-beta
+  ```
+
+1. Create and switch to a new testing branch in the Drupal 8 codebase:
+
+  ```bash{promptUser: user}
+  git checkout -b d9-beta
+  ```
+
+1. Pull the `drupal9-beta3--from-8.8.6--early-access-not-for-production-use` branch into your codebase:
+
+  ```bash{promptUser: user}
+  git pull https://github.com/pantheon-systems/drops-8.git drupal9-beta3--from-8.8.6--early-access-not-for-production-use
+  ```
+
+1. Modify the `pantheon.yml` file to specify PHP 7.4 and Drush 8:
+
+  ```yaml:title=pantheon.yml
+  php_version: 7.4
+  drush_version: 8
+  ```
+
+1. Run `update.php` on your new Drupal 9 site:
+
+  ```bash{promptUser: user}
+  terminus drush <site>.<env> updatedb
+  ```
 
 ## FAQ
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -11,7 +11,7 @@ Drupal 9 is, according to [drupal.org](https://www.drupal.org/docs/understanding
 
 > "...a cleaned-up version of Drupal 8... \[with] deprecated code removed and third-party dependencies updated."
 
-Drupal 9 updates Drupal’s underlying dependencies like [Symfony 4.4](https://symfony.com/releases/4.4) and [Twig 2](https://twig.symfony.com/doc/2.x/index.html), removes several deprecated API functions in favor of better options, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 & beyond.
+Drupal 9 updates Drupal’s underlying dependencies like [Symfony 4.4](https://symfony.com/releases/4.4) and [Twig 2](https://twig.symfony.com/doc/2.x/index.html), removes several deprecated API functions in favor of better options, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond.
 
 <Alert title="Early Access Only - Not for Production Use" type="danger">
 
@@ -117,10 +117,10 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
   git checkout -b d9-beta
   ```
 
-1. Pull the `drupal9-beta3--from-8.8.6--early-access-not-for-production-use` branch into your codebase:
+1. Pull the `drupal9.0.0` tag into your codebase:
 
   ```bash{promptUser: user}
-  git pull https://github.com/pantheon-systems/drops-8.git drupal9-beta3--from-8.8.6--early-access-not-for-production-use
+  git pull https://github.com/pantheon-systems/drops-8.git drupal9.0.0--from-8.9.0--early-access-not-for-production-use
   ```
 
 1. Modify the `pantheon.yml` file to specify PHP 7.4 and Drush 8:

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -46,7 +46,7 @@ Join our Early Access program to test out both Drupal 9 and Pantheon Integrated 
 
 1. [Fill out this form](https://docs.google.com/forms/d/1lahWKMT2VHXfr9hg15VIQY2Kn6z_j77o7Te6hZqsNgw) to get access to our “Drupal 9 Early Access” group. Once you are added, you'll have access to a new "Drupal 9 Early Access" site creation option from your Pantheon Dashboard.
 
-1. Spin up a new "Drupal 9 Early Access" site with `ic-demo-2020-` as a site name prefix (i.e., `ic-demo-2020-beta3-d9-test`). This will give you the [Drupal 9 starter codebase](https://github.com/stevector/drupal-9-project) and will automatically trigger a Composer install and `git commit` on site creation.
+1. Spin up a new "Drupal 9 Early Access" site with `ic-demo-2020-` as a site name prefix (i.e., `ic-demo-2020-d9-preview`). This will give you the [Drupal 9 starter codebase](https://github.com/stevector/drupal-9-project) and will automatically trigger a Composer install and `git commit` on site creation.
 
 ## Create a Drupal 9 Site with Continuous Integration via Build Tools
 
@@ -105,30 +105,32 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
   git clone <url for site repo>
   ```
 
-1. Use Terminus to create a [Multidev](/multidev) environment called `d9-beta` on your Drupal 8 site for testing:
+1. Use Terminus to create a [Multidev](/multidev) environment called `d9-preview` on your Drupal 8 site for testing:
 
   ```bash{promptUser: user}
-  terminus multidev:create <site>.<env> d9-beta
+  terminus multidev:create <site>.<env> d9-preview
   ```
 
 1. Create and switch to a new testing branch in the Drupal 8 codebase:
 
   ```bash{promptUser: user}
-  git checkout -b d9-beta
+  git checkout -b d9-preview
   ```
 
-1. Pull the `drupal9.0.0` tag into your codebase:
+1. Pull the `9.0.0` tag into your codebase:
 
   ```bash{promptUser: user}
-  git pull https://github.com/pantheon-systems/drops-8.git drupal9.0.0--from-8.9.0--early-access-not-for-production-use
+  git pull https://github.com/pantheon-systems/drops-8.git 9.0.0
   ```
 
-1. Modify the `pantheon.yml` file to specify PHP 7.4 and Drush 8:
+1. Modify the `pantheon.yml` file to specify PHP 7.3 or newer and Drush 8:
 
   ```yaml:title=pantheon.yml
   php_version: 7.4
   drush_version: 8
   ```
+
+Note that Drupal 9 is not yet compatible with the pre-installed Drush 10.
 
 1. Run `update.php` on your new Drupal 9 site:
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -38,7 +38,7 @@ Test Drupal 9 with a fresh installation using either our Integrated Composer Ear
 | [**Integrated Composer**](#create-a-new-drupal-9-site-with-integrated-composer)        | • Composer automatically runs on Pantheon <br /> • Lean repository (vendor dir not in git) <br /> • Integrated 1-click Pantheon updates & Custom Upstreams | • Early Access only <br /> • Requires a unique site-name prefix                                                            |
 | [**Build Tools**](#create-a-drupal-9-site-with-continuous-integration-via-build-tools) | • Composer automatically runs via CI <br /> • Pull request-based workflow <br /> • Supports automated testing                                              | • Requires 3rd-party CI <br /> • Terminus required <br /> • Composer updates happen outside the 1-click Pantheon Dashboard |
 
-If you're not ready to create a new site yet, you can also [check an existing site's compatibility to upgrade](#test-an-existing-drupal-site-for-drupal-9-upgrade-compatibility). Once you're ready, [test upgrade an existing pantheon drupal 8 site to drupal 9](#test-upgrade-an-existing-pantheon-drupal-8-site-to-drupal-9).
+If you're not ready to create a new site yet, you can also [check an existing site's compatibility to upgrade](#test-an-existing-drupal-site-for-drupal-9-upgrade-compatibility). Once you're ready, [test-upgrade an existing Pantheon Drupal 8 site to Drupal 9](#test-upgrade-an-existing-pantheon-drupal-8-site-to-drupal-9).
 
 ## Create a New Drupal 9 Site with Integrated Composer
 
@@ -95,11 +95,11 @@ $node = Node::load(1);
 
 Since most of these changes are relatively minor, there are a number of [deprecation checking and correction tools](https://www.drupal.org/docs/9/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/deprecation-checking-and-correction-tools) available.
 
-## Test Upgrade an Existing Pantheon Drupal 8 Site to Drupal 9
+## Test-upgrade an Existing Pantheon Drupal 8 Site to Drupal 9
 
-Already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Leverage the amazing power of our Multidev tooling to test Drupal 9 in a Git branch.
+Are you already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Leverage the amazing power of our Multidev tooling to test Drupal 9 in a Git branch.
 
-1. Clone your Drupal 8 [site’s codebase to your computer](https://pantheon.io/docs/local-development#get-the-code). You can create a new Drupal 8 site or use an existing Drupal 8 site:
+1. Clone your Drupal 8 [site’s codebase to your computer](/local-development#get-the-code). You can create a new Drupal 8 site or use an existing Drupal 8 site:
 
   ```bash{promptUser: user}
   git clone <url for site repo>

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -97,15 +97,16 @@ Since most of these changes are relatively minor, there are a number of [depreca
 
 ## Test-upgrade an Existing Pantheon Drupal 8 Site to Drupal 9
 
-Are you already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Leverage the amazing power of our Multidev tooling to test Drupal 9 in a Git branch.
+Are you already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Use our [Multidev](/multidev) feature to test Drupal 9 in a new branch.
 
-1. Clone your Drupal 8 [site’s codebase to your computer](/local-development#get-the-code). You can create a new Drupal 8 site or use an existing Drupal 8 site:
+1. Clone your Drupal 8 site’s codebase [to your computer](/local-development#get-the-code) and change directory to it. You can create a new Drupal 8 site or use an existing Drupal 8 site:
 
   ```bash{promptUser: user}
   git clone <url for site repo>
+  cd <site-name>
   ```
 
-1. Use Terminus to create a [Multidev](/multidev) environment called `d9-preview` on your Drupal 8 site for testing:
+1. Use Terminus to create a Multidev environment called `d9-preview` on your Drupal 8 site for testing:
 
   ```bash{promptUser: user}
   terminus multidev:create <site>.<env> d9-preview
@@ -130,7 +131,14 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
   drush_version: 8
   ```
 
-Note that Drupal 9 is not yet compatible with the pre-installed Drush 10.
+  Note that Drupal 9 is not yet compatible with the pre-installed Drush 10.
+
+1. Commit and push your changes:
+
+  ```bash{promptUser: user}
+  git commit -am "test upgrade to Drupal 9"
+  git push origin d9-preview
+  ```
 
 1. Run `update.php` on your new Drupal 9 site:
 


### PR DESCRIPTION
## Summary

**[Drupal 9](https://pantheon.io/docs/drupal-9)** - Gives users the steps to upgrade to an existing site to Drupal 9. [PR](#)

## Effect

The following changes are already committed:

- put the steps back to upgrade to D9 (reverted commit)
- 

## Remaining Work

The following changes still need to be completed:

- [ ] update steps with correct numbers and content
- [ ] tech edit
- [x] copy edit

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
