### PR TITLE
Remove Elite Starter Plan

### DIFF
--- a/source/content/disaster-recovery.md
+++ b/source/content/disaster-recovery.md
@@ -22,7 +22,7 @@ Recovery Time Objective (**RTO**) is the target amount of time within which a bu
 
 ## Access
 
-Site Disaster Recovery is available for purchase as an add-on to all Elite site plans except Elite Starter. For more information, please [contact Sales](https://pantheon.io/contact-us?docs).
+Site Disaster Recovery is available for purchase as an add-on to all Elite site plans. For more information, please [contact Sales](https://pantheon.io/contact-us?docs).
 
 ![Chart showing Pantheon's zone-based disaster recovery architecture](../images/site-dr-diagram.png)
 


### PR DESCRIPTION
## Summary

**[Site Disaster Recovery](https://pantheon.io/docs/disaster-recovery)** - Removing reference to Legacy Plan "Elite Starter".

- This plan is no longer being offered.
- [Based on this Google Search](https://www.google.com/search?ei=Z1XfXvrZMpW-0PEPmu-v-AE&q=site%3Ahttps%3A%2F%2Fpantheon.io+%22elite+starter%22&oq=site%3Ahttps%3A%2F%2Fpantheon.io+%22elite+starter%22&gs_lcp=CgZwc3ktYWIQA1DBGljBGmC4HGgAcAB4AIABSogBigGSAQEymAEAoAEBqgEHZ3dzLXdpeg&sclient=psy-ab&ved=0ahUKEwi6qb7ntPTpAhUVHzQIHZr3Cx8Q4dUDCAw&uact=5), it seems the only place where it is still referenced is on this page.
- [According to Looker](/explore/_pbi/sites?toggle=fil&qid=7xrLOsIkejhYpSIXtMKrzI), there are 22 sites currently still on "Elite Starter", but when they are renewed, if they stayed on an Elite Plan, they would presumably not be on a Legacy Plan/"Elite Starter".

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
