### PR TITLE
Update modules-known-issues.md

### DIFF
--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -81,16 +81,6 @@ ___
 
 ___
 
-## [CiviCRM](https://www.drupal.org/project/civicrm)
-
-<ReviewDate date="2020-05-15" />
-
-**Issue**: The `sites/default/civicrm.settings.php` file has a number of lines that tell CiviCRM how to access the database, file uploads, and temporary files. The file is using `$env['conf']['pantheon_binding']` and other undocumented ways instead of the `$_ENV['HOME']` [variable](/read-environment-config#hard-coded-directory-references-and-_envhome), which may cause issues loading some resources on CiviCRM-generated pages.
-
-**Solution**: A member of Pantheon's Support team has filed a [PR that would fix this issue](https://github.com/herbdool/civicrm-starterkit-drops-7/pull/17) with the starter kit's maintainer. Until that PR is merged, you can copy the [relevant changes](https://github.com/herbdool/civicrm-starterkit-drops-7/pull/17/commits/1d194772d79e2d3ec186d370c78fcfede784c6dd) into your site's `sites/default/default.civicrm.settings.php`.
-
-___
-
 ## [Composer Manager](https://www.drupal.org/project/composer_manager)
 
 <ReviewDate date="2020-02-10" />


### PR DESCRIPTION
Propose removing CiviCRM as https://github.com/herbdool/civicrm-starterkit-drops-7/pull/17 has been closed.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Drupal Modules with Known Issues](https://pantheon.io/docs/modules-known-issues)** - Removes the entry for CiviCRM, as the issue was resolved upstream, and mitigated by COE.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

-
-

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
