### PR TITLE
fix title links and pagication buttons

### DIFF
--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -99,8 +99,16 @@ class ChangelogTemplate extends React.Component {
           </article>
           <TOC title="Contents" />
           <NavButtons
-            prev={ this.props.pageContext.previous ? `/${this.props.pageContext.previous}` : null }
-            next={ this.props.pageContext.next ? `/${this.props.pageContext.next}` : null }
+            prev={
+              this.props.pageContext.previous
+                ? `/${this.props.pageContext.previous}`
+                : null
+            }
+            next={
+              this.props.pageContext.next
+                ? `/${this.props.pageContext.next}`
+                : null
+            }
             prevTitle="Older"
             nextTitle="Newer"
           />

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -99,8 +99,8 @@ class ChangelogTemplate extends React.Component {
           </article>
           <TOC title="Contents" />
           <NavButtons
-            prev={`/${this.props.pageContext.previous}`}
-            next={`/${this.props.pageContext.next}`}
+            prev={ this.props.pageContext.previous ? `/${this.props.pageContext.previous}` : null }
+            next={ this.props.pageContext.next ? `/${this.props.pageContext.next}` : null }
             prevTitle="Older"
             nextTitle="Newer"
           />

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -98,13 +98,13 @@ class ChangelogTemplate extends React.Component {
             </div>
           </article>
           <TOC title="Contents" />
+          <NavButtons
+            prev={`/${this.props.pageContext.previous}`}
+            next={`/${this.props.pageContext.next}`}
+            prevTitle="Older"
+            nextTitle="Newer"
+          />
         </div>
-        <NavButtons
-          prev={this.props.pageContext.previous}
-          next={this.props.pageContext.next}
-          prevTitle="Older"
-          nextTitle="Newer"
-        />
       </Layout>
     )
   }

--- a/src/templates/changelogs.js
+++ b/src/templates/changelogs.js
@@ -150,16 +150,6 @@ export const pageQuery = graphql`
             slug
           }
         }
-        next {
-          fields {
-            slug
-          }
-        }
-        previous {
-          fields {
-            slug
-          }
-        }
       }
     }
   }

--- a/src/templates/changelogs.js
+++ b/src/templates/changelogs.js
@@ -100,7 +100,7 @@ class ChangelogsTemplate extends React.Component {
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                 {changelogs.map(changelog => (
                   <React.Fragment key={changelog.id}>
-                    <Link to={changelog.node.fields.slug}>
+                    <Link to={`/${changelog.node.fields.slug}`}>
                       <h2 id={changelog.node.fields.slug}>
                         {changelog.node.frontmatter.title}
                       </h2>
@@ -113,13 +113,13 @@ class ChangelogsTemplate extends React.Component {
               </div>
             </div>
             <TOC title="Contents" />
+            <NavButtons
+              prev={this.props.pageContext.previous}
+              next={this.props.pageContext.next}
+              prevTitle="Older"
+              nextTitle="Newer"
+            />
           </div>
-          <NavButtons
-            prev={this.props.pageContext.previous}
-            next={this.props.pageContext.next}
-            prevTitle="Older"
-            nextTitle="Newer"
-          />
         </div>
       </Layout>
     )
@@ -133,7 +133,7 @@ export const pageQuery = graphql`
     allMdx(
       filter: {
         fileAbsolutePath: { regex: "/changelogs/" }
-        frontmatter: { draft: {ne: true}}
+        frontmatter: { draft: { ne: true } }
       }
       sort: { fields: [fileAbsolutePath], order: DESC }
       skip: $skip
@@ -146,6 +146,16 @@ export const pageQuery = graphql`
           frontmatter {
             title
           }
+          fields {
+            slug
+          }
+        }
+        next {
+          fields {
+            slug
+          }
+        }
+        previous {
           fields {
             slug
           }


### PR DESCRIPTION
## Summary

**[Changelogs](https://pantheon.io/docs/changelog)** - Fixed links from main the individual changelog pages in titles, and moved pagination buttons to be visible..

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
