### PR TITLE
june 16 batch of updated tags and categories

### DIFF
--- a/source/content/account-billing.md
+++ b/source/content/account-billing.md
@@ -1,8 +1,8 @@
 ---
 title: Account Billing in the User Dashboard
 description: View billing history (invoices and transactions) or edit credit card profiles to manage billing for sites in bulk within the Billing tab of the Account tool in the User Dashboard.
-tags: [billing]
-categories: [manage,go-live]
+categories: [platform]
+tags: [billing, dashboard]
 ---
 ## Access Account Billing
 1. Go to the User Dashboard and select **<span class="glyphicons glyphicons-cogwheel"></span> Account**.

--- a/source/content/annual-billing.md
+++ b/source/content/annual-billing.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Annual Billing
 description: Learn how you can save money by switching to annual billing.
-tags: [dashboard]
 categories: [get-started]
+tags: [agencies, billing, dashboard]
 searchboost: 70
 ---
 

--- a/source/content/code.md
+++ b/source/content/code.md
@@ -1,8 +1,8 @@
 ---
 title: Your Site Code on Pantheon
 description: Learn how to work with your site's code on the Pantheon Dashboard.
-tags: [git, dashboard]
-categories: [get-started, develop]
+categories: [develop]
+tags: [code, dashboard, files, git]
 ---
 The Code tool within the Pantheon Dashboard on any environment allows you to interact with your site's code and review the commit log.
 

--- a/source/content/contribute.md
+++ b/source/content/contribute.md
@@ -1,8 +1,8 @@
 ---
 title: Contributing to Pantheon Docs
 description: Learn how you can contribute to the Pantheon open-source documentation project on GitHub.
+categories: [get-started]
 tags: [collaborate]
-categories: [about]
 ---
 Become one of our [contributors](/contributors)! Help us create relevant and useful content for developers like yourself. See something you'd like to add or change? We love pull requests!
 

--- a/source/content/cookies.md
+++ b/source/content/cookies.md
@@ -1,8 +1,8 @@
 ---
 title: Working with Cookies on Pantheon
 description: Tips and tricks for working with cookies on your Pantheon Drupal and WordPress sites.
-tags: [cacheedge]
 categories: [performance]
+tags: [cache, code, cookies]
 ---
 
 This page covers working with basic cookies on Pantheon. If you're looking to create session based cookies to bypass caching, refer to [Using Your Own Session-Syle Cookies](/caching-advanced-topics/#using-your-own-session-style-cookies) from our Caching: Advanced Topics doc.

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -2,8 +2,8 @@
 title: WordPress and Drupal Core Updates
 description: Detailed information on applying and debugging upstream updates from Pantheon or a Custom Upstream.
 categories: [get-started, workflow,develop]
-tags: [dashboard, devterminus, git]
-contributors: [cityofoaksdesign, rachelwhitton, alexfornuto]
+categories: [manage]
+tags: [dashboard, git, terminus, updates]
 reviewed: "2020-02-06"
 ---
 Pantheon maintains core upstream repositories for [WordPress](https://github.com/pantheon-systems/wordpress), [Drupal 8](https://github.com/pantheon-systems/drops-8), and [Drupal 7](https://github.com/pantheon-systems/drops-7) which act as a parent repository to site repositories. Updates made by Pantheon in the core upstream repository, in addition to [updates made by maintainers of Custom Upstreams](/maintain-custom-upstream), become available downstream as a one-click update.

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -1,7 +1,6 @@
 ---
 title: WordPress and Drupal Core Updates
 description: Detailed information on applying and debugging upstream updates from Pantheon or a Custom Upstream.
-categories: [get-started, workflow,develop]
 categories: [manage]
 tags: [dashboard, git, terminus, updates]
 reviewed: "2020-02-06"

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -2,6 +2,8 @@
 title: 'Custom Certificates on The Pantheon Global CDN'
 description: For contract customers who require dedicated, custom TLS certificates
 reviewed: "2020-04-22"
+categories: [go-live]
+tags: [cdn, https, professional-services]
 ---
 
 ## Access

--- a/source/content/cygwin-windows.md
+++ b/source/content/cygwin-windows.md
@@ -1,8 +1,8 @@
 ---
 title: Install Cygwin on Windows
 description: Learn how to install and configure Cygwin on Windows computers for Pantheon sites.
-tags: [local]
 categories: [develop]
+tags: [local, ssh]
 reviewed: "2020-02-05"
 ---
 

--- a/source/content/database-connection-errors.md
+++ b/source/content/database-connection-errors.md
@@ -1,8 +1,8 @@
 ---
 title: Database Connection Errors
 description: Drupal Pressflow core, WordPress core, and the causes and solutions for database connection errors.
-tags: [debugdb]
 categories: [troubleshoot]
+tags: [code, database, files]
 ---
 There is an issue connecting to the Pantheon database if your site suddenly reverts to `install.php`, or you see database connection errors like the following:
  ![Can't connect to local MySQL server through socket](../images/mysql-connection-error.png)

--- a/source/content/debug-connections.md
+++ b/source/content/debug-connections.md
@@ -1,8 +1,8 @@
 ---
 title: Debugging Connectivity Issues
 description: Learn how to test and resolve connectivity issues affecting your Pantheon sites.
-tags: [debugfiles]
 categories: [troubleshoot]
+tags: [cli, ssh]
 ---
 
 ## Connectivity Error Message

--- a/source/content/debug-mysql-new-relic.md
+++ b/source/content/debug-mysql-new-relic.md
@@ -1,8 +1,8 @@
 ---
 title: MySQL Troubleshooting with New Relic Pro
 description: Use integrated reporting services with New Relic Pro to isolate MySQL performance issues on your Drupal or WordPress sites.
-tags: [newrelic, debugdb]
-categories: [troubleshoot,performance,go-live]
+categories: [troubleshoot]
+tags: [database, newrelic]
 ---
 While going through MySQL and PHP slow logs is a great way to find issues, modern reporting services that are integrated with your site help speed the process up tremendously. There are a few different systems to choose from, but at Pantheon we use [New Relic Pro](/new-relic). This article explains how you can troubleshoot MySQL databases with New Relic Pro. 
 

--- a/source/content/debug-slow-performance.md
+++ b/source/content/debug-slow-performance.md
@@ -1,8 +1,8 @@
 ---
 title: Debugging Slow Performance
 description: Identify common problems with Drupal or WordPress performance speeds and deploy solutions.
-tags: [logs, debugcode]
-categories: [troubleshoot,performance]
+categories: [performance]
+tags: [cache, code, logs, measure]
 ---
 This article covers the most common causes for performance problems, demonstrates how to diagnose bottlenecks, and provides actionable solutions for developers.
 
@@ -20,7 +20,7 @@ Each loop executed user\_load(1, TRUE), then triggered the error. Times are rou
 |:------------- |:------ |:-------- |:-------- |:--------- |:----------- |:-------------|
 | **none**      | 0.00s  | 0.08s    | 0.17s    | 0.30s     | 3.04s       | 32.81s       |
 | **E_NOTICE**  | 0.01s  | 0.16s    | 0.34s    | 0.71s     | 7.10s       | 79.52s       |
-| **E_WARNING** | 0.01s  | 0.16s    | 0.33s    | 0.70s     | 7.67s       | 134.68	    	|
+| **E_WARNING** | 0.01s  | 0.16s    | 0.33s    | 0.70s     | 7.67s       | 134.68       |
 
 Turning off error reporting suppresses the symptom, not the problem, and **PHP execution will still be slow as long as there are errors**.
 

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -1,9 +1,9 @@
 ---
 title: Introduction to the Domain Name System
 description: Learn what DNS is, and how to utilize it to configure your domain name to Pantheon's servers.
-tags: [dns]
 use: [docs_tags]
 categories: [go-live]
+tags: [dns]
 contributors: [alexfornuto]
 ---
 

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -1,8 +1,8 @@
 ---
 title: Platform and Custom Domains
 description: Work with platform domains or connect custom domains in the Site Dashboard, then redirect requests via PHP to standardize traffic on HTTPS and a primary domain.
-tags: [redirects, variables, dns]
-categories: [go-live,develop]
+categories: [go-live]
+tags: [dashboard, dns, https, redirects]
 searchboost: 150
 use:
     - docs_tags

--- a/source/content/environment-indicator.md
+++ b/source/content/environment-indicator.md
@@ -1,8 +1,8 @@
 ---
 title: Configuring Environment Indicators
 description: Learn how to implement an environment indicator for Drupal and WordPress sites running on Pantheon.
-tags: [workflow]
 categories: [develop]
+tags: [site, terminus, workflow, webops]
 ---
 Each site on Pantheon comes with three environments: Dev, Test, and Live. This allows you to develop and test features without impacting the live site. Additional development environments are available with [Multidev](/multidev).
 

--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -1,8 +1,8 @@
 ---
 title: External Libraries on Pantheon
 description: Learn to incorporate external libraries on the Pantheon Website Management Platform.
-tags: [code,libraries,plugins,modules]
 categories: [platform]
+tags: [code, libraries, modules, plugins]
 reviewed: "2020-05-18"
 ---
 

--- a/source/content/faq.md
+++ b/source/content/faq.md
@@ -1,8 +1,8 @@
 ---
 title: Frequently Asked Questions
 description: Frequently asked questions about Drupal or WordPress sites on Pantheon.
-tags: [Drupal, WordPress, FAQ]
 categories: [platform]
+tags: [support]
 ---
 ## Getting Started
 

--- a/source/content/git-faq.md
+++ b/source/content/git-faq.md
@@ -1,8 +1,8 @@
 ---
 title: Git FAQs
 description: Answers to common questions about Git, Drupal, WordPress and Pantheon.
-tags: [git]
 categories: [develop]
+tags: [git, iterate, local, workflow]
 contributors: [mrfelton, alexfornuto]
 reviewed: "2020-03-16"
 ---

--- a/source/content/git-resolve-merge-conflicts.md
+++ b/source/content/git-resolve-merge-conflicts.md
@@ -1,8 +1,8 @@
 ---
 title: Resolve Git Merge Conflicts
 description: Learn how to resolve conflicts in your site code base. 
-tags: [git]
-categories: [develop]
+categories: [troubleshoot]
+tags: [git, local, webops]
 contributors: [alexfornuto]
 reviewed: "2020-02-11"
 ---

--- a/source/content/git.md
+++ b/source/content/git.md
@@ -2,7 +2,7 @@
 title: Starting With Git
 description: Use Git version control to deploy code to your Drupal or WordPress site's development environment.
 categories: [develop]
-tags: [git,webops]
+tags: [code, git, local, webops, workflow]
 reviewed: "2020-02-07"
 ---
 Git is the version control tool at the heart of the Pantheon WebOps<Popover title="WebOps" content="WebOps is a set of practices that facilitates collaboration and automates processes to improve web team productivity." /> workflow. If you like to [develop locally](/local-development), it's a good way to streamline your website operations: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.

--- a/source/content/global-cdn-caching.md
+++ b/source/content/global-cdn-caching.md
@@ -1,8 +1,8 @@
 ---
 title: Global CDN Caching for High Performance with Drupal and WordPress
 description: Configure and verify edge caching is working on your WordPress or Drupal sites.
-tags: [cacheedge]
 categories: [performance]
+tags: [cache, cdn]
 ---
 Pantheon's Global CDN supports caching to accelerate both static content and anonymous pages for sites on the platform. By serving data from cache servers all over the world, website visitors receive a response without waiting to access the application container. Clusters of these cache servers in each region are called **points of presence** or **POPs** for short. When a website uses these POPs effectively, the site can free up its PHP workers and database to process more dynamic requests. Each POP can handle hundreds of thousands of requests per second, much more than a site's own PHP and database containers.
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -2,8 +2,8 @@
 title: Pantheon Global CDN
 description: Improve Site Performance and Security with Pantheon's Global CDN.
 reviewed: "2020-02-27"
-tags: [CDN,security]
-categories: [develop]
+categories: [performance]
+tags: [cache, cdn, launch, security]
 ---
 
 Pantheon's [Global CDN](https://pantheon.io/features/global-cdn) is a core platform offering, with improved performance and security for customer sites. Content is served from 70+ global **POP**s (Points Of Presence) where site pages and assets are cached, and [HTTPS](/https) certificates are fully managed using [Let's Encrypt](https://letsencrypt.org).

--- a/source/content/guides/collaborative-development.md
+++ b/source/content/guides/collaborative-development.md
@@ -1,8 +1,8 @@
 ---
 title: Collaborative Development Using GitHub and Pantheon
 description: Use GitHub to collaborate with the team members on your Pantheon site.
-tags: [workflow, tools, moreguides]
-categories: [manage,develop]
+categories: [develop]
+tags: [collaborate, git, local, webops, workflow]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [bmackinney, jessifischer, mrfelton]

--- a/source/content/guides/frontend-performance.md
+++ b/source/content/guides/frontend-performance.md
@@ -1,8 +1,8 @@
 ---
 title: Frontend Performance
 description: Learn how to ace an online speed test with Pantheon's Global CDN.
-tags: [siteintegrations]
-categories: [automate]
+categories: [performance]
+tags: [cache, cdn, measure, traffic]
 type: guide
 layout: doc
 image: CDN-speedTest-docs-guide

--- a/source/content/guides/jenkins.md
+++ b/source/content/guides/jenkins.md
@@ -1,8 +1,8 @@
 ---
 title: Automatically Test and Deploy GitHub Changes to Pantheon from an Existing Jenkins Server
 description: Configure an existing Jenkins server to automatically test and deploy code changes to Pantheon when pushed to GitHub.
-tags: [siteintegrations]
-categories: [workflow]
+categories: [automate]
+tags: [collaborate, continuous-integration, git, iterate]
 type: guide
 permalink: docs/guides/:basename/
 date: 6/20/2017

--- a/source/content/guides/jira.md
+++ b/source/content/guides/jira.md
@@ -1,9 +1,9 @@
 ---
 title: Integrate Jira on Pantheon with Quicksilver Hooks
 description: Learn how to integrate Atlassian's issue tracking service, Jira, with the Pantheon Site Dashboard.
-tags: [siteintegrations]
-categories: [workflow]
 layout: doc
+categories: [integrate]
+tags: [collaborate, quicksilver, webops, workflow]
 permalink: docs/guides/:basename/
 date: 5/4/2017
 contributors: [scottmassey]

--- a/source/content/guides/lando.md
+++ b/source/content/guides/lando.md
@@ -3,6 +3,7 @@ title: Install and Configure Lando
 description: Install and Configure Lando for local development of WordPress sites.
 contributors: [digisavvy]
 categories: [develop]
+tags: [code, iterate, lando, local, webops]
 featuredcontributor: true
 type: guide
 permalink: docs/guides/:basename/

--- a/source/content/guides/new-relic-deploys.md
+++ b/source/content/guides/new-relic-deploys.md
@@ -1,8 +1,8 @@
 ---
 title: Automatically Label Code Changes in New Relic using Quicksilver Hooks
 description: A guide to integrating Pantheon and New Relic for deployment labeling.
-tags: [siteintegrations]
-categories: [workflow]
+categories: [automate]
+tags: [code, newrelic, quicksilver, workflow]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/1/2017

--- a/source/content/guides/phpstorm-composer.md
+++ b/source/content/guides/phpstorm-composer.md
@@ -3,8 +3,9 @@ title: PhpStorm for Composer Managed Drupal 8 Sites
 description: Learn how to configure JetBrains PhpStorm for Pantheon sites managed with Composer using a GitHub Pull Request workflow.
 type: guide
 permalink: docs/guides/:basename/
-tags: [siteintegrations]
+cms: "Drupal 8"
 categories: [integrate]
+tags: [code, composer, iterate, local]
 contributors: [LukasRos, rachelwhitton]
 multidev: true
 ---

--- a/source/content/guides/pingdom-uptime-check.md
+++ b/source/content/guides/pingdom-uptime-check.md
@@ -1,8 +1,8 @@
 ---
 title: Pingdom Uptime Check
 description: How to create and configure a Pingdom Uptime check on a Pantheon site.
-tags: [siteintegrations]
 categories: [integrate]
+tags: [measure, site, traffic]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/14/2017

--- a/source/content/guides/pivotal-tracker.md
+++ b/source/content/guides/pivotal-tracker.md
@@ -1,8 +1,8 @@
 ---
 title: Integrate Pivotal Tracker Project Management Application with a site on Pantheon
 description: Using Pivotal Tracker to track application development progress, using Quicksilver webhooks.
-tags: [siteintegrations]
 categories: [integrate]
+tags: [code, collaborate, webops, workflow]
 type: guide
 permalink: docs/guides/:basename/
 date: 6/20/2017

--- a/source/content/guides/sendgrid.md
+++ b/source/content/guides/sendgrid.md
@@ -1,8 +1,8 @@
 ---
 title: Using SendGrid To Deliver Email
 description: Detailed information on using SendGrid to deliver email through your WordPress and Drupal site.
-tags: [email, plugins, modules]
 categories: [integrate]
+tags: [code, email, modules, plugins]
 type: guide
 permalink: docs/guides/:basename/
 contributors: [erikmathy, rvtraveller, wbconnor, sarahg, sdubois]

--- a/source/content/guides/trello.md
+++ b/source/content/guides/trello.md
@@ -1,8 +1,8 @@
 ---
 title: Integrate Trello on Pantheon with Quicksilver Hooks
 description: Learn how to integrate Trello with your dev workflow on Pantheon.
-tags: [siteintegrations]
 categories: [integrate]
+tags: [collaborate, quicksilver, webops, workflow]
 type: guide
 permalink: docs/guides/:basename/
 date: 5/4/2017

--- a/source/content/hosts-file.md
+++ b/source/content/hosts-file.md
@@ -1,8 +1,8 @@
 ---
 title: Modify the Local Hosts File
 description: How to find and modify a local hosts file.
-tags: [local, dns]
-categories: [go-live,develop]
+categories: [go-live]
+tags: [cli, dns, local]
 contributors: [alexfornuto]
 ---
 

--- a/source/content/http-to-https.md
+++ b/source/content/http-to-https.md
@@ -1,8 +1,8 @@
 ---
 title: Switching Sites from HTTP to HTTPS
 description: Best-practice HTTPS configurations for WordPress and Drupal to fix mixed-content browser warnings and excessive redirects.
-tags: [security]
-categories: [develop]
+categories: [go-live]
+tags: [https, launch, redirects, security]
 reviewed: "2020-02-12"
 ---
 

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -1,8 +1,8 @@
 ---
 title: "HTTPS on Pantheon's Global CDN"
 description: "Learn the specifics of Pantheon's Free and Automated HTTPS, powered by Let's Encrypt"
-tags: [dns, security]
-categories: [go-live,develop]
+categories: [go-live]
+tags: [cdn, dns, https, security]
 layout: doc
 permalink: docs/:basename/
 searchboost: 200

--- a/source/content/kill-mysql-queries.md
+++ b/source/content/kill-mysql-queries.md
@@ -1,8 +1,8 @@
 ---
 title: Identify and Kill Queries with MySQL Command-Line Tool
 description: Learn how to identify and kill long-running MySQL queries on your WordPress or Drupal site in a few commands.
-tags: [debugdb]
-categories: [develop,troubleshoot]
+categories: [troubleshoot]
+tags: [cli, database]
 reviewed: "2020-02-05"
 ---
 Long-running MySQL queries keep other transactions from accessing the necessary tables to execute a request, leaving your users on hold. To kill these queries, you'll need to [access the environment's MySQL Database](/mysql-access).

--- a/source/content/ldap-and-ldaps.md
+++ b/source/content/ldap-and-ldaps.md
@@ -1,8 +1,8 @@
 ---
 title: LDAP and LDAPS
 description: Detailed information on how to configure LDAP and LDAPS on your Pantheon Drupal or WordPress website.
-tags: [siteintegrations, secure-integration, ldap, ldaps]
 categories: [integrate]
+tags: [code, modules, plugins, security]
 ---
 [Lightweight Directory Access Protocol](https://en.wikipedia.org/wiki/Lightweight_Directory_Access_Protocol) (LDAP) as a provider is not available on Pantheon. For sites at the Elite plan level that need a secure tunnel between your firewall, contact your sales representative regarding [Pantheon Secure Integration](https://pantheon.io/features/secure-integration).
 

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -1,8 +1,8 @@
 ---
 title: Local Development
 description: Suggestions and solutions for working locally on your Pantheon Drupal or WordPress site.
-tags: [local development, sftp, Lando, workflow]
 categories: [develop]
+tags: [git, lando, local, sftp, workflow]
 reviewed: "2019-11-27"
 ---
 

--- a/source/content/maintain-custom-upstream.md
+++ b/source/content/maintain-custom-upstream.md
@@ -1,8 +1,8 @@
 ---
 title: Best Practices for Maintaining Custom Upstreams
 description: Detailed information on how to maintain Custom Upstreams and distribute updates downstream.
-tags: [upstreams, workflow]
 categories: [develop]
+tags: [git, upstreams, workflow]
 ---
 Maintainers of [Custom Upstreams](/custom-upstream) bear the responsibility of pulling in core updates from Pantheon. Regardless of update type, always test changes before you distribute them to your sites. We recommend the following workflow to maintain Custom Upstreams on Pantheon. In this example, we will be updating core.
 

--- a/source/content/managed-updates.md
+++ b/source/content/managed-updates.md
@@ -2,8 +2,8 @@
 title: Managed Updates
 description: Descriptions of the Managed Updates products and requirements for Drupal 8 compatibility
 reviewed: "2020-05-14"
-categories: [platform]
-tags: [updates, professional services]
+categories: [manage]
+tags: [composer, professional-services, updates, workflow]
 ---
 
 [Managed Updates](https://pantheon.io/professional-services/managed-updates?docs) is a service offered by our [Professional Services](/professional-services) team. We help keep your site updated so you can focus on what's important. Learn more about Managed Updates in the [Managing Updates for WordPress and Drupal webinar](https://pantheon.io/resources/managed-updates-webinar?docs)

--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -1,8 +1,8 @@
 ---
 title: Manually Migrate Sites to Pantheon
 description: Learn how to manually migrate a Drupal or WordPress site to Pantheon
-tags: [migratemanual]
 categories: [get-started]
+tags: [code, dashboard, migrate, site]
 ---
 Manually migrate your site to Pantheon when any of the following apply:
 

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -1,8 +1,8 @@
 ---
 title: Migrate Sites to Pantheon
 description: General instructions for preparing and migrating remotely-hosted Drupal or WordPress sites to Pantheon.
-tags: [migrateguided]
 categories: [get-started]
+tags: [dashboard, migrate, site]
 ---
 ## Before You Begin
 

--- a/source/content/mobile-redirection.md
+++ b/source/content/mobile-redirection.md
@@ -1,8 +1,8 @@
 ---
 title: Enabling Mobile Redirection with Cloudflare
 description: Learn how to use Cloudflare to set up mobile redirection on your Drupal or WordPress site.
-tags: [redirects]
 categories: [go-live]
+tags: [cdn, https, redirects]
 ---
 
 Cloudflare's mobile redirect service is available to domains hosting DNS on any of their plans. For details, see [About Cloudflare Mobile Redirect](https://support.cloudflare.com/hc/en-us/articles/200168336-About-Cloudflare-Mobile-Redirect).

--- a/source/content/modules-plugins-known-issues.md
+++ b/source/content/modules-plugins-known-issues.md
@@ -1,8 +1,8 @@
 ---
 title: Modules and Plugins with Known Issues
 description: A list of Drupal modules and WordPress plugins that are not supported and/or require workarounds.
-tags: [debugcode, siteintegrations]
-categories: [troubleshoot, integrate]
+categories: [troubleshoot]
+tags: [modules, plugins, site]
 contributors: [alexfornuto]
 reviewed: "2020-01-08"
 ---

--- a/source/content/modules.md
+++ b/source/content/modules.md
@@ -2,8 +2,9 @@
 title: Pantheon Modules
 description: Details on specific Drupal modules developed and maintained for the Pantheon Website Management Platform workflow.
 contributors: [eabquina]
-tags: [siteintegrations, infrastructure, cacheedge]
-categories: [performance,integrate,platform]
+cms: "Drupal"
+categories: [platform]
+tags: [cache, libraries, modules, site]
 reviewdate: "2020-02-04"
 ---
 Pantheon maintains several modules to extend and integrate Drupal on the platform. For real time discussion of these modules, find Pantheon developers in our [Pantheon Community](/pantheon-community) Slack channel.

--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -1,8 +1,8 @@
 ---
 title: Accessing MySQL Databases
 description: Configure and troubleshoot your Pantheon website's MySQL database connections.
-tags: [local]
 categories: [develop]
+tags: [database, local, ssh]
 ---
 Pantheon provides direct access for your MySQL databases, both for debugging and for importing large databases. Each site environment (Dev, Test and Live) has a separate database, so credentials for one cannot be used on another. The credentials are automatically included in your site configuration.
 

--- a/source/content/opensolr.md
+++ b/source/content/opensolr.md
@@ -1,8 +1,8 @@
 ---
 title: Using Opensolr With Pantheon Sites
 description: Learn how to create and configure Opensolr with Solr for advanced search indexing features for your Drupal sites.
-tags: [solr,opensolr,search,Drupal,]
 categories: [integrate]
+tags: [modules, solr]
 contributors: [carolynshannon]
 reviewed: "2019-11-06"
 ---

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -1,8 +1,8 @@
 ---
 title: Investigate and Remedy Traffic Events
 description: Determine and address the causes of unexpected traffic
-tags: [billing, logs]
 categories: [troubleshoot]
+tags: [billing, logs, measure, traffic]
 contributors: [edwardangert]
 reviewed: "2020-03-03"
 ---

--- a/source/content/organization-dashboard.md
+++ b/source/content/organization-dashboard.md
@@ -1,8 +1,8 @@
 ---
 title: Managing Sites and Teams with the Pantheon Organization Dashboard
 description: Detailed information on how to add users and sites to your organization.
-tags: [manage]
-categories: [manage]
+categories: [platform]
+tags: [agencies, collaborate, dashboard, organizations, teams]
 ---
 The Organization Dashboard is where Organization Administrators and Team Members manage all their sites in a single location. If you are an Administrator or Team Member for your Organization, you can access support requests, add or remove organizational team members, and manage new or existing sites.
 

--- a/source/content/php-slow-log.md
+++ b/source/content/php-slow-log.md
@@ -1,8 +1,8 @@
 ---
 title: PHP Slow Log
 description: Improve the stability of your Drupal or WordPress site using PHP Slow Log and PHP FPM Error Log to identify serious performance issues.
-tags: [logs]
 categories: [performance]
+tags: [cli, logs, sftp]
 reviewed: "2020-01-13"
 ---
 One of the key ways to find issues on your website is to check your PHP logs. This article instructs you on how to use your PHP slow log and PHP FPM error logs to find performance issues and PHP errors on Pantheon sites.

--- a/source/content/platform-upgrade.md
+++ b/source/content/platform-upgrade.md
@@ -1,6 +1,8 @@
 ---
 title: Deployment Infrastructure Upgrade
 description: Details on the current infrastructure upgrade.
+categories: [platform]
+tags: [dashboard, updates]
 ---
 If your site dashboard displays the following **Deployment Infrastructure Upgrade** notice, we recommend waiting to make code changes until maintenance completes:
 

--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -1,8 +1,8 @@
 ---
 title: Configure Redirects
 description: Review considerations and recommendations on how to handle redirect logic via Primary Domains or PHP.
-tags: [redirects, variables, dns]
-categories: [go-live,develop]
+categories: [go-live]
+tags: [dns, https, redirects]
 reviewed: "2020-02-12"
 ---
 

--- a/source/content/reducing-large-repos.md
+++ b/source/content/reducing-large-repos.md
@@ -1,8 +1,8 @@
 ---
 title: Reducing Large Repositories
 description: Learn how to reduce the size of large Drupal or WordPress site repositories for optimized performance and reliability on Pantheon.
-tags: [git]
 categories: [develop]
+tags: [files, git, local, workflow]
 contributors: [alexfornuto]
 ---
 

--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -1,8 +1,8 @@
 ---
 title: Relaunch Existing Pantheon Site
 description: Take a new site live by moving custom domains from one Site Dashboard to another, with minimal HTTPS interruptions.
-tags: [dns,migration]
 categories: [go-live]
+tags: [dns, https, launch, migrate]
 ---
 Sites are considered launched on Pantheon once traffic is routed through custom domain(s). Relaunching a previously launched site is done by rerouting traffic from the existing Site Dashboard to an entirely new Site Dashboard.
 

--- a/source/content/secure-integration.md
+++ b/source/content/secure-integration.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Secure Integration
 description: Configuring your Drupal or WordPress site to use Secure Integration as a defense-in-depth solution to access systems behind firewalls.
-tags: [infrastructure, security]
-categories: [platform,develop]
+categories: [platform]
+tags: [database, professional-services, redis, security]
 ---
 [Pantheon Secure Integration](https://pantheon.io/features/secure-integration), formerly known as Pantheon Enterprise Gateway (PEG), creates a secure tunnel between your firewall and your public facing website. This is available for customers with an annual contract. [Contact us](https://pantheon.io/contact-us) for more information.
 

--- a/source/content/security.md
+++ b/source/content/security.md
@@ -1,8 +1,8 @@
 ---
 title: Lock Environments with the Dashboard Security Tool
 description: Learn how to use the Security tool in the Site Dashboard to keep your work hidden from the public for Drupal or WordPress site development.
-tags: [security]
 categories: [develop]
+tags: [dashboard, security, users]
 ---
 
 There are occasions while you are working on your site that you would like to keep your progress hidden from the world as you prepare to go live or make updates.

--- a/source/content/single-application-sites.md
+++ b/source/content/single-application-sites.md
@@ -1,8 +1,8 @@
 ---
 title: Managing Drupal and WordPress Subsites Under a Single Domain
 description: Best practices for having Drupal or WordPress subsites on one domain.
-tags: [redirects]
 categories: [go-live]
+tags: [multisite, redirects]
 ---
 Pantheon only supports one application codebase and one database per site. We do not support database prefixes or Drupal multisite. Our workflow, backup, and deployment tools only perform as expected given the standard Pantheon setup.
 

--- a/source/content/ssh-tunnels.md
+++ b/source/content/ssh-tunnels.md
@@ -1,8 +1,8 @@
 ---
 title: Secure Connections to Pantheon Services via TLS or SSH Tunnels
 description: Detailed information on securely connecting to your database and caching service using SSH tunnels.
-tags: [local, security]
 categories: [develop]
+tags: [database, local, ssh, redis, webops]
 contributors: [bwood]
 ---
 For additional security, Pantheon provides the ability to securely connect to your database and caching service over an encrypted connection using [secure shell tunneling](https://en.wikipedia.org/wiki/Tunneling_protocol#Secure_shell_tunneling). This will increase the security of your remote connection, especially in a public or untrusted environment.

--- a/source/content/symlinks-assumed-write-access.md
+++ b/source/content/symlinks-assumed-write-access.md
@@ -1,8 +1,8 @@
 ---
 title: Symlinks and Assumed Write Access
 description: Learn how to create symbolic links from the code directory to a file.
-tags: [debugfiles]
 categories: [troubleshoot]
+tags: [cli, code, files]
 reviewed: "2020-03-13"
 ---
 

--- a/source/content/tax-exempt-status.md
+++ b/source/content/tax-exempt-status.md
@@ -1,8 +1,8 @@
 ---
 title: Request Tax Exempt Status
 description: Provide this information to file your qualified tax exempt status with Pantheon.
-tags: [billing]
 categories: [manage]
+tags: [billing, organizations]
 contributors: [edwardangert]
 searchboost: 150
 reviewed: "2020-03-24"

--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -1,8 +1,8 @@
 ---
 title: Temporary File Management
 description: Understand Pantheon's default temporary path and learn how to debug .tmp file errors.
-tags: [debugcode, infrastructure]
-categories: [troubleshoot,platform]
+categories: [platform]
+tags: [cli, code, files]
 ---
 
 <Alert title="Exports" type="export">

--- a/source/content/undo-commits.md
+++ b/source/content/undo-commits.md
@@ -1,8 +1,8 @@
 ---
 title: Undo Git Commits
 description: Learn how to revert a Git commit before and after pushing to Pantheon.
-tags: [debugcode, git]
-categories: [troubleshoot,develop]
+categories: [develop]
+tags: [cli, code, git, local, workflow]
 ---
 
 We all make mistakes, and Git does a fantastic job of keeping track of them for us. For example, a common problem is overwriting Drupal or WordPress core. We try our [best to warn you ](/core-updates) but it is still possible to overwrite core on a local environment and push to Pantheon. Fortunately, this is reversible, but will require a little work.

--- a/source/content/user-dashboard.md
+++ b/source/content/user-dashboard.md
@@ -1,8 +1,8 @@
 ---
 title: User Dashboard and Account
 description: The Pantheon user entity and its relationship to Drupal or WordPress sites, teams, and organizations.
-tags: [dashboard]
 categories: [get-started]
+tags: [dashboard, organizations, users]
 ---
 
 Access all of your sites and manage your account information from the User Dashboard.

--- a/source/content/videos/local.md
+++ b/source/content/videos/local.md
@@ -3,8 +3,8 @@ title: Local Development
 description: Sync your code, database, and files for local development.
 contributors:  [dwayne]
 permalink:  docs/videos/:basename/
-tags: [local]
 categories: [develop]
+tags: [git, lando, local, sftp, workflow]
 layout: video
 searchboost: 50
 type: video


### PR DESCRIPTION
Followup to #5775 JIRA/DOC-17

## Summary

**[pantheon.io/docs](https://pantheon.io/docs)** - Part of a greater effort to have each page of the Docs site properly categorized and tagged with a consistency the Docs site has never experienced before. [PR 5775](https://github.com/pantheon-systems/documentation/pull/57775) + [PR 5789](https://github.com/pantheon-systems/documentation/pull/5789) + [PR 5799](https://github.com/pantheon-systems/documentation/pull/5799) + [PR 5805](https://github.com/pantheon-systems/documentation/pull/5805)

## Remaining Work
The following changes still need to be completed:

- [ ] sanity check

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
