### PR TITLE
Update protected web paths documentation

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -38,7 +38,8 @@ The `pantheon.upstream.yml` file provided by your upstream might define protecte
 
 #### Considerations
 
-* Specify the exact path; no regex or wildcards allowed
+* Specify the exact path; path is case-sensitive
+* No regex or wildcards allowed
 * Paths begin with a leading `/` and are relative to your docroot
 * Limited to 24 protected paths
 * You may not be able to protect files or paths with special characters


### PR DESCRIPTION
Closes: #

## Summary

**[Pantheon YAML Configuration Files](https://pantheon.io/docs/pantheon-yml)** - Adds path case-sensitivity requirement for the Protected Web Paths settings of pantheon.yml

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
