### PR TITLE
Extend Multidev and COVID offer to Sept

### DIFF
--- a/source/content/crisis-response-upstream.md
+++ b/source/content/crisis-response-upstream.md
@@ -14,7 +14,7 @@ The **Pantheon Crisis Response WordPress Upstream** is a specialized WordPress [
 
 ![Crisis Response WP home page](../images/covid-response-home.png)
 
-If you are a government, medical, or educational institution with a crisis communications website, or a non-profit organization directly providing relief, we will [provide the full service of our WebOps platform](https://pantheon.io/resources-navigate-covid-19) at no charge until at least July 1, 2020—or more, as the situation warrants. We want you to deliver vital information to the public without worrying about traffic cost or site availability.
+If you are a government, medical, or educational institution with a crisis communications website, or a non-profit organization directly providing relief, we will [provide the full service of our WebOps platform](https://pantheon.io/resources-navigate-covid-19) at no charge until at least September 1, 2020—or more, as the situation warrants. We want you to deliver vital information to the public without worrying about traffic cost or site availability.
 
 ## Features
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -10,7 +10,7 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) for more information (note: this offer has been extended since the post was published).
 
 </Alert>
 
@@ -24,8 +24,8 @@ Yes! Multidev is available to all users until September 1, 2020.
 
 After that, users will have access to Multidev if they:
 
- - Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs)).
- - Are a Direct Online customer with Gold support or above.
+- Have been assigned a role as a member of an Organization that has the Multidev Feature (like a [Pantheon Preferred Partner](https://pantheon.io/plans/partner-program?docs)).
+- Are a Direct Online customer with Gold support or above.
 
 If you fully meet either of these conditions and still don't have access to Multidev, please [contact support](https://dashboard.pantheon.io/#support).
 

--- a/source/content/multidev-faq.md
+++ b/source/content/multidev-faq.md
@@ -10,17 +10,17 @@ For information about what Multidev is and how to use it, see our full guide on 
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
 
 </Alert>
 
-Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~ until July 1, 2020. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
+Multidev is available to all accounts ~~with [Gold support](/support/#support-features-and-response-times) and above~~ until September 1, 2020. Organizations with Multidev can assign unprivileged users who can access Multidev environments. See [Change Management](/change-management) for more information about roles and permissions.
 
 Visit the [Partner Program Page](https://pantheon.io/plans/partner-program?docs) to learn more about the benefits of becoming a Pantheon Partner Agency, or [contact us](https://pantheon.io/contact-us?docs).
 
 ### Should I have access to Multidev?
 
-Yes! Multidev is available until July 1, 2020.
+Yes! Multidev is available to all users until September 1, 2020.
 
 After that, users will have access to Multidev if they:
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -16,7 +16,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) (note: the offer has been extended since the post was published).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) (note: this offer has been extended since the post was published).
 
 </Alert>
 

--- a/source/content/multidev.md
+++ b/source/content/multidev.md
@@ -16,7 +16,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post for more information](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1st) (note: the offer has been extended since the post was published).
 
 </Alert>
 

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -18,7 +18,7 @@ Creating a Multidev environment creates an application container with a database
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: this offer has been extended since the post was published).
 
 </Alert>
 
@@ -53,7 +53,7 @@ As a workaround, we recommend following development best practice workflows by [
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: this offer has been extended since the post was published).
 
 </Alert>
 

--- a/source/content/organization-faq.md
+++ b/source/content/organization-faq.md
@@ -18,7 +18,7 @@ Creating a Multidev environment creates an application container with a database
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
 
 </Alert>
 
@@ -53,7 +53,7 @@ As a workaround, we recommend following development best practice workflows by [
 
 <Alert title="Note" type="info" >
 
-To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through July 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information.
+To support the large number of web teams whose day-to-day operations are disrupted by the COVID-19 pandemic, we are making Multidev available for no additional charge to all customers through September 1, 2020. See the [blog post](https://pantheon.io/blog/why-were-making-multidev-free-through-july-1stfor) for more information (note: the offer has been extended since the post was published).
 
 </Alert>
 


### PR DESCRIPTION
## Summary

**[Multidev](https://pantheon.io/docs/multidev)** and **[Crisis Response Upstream](https://pantheon.io/docs/crisis-response-upstream)** - The Multidev and COVID Response site offers have been extended to Sept 1, 2020. [PR 5809](https://github.com/pantheon-systems/documentation/pull/5809)

## Effect

The following changes are already committed:

- change dates on offers

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
