### PR TITLE
Categorize and Tag Pantheon Docs pt 2

### DIFF
--- a/source/content/access-management.md
+++ b/source/content/access-management.md
@@ -1,8 +1,8 @@
 ---
 title: Access Management for Site Owners and Administrators
 description: Learn how to remove a team member or outside resource from a Pantheon site.
-tags: [manage]
 categories: [manage]
+tags: [users, security, organizations, agencies]
 ---
 
 When a person with access to your site(s) on the platform leaves the company or project, it is important to immediately remove them from the team so that they no longer have access to make changes to your site.

--- a/source/content/add-client-site.md
+++ b/source/content/add-client-site.md
@@ -1,8 +1,8 @@
 ---
 title: Add a Client Site to Your Organization Dashboard
 description: Learn how to add a client to your Partner Agency to share special features and pricing.
-tags: [manage, billing]
-categories: [manage,go-live]
+categories: [platform]
+tags: [agencies, billing, organizations]
 contributors: [edwardangert]
 searchboost: 150
 ---

--- a/source/content/advanced-global-cdn.md
+++ b/source/content/advanced-global-cdn.md
@@ -1,8 +1,8 @@
 ---
 title: Advanced Global CDN
 description: Pantheon Professional Services can help you uniquely optimize our Global CDN
-categories: [develop]
-tags: [CDN, security]
+categories: [performance]
+tags: [cdn, security, professional-services]
 reviewed: "2020-02-27"
 ---
 

--- a/source/content/advanced-redirects.md
+++ b/source/content/advanced-redirects.md
@@ -1,8 +1,8 @@
 ---
 title: Advanced Redirects and Restrictions
 description: Configure custom redirect logic for specific scenarios
-tags: [redirects, variables, dns, domains]
-categories: [go-live,develop]
+categories: [go-live]
+tags: [redirects, https, dns, launch]
 reviewed: "2020-02-12"
 ---
 

--- a/source/content/agency-tips.md
+++ b/source/content/agency-tips.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Agency Tips
 description: Tips for agencies working on Pantheon.
-tags: [tools]
 categories: [manage]
+tags: [agencies, organizations, collaborate]
 contributors: [davidneedham]
 searchboost: 90
 ---

--- a/source/content/alternative-php-cache.md
+++ b/source/content/alternative-php-cache.md
@@ -1,8 +1,8 @@
 ---
 title: What is APC and what is it used for?
 description: Understand Alternative PHP Cache and its uses within the Pantheon WebOps workflow.
-tags: [APC,caching,PHP,Redis]
 categories: [platform]
+tags: [cache, workflow]
 reviewed: "2020-05-05"
 ---
 APC stands for the [Alternative PHP Cache](https://secure.php.net/manual/en/book.apc.php "Alternative PHP Cache manual on php.net"). PHP is a dynamic language that is compiled on-demand into bytecode at execution time. To improve performance, APC stores this bytecode so that it can be reused instead of having to be recompiled each time.

--- a/source/content/application-containers.md
+++ b/source/content/application-containers.md
@@ -1,8 +1,8 @@
 ---
 title: All About Application Containers
 description: Information on Pantheon's container-based, grid-model infrastructure.
-tags: [infrastructure]
 categories: [platform]
+tags: [webops]
 reviewed: "2020-04-24"
 ---
 

--- a/source/content/bots-and-indexing.md
+++ b/source/content/bots-and-indexing.md
@@ -1,8 +1,8 @@
 ---
 title: Bots and Indexing on Pantheon
 description: Information on managing bots and indexing while avoiding performance degradation on your Pantheon WordPress or Drupal site.
-tags: [infrastructure]
 categories: [platform]
+tags: [measure, traffic]
 ---
 Bots are part of every public-facing website's lifecycle. We wouldn't be able to find a thing on the internet without them! Bots perform the hard work taken for granted when browsing the multitudes of indexed search results from any given search engine. In the wrong hands, bots can become nagging nuisances slowing down or even taking down your site.
 

--- a/source/content/cache-control.md
+++ b/source/content/cache-control.md
@@ -2,7 +2,7 @@
 title: Bypassing Cache with HTTP Headers
 description: Set HTTP headers to disable caching along Pantheon's edge layer, Varnish.
 categories: [performance]
-tags: [cache, cdn]
+tags: [cache, cdn, cookies]
 ---
 ## Exclude Specific Pages from Caching
 You can use a variety of mechanisms to determine which responses from your Drupal or WordPress site should be excluded from caching. Ultimately, these mechanisms result in setting HTTP headers that signal cacheability to Varnish and recipients of the response, like a browser.

--- a/source/content/cache-control.md
+++ b/source/content/cache-control.md
@@ -1,8 +1,8 @@
 ---
 title: Bypassing Cache with HTTP Headers
 description: Set HTTP headers to disable caching along Pantheon's edge layer, Varnish.
-tags: [cacheedge]
 categories: [performance]
+tags: [cache, cdn]
 ---
 ## Exclude Specific Pages from Caching
 You can use a variety of mechanisms to determine which responses from your Drupal or WordPress site should be excluded from caching. Ultimately, these mechanisms result in setting HTTP headers that signal cacheability to Varnish and recipients of the response, like a browser.

--- a/source/content/change-management.md
+++ b/source/content/change-management.md
@@ -1,8 +1,8 @@
 ---
 title: Role-Based Permissions & Change Management
 description: Features and benefits of role-based permissions for Pantheon Drupal and WordPress sites.
-tags: [tools]
 categories: [manage]
+tags: [agencies, organizations, users]
 ---
 Change Management is an [Organization](/organizations) feature that enables role-based permissions for users in the organization. It is automatically enabled for all Organizations.
 

--- a/source/content/clear-caches.md
+++ b/source/content/clear-caches.md
@@ -1,8 +1,8 @@
 ---
 title: Clearing Caches for Drupal and WordPress
 description: Learn how to clear cache for Drupal and WordPress sites on Pantheon's Global CDN.
-tags: [cacheapp]
 categories: [performance]
+tags: [cache, cdn]
 ---
 Pantheon extends the core functionality of caching mechanisms within WordPress and Drupal so that caches are cleared within the site's frame and from our [Global CDN](/global-cdn) service.
 

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -1,8 +1,8 @@
 ---
 title: Getting the Client IP Address
 description: Getting the client IP address to set up geolocation capabilities on your Pantheon site.
-categories: [manage]
-tags: [billing]
+categories: [develop]
+tags: [cdn]
 reviewed: "2020-03-09"
 ---
 

--- a/source/content/client-ip.md
+++ b/source/content/client-ip.md
@@ -1,8 +1,8 @@
 ---
 title: Getting the Client IP Address
 description: Getting the client IP address to set up geolocation capabilities on your Pantheon site.
-tags: [Drupal, geolocation]
-categories: [develop]
+categories: [manage]
+tags: [billing]
 reviewed: "2020-03-09"
 ---
 

--- a/source/content/cloud-optimization.md
+++ b/source/content/cloud-optimization.md
@@ -1,8 +1,8 @@
 ---
 title: Optimization for Pantheon and the Cloud
 description: Learn how to optimize your Drupal or WordPress site to efficiently function on Pantheon's cloud.
-tags: [infrastructure]
-categories: [performance,platform]
+categories: [performance]
+tags: [cache, cdn]
 ---
 Pantheon as a platform attempts to balance the tradeoff between high performance and high availability. It is important to reduce single points of failure and insure scalability, but this effort can introduce complexity and latency vs. a “one box” architecture.
 

--- a/source/content/cms-admin.md
+++ b/source/content/cms-admin.md
@@ -3,7 +3,7 @@ title: Working in the WordPress Dashboard and Drupal Admin Interface
 description: Learn how to build sites using the WordPress and Drupal admin interfaces in SFTP mode on Pantheon.
 searchboost: 150
 categories: [develop]
-tags: [site]
+tags: [site, sftp, dashboard]
 ---
 Pantheon's Site Dashboard provides two connection modes to support various development workflows, such as pushing commits from your local with [Git](/git) or working in the WordPress or Drupal admin interface in [SFTP](/sftp) mode. Admin tools and command-line interfaces require write access to the codebase, which is only provided to development environments (Dev or [Multidev](/multidev)) in **SFTP** mode.
 

--- a/source/content/cms-admin.md
+++ b/source/content/cms-admin.md
@@ -1,9 +1,9 @@
 ---
 title: Working in the WordPress Dashboard and Drupal Admin Interface
 description: Learn how to build sites using the WordPress and Drupal admin interfaces in SFTP mode on Pantheon.
-tags: [admin]
 searchboost: 150
 categories: [develop]
+tags: [site]
 ---
 Pantheon's Site Dashboard provides two connection modes to support various development workflows, such as pushing commits from your local with [Git](/git) or working in the WordPress or Drupal admin interface in [SFTP](/sftp) mode. Admin tools and command-line interfaces require write access to the codebase, which is only provided to development environments (Dev or [Multidev](/multidev)) in **SFTP** mode.
 

--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -2,7 +2,7 @@
 title: Composer Fundamentals and WebOps Workflows
 description: Start with Composer basics then explore suggested WebOps workflows for WordPress and Drupal sites on Pantheon.
 categories: [develop]
-tags: [composer, workflow, updates]
+tags: [composer, workflow, updates, webops]
 searchboost: 150
 ---
 Composer is a PHP dependency manager that provides an alternative, more modern way to manage the external code used by a WordPress or Drupal site. At its primary level, Composer needs:

--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -1,8 +1,8 @@
 ---
 title: Composer Fundamentals and WebOps Workflows
 description: Start with Composer basics then explore suggested WebOps workflows for WordPress and Drupal sites on Pantheon.
-tags: [automation, workflow, composer]
 categories: [develop]
+tags: [composer, workflow, updates]
 searchboost: 150
 ---
 Composer is a PHP dependency manager that provides an alternative, more modern way to manage the external code used by a WordPress or Drupal site. At its primary level, Composer needs:

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -1,8 +1,8 @@
 ---
 title: Create a Custom Upstream
 description: Connect a remote repository with Pantheon to use as a starting point for new sites.
-tags: [tools, workflow]
-categories: [manage,develop]
+categories: [develop]
+tags: [upstreams, workflow, webops]
 ---
 Pantheon Custom Upstreams are a self-serve feature available to anyone with access to the Organization Dashboard of an eligible plan. Once an Organization Administrator creates a Custom Upstream, members of the organization will be able to create new sites from a set common codebase. For an overview of this feature, see [Introduction to Custom Upstreams](/custom-upstream). In order to use a specific Custom Upstream on multiple Organizations, the upstream must be created within each Organization’s Dashboard.
 

--- a/source/content/create-sites.md
+++ b/source/content/create-sites.md
@@ -1,8 +1,8 @@
 ---
 title: Creating Sites
-description:  Create a new Drupal or WordPress site on Pantheon.
-tags: [create]
+description: Create a new Drupal or WordPress site on Pantheon.
 categories: [get-started]
+tags: [site, dashboard]
 ---
 The Pantheon Dashboard provides a quick "click to install" method of creating new sites. In less than five minutes, you'll have a new site up and running on the platform.
 

--- a/source/content/database-workflow.md
+++ b/source/content/database-workflow.md
@@ -1,8 +1,8 @@
 ---
 title: Database Workflow Tool
 description: Learn about the database that runs in your Pantheon Drupal or WordPress site.
-tags: [services, dashboard, workflow]
-categories: [get-started,platform,develop]
+categories: [platform]
+tags: [dashboard, database, workflow]
 ---
 The Pantheon platform provides each site environment with a dedicated MySQL container running [MariaDB](https://en.wikipedia.org/wiki/MariaDB) that can be maintained remotely or locally. For a comprehensive list of MySQL settings, [access your database](/mysql-access/#database-connection-information) and use the [SHOW VARIABLES](https://dev.mysql.com/doc/refman/5.7/en/show-variables.html) statement.
 

--- a/source/content/delete-account.md
+++ b/source/content/delete-account.md
@@ -1,8 +1,8 @@
 ---
 title: Deleting Your Pantheon Account
 description: Learn how to completely remove your Pantheon account.
-tags: [manage]
 categories: [manage]
+tags: [billing, site]
 ---
 Follow the steps below to completely delete your site(s).
 

--- a/source/content/delete-site.md
+++ b/source/content/delete-site.md
@@ -1,8 +1,8 @@
 ---
 title: Deleting a Site on Pantheon
 description: Information on removing a Drupal or WordPress site from Pantheon.
-tags: [manage]
 categories: [manage]
+tags: [billing, site, sandbox]
 ---
 At some point, you may need or want to delete one of your sites on Pantheon. The number of free sites you can create is increased after a free site is deleted, or after it has converted to a paid plan.
 

--- a/source/content/deploybot.md
+++ b/source/content/deploybot.md
@@ -1,8 +1,8 @@
 ---
 title:  Deploy to Pantheon from an External Repository using DeployBot
 description: Learn how to set up and use DeployBot to deploy from repositories hosted with a third party provider, like GitHub, to Pantheon.
-categories: [workflow,develop]
-tags: [siteintegrations, workflow]
+categories: [automate]
+tags: [git, workflow]
 contributors: [ataylorme, rachelwhitton]
 ---
 
@@ -28,7 +28,7 @@ There are a few known limitations to consider before proceeding:
 ### Example Workflow
 Let's say I use [Composer](/composer) to manage my WordPress site's plugin and theme requirements, and only track core and custom code in version control. I could host the lean source code repository on GitHub, then use DeployBot to run build commands that install my dependencies and deploy the full application to Pantheon's Dev environment. Here's what my `composer.json` file might look like for my site:
 
-```
+```json:title=composer.json
 {
   "minimum-stability": "dev",
   "config"      : {

--- a/source/content/deprecated-constructor-notices.md
+++ b/source/content/deprecated-constructor-notices.md
@@ -2,7 +2,7 @@
 title: Debug Intermittent PHP 7 Notices
 description: Debug and fix "Deprecated Constructor" notices in your Pantheon site.
 categories: [troubleshoot]
-tags: [debugcode]
+tags: [code]
 contributors: [greg-1-anderson]
 ---
 

--- a/source/content/dns-providers.md
+++ b/source/content/dns-providers.md
@@ -2,7 +2,7 @@
 title: DNS Host-specific DNS Instructions
 description: A list of docs to help you connect your Pantheon site to your domain
 categories: [go-live]
-tags: [dns, domains]
+tags: [dns]
 reviewed: "2020-04-16"
 ---
 

--- a/source/content/email.md
+++ b/source/content/email.md
@@ -1,8 +1,8 @@
 ---
 title: Email on Pantheon
 description: Detailed information on outgoing mail and email hosting for your Pantheon Drupal or WordPress site.
-tags: [services]
 categories: [platform]
+tags: [email]
 ---
 ## Incoming Email
 

--- a/source/content/files.md
+++ b/source/content/files.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Filesystem
 description: Detailed information on how to access and optimize the Pantheon filesystem.
-tags: [infrastructure, sftpfiles]
-categories: [platform,develop]
+categories: [platform]
+tags: [code, files]
 ---
 
 Files are large pieces of static content not stored in your database, usually images, documents, or user uploads. Because they are distinct from your site's [code](/code), they are excluded from version control via Pantheon's `.gitignore` files <Popover content="The <a class='external' href='https://git-scm.com/docs/gitignore'>.gitignore file</a> is located at the root of the site's codebase and instructs Git on which paths to ignore." />:

--- a/source/content/filezilla.md
+++ b/source/content/filezilla.md
@@ -1,8 +1,8 @@
 ---
 title: FileZilla on Pantheon
 description: Information about using the FileZilla FTP client for your Pantheon Drupal or WordPress site.
-tags: [sftp, filezilla]
 categories: [develop]
+tags: [sftp, files]
 ---
 
 [FileZilla](https://FileZilla-project.org/) is a free open source FTP client that is available for Windows, Mac OS X, and Linux.

--- a/source/content/guides/build-tools/04-configure.md
+++ b/source/content/guides/build-tools/04-configure.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Manage Configuration
 description: In step four of the Build Tools guide, learn how to manage your site configuration.
-categories: [workflow]
-tags: [build-tools, drupal, manage]
+categories: [develop]
+tags: [workflow, composer, continuous-integration, webops, terminus]
 anchorid: configure
 type: guide
 permalink: docs/guides/build-tools/configure/

--- a/source/content/guides/build-tools/08-custom-theme.md
+++ b/source/content/guides/build-tools/08-custom-theme.md
@@ -2,8 +2,9 @@
 title: Build Tools
 subtitle: Create a Custom Theme
 description: In step eight of the Build Tools guide, learn how to create a custom theme as part of the build tooks workflow.
+cms: "Drupal"
 categories: [develop]
-tags: [build-tools, drupal]
+tags: [themes, workflow]
 buildtools: true
 anchorid: custom-theme
 type: guide

--- a/source/content/guides/build-tools/09-update.md
+++ b/source/content/guides/build-tools/09-update.md
@@ -2,8 +2,9 @@
 title: Build Tools
 subtitle: Update Your Project
 description: In step nine of the Build Tools guide, learn how to update your site as part of the continuous integration process.
+cms: "Drupal"
 categories: [develop]
-tags: [build-tools, automate, composer]
+tags: [updates, continuous-integration, composer, workflow]
 buildtools: true
 anchorid: update
 type: guide

--- a/source/content/guides/load-testing-with-blazemeter.md
+++ b/source/content/guides/load-testing-with-blazemeter.md
@@ -1,8 +1,8 @@
 ---
 title: Load Testing Drupal and WordPress with BlazeMeter
 description: Learn how to use BlazeMeter to load test your Pantheon Drupal or WordPress site.
-tags: [newrelic, moreguides]
-categories: [performance,go-live]
+categories: [performance]
+tags: [launch, measure, newrelic]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [jessifischer]

--- a/source/content/guides/lockr.md
+++ b/source/content/guides/lockr.md
@@ -1,8 +1,8 @@
 ---
 title: Using Lockr to Secure and Manage API and Encryption Keys
 description: Detailed information on how to set up and use Lockr in your WordPress and Drupal site.
-tags: [siteintegrations, security, moreguides]
-categories: [integrate,develop]
+categories: [integrate]
+tags: [plugins, security]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [cteitzel]

--- a/source/content/guides/partial-composer.md
+++ b/source/content/guides/partial-composer.md
@@ -2,8 +2,8 @@
 title: Manage Some Dependencies with Composer
 description: Get your feet wet with Composer on WordPress or Drupal 7 before going all in.
 contributors: [rachelwhitton, dustinleblanc, wbconnor, sarahg]
-tags: [automation, workflow, moreguides, composer]
 categories: [develop]
+tags: [composer, workflow, updates]
 type: guide
 permalink: docs/guides/:basename/
 ---

--- a/source/content/guides/rerouting-outbound-email.md
+++ b/source/content/guides/rerouting-outbound-email.md
@@ -1,8 +1,9 @@
 ---
 title: Prevent Spamming During Drupal Debugging and Testing
 description: Set up the Drupal reroute_email module on your Pantheon Drupal site.
-tags: [workflow, moreguides]
+cms: "Drupal"
 categories: [develop]
+tags: [workflow, email]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [ari]

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -1,8 +1,9 @@
 ---
 title: Using Terminus to Create and Update Drupal Sites on Pantheon
 description: Detailed information on creating and updating new Pantheon Drupal sites using Terminus and the command line.
-tags: [devterminus, create, moreguides]
-categories: [get-started, workflow,develop]
+cms: "Drupal"
+categories: [get-started]
+tags: [terminus, drush]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [erikmathy]

--- a/source/content/guides/two-factor-authentication.md
+++ b/source/content/guides/two-factor-authentication.md
@@ -1,8 +1,8 @@
 ---
 title: Secure Your Site with Two-Factor Authentication
 description: Set up two-factor authentication on your Pantheon Drupal or WordPress site as an added security measure.
-tags: [siteintegrations, security, moreguides]
-categories: [drupal,integrate,develop]
+categories: [integrate]
+tags: [security, saml, users]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [populist]

--- a/source/content/load-and-performance-testing.md
+++ b/source/content/load-and-performance-testing.md
@@ -1,8 +1,8 @@
 ---
 title: Load and Performance Testing
 description: Learn how to monitor internal execution performance of your Pantheon Drupal or WordPress site.
-tags: [newrelic]
-categories: [performance,go-live]
+categories: [performance]
+tags: [measure, newrelic, professional-services]
 reviewed: "2020-04-02"
 ---
 

--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -1,8 +1,8 @@
 ---
 title: Use Pantheon Localdev to Develop Sites Locally
 description: Localdev makes it easy to develop your sites locally with the Pantheon workflow.
-tags: [Localdev, tools, workflow]
 categories: [develop]
+tags: [localdev, local, workflow]
 earlyaccess: true
 earlynote: The documentation on this page discusses features and options that are still in production. Pantheon Support for Localdev may be limited.
 contributors: [edwardangert]

--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -1,8 +1,8 @@
 ---
 title: Log Files on Pantheon
 description: Use log files to identify errors, track response times, analyze visitors and more on your WordPress or Drupal site.
-tags: [logs, services]
-categories: [performance,platform]
+categories: [platform]
+tags: [logs, newrelic, workflow]
 reviewed: "2020-01-13"
 ---
 Log files track and record your site's activity to help you find, debug, and isolate current or potential problems on your site. Each environment (Multidev, Dev, Test, and Live) has their own respective log files, which can be obtained via SFTP. Application-level logs can be accessed through Drupal directly. In addition to logs, [New Relic Pro](/new-relic) is a great way to help diagnose and fix errors and performance bottlenecks.

--- a/source/content/machine-tokens.md
+++ b/source/content/machine-tokens.md
@@ -1,8 +1,8 @@
 ---
 title: Creating and Revoking Machine Tokens
 description: Learn how to create a machine token in order to use Terminus on your Drupal or WordPress site.
-tags: [site, security]
-categories: [automate,develop]
+categories: [integrate]
+tags: [sso, security, terminus]
 ---
 
 Machine tokens are used to uniquely identify your machine and securely authenticate via [Terminus](https://github.com/pantheon-systems/cli#installation), as of the 0.10.2 release.

--- a/source/content/managing-edu-plus.md
+++ b/source/content/managing-edu-plus.md
@@ -1,8 +1,8 @@
 ---
 title: Managing Site Plan Changes for EDU+ Sites
 description: Learn how to manage site plan changes for Pantheon EDU+ sites.
-tags: [manage]
 categories: [manage]
+tags: [organizations, billing]
 reviewed: "2020-03-11"
 ---
 

--- a/source/content/migrate-cpanel.md
+++ b/source/content/migrate-cpanel.md
@@ -1,8 +1,8 @@
 ---
 title: Exporting Sites from GoDaddy with cPanel
 description: Learn how to migrate Drupal or WordPress sites to Pantheon from hosts that block cPanel exports.
-tags: [export]
 categories: [get-started]
+tags: [migrate]
 ---
 There are some hosting providers that block complete site exports from cPanel, making it difficult to migrate the site elsewhere. The following steps will walk you through how to export sites with limited cPanel access, such as GoDaddy.
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -2,7 +2,7 @@
 title: Multidev FAQ
 description: A quick reference to answer some of the most frequently asked questions about Multidev.
 categories: [develop]
-tags: [collaborate, workflow, webops]
+tags: [collaborate, workflow, webops, multidev]
 ---
 For information about what Multidev is and how to use it, see our full guide on [Multidev](/multidev).
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -1,8 +1,8 @@
 ---
 title: Multidev FAQ
 description: A quick reference to answer some of the most frequently asked questions about Multidev.
-tags: [tools, workflow]
 categories: [develop]
+tags: [collaborate, workflow, webops]
 ---
 For information about what Multidev is and how to use it, see our full guide on [Multidev](/multidev).
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -2,7 +2,7 @@
 title: Multidev
 description: Detailed information on using Pantheon's Multidev environment for your Drupal or WordPress site.
 categories: [develop]
-tags: [git, cli, workflow, collaborate]
+tags: [multidev, git, cli, workflow, collaborate]
 ---
 Multidev is development environments for teams and allows a developer to fork the entire stack (code and content), work independently, then merge the code changes back into the master. Each forked branch will have its own separate development environment, including database and files.
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -1,8 +1,8 @@
 ---
 title: Multidev
 description: Detailed information on using Pantheon's Multidev environment for your Drupal or WordPress site.
-tags: [git, tools, workflow]
-categories: [develop,manage,develop]
+categories: [develop]
+tags: [git, cli, workflow, collaborate]
 ---
 Multidev is development environments for teams and allows a developer to fork the entire stack (code and content), work independently, then merge the code changes back into the master. Each forked branch will have its own separate development environment, including database and files.
 

--- a/source/content/myisam-to-innodb.md
+++ b/source/content/myisam-to-innodb.md
@@ -1,8 +1,8 @@
 ---
 title: Converting MySQL Tables From MyISAM to InnoDB
 description: Improve the reliability and performance of your MySQL database by moving to InnoDB.
-tags: [status]
-categories: [performance,go-live]
+categories: [develop]
+tags: [database, cli]
 reviewed: "2020-03-16"
 ---
 Before [InnoDB](https://dev.mysql.com/doc/refman/5.5/en/innodb-storage-engine.html), indexes would get corrupted, updates meant table locks—not just row locks, and there was no support for transactions. Since the advent of InnoDB we've come a long way.

--- a/source/content/new-relic.md
+++ b/source/content/new-relic.md
@@ -1,8 +1,8 @@
 ---
 title: New Relic APM Pro
 description: Learn how to enable and use New Relic performance metrics and reports for your Drupal or WordPress site on Pantheon.
-tags: [New Relic, performance, analytics]
 categories: [performance]
+tags: [logs, measure, newrelic]
 reviewed: "2020-05-27"
 ---
 

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -1,8 +1,8 @@
 ---
 title: Parsing Nginx Access Logs with GoAccess
 description: Learn how to parse the nginx-access.log file with GoAccess to gather information on your visitors and referral traffic.
-tags: [logs, nginx, goacess]
 categories: [performance]
+tags: [logs, measure]
 contributors: [albertcausing, sarahg]
 reviewed: "2020-05-06"
 ---

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Organizations FAQs
 description: Commonly asked questions and answers about Agency Partner Organizations using the Pantheon Platform.
-tags: [manage]
 categories: [manage]
+tags: [organizations]
 ---
 ## Multidev
 

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -2,7 +2,7 @@
 title: Pantheon Organizations FAQs
 description: Commonly asked questions and answers about Agency Partner Organizations using the Pantheon Platform.
 categories: [manage]
-tags: [organizations]
+tags: [organizations, agencies, multidev]
 ---
 ## Multidev
 

--- a/source/content/organizations.md
+++ b/source/content/organizations.md
@@ -1,8 +1,8 @@
 ---
 title: Organizations
 description: Detailed information on Pantheon organization types and the features available to them.
-tags: [manage]
 categories: [manage]
+tags: [organizations]
 ---
 
 Pantheon Organizations bring together users, sites, Custom Upstreams, Multidev, and support to provide administrators with the tools needed to effectively manage a large number of sites.

--- a/source/content/outgoing-ips.md
+++ b/source/content/outgoing-ips.md
@@ -1,8 +1,8 @@
 ---
 title: Dynamic Outgoing IP Addresses
 description: Understand how outgoing requests are made for WordPress and Drupal sites on Pantheon.
-tags: [infrastructure]
 categories: [platform]
+tags: [email, sso, saml]
 ---
 Outgoing requests sent by Drupal and WordPress applications facilitate tasks between your site and external services, such as authentication and payment gateways.
 

--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -1,8 +1,8 @@
 ---
 title: Use the Pantheon WebOps Workflow
 description: Understand the Pantheon WebOps workflow, and how to use separate Dev, Test, and Live environments for your Drupal or WordPress sites.
-tags: [workflow, dashboard]
-categories: [get-started,develop]
+categories: [get-started]
+tags: [workflow, dashboard, webops]
 ---
 
 <Alert title="Note" type="info">

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -2,7 +2,7 @@
 title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
 categories: [platform]
-tags: [https, launch]
+tags: [https, launch, code, workflow]
 ---
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
-tags: [pantheonyml, infrastructure]
-categories: [workflow,platform]
+categories: [platform]
+tags: [https, launch]
 ---
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
 

--- a/source/content/pantheon_stripped.md
+++ b/source/content/pantheon_stripped.md
@@ -1,8 +1,8 @@
 ---
 title: Considerations for Google Analytics and PANTHEON_STRIPPED
 description: Information on why PANTHEON_STRIPPED is placed in the utm_source URL parameter.
-tags: [cacheedge]
-categories: [performance]
+categories: [troubleshoot]
+tags: [cache, cdn, measure]
 ---
 Typically, Pantheon's edge cache uses the entire request URL, including query string parameters, as the content cache key. In some cases, the query parameters do not affect the content returned in the response and we can optimize your site's performance by safely ignoring these parameters from a cache perspective. For example, specific Google Analytics query parameters are used solely by JavaScript to track different AdWords campaigns running for the same page on your site.
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -1,8 +1,8 @@
 ---
 title: Automate and Integrate your WebOps Workflow with Quicksilver
 description: Learn how to use Quicksilver to automate your WebOps workflow.
-tags: [pantheonyml, infrastructure]
-categories: [automate,platform]
+categories: [automate]
+tags: [quicksilver, webops, workflow]
 reviewed: "2020-03-10"
 ---
 

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -1,8 +1,8 @@
 ---
 title: Installing Redis on Drupal or WordPress
 description: Understand how to use Redis as a caching mechanism for your Pantheon site.
-tags: [cacheapp, addons]
-categories: [performance,develop]
+categories: [performance]
+tags: [cache, plugins, modules]
 contributors: [cityofoaksdesign]
 ---
 Redis is an open-source, networked, in-memory, key-value data store that can be used as a drop-in caching backend for your Drupal or WordPress website.

--- a/source/content/regions.md
+++ b/source/content/regions.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Site Regions and Data Residency
 description: Learn how to launch sites in Australia, Canada, or the European Union.
-tags: [create, regions]
 categories: [get-started]
+tags: [launch, site]
 contributors: [edwardangert, rachelwhitton, ari]
 searchboost: 150
 ---

--- a/source/content/required-reading.md
+++ b/source/content/required-reading.md
@@ -1,8 +1,8 @@
 ---
 title: 'Required Reading: Essential Pantheon Documentation'
 description: Recommended documentation to learn about Pantheon Website Management Platform's technologies.
-tags: [getstarted]
-categories: [getstarted]
+categories: [get-started]
+tags: [workflow]
 ---
 Pantheon is not web hosting. It is a highly-tuned, distributed, and instantly scalable [WebOps](https://en.wikipedia.org/wiki/Web_operations) platform. Pantheon also integrates development best practices and tools into the platform, to get the developer back to writing code, not configuring servers and carrying pagers.
 

--- a/source/content/required-reading.md
+++ b/source/content/required-reading.md
@@ -1,6 +1,6 @@
 ---
 title: 'Required Reading: Essential Pantheon Documentation'
-description: Recommended documentation to learn about Pantheon Website Management Platform's technologies.
+description: Recommended documentation to learn about Pantheon WebOps management mlatform's technologies.
 categories: [get-started]
 tags: [workflow]
 ---

--- a/source/content/rsync-and-sftp.md
+++ b/source/content/rsync-and-sftp.md
@@ -1,8 +1,8 @@
 ---
 title: rsync and SFTP
 description: Transfer large files using an SFTP client or rsync using Drupal 6, Drupal 7, or WordPress for Pantheon.
-tags: [sftpfiles]
 categories: [develop]
+tags: [files, sftp, rsync]
 ---
 If you have more than 500 MB of content to be transferred to your `/files` directory (`sites/default/files` for Drupal and `wp-content/uploads` for WordPress), you won't be able to use your Pantheon Dashboard to import. Instead, you'll need to use a SFTP client or rsync to transfer.
 

--- a/source/content/server_name-and-server_port.md
+++ b/source/content/server_name-and-server_port.md
@@ -1,8 +1,8 @@
 ---
 title: SERVER_NAME and SERVER_PORT on Pantheon
 description: Learn how to work around SERVER_NAME and SERVER_PORT variables in your Pantheon Website Management Platform environment configuration.
-tags: [variables]
-categories: [develop]
+categories: [platform]
+tags: [site]
 ---
 Some code relies on `$_SERVER['SERVER_NAME']` and `$_SERVER['SERVER_PORT']` to construct URLs, either to "call itself" or to create URLs that are passed to third parties and expect to be routed back. This doesn't work well on Pantheon because the environmental data will be for ephemeral container data.
 

--- a/source/content/sftp.md
+++ b/source/content/sftp.md
@@ -1,8 +1,8 @@
 ---
 title: Developing on Pantheon Directly with SFTP Mode
 description: Detailed information on how to use SFTP Mode to directly develop your Drupal or WordPress site on Pantheon.
-tags: [admin]
 categories: [develop]
+tags: [files, sftp, code]
 reviewed: "2020-02-18"
 ---
 

--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -1,8 +1,8 @@
 ---
 title: Using SimpleSAMLphp with Shibboleth SSO
 description: Using SimpleSAMLphp to configure a single sign-on system for your Drupal or WordPress site.
-tags: [siteintegrations, security]
-categories: [integrate,develop]
+categories: [integrate]
+tags: [security, sso, users]
 contributors: [kyletaylored]
 ---
 

--- a/source/content/site-access.md
+++ b/source/content/site-access.md
@@ -1,8 +1,8 @@
 ---
 title: Accessing an Account After the Owner Leaves
 description: Learn how to access an account and set a new owner to a Drupal or WordPress site.
-tags: [manage]
 categories: [manage]
+tags: [users, security, organizations, agencies, billing]
 ---
 
 Site ownership is a self-service feature, and Pantheon does not transfer ownership from one owner to another. Best practice is to own your site in your name with a permanently reachable email.

--- a/source/content/site-billing.md
+++ b/source/content/site-billing.md
@@ -1,8 +1,8 @@
 ---
 title: Billing in the Site Dashboard
 description: Add a new credit card, remove the current card or transfer billing to a new site owner within the Billing tab of the Settings tool in the Site Dashboard.
-tags: [billing]
-categories: [manage,go-live]
+categories: [manage]
+tags: [billing, dashboard]
 reviewed: "2020-01-10"
 ---
 

--- a/source/content/site-owner-faq.md
+++ b/source/content/site-owner-faq.md
@@ -1,8 +1,8 @@
 ---
 title: New Site Owner FAQs
 description: Learn about common billing and administrative tasks performed by a Pantheon Drupal or WordPress site owner.
-tags: [manage, billing]
-categories: [manage,go-live]
+categories: [manage]
+tags: [teams, billing, agencies, users]
 ---
 When you become a site owner, you receive administrator permissions to manage the billing information, team members, and site settings.
 

--- a/source/content/site-plan.md
+++ b/source/content/site-plan.md
@@ -1,8 +1,8 @@
 ---
 title: Manage Plans in the Site Dashboard
 description: Upgrade a free site to a paid plan or downgrade a site's current plan within the Site Dashboard.
-tags: [billing]
-categories: [manage,go-live]
+categories: [platform]
+tags: [billing, dashboard, site]
 contributors: [cityofoaksdesign]
 ---
 

--- a/source/content/site-plans-faq.md
+++ b/source/content/site-plans-faq.md
@@ -1,8 +1,8 @@
 ---
 title: Site Plans FAQs
 description: Find answers to common questions related to Pantheon's site plans.
+categories: [manage]
 tags: [billing]
-categories: [manage,go-live]
 searchboost: 70
 reviewed: "2020-04-23"
 ---

--- a/source/content/sites.md
+++ b/source/content/sites.md
@@ -1,8 +1,8 @@
 ---
 title: The Site Dashboard
 description: Learn how to use the Pantheon Site Dashboard to build and manage your Drupal or WordPress sites.
+categories: [platform]
 tags: [dashboard]
-categories: [getstarted]
 reviewed: "2020-02-07"
 ---
 The Site Dashboard is where you can find all the tools you need to successfully build, launch, and manage your site.

--- a/source/content/solr.md
+++ b/source/content/solr.md
@@ -1,8 +1,8 @@
 ---
 title: Apache Solr on Pantheon
 description: Detailed information on using Apache Solr on your Pantheon Drupal or WordPress site.
-tags: [addons]
-categories: [develop]
+categories: [integrate]
+tags: [solr]
 ---
 Apache Solr is a system for indexing and searching site content. Pantheon provides Apache Solr as a service for most plans including Sandbox, on all environments. No permission or action is required from Pantheon to use Solr. 
 <Partial file="solr-version.md" />

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -1,8 +1,8 @@
 ---
 title: Generate and Add SSH Keys
 description: Understand how to generate SSH keys to configure Git, SFTP, or Drupal Drush.
-tags: [security, dashboard]
-categories: [get-started,develop]
+categories: [get-started]
+tags: [security, dashboard, ssh]
 reviewed: "2020-02-07"
 ---
 

--- a/source/content/sso-organizations.md
+++ b/source/content/sso-organizations.md
@@ -1,8 +1,8 @@
 ---
 title: Single Sign-On for Pantheon Organizations
 description: Detailed information to enable SAML single sign-on for your organization.
-tags: [security, tools]
-categories: [manage,develop]
+categories: [manage]
+tags: [security, organizations]
 ---
 Single sign-on (SSO) allows users to authenticate against your Identity Provider (IdP) when logging into the Pantheon Dashboard. For more information, see [SSO and Identity Federation on Pantheon](/sso).
 

--- a/source/content/sso.md
+++ b/source/content/sso.md
@@ -1,8 +1,8 @@
 ---
 title: SSO and Identity Federation on Pantheon
 description: Use SSO to centrally manage user identities and provide seamless integration across multiple applications.
-tags: [security, tools]
-categories: [manage,develop]
+categories: [integrate]
+tags: [security, sso, users]
 ---
 Many organizations need to centrally manage their user's identities and provide seamless integration across multiple applications. Numerous Pantheon customers, including higher educational institutions, school districts, local governments, and other groups use a variety of single sign-on (SSO) solutions. Learn more about [Single Sign-On for Pantheon Organizations](/sso-organizations).
 

--- a/source/content/start-state.md
+++ b/source/content/start-state.md
@@ -1,8 +1,8 @@
 ---
 title: Choosing Your Start State
 description: See available options for starting new Drupal or WordPress sites and site import considerations.
-tags: [create]
 categories: [get-started]
+tags: [upstreams, site]
 ---
 The site's framework is selected during the creation process. Pantheon Upstreams provide default installations of WordPress, Drupal 8 and Drupal 7. [Custom Upstreams](/custom-upstream) are available to team members when the organization is associated during site creation.
 

--- a/source/content/support.md
+++ b/source/content/support.md
@@ -1,8 +1,8 @@
 ---
 title: Get Support
 description: Learn how to access Pantheon's expert team and what your support package includes.
-tags: [dashboard]
-categories: [get-started]
+categories: [platform]
+tags: [dashboard, support]
 reviewed: "2020-02-11"
 ---
 

--- a/source/content/team-management.md
+++ b/source/content/team-management.md
@@ -1,8 +1,8 @@
 ---
 title: Site Team Management
 description: Working with the Pantheon Website Management Platform deployment tools in a team driven environment.
-tags: [manage]
 categories: [manage]
+tags: [billing, agencies, organizations, users]
 ---
 Pantheon has powerful workflow tools that are packed with real-time features that are great for people working in teams, and getting started is easy.
 

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -1,8 +1,8 @@
 ---
 title: Testing Global CDN Caching
 description: Detailed information on how to determine if CDN caching is working on your site.
-tags: [cacheedge]
 categories: [performance]
+tags: [cache, cdn]
 ---
 ## Verify the Global CDN is Working on Your Pantheon Site
 

--- a/source/content/timeouts.md
+++ b/source/content/timeouts.md
@@ -1,8 +1,8 @@
 ---
 title: Timeouts on Pantheon
 description: Detailed information about timeout errors on your site.
-tags: [debugging, timeouts, drush, terminus, drupal, wordpress, solr]
-categories: [troubleshoot,platform]
+categories: [troubleshoot]
+tags: [cron, drush, ssh, solr, terminus]
 reviewed: "2020-03-18"
 ---
 Rules are for the good of the group, and timeouts are no exception. Timeouts are configured to fit normal program execution. Sometimes timeouts can be reached when working with inefficient code or when attempting to execute a long-running job that would be better suited for [Terminus](/terminus).

--- a/source/content/traffic-limits.md
+++ b/source/content/traffic-limits.md
@@ -1,8 +1,8 @@
 ---
 title: Traffic Limits and Overages
 description: Information on how Pantheon measures site traffic
-tags: [billing]
-categories: [manage,go-live]
+categories: [performance]
+tags: [billing, measure, traffic]
 reviewed: "2020-02-26"
 ---
 Pantheon defines plan levels based on traffic to help site owners pick the right plan based on expected or historical traffic. To verify that sites receive traffic within their plan limit, we count requests served by the platform. Our [Metrics in the Site Dashboard](/metrics) outlines available traffic metrics, where to find them in the Dashboard, and why they [rarely match other analytics](#why-doesnt-pantheons-traffic-metrics-match-my-other-analytics) like Google Analytics.

--- a/source/content/vanity-domains.md
+++ b/source/content/vanity-domains.md
@@ -1,8 +1,8 @@
 ---
 title: Vanity Domains
 description: Replace "pantheonsite.io" within Pantheon environments by adding a custom vanity domain.
-tags: [tools, dns]
-categories: [manage,go-live]
+categories: [develop]
+tags: [collaborate, dns, agencies]
 ---
 Pantheon Partners, Strategic Partners, Enterprise accounts, Resellers, and OEM Partners have the ability to provision a custom vanity domain for each environment on every site running on the platform, in addition to the default Platform domain (`pantheonsite.io`).
 

--- a/source/content/videos/cache.md
+++ b/source/content/videos/cache.md
@@ -3,8 +3,8 @@ title: Caching
 description: Understand frontend and backend caching on our platform.
 contributors:  [dwayne]
 permalink:  docs/videos/:basename/
-tags: [cacheedge]
-categories: [develop, cli,performance]
+categories: [performance]
+tags: [cache]
 layout: video
 searchboost: 50
 type: video

--- a/source/content/videos/drush.md
+++ b/source/content/videos/drush.md
@@ -3,9 +3,10 @@ title: Drush
 description: Interact with Drupal from the command line.
 contributors:  [scottmassey]
 permalink:  docs/videos/:basename/
-tags: [devdrush]
-categories: [develop,drupal,workflow]
 layout: video
+cms: "Drupal"
+categories: [develop]
+tags: [drush, cli]
 searchboost: 50
 type: video
 ---

--- a/source/content/videos/git.md
+++ b/source/content/videos/git.md
@@ -3,8 +3,8 @@ title: Git
 description: Understand and use Git with Pantheon.
 contributors:  [scottmassey]
 permalink:  docs/videos/:basename/
-tags: [git]
-categories: [develop, cli,develop]
+categories: [develop]
+tags: [git, cli, workflow]
 layout: video
 searchboost: 50
 type: video

--- a/source/content/videos/pantheon-yml.md
+++ b/source/content/videos/pantheon-yml.md
@@ -3,8 +3,8 @@ title: The Pantheon.yml Configuration File
 description: Configure our platform for your needs.
 contributors:  [davidneedham]
 permalink:  docs/videos/:basename/
-tags: [pantheonyml]
-categories: [develop, cli, workflow,platform]
+categories: [develop]
+tags: [site, code]
 layout: video
 type: video
 searchboost: 50

--- a/source/content/videos/sftp.md
+++ b/source/content/videos/sftp.md
@@ -3,8 +3,8 @@ title: On-Server Development
 description: Develop on Pantheon directly via SFTP.
 contributors:  [scottmassey]
 permalink:  docs/videos/:basename/
-tags: [admin, sftpfiles]
 categories: [develop]
+tags: [files, sftp, code]
 searchboost: 50
 layout: video
 type: video

--- a/source/content/videos/terminus.md
+++ b/source/content/videos/terminus.md
@@ -3,8 +3,8 @@ title: Introduction to Terminus
 description: The Pantheon CLI.
 contributors:  [scottmassey]
 permalink:  docs/videos/:basename/
-categories: [develop,workflow]
-tags: [devterminus]
+categories: [develop]
+tags: [terminus, workflow, cli, wp-cli, drush]
 layout: video
 type: video
 searchboost: 50

--- a/source/content/webops-dashboard.md
+++ b/source/content/webops-dashboard.md
@@ -1,8 +1,8 @@
 ---
 title: Visualize Site Activity with the WebOps Dashboard
 description: Gain valuable insight to your site's development and collaboration with Pantheon's WebOps Dashboard.
-tags: [dashboard, webops, analytics]
-categories: [get-started,platform]
+categories: [platform]
+tags: [dashboard, webops, measure]
 contributors: [edwardangert]
 searchboost: 150
 ---

--- a/source/content/winscp.md
+++ b/source/content/winscp.md
@@ -1,8 +1,8 @@
 ---
 title: Using WinSCP on Pantheon
 description: Detailed information about the Pantheon SFTP connection WinSCP SFTP client.
-tags: [sftpfiles]
 categories: [develop]
+tags: [files, sftp]
 ---
 [WinSCP](https://winscp.net/eng/index.php) is an open source graphical SFTP client for Windows that also supports the Legacy SCP protocol.
 


### PR DESCRIPTION
Followup to #5775 JIRA/DOC-17

## Summary

**[pantheon.io/docs](https://pantheon.io/docs)** - Part of a greater effort to have each page of the Docs site properly categorized and tagged with a consistency the Docs site has never experienced before. [PR 5775](https://github.com/pantheon-systems/documentation/pull/57775) + [PR 5789](https://github.com/pantheon-systems/documentation/pull/5789)

## Remaining Work
The following changes still need to be completed:

- [ ] sanity check

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
