### PR TITLE
remove drush references

### DIFF
--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -60,7 +60,6 @@ $aliases['example.*'] = array(
   'ssh-options' => '-p 2222 -o "AddressFamily inet"',
   'path-aliases' => array(
     '%files' => 'files',
-    '%drush-script' => 'drush',
    ),
 );
 ```
@@ -72,7 +71,6 @@ Drush 9 aliases are written one file per site to the directory `$HOME/.drush/sit
   host: appserver.${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1.drush.in
   paths:
     files: files
-    drush-script: drush
   uri: ${env-name}-example.pantheonsite.io
   user: ${env-name}.3eb7b5dd-8b90-4272-8a80-5474015c37f1
   ssh:


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Fixes: #5736

## Summary

**[Drupal Drush Command-Line Utility](https://pantheon.io/docs/drush)** - Updates example configuration files based on upcoming changes to Terminus.


## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [x] Review from @greg-1-anderson 
- [ ] Hold for release (see https://github.com/pantheon-systems/terminus/pull/2076)

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
