### PR TITLE
switch to the orb's default branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pfe: pantheon-systems/front-end@dev:main-instead-of-master
+  pfe: pantheon-systems/front-end@dev:master
   queue: eddiewebb/queue@1.5.0
 
 workflows:
@@ -13,7 +13,6 @@ workflows:
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
           gatsby-cache-version: "v1.4.1"
-          default-branch: "main"
           pre-steps:
             - checkout
             - run:
@@ -62,8 +61,7 @@ jobs:
           BUILD_PATH: /home/circleci/project
     working_directory: ~/project
     steps:
-      - pfe/set-terminus-env:
-          default-branch: "main"
+      - pfe/set-terminus-env
       - checkout
       - run:
           name: Import Functions and Variables


### PR DESCRIPTION
## Summary

**Build Upgrade** - Switched our build process back to the main branch of the frontend orb.


## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
