### PR TITLE
Update sendgrid.md

### DIFF
--- a/source/content/guides/sendgrid.md
+++ b/source/content/guides/sendgrid.md
@@ -255,7 +255,7 @@ You can explore the Statistics and Email Reports from within your site's account
 
 ## Congratulations!
 
-You have now successfully integrated an industrial strength, simple to use, email delivery service into your website. If you have any questions, contact [SendGrid's support team](https://support.sendgrid.com/hc/en-us) or check out SendGrid’s [Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html) for advanced tips on how to create and publish DNS records for increased deliverability.
+You have now successfully integrated an industrial strength, simple to use, email delivery service into your website. If you have any questions, contact [SendGrid's support team](https://support.sendgrid.com/hc/en-us) or check out SendGrid’s [Email Infrastructure Guide](https://sendgrid.com/resource/the-email-infrastructure-guide-build-it-or-buy-it) for advanced tips on how to create and publish DNS records for increased deliverability.
 
 ## Troubleshooting
 In some cases, other WordPress plugins can conflict with the Sendgrid plugin and cause it to use PHPMailer instead of SendGrid.


### PR DESCRIPTION
**[SendGrid Guide](https://pantheon.io/docs/guides/sendgrid)** - Fixes broken link to SendGrid's guide.

## Summary
At https://pantheon.io/docs/guides/sendgrid#congratulations
The link to [SendGrid’s Email Infrastructure Guide](https://go.sendgrid.com/SendGrid-Infrastructure-Guide.html) leads to a 404
The link should be changed to: https://sendgrid.com/resource/the-email-infrastructure-guide-build-it-or-buy-it/

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
