### PR TITLE
june 15 batch of updated tags and categories

### DIFF
--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -1,8 +1,8 @@
 ---
 title: 'Caching: Advanced Topics'
 description: Advanced details about Pantheon's edge caching layer, cookies, and PHP sessions.
-tags: [caching]
-categories: [platform,performance]
+categories: [performance]
+tags: [cache, cookies, security, webops]
 ---
 ## Allow a User to Bypass the Cache
 

--- a/source/content/code-of-conduct.md
+++ b/source/content/code-of-conduct.md
@@ -3,7 +3,7 @@ title: Pantheon Community Code of Conduct
 description: Pantheon is dedicated to a positive and harassment-free community experience for everyone.
 contributors: [joshkoenig, rachelwhitton]
 date: 9/27/2016
-categories: [get-started]
+categories: [about]
 tags: [collaborate]
 ---
 

--- a/source/content/code-of-conduct.md
+++ b/source/content/code-of-conduct.md
@@ -3,6 +3,8 @@ title: Pantheon Community Code of Conduct
 description: Pantheon is dedicated to a positive and harassment-free community experience for everyone.
 contributors: [joshkoenig, rachelwhitton]
 date: 9/27/2016
+categories: [get-started]
+tags: [collaborate]
 ---
 
 ## Our Pledge

--- a/source/content/contribute.md
+++ b/source/content/contribute.md
@@ -1,6 +1,8 @@
 ---
 title: Contributing to Pantheon Docs
 description: Learn how you can contribute to the Pantheon open-source documentation project on GitHub.
+tags: [collaborate]
+categories: [about]
 ---
 Become one of our [contributors](/contributors)! Help us create relevant and useful content for developers like yourself. See something you'd like to add or change? We love pull requests!
 

--- a/source/content/custom-upstream.md
+++ b/source/content/custom-upstream.md
@@ -1,8 +1,8 @@
 ---
 title: Introduction to Custom Upstreams
 description: Learn how to use Custom Upstreams to free up developer time.
-tags: [tools, workflow, upstreams]
-categories: [platform,manage,develop]
+categories: [get-started]
+tags: [collaborate, launch, upstreams, webops, workflow]
 ---
 
 <Youtube src="b1lNrZL0xxM" title="Pantheon Custom Upstreams" />

--- a/source/content/disaster-recovery.md
+++ b/source/content/disaster-recovery.md
@@ -1,8 +1,8 @@
 ---
 title: Site Disaster Recovery
 description: Learn how mission-critical websites can stay online in the event of a total zone failure
-tags: [services,disaster recovery]
 categories: [platform]
+tags: [backup, professional-services, site, webops]
 reviewed: "2020-02-26"
 ---
 

--- a/source/content/doc-template.md
+++ b/source/content/doc-template.md
@@ -2,7 +2,7 @@
 title: Pantheon Documentation Template.
 description: A short description of the doc.
 contributors: [alexfornuto]
-categories: [get-started]
+categories: [about]
 tags: [collaborate]
 ---
 

--- a/source/content/doc-template.md
+++ b/source/content/doc-template.md
@@ -2,9 +2,11 @@
 title: Pantheon Documentation Template.
 description: A short description of the doc.
 contributors: [alexfornuto]
+categories: [get-started]
+tags: [collaborate]
 ---
 
-This self-referencing document can be used as a starting point to write your own new doc for Pantheon. Start with an overview of the topic, which may include a summary of what will be accomplished after following the instructions. 
+This self-referencing document can be used as a starting point to write your own new doc for Pantheon. Start with an overview of the topic, which may include a summary of what will be accomplished after following the instructions.
 
 See our [Style Guide](/style-guide) for reference on our usage of Markdown and custom JSX components.
 

--- a/source/content/guides/asana.md
+++ b/source/content/guides/asana.md
@@ -1,8 +1,8 @@
 ---
 title: Integrating Asana with Pantheon using Quicksilver Hooks
 description: Learn how to integrate Asana project management application with the Pantheon.
-tags: [siteintegrations]
-category: [integrate]
+categories: [integrate]
+tags: [collaborate, continuous-integration, iterate, quicksilver, workflow]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/4/2017

--- a/source/content/guides/behat.md
+++ b/source/content/guides/behat.md
@@ -2,7 +2,8 @@
 title: Automate Testing with Behat
 description: Learn how to install Behat and write simple tests.
 type: guide
-tags: [moreguides]
+categories: [automate]
+tags: [continuous-integration, iterate, site, webops]
 permalink: docs/guides/:basename/
 contributors: [ataylorme]
 ---

--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Introduction
 description: Describes the Build Tools project and how it works with Composer, Git, and Continuous Integration as part of an advanced WebOps workflow.
-categories: [workflow]
-tags: [build-tools, automate, composer]
+categories: [develop]
+tags: [collaborate, composer, continuous-integration, webops, workflow]
 contributors: [greg-1-anderson, stevector, ataylorme, rachelwhitton, fatimask]
 type: guide
 anchorid: build-tools

--- a/source/content/guides/build-tools/02-create-project.md
+++ b/source/content/guides/build-tools/02-create-project.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Create a New Project
 description: In step two of the Build Tools guide, learn how to create a new Build Tools project.
-categories: [workflow]
-tags: [build-tools, automate, composer]
+categories: [develop]
+tags: [composer, terminus, webops, workflow]
 buildtools: true
 anchorid: create-project
 type: guide

--- a/source/content/guides/build-tools/03-pr-workflow.md
+++ b/source/content/guides/build-tools/03-pr-workflow.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Pull Request/Merge Request Workflow
 description: In step three of the Build Tools guide, learn how to use pull requests as part of your workflow.
-categories: [workflow]
-tags: [build-tools, develop]
+categories: [develop]
+tags: [collaborate, continuous-integration, git, webops, workflow]
 buildtools: true
 anchorid: pr-workflow
 type: guide

--- a/source/content/guides/build-tools/05-extend.md
+++ b/source/content/guides/build-tools/05-extend.md
@@ -2,8 +2,9 @@
 title: Build Tools
 subtitle: Add a New Module
 description: In step five of the Build Tools guide, learn how to add new modules to your site.
-categories: [workflow]
-tags: [build-tools, drupal, composer]
+cms: "Drupal"
+categories: [develop]
+tags: [composer, local, modules, site, terminus]
 buildtools: true
 anchorid: extend
 type: guide

--- a/source/content/guides/build-tools/06-tests.md
+++ b/source/content/guides/build-tools/06-tests.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Write a New Test
 description: In step six of the Build Tools guide, learn how to use the pre-configured site tests, or customize your own.
-categories: [workflow]
-tags: [build-tools, automate]
+categories: [develop]
+tags: [continuous-integration, iterate, webops, workflow]
 buildtools: true
 anchorid: behat
 type: guide
@@ -15,7 +15,7 @@ The Pantheon example projects include some basic tests to validate basic capabil
 
 The [`behat-pantheon.yml`](https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/behat-pantheon.yml) file sets the path for a project's collection of Behat tests. Any file with a `.feature` suffix in a listed directory will be executed as part of the standard test run on CircleCI.
 
-There are also visual regression tests using [Backstopjs](https://github.com/garris/BackstopJS ) that run when `composer.lock` has changed, but `composer.json` has not. The scripts are a part of the template repositories: [example-wordpress-composer](https://github.com/pantheon-systems/example-wordpress-composer) and [example-drops-8-composer](https://github.com/pantheon-systems/example-drops-8-composer)
+There are also visual regression tests using [Backstopjs](https://github.com/garris/BackstopJS) that run when `composer.lock` has changed, but `composer.json` has not. The scripts are a part of the template repositories: [example-wordpress-composer](https://github.com/pantheon-systems/example-wordpress-composer) and [example-drops-8-composer](https://github.com/pantheon-systems/example-drops-8-composer)
 
 ## Extending the Example Test Suite
 The following is an example of how to increase test coverage for your project by validating site configuration. This test will confirm the [site slogan implemented in a previous lesson](/guides/build-tools/pr-workflow#create-a-pull-request) has been applied to the associated Multidev environment:

--- a/source/content/guides/build-tools/07-merge.md
+++ b/source/content/guides/build-tools/07-merge.md
@@ -2,8 +2,8 @@
 title: Build Tools
 subtitle: Merge Your Work
 description: In step seven of the Build Tools guide, learn how to merge your branches into the master branch.
-categories: [workflow]
-tags: [build-tools]
+categories: [develop]
+tags: [git, iterate, webops, workflow]
 buildtools: true
 anchorid: merge
 type: guide

--- a/source/content/guides/edt/01-essentialdevelopertraining.md
+++ b/source/content/guides/edt/01-essentialdevelopertraining.md
@@ -2,8 +2,9 @@
 title: Essential Developer Training
 subtitle: Introduction
 description: This Self Serve Essential Developer Training guide is designed to help any Pantheon user quickly master workflow and tooling
-tags: [moreguides, essentialdevelopertrainging]
 layout: guide
+categories: [get-started]
+tags: [cli, continuous-integration, terminus, webops, workflow]
 type: guide
 anchorid: edt
 generator: pagination

--- a/source/content/guides/edt/02-introduction-and-architecture.md
+++ b/source/content/guides/edt/02-introduction-and-architecture.md
@@ -3,6 +3,8 @@ title: Essential Developer Training
 subtitle: Architecture
 anchorid: architecture
 layout: guide
+categories: [platform]
+tags: [cdn, workflow]
 edt: true
 type: guide
 generator: pagination

--- a/source/content/guides/edt/03-developer-workflow.md
+++ b/source/content/guides/edt/03-developer-workflow.md
@@ -4,6 +4,8 @@ subtitle: Developer Workflow
 anchorid: developer-workflow
 edt: true
 layout: guide
+categories: [develop]
+tags: [dashboard, git, sftp, webops, workflow]
 type: guide
 generator: pagination
 pagination:

--- a/source/content/guides/edt/04-multidev.md
+++ b/source/content/guides/edt/04-multidev.md
@@ -4,6 +4,8 @@ subtitle: Multidev
 anchorid: multidev
 edt: true
 layout: guide
+categories: [develop]
+tags: [git, iterate, multidev, webops, workflow]
 type: guide
 generator: pagination
 pagination:

--- a/source/content/guides/edt/05-terminus-cli.md
+++ b/source/content/guides/edt/05-terminus-cli.md
@@ -4,6 +4,8 @@ subtitle: Command Line Interface
 anchorid: command-line-interface
 edt: true
 layout: guide
+categories: [develop]
+tags: [cli, drush, terminus, wp-cli, workflow]
 type: guide
 generator: pagination
 pagination:

--- a/source/content/guides/edt/06-quicksilver-external-integrations.md
+++ b/source/content/guides/edt/06-quicksilver-external-integrations.md
@@ -4,6 +4,8 @@ subtitle: External Integrations
 anchorid: external-integrations
 edt: true
 layout: guide
+categories: [integrate]
+tags: [collaborate, continuous-integration, quicksilver, webops, workflow]
 type: guide
 generator: pagination
 pagination:

--- a/source/content/guides/edt/07-performance.md
+++ b/source/content/guides/edt/07-performance.md
@@ -4,6 +4,8 @@ subtitle: Performance
 anchorid: performance
 edt: true
 layout: guide
+categories: [performance]
+tags: [cache, cdn]
 type: guide
 generator: pagination
 pagination:

--- a/source/content/guides/edt/08-going-live.md
+++ b/source/content/guides/edt/08-going-live.md
@@ -4,6 +4,8 @@ subtitle: Going Live
 anchorid: going-live
 edt: true
 layout: guide
+categories: [go-live]
+tags: [dns, launch]
 type: guide
 survey: true
 generator: pagination

--- a/source/content/guides/launch/01-introduction.md
+++ b/source/content/guides/launch/01-introduction.md
@@ -2,7 +2,8 @@
 title: Launch Essentials
 subtitle: Introduction
 description: Tips and tricks for launching sites on Pantheon like you're in a 55-foot tall jungle-walking robot exoskeleton, killin it.
-tags: [golive]
+categories: [go-live]
+tags: [collaborate, launch, site, webops, workflow]
 layout: guide
 type: guide
 anchorid: introduction

--- a/source/content/guides/launch/02-plans.md
+++ b/source/content/guides/launch/02-plans.md
@@ -3,6 +3,8 @@ title: Launch Essentials
 subtitle: Upgrade Site Plan
 description: Part two of our Launch Essentials guide covers upgrading your site to the proper plan to cover your needs.
 layout: guide
+categories: [go-live]
+tags: [agencies, billing, launch, webops]
 anchorid: plans
 launch: true
 type: guide

--- a/source/content/guides/launch/03-domains.md
+++ b/source/content/guides/launch/03-domains.md
@@ -6,6 +6,8 @@ launch: true
 anchorid: domains
 generator: pagination
 layout: guide
+categories: [go-live]
+tags: [dns, https, launch, webops]
 type: guide
 pagination:
     provider: data.launchpages

--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -6,6 +6,8 @@ launch: true
 anchorid: dns
 generator: pagination
 layout: guide
+categories: [go-live]
+tags: [dns, https, launch, webops]
 type: guide
 pagination:
     provider: data.launchpages

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -6,6 +6,8 @@ launch: true
 anchorid: redirects
 generator: pagination
 layout: guide
+categories: [go-live]
+tags: [dns, https, launch, webops]
 type: guide
 pagination:
     provider: data.launchpages

--- a/source/content/guides/launch/06-launch-check.md
+++ b/source/content/guides/launch/06-launch-check.md
@@ -6,6 +6,8 @@ launch: true
 anchorid: launch-check
 generator: pagination
 layout: guide
+categories: [go-live]
+tags: [backup, launch, webops]
 type: guide
 pagination:
     provider: data.launchpages

--- a/source/content/guides/launch/07-next-steps.md
+++ b/source/content/guides/launch/07-next-steps.md
@@ -7,6 +7,8 @@ survey: true
 anchorid: launch-check
 generator: pagination
 layout: guide
+categories: [go-live]
+tags: [launch, webops]
 type: guide
 pagination:
     provider: data.launchpages

--- a/source/content/guides/pagerduty/01-introduction.md
+++ b/source/content/guides/pagerduty/01-introduction.md
@@ -2,8 +2,9 @@
 title: Incident Management
 subtitle: Introduction
 description: Configure uptime monitors with New Relic to automatically open an incident in PagerDuty and notify whoever's on-call, following a set escalation path.
-tags: [golive]
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 anchorid: introduction
 pagerduty: true

--- a/source/content/guides/pagerduty/02-monitor.md
+++ b/source/content/guides/pagerduty/02-monitor.md
@@ -3,6 +3,8 @@ title: Incident Management
 subtitle: New Relic Ping Monitors
 description: Page two of our guide on Pagerduty integration with New Relic for incident management.
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 anchorid: monitor
 pagerduty: true

--- a/source/content/guides/pagerduty/03-schedule.md
+++ b/source/content/guides/pagerduty/03-schedule.md
@@ -6,6 +6,8 @@ pagerduty: true
 anchorid: schedule
 generator: pagination
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 pagination:
     provider: data.pagerdutypages

--- a/source/content/guides/pagerduty/04-notify.md
+++ b/source/content/guides/pagerduty/04-notify.md
@@ -6,6 +6,8 @@ pagerduty: true
 anchorid: notify
 generator: pagination
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 pagination:
     provider: data.pagerdutypages

--- a/source/content/guides/pagerduty/05-slack.md
+++ b/source/content/guides/pagerduty/05-slack.md
@@ -6,6 +6,8 @@ pagerduty: true
 anchorid: slack
 generator: pagination
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 pagination:
     provider: data.pagerdutypages

--- a/source/content/guides/pagerduty/06-next-steps.md
+++ b/source/content/guides/pagerduty/06-next-steps.md
@@ -7,6 +7,8 @@ pagerduty: true
 anchorid: next-steps
 generator: pagination
 layout: guide
+categories: [performance]
+tags: [logs, measure, newrelic, teams, webops]
 type: guide
 pagination:
     provider: data.pagerdutypages

--- a/source/content/guides/quickstart/01-introduction.md
+++ b/source/content/guides/quickstart/01-introduction.md
@@ -2,8 +2,9 @@
 title: Quick Start
 subtitle: Introduction
 description: The Quick Start guide is designed to get you started on Pantheon.
-tags: [getstarted, drupal, wordpress]
 layout: guide
+categories: [get-started]
+tags: [launch, sandbox, site, webops, workflow]
 type: guide
 anchorid: quickstart
 generator: pagination

--- a/source/content/guides/quickstart/02-user-dashboard.md
+++ b/source/content/guides/quickstart/02-user-dashboard.md
@@ -4,6 +4,8 @@ subtitle: User Dashboard
 description: In part two of our Quick Start guide, learn about the Pantheon User Dashboard
 anchorid: user-dashboard
 layout: guide
+categories: [get-started]
+tags: [dashboard]
 type: guide
 quickstart: true
 generator: pagination

--- a/source/content/guides/quickstart/03-create-new-site.md
+++ b/source/content/guides/quickstart/03-create-new-site.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: create-new-site
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [dashboard, users, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/04-site-dashboard.md
+++ b/source/content/guides/quickstart/04-site-dashboard.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: site-dashboard
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [dashboard, site, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/05-create-test-live.md
+++ b/source/content/guides/quickstart/05-create-test-live.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: create-test-live
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [dashboard, iterate, launch, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/06-clone-live-to-dev.md
+++ b/source/content/guides/quickstart/06-clone-live-to-dev.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: clone-live-to-dev
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [dashboard, iterate, launch, webops, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/07-connection-modes.md
+++ b/source/content/guides/quickstart/07-connection-modes.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: connection-modes
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [code, dashboard, git, sftp, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/08-onserver-dev-part1.md
+++ b/source/content/guides/quickstart/08-onserver-dev-part1.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: onserver-dev-part1
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [dashboard, iterate, site, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/09-onserver-dev-part2.md
+++ b/source/content/guides/quickstart/09-onserver-dev-part2.md
@@ -6,6 +6,8 @@ quickstart: true
 anchorid: onserver-dev-part2
 generator: pagination
 layout: guide
+categories: [get-started]
+tags: [code, dashboard, iterate, sftp]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/quickstart/10-next-steps.md
+++ b/source/content/guides/quickstart/10-next-steps.md
@@ -7,6 +7,8 @@ anchorid: next-steps
 generator: pagination
 survey: true
 layout: guide
+categories: [get-started]
+tags: [launch, webops, workflow]
 type: guide
 pagination:
   provider: data.quickstartpages

--- a/source/content/guides/trainers.md
+++ b/source/content/guides/trainers.md
@@ -3,7 +3,8 @@ title: Using Pantheon as a Training Platform for WordPress and Drupal
 description: Best practices for training a group of students using Pantheon
 layout: doc
 permalink: docs/guides/:basename/
-tags: [moreguides]
+categories: [platform]
+tags: [collaborate, sandbox, upstreams, webops]
 contributors: [stevector, dwayne, davidneedham, tessak22]
 date: 3/26/2018
 ---

--- a/source/content/guides/visual-diff-with-wraith.md
+++ b/source/content/guides/visual-diff-with-wraith.md
@@ -1,8 +1,8 @@
 ---
 title: Using Wraith for Visual Regression Testing
 description: Learn how to use Wraith for visual regression testing with composite images.
-tags: [siteintegrations, moreguides]
-categories: [workflow]
+categories: [automate]
+tags: [iterate, launch, site]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [kate]

--- a/source/content/guides/visual-diff-with-wraith.md
+++ b/source/content/guides/visual-diff-with-wraith.md
@@ -2,7 +2,7 @@
 title: Using Wraith for Visual Regression Testing
 description: Learn how to use Wraith for visual regression testing with composite images.
 categories: [automate]
-tags: [iterate, launch, site]
+tags: [iterate, launch, site, testing]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [kate]

--- a/source/content/guides/woocommerce/01-introduction.md
+++ b/source/content/guides/woocommerce/01-introduction.md
@@ -2,10 +2,12 @@
 title: WooCommerce Quick Start
 subtitle: Introduction
 description: This guide covers how to quickly spinup a new WooCommerce site on Pantheon.
-tags: [woocommerce]
 contributors: [BFTrick]
 featuredcontributor: true
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [plugins, site]
 type: guide
 anchorid: woocommerce
 woocommerce: true

--- a/source/content/guides/woocommerce/02-store-setup.md
+++ b/source/content/guides/woocommerce/02-store-setup.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: store-setup
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [plugins, site]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/woocommerce/03-configure.md
+++ b/source/content/guides/woocommerce/03-configure.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: configure
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [plugins, site]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/woocommerce/04-commit.md
+++ b/source/content/guides/woocommerce/04-commit.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: commit
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [plugins, sftp, site]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/woocommerce/05-initialize-prod.md
+++ b/source/content/guides/woocommerce/05-initialize-prod.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: initalize-prod
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [launch, plugins, site]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/woocommerce/06-develop.md
+++ b/source/content/guides/woocommerce/06-develop.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: develop
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [iterate, plugins, site, themes, webops]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/woocommerce/07-launch.md
+++ b/source/content/guides/woocommerce/07-launch.md
@@ -6,6 +6,9 @@ woocommerce: true
 anchorid: launch
 generator: pagination
 layout: guide
+cms: "WordPress"
+categories: [get-started]
+tags: [launch, site]
 type: guide
 pagination:
     provider: data.woocommercepages

--- a/source/content/guides/wordpress-git/01-introduction.md
+++ b/source/content/guides/wordpress-git/01-introduction.md
@@ -3,6 +3,9 @@ title: Using Git with SFTP & WordPress
 subtitle: Add Git-Based Version Control to Your SFTP Workflow
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [git, sftp, workflow]
 type: guide
 contributors: [scottmassey, rachelwhitton]
 anchorid: wordpress-git

--- a/source/content/guides/wordpress-git/02-plugins.md
+++ b/source/content/guides/wordpress-git/02-plugins.md
@@ -4,6 +4,9 @@ subtitle: Install Plugins
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 anchorid: plugins
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [git, plugins, sftp]
 type: guide
 permalink: docs/guides/wordpress-git/plugins/
 editpath: wordpress-git/02-plugins.md

--- a/source/content/guides/wordpress-git/03-themes.md
+++ b/source/content/guides/wordpress-git/03-themes.md
@@ -4,6 +4,9 @@ subtitle: Manage Themes
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 anchorid: themes
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [git, sftp, themes]
 type: guide
 permalink: docs/guides/wordpress-git/themes/
 editpath: wordpress-git/03-themes.md

--- a/source/content/guides/wordpress-git/04-media.md
+++ b/source/content/guides/wordpress-git/04-media.md
@@ -4,6 +4,9 @@ subtitle: Upload Media
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 anchorid: media
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [files, git, sftp]
 type: guide
 permalink: docs/guides/wordpress-git/media/
 editpath: wordpress-git/04-media.md

--- a/source/content/guides/wordpress-git/05-remove-editor.md
+++ b/source/content/guides/wordpress-git/05-remove-editor.md
@@ -4,6 +4,9 @@ subtitle: Edit Site Configuration
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 anchorid: remove-editor
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [git, sftp]
 type: guide
 permalink: docs/guides/wordpress-git/remove-editor/
 editpath: wordpress-git/05-remove-editor.md

--- a/source/content/guides/wordpress-git/06-next-steps.md
+++ b/source/content/guides/wordpress-git/06-next-steps.md
@@ -4,6 +4,9 @@ subtitle: Next Steps
 description: Beginners guide on how to use the WordPress Dashboard, an SFTP client, and your text editor of choice to work quickly, safely and easily on Pantheon's Git-based platform.
 anchorid: next-steps
 layout: guide
+cms: "WordPress"
+categories: [develop]
+tags: [git, sftp]
 type: guide
 permalink: docs/guides/wordpress-git/next-steps/
 editpath: wordpress-git/06-next-steps.md

--- a/source/content/headless.md
+++ b/source/content/headless.md
@@ -1,8 +1,8 @@
 ---
 title: Running WordPress and Drupal as a Backend API
 description: Learn about headless development models for decoupled architecture on Pantheon.
-tags: [infrastructure]
-categories: [platform]
+categories: [develop]
+tags: [modules, plugins]
 contributors: [eabquina, rachelwhitton]
 ---
 Pantheon supports running WordPress and Drupal as an API (Application Programming Interface) for the backend of headless sites, which enables the CMS to interact with external frontend applications over HTTP requests.

--- a/source/content/horizontal-scalability.md
+++ b/source/content/horizontal-scalability.md
@@ -1,8 +1,8 @@
 ---
 title: Horizontal Scalability
 description: Learn about scaling web applications and architecture of every Pantheon environment.
-tags: [infrastructure]
 categories: [platform]
+tags: [billing, launch]
 ---
 Pantheon's distributed infrastructure facilitates horizontal scalability through the automated process of provisioning additional lightweight containers. This allows us to take sites from hundreds of pages served to hundreds of millions without downtime.
 

--- a/source/content/hotfixes.md
+++ b/source/content/hotfixes.md
@@ -1,8 +1,8 @@
 ---
 title: Hotfixes
 description: Learn how to deploy and test hot fixes and preserve orphan commits on your Pantheon Drupal or WordPress site.
-tags: [debugcode]
 categories: [troubleshoot]
+tags: [code, collaborate, git, webops, workflow]
 ---
 For Experts only. You should not need to attempt this if you use [Multidev](/multidev) and keep commits from reaching Dev that you do not intend on deploying.
 

--- a/source/content/live-workshop-resources.md
+++ b/source/content/live-workshop-resources.md
@@ -3,6 +3,7 @@ title: Live Workshop Resources
 description: Resources and feedback forms for Pantheon Live Workshop Sessions.
 contributors: [davidneedham]
 layout: resource
+categories: [troubleshoot]
 ---
 
 <ResourceSelector />

--- a/source/content/metrics.md
+++ b/source/content/metrics.md
@@ -1,7 +1,8 @@
 ---
 title: Metrics in the Site Dashboard
 description: Measure your site's traffic with the Metrics tool, found in the Live environment of the Site Dashboard.
-tags: [performance, logs]
+categories: [platform]
+tags: [billing, dashboard, measure, traffic]
 ---
 ## Access Metrics
 1. Navigate to **<span class="glyphicons glyphicons-charts"></span> Metrics** within the **<span class="glyphicons glyphicons-cardio"></span> Live** environment of your Site Dashboard.

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -1,8 +1,9 @@
 ---
 title: Drupal Modules with Known Issues
 description: A list of Drupal modules that are not supported and/or require workarounds.
-tags: [Drupal, modules]
-categories: [troubleshoot, integrate]
+cms: "Drupal"
+categories: [troubleshoot]
+tags: [modules]
 ---
 
 This page lists modules that may not function as expected or are currently problematic on the Pantheon platform. This is not a comprehensive list (see [other issues](#other-issues)). We continually update it as problems are reported and/or solved. If you are aware of any modules that do not work as expected, please [contact support](/support).

--- a/source/content/mysql-slow-log.md
+++ b/source/content/mysql-slow-log.md
@@ -1,8 +1,8 @@
 ---
 title: MySQL Slow Log
 description: Use a Drupal or WordPress site's MySQL Slow Log to troubleshoot MySQL and identify serious performance issues.
-tags: [debugdb]
 categories: [troubleshoot]
+tags: [cli, database]
 ---
 Analyzing the MySQL slow log is an important part of troubleshooting client issues before and after launch. Below are various methods for retrieving and examining them.
 

--- a/source/content/mysql-workbench.md
+++ b/source/content/mysql-workbench.md
@@ -1,8 +1,8 @@
 ---
 title: Using MySQL Workbench to Access a Database
 description: Detailed information on using MySQL Workbench for creating, executing, and optimizing SQL queries.
-tags: [debugdb]
-categories: [troubleshoot]
+categories: [manage]
+tags: [database, local]
 ---
 [MySQL Workbench](https://dev.mysql.com/downloads/workbench/) provides DBAs and developers an integrated tools environment for: database design & modeling; SQL development; database administration; and support for Windows, Mac OS X, and Linux.
 

--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -1,8 +1,8 @@
 ---
 title: Serving Sites from the Web Subdirectory
 description: Learn how to create a nested docroot to serve your Pantheon site from.
-tags: [pantheonyml, workflow]
-categories: [workflow,platform,develop]
+categories: [platform]
+tags: [code, site, terminus, workflow]
 contributors:
  - ataylorme
 ---

--- a/source/content/pantheon-community.md
+++ b/source/content/pantheon-community.md
@@ -2,6 +2,8 @@
 title: The Pantheon Community
 description: Share best practices with other experienced and active users of Pantheon's platform.
 contributors: [tessak22]
+categories: [get-started]
+tags: [collaborate, support]
 ---
 Pantheon fosters a community for those actively making use of the platform, primarily website development professionals. If you are an active developer on the Pantheon platform, you may benefit from joining our community, through several channels:
 

--- a/source/content/php-errors.md
+++ b/source/content/php-errors.md
@@ -1,8 +1,8 @@
 ---
 title: PHP Errors and Exceptions
 description: Detailed information about basic PHP errors on your Pantheon Drupal or WordPress site.
-tags: [debugcode]
 categories: [troubleshoot]
+tags: [code, site, webops]
 ---
 There are three basic kinds of PHP errors:
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -1,8 +1,8 @@
 ---
 title: Upgrade PHP Versions
 description: Learn how to upgrade PHP versions to resolve  compatibility issues.
-tags: [pantheonyml, services]
-categories: [workflow,platform]
+categories: [platform]
+tags: [libraries, updates]
 ---
 Upgrading your site's PHP version will improve the security, performance, and supportability of your site. See our blog post for an [example of 62% performance gains after upgrading](https://pantheon.io/blog/php-7-now-available-all-sites-pantheon).
 

--- a/source/content/phpinfo.md
+++ b/source/content/phpinfo.md
@@ -1,8 +1,9 @@
 ---
 title: Securely Working with phpinfo
 description: Important security considerations when working with phpinfo on your Pantheon Drupal site.
-tags: [debugcode, services]
-categories: [troubleshoot,platform]
+cms: "Drupal"
+categories: [develop]
+tags: [code, database]
 ---
 We serve our customers by provisioning isolated Linux containers with an optimized PHP stack. The php.ini is part of a highly tuned configuration and is not user-configurable. We continually deploy new builds of PHP and you also have the ability to [upgrade PHP versions](/php-versions). If you'd like to see a comprehensive list of what's installed with the version of PHP in use by a particular environment, you may use [phpinfo](https://secure.php.net/manual/en/function.phpinfo.php). We also have [example PHP info](/php-versions/#available-php-versions) for each version of PHP on the platform.
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -1,8 +1,8 @@
 ---
 title: Platform Considerations
 description: A list of the Pantheon platform considerations for your Drupal or WordPress sites.
-tags: [infrastructure]
 categories: [platform]
+tags: [files, libraries, security, webops]
 ---
 
 This page is used to keep track of common platform considerations, mostly derived from Pantheon's distributed nature. Check back often, as we are keeping it up to date as we make improvements to address these limitations.

--- a/source/content/platform-resources.md
+++ b/source/content/platform-resources.md
@@ -1,8 +1,8 @@
 ---
 title: Platform Resources for Legacy Plans
 description: Get detailed information about platform resources for your Drupal or WordPress site.
-tags: [services]
 categories: [platform]
+tags: [billing]
 ---
 
 This page reflects resources for legacy site plans. Sites that have been upgraded or launched to our new plans should refer to [Site Plans FAQs](/site-plans-faq/) for current information.

--- a/source/content/port-2222.md
+++ b/source/content/port-2222.md
@@ -1,8 +1,8 @@
 ---
 title: Port 2222 Blocked Workaround
 description: Instructions for accessing Port 2222 using an SSH tunnel on your Pantheon Drupal or WordPress site.
-tags: [debugcode]
 categories: [troubleshoot]
+tags: [files, ssh]
 ---
 In order to push and pull code to your Pantheon site, you'll need access to port 2222. If for some reason this port isn't open to you, either because of a corporate firewall or router configuration, you'll get an error like the following:
 ```

--- a/source/content/read-environment-config.md
+++ b/source/content/read-environment-config.md
@@ -1,8 +1,8 @@
 ---
 title: Reading Pantheon Environment Configuration
 description: Learn about the separation of configuration and code for your Drupal or WordPress site within the Pantheon's runtime container environment.
-tags: [variables, infrastructure]
-categories: [platform,develop]
+categories: [platform]
+tags: [code, database, files, redis]
 ---
 
 Pantheon promotes the separation of configuration and code, especially where security is a concern. You should never copy/paste credentials from your Dashboard into any of your site's code.

--- a/source/content/resetting-passwords.md
+++ b/source/content/resetting-passwords.md
@@ -2,7 +2,7 @@
 title: Resetting Passwords
 description: Learn how to reset passwords for WordPress, Drupal, and the Pantheon Dashboard. 
 categories: [troubleshoot]
-tags: [dashboard, teams, users]
+tags: [dashboard, teams, users, security]
 ---
 ## Pantheon Dashboard Login
 If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password) and follow the instructions.

--- a/source/content/resetting-passwords.md
+++ b/source/content/resetting-passwords.md
@@ -1,8 +1,8 @@
 ---
 title: Resetting Passwords
 description: Learn how to reset passwords for WordPress, Drupal, and the Pantheon Dashboard. 
-tags: [debugdb]
 categories: [troubleshoot]
+tags: [dashboard, teams, users]
 ---
 ## Pantheon Dashboard Login
 If you need to reset your Pantheon Dashboard user password,logout and [visit this page](https://dashboard.pantheon.io/reset-password) and follow the instructions.

--- a/source/content/restore-environment-backup.md
+++ b/source/content/restore-environment-backup.md
@@ -1,8 +1,8 @@
 ---
 title: Restoring an Environment from a Backup
 description: Detailed information on how to safely restore a Drupal or WordPress site backup to any environment.
-tags: [debugfiles]
 categories: [troubleshoot]
+tags: [backup, dashboard, git, webops, workflow]
 ---
 
 Each site environment's backups are located on the Backups tab for that environment in the Pantheon Dashboard.

--- a/source/content/terminus-2-0.md
+++ b/source/content/terminus-2-0.md
@@ -3,7 +3,7 @@ title: Terminus 2.0
 description: Learn what's new with the latest Terminus major version upgrade.
 contributors: [alexfornuto]
 categories: [platform]
-tags: [cli, drush, local, wp-cli, webops]
+tags: [cli, drush, local, wp-cli, terminus]
 ---
 
 <Alert title="Note" type="info" >

--- a/source/content/terminus-2-0.md
+++ b/source/content/terminus-2-0.md
@@ -2,6 +2,8 @@
 title: Terminus 2.0
 description: Learn what's new with the latest Terminus major version upgrade.
 contributors: [alexfornuto]
+categories: [platform]
+tags: [cli, drush, local, wp-cli, webops]
 ---
 
 <Alert title="Note" type="info" >

--- a/source/content/terminus.md
+++ b/source/content/terminus.md
@@ -5,8 +5,8 @@ terminuspage: true
 description: Manual for the Terminus command line interface for advanced interaction with the Pantheon platform.
 type: terminuspage
 layout: terminuspage
-tags: [terminus, workflow, command line, WP-CLI, Drush]
 categories: [develop]
+tags: [cli, drush, terminus, workflow, wp-cli]
 permalink: docs/:basename/
 nexturl: terminus/install/
 image: terminus-thumbLarge

--- a/source/content/terminus/commands.md
+++ b/source/content/terminus/commands.md
@@ -5,6 +5,8 @@ description: Look up Terminus commands.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, workflow]
 nexturl: terminus/scripting/
 previousurl: terminus/examples/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/commands.md
+++ b/source/content/terminus/commands.md
@@ -6,7 +6,7 @@ terminuspage: true
 type: terminuspage
 layout: terminuspage
 categories: [develop]
-tags: [cli, local, terminus, workflow]
+tags: [reference, cli, local, terminus, workflow]
 nexturl: terminus/scripting/
 previousurl: terminus/examples/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/configuration.md
+++ b/source/content/terminus/configuration.md
@@ -5,6 +5,8 @@ description: Learn how to configure your local Terminus configuration file.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, workflow]
 nexturl: terminus/updates/
 previousurl: terminus/plugins/create/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/examples.md
+++ b/source/content/terminus/examples.md
@@ -7,6 +7,8 @@ terminuspage: true
 showtoc: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, updates, workflow]
 nexturl: terminus/commands/
 previousurl: terminus/install/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/get-started/legacy.md
+++ b/source/content/terminus/get-started/legacy.md
@@ -6,6 +6,8 @@ terminuslegacy: true
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, workflow]
 permalink: docs/terminus/get-started/:basename/
 image: terminus-thumbLarge
 searchboost: 50

--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -7,6 +7,8 @@ terminuspage: true
 showtoc: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, workflow]
 permalink: docs/terminus/:basename/
 nexturl: terminus/examples/
 previousurl: terminus/

--- a/source/content/terminus/plugins.md
+++ b/source/content/terminus/plugins.md
@@ -5,6 +5,8 @@ description: Use plugins to extend what you can do with Terminus.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, plugins, terminus, workflow]
 nexturl: terminus/plugins/directory/
 previousurl: terminus/scripting/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/plugins.md
+++ b/source/content/terminus/plugins.md
@@ -6,7 +6,7 @@ terminuspage: true
 type: terminuspage
 layout: terminuspage
 categories: [develop]
-tags: [cli, local, plugins, terminus, workflow]
+tags: [cli, local, plugins, terminus, reference]
 nexturl: terminus/plugins/directory/
 previousurl: terminus/scripting/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/plugins/create.md
+++ b/source/content/terminus/plugins/create.md
@@ -7,6 +7,8 @@ terminuscreate: true
 showtoc: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, plugins, terminus, workflow]
 nexturl: terminus/configuration/
 previousurl: terminus/plugins/directory/
 permalink: docs/terminus/plugins/:basename/

--- a/source/content/terminus/plugins/directory.md
+++ b/source/content/terminus/plugins/directory.md
@@ -5,6 +5,8 @@ description: A non-exclusive directory of plugins to extend the features of Term
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, plugins, terminus, workflow]
 nexturl: terminus/plugins/create/
 previousurl: terminus/plugins/
 permalink: docs/terminus/plugins/:basename/

--- a/source/content/terminus/scripting.md
+++ b/source/content/terminus/scripting.md
@@ -5,7 +5,7 @@ description: Automate your workflow with Terminus.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
-categories: [develop]
+categories: [automate]
 tags: [cli, local, terminus, workflow]
 nexturl: terminus/plugins/
 previousurl: terminus/commands/

--- a/source/content/terminus/scripting.md
+++ b/source/content/terminus/scripting.md
@@ -5,6 +5,8 @@ description: Automate your workflow with Terminus.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, terminus, workflow]
 nexturl: terminus/plugins/
 previousurl: terminus/commands/
 permalink: docs/terminus/:basename/

--- a/source/content/terminus/updates.md
+++ b/source/content/terminus/updates.md
@@ -6,6 +6,8 @@ terminuspage: true
 showtoc: true
 type: terminuspage
 layout: terminuspage
+categories: [develop]
+tags: [cli, local, plugins, terminus, updates, workflow]
 permalink: docs/terminus/:basename/
 previousurl: terminus/configuration/
 image: terminus-thumbLarge

--- a/source/content/visual-studio-code.md
+++ b/source/content/visual-studio-code.md
@@ -1,7 +1,8 @@
 ---
 title: Configuring Visual Studio Code for Pantheon
 description: Develop your Pantheon site locally using Visual Studio Code to edit and sync code.
-tags: [local, sftp]
+categories: [develop]
+tags: [code, collaborate, git, local, sftp]
 contributors: [sarahg, alexfornuto]
 reviewed: "2019-10-16"
 ---

--- a/source/style-guide.md
+++ b/source/style-guide.md
@@ -2,6 +2,8 @@
 title: Style Guide
 description: Formatting rules and guidelines for Pantheon's open-source documentation.
 contributors: [alexfornuto, rachelwhitton]
+categories: [get-started]
+tags: [git, sftp]
 ---
 
 All documentation repositories should adhere to a [style guide](https://en.wikipedia.org/wiki/Style_guide). This document serves to define and detail the style conventions used in Pantheon's Documentation.


### PR DESCRIPTION
Followup to #5775 JIRA/DOC-17

## Summary

**[pantheon.io/docs](https://pantheon.io/docs)** - Part of a greater effort to have each page of the Docs site properly categorized and tagged with a consistency the Docs site has never experienced before. [PR 5775](https://github.com/pantheon-systems/documentation/pull/57775) + [PR 5789](https://github.com/pantheon-systems/documentation/pull/5789) + [PR 5799](https://github.com/pantheon-systems/documentation/pull/5799)

## Remaining Work
The following changes still need to be completed:

- [ ] sanity check

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
