### PR TITLE
remove duplication of pre-launch load test section

### DIFF
--- a/source/content/onboarding.md
+++ b/source/content/onboarding.md
@@ -24,9 +24,7 @@ If a Custom SSL Certificate is mission critical to your web property, you can br
 
 ## Pre-launch Load Testing
 
-Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the Onboarding team we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
-
-Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services?docs) for details.
+Load tests can be critical steps in ensuring a successful launch. See [Onboarding Services Pre-Launch Load Testing](/onboarding#pre-launch-load-testing) for details.
 
 ## Additional Services
 

--- a/source/content/onboarding.md
+++ b/source/content/onboarding.md
@@ -24,7 +24,9 @@ If a Custom SSL Certificate is mission critical to your web property, you can br
 
 ## Pre-launch Load Testing
 
-Load tests can be critical steps in ensuring a successful launch. See [Onboarding Services Pre-Launch Load Testing](/onboarding#pre-launch-load-testing) for details.
+Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the Professional Services team, we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+
+Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services?docs) for more information.
 
 ## Additional Services
 

--- a/source/content/onboarding.md
+++ b/source/content/onboarding.md
@@ -24,9 +24,11 @@ If a Custom SSL Certificate is mission critical to your web property, you can br
 
 ## Pre-launch Load Testing
 
-Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the Professional Services team, we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+Load tests provide critical insight into how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings.
 
-Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services?docs) for more information.
+Using proprietary tools developed by the Onboarding team, we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
+
+[Contact us](https://pantheon.io/professional-services?docs) for more information.
 
 ## Additional Services
 

--- a/source/content/professional-services.md
+++ b/source/content/professional-services.md
@@ -48,9 +48,7 @@ Implement additional services like IP-based geolocation, extended WAF, Image Opt
 
 ## Pre-launch Load Testing
 
-Load tests can be critical steps in ensuring a successful launch. Using proprietary tools developed by the PS team, we generate traffic to your Live site, simulating complex user interactions if needed. There is no better way to expose and identify potential performance bottlenecks before you’ve launched your site.
-
-Load tests provide critical insight for how a site will perform in the wild and through peak traffic spikes. Load tests ensure that your website launches smoothly and that it is ready to absorb the high traffic that success brings. [Contact us](https://pantheon.io/professional-services?docs) for details.
+Load tests can be critical steps in ensuring a successful launch. See [Onboarding Services Pre-Launch Load Testing](/onboarding#pre-launch-load-testing) for details.
 
 ## Custom Application Services
 


### PR DESCRIPTION
## Summary

**[Professional Services](https://pantheon.io/docs/professional-services)** - Change Pre-Launch Load Testing section to remove duplication and redirect to Onboarding Services page.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
