### PR TITLE
Continues #5764

### DIFF
--- a/source/content/guides/sendgrid.md
+++ b/source/content/guides/sendgrid.md
@@ -5,7 +5,7 @@ tags: [email, plugins, modules]
 categories: [integrate]
 type: guide
 permalink: docs/guides/:basename/
-contributors: [erikmathy, rvtraveller, wbconnor, sarahg]
+contributors: [erikmathy, rvtraveller, wbconnor, sarahg, sdubois]
 date: 9/8/2015
 reviewed: "2020-05-27"
 ---
@@ -28,6 +28,8 @@ One of the most common reasons that email gets blocked is because it originates 
 3. Click **Create API Key** to define the name and permissions for the API key your site will use. Click **Create & View** to complete the process.
 
 4. The API key will only be displayed once. Copy the key and save it somewhere secure until you can apply it to the site.
+
+5. From the **Settings Menu** click **Sender Authentication**. SendGrid now requires users to identify their sender identity through either **Domain Authentication** or **Single Sender Verification**. A more detailed explanation of these options can be found in the [SendGrid Documentation](https://sendgrid.com/docs/for-developers/sending-email/sender-identity/)
 
 ## Integrating Sendgrid With Drupal and WordPress
 

--- a/source/content/guides/sendgrid.md
+++ b/source/content/guides/sendgrid.md
@@ -21,15 +21,15 @@ One of the most common reasons that email gets blocked is because it originates 
 
 1. Get started by [signing up](https://sendgrid.com/partners/pantheon) for an account and selecting a plan that meets your business needs. After receiving your confirmation email, sign in to your [SendGrid account](https://sendgrid.com/login).
 
-2. From within the **Settings** menu, click **API Keys**:
+1. From within the **Settings** menu, click **API Keys**:
 
   ![SendGrid Multiple User setup](../../images/guides/sendgrid/sendgrid-api-keys.png)
 
-3. Click **Create API Key** to define the name and permissions for the API key your site will use. Click **Create & View** to complete the process.
+1. Click **Create API Key** to define the name and permissions for the API key your site will use. Click **Create & View** to complete the process.
 
-4. The API key will only be displayed once. Copy the key and save it somewhere secure until you can apply it to the site.
+1. The API key will only be displayed once. Copy the key and save it somewhere secure until you can apply it to the site.
 
-5. From the **Settings Menu** click **Sender Authentication**. SendGrid now requires users to identify their sender identity through either **Domain Authentication** or **Single Sender Verification**. A more detailed explanation of these options can be found in the [SendGrid Documentation](https://sendgrid.com/docs/for-developers/sending-email/sender-identity/)
+1. From the **Settings Menu** click **Sender Authentication**. SendGrid requires accounts created after April 6th 2020 to identify their sender identity through either **Domain Authentication** or **Single Sender Verification**. A more detailed explanation of these options can be found in the [SendGrid Documentation](https://sendgrid.com/docs/for-developers/sending-email/sender-identity/).
 
 ## Integrating Sendgrid With Drupal and WordPress
 

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -362,7 +362,7 @@
   linkedin: //www.linkedin.com/in/kyletaylored
   drupal: //www.drupal.org/u/kyletaylored
   bio: Sales Engineer at Pantheon. Drupal developer and open source evangelist. Startup Weekend Facilitator. President at TechMill Denton.
-  - id: sdubois
+- id: sdubois
   name: Steven DuBois
   avatar: //avatars.githubusercontent.com/u/479460
   github: //github.com/sdubois

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -362,3 +362,10 @@
   linkedin: //www.linkedin.com/in/kyletaylored
   drupal: //www.drupal.org/u/kyletaylored
   bio: Sales Engineer at Pantheon. Drupal developer and open source evangelist. Startup Weekend Facilitator. President at TechMill Denton.
+  - id: sdubois
+  name: Steven DuBois
+  avatar: //avatars.githubusercontent.com/u/479460
+  github: //github.com/sdubois
+  linkedin: //www.linkedin.com/in/steven-dubois-31987721/
+  drupal: //www.drupal.org/u/srdtwc
+  bio: Support Dispatcher and Web Developer at DevCollaborative.


### PR DESCRIPTION
Continues: #5764

## Summary

**[Doc Title](https://pantheon.io/docs/guides/sendgrid)** - Add instructions for configuring sender identity with link to SendGrid documentation.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
