### PR TITLE
Clarify rsync limitation

### DIFF
--- a/source/content/rsync-and-sftp.md
+++ b/source/content/rsync-and-sftp.md
@@ -52,7 +52,7 @@ rsync is available, but it is a more advanced tool that requires experience with
 
 <Alert title="Note" type="info">
 
-You must replace `[env]` with the target environment and `[uuid]` with the [Site UUID](/sites#site-uuid) to connect. The values are case sensitive and should be lower case (e.g., dev, test, live).
+Either the source or the destination must be a local file or directory; both cannot be remote. You must replace `[env]` with the target environment and `[uuid]` with the [Site UUID](/sites#site-uuid) to connect. The values are case sensitive and should be lower case (e.g., dev, test, live).
 
 </Alert>
 


### PR DESCRIPTION
Either the source or the destination must be a local file or directory; both cannot be remote.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: NA

## Summary

**[rsync and SFTP](https://pantheon.io/docs/rsync-and-sftp)** - Notes that Rsync requires either a local source or destination.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
