### PR TITLE
Suggestion to Add Anchor Link

### DIFF
--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -110,7 +110,7 @@ Dealing with changes to your site's configuration, stored in the database, can b
 
 By design, code changes via SFTP are prevented in Test and Live. All code changes should be done in Dev. There are two ways to update code in Test or Live:
 
-1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard or Terminus as outlined above.
+1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard or Terminus as outlined above, beginning in the [Combine Code from Dev and Content from Live in Test](#combine-code-from-dev-and-content-from-live-in-test) section.
 
 2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm. Pushing a [hotfix via Git tags](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
 

--- a/source/content/sftp.md
+++ b/source/content/sftp.md
@@ -126,7 +126,7 @@ We recommend [adding an SSH Key](/ssh-keys), which allows more security than a s
 
 ### I can't write to my codebase on Test or Live.
 
-This is by design. Please see [Using the Pantheon Workflow](/pantheon-workflow#understanding-write-permissions-in-test-and-live) to learn why.
+This is part of the [Pantheon WebOps workflow](/pantheon-workflow) that keeps code and content safe. Please see [Using the Pantheon Workflow](/pantheon-workflow#understanding-write-permissions-in-test-and-live) to learn more about why.
 
 ### SFTP changes do not show up in the Site Dashboard.
 


### PR DESCRIPTION
## Summary

**[Use the Pantheon WebOps Workflow](https://pantheon.io/docs/pantheon-workflow)** - Suggestion to add an anchor link in the "Understanding Write Permissions in Test and Live" section directly to the "Combine Code from Dev and Content from Live in Test" section, with the most benefit being gained from users coming to the former section directly from documentation at https://pantheon.io/docs/sftp#i-cant-write-to-my-codebase-on-test-or-live.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
