### PR TITLE
Wordfence instruction

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -681,6 +681,8 @@ ___
 
 ## [Wordfence](https://wordpress.org/plugins/wordfence/)
 
+<ReviewDate date="2020-07-15" />
+
 **Issue:** Wordfence assumes write access to several files in the code base to store configuation and log files.
 
 **Solution:** Prepare your environment before installing Wordfence with the proper symlinks and configuration files:
@@ -765,7 +767,7 @@ export ENV=dev
   terminus wp $SITE.$ENV -- plugin install --activate wordfence
   Installing Wordfence Security – Firewall & Malware Scan (7.4.9)
   Warning: Failed to create directory '/.wp-cli/cache/': mkdir(): Read-only file system.
-  Downloading installation package from https://downloads.wordpress.org/plugin/wordfence.7.4.8.zip...
+  Downloading installation package from https://downloads.wordpress.org/plugin/wordfence.7.4.9.zip...
   Unpacking the package...
   Installing the plugin...
   Plugin installed successfully.

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -741,10 +741,10 @@ export ENV=dev
   touch /tmp/wordfence-waf.php /tmp/.user.ini
   ```
 
-1. Connect to your environment over SFTP, create the required directories, and push the new files. You can get the SFTP path from the Site Dashboard under **Connection Info**:
+1. Connect to your environment over SFTP, create the required directories, and push the new files. You don't need to switch the environment back to SFTP mode, since you're not changing anything in the [codebase](/pantheon-workflow#code). You can get the SFTP path from the Site Dashboard under **Connection Info**:
 
   ```bash{promptUser: user}
-  sftp -o Port=2222 waf5.615e6ebd-1cfa-4fef-9e9f-42cc828d47c6@appserver.waf5.615e6ebd-1cfa-4fef-9e9f-42cc828d47c6.drush.in
+  sftp -o Port=2222 env.UUID@appserver.env.UUID.drush.in
   ```
 
   ```bash{promptUser: sftp}{outputLines: 4-5,7-8}

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -64,7 +64,7 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 ```
 
-Plugins and Themes with issues resolved by this include:
+Plugins and Themes with issues resolved (at least partially) by this include:
 
 - [Divi WordPress Theme & Visual Page Builder](https://www.elegantthemes.com/gallery/divi/)
 - [Event Espresso](https://eventespresso.com/)
@@ -72,6 +72,7 @@ Plugins and Themes with issues resolved by this include:
 - [Thrive Theme Builder](https://thrivethemes.com/themebuilder/)
 - [Visual Composer: Website Builder](https://visualcomposer.io/)
 - [WPBakery: Page Builder](https://wpbakery.com/)
+- [Wordfence Security](https://wordpress.org/plugins/wordfence/)
 - [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)
 
 ## [AMP for WP – Accelerated Mobile Pages](https://wordpress.org/plugins/accelerated-mobile-pages/)

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -681,13 +681,10 @@ ___
 
 ## [Wordfence](https://wordpress.org/plugins/wordfence/)
 
-**Issue 1:** Enabling the Live Traffic tracking feature within Wordfence sends cookies which conflict with platform-level page caching.
 
-**Solution:** Disable Wordfence-generated cookies by disabling Live Traffic within the Wordfence options page. See the  [WordPress support forum](https://wordpress.org/support/topic/wfvt-cookie?replies=5) for details.
+**Issue 1:** The Wordfence firewall expects specific write access to `wp-content/wflogs` during activation. Adding a symlink does not mitigate this, so using the Wordfence firewall is not supported on the platform. This has been [reported as an issue](https://wordpress.org/support/topic/write-logs-to-the-standard-file-path/) within the plugin support forum.
 
-**Issue 2:** The Wordfence firewall expects specific write access to `wp-content/wflogs` during activation. Adding a symlink does not mitigate this, so using the Wordfence firewall is not supported on the platform. This has been [reported as an issue](https://wordpress.org/support/topic/write-logs-to-the-standard-file-path/) within the plugin support forum.
-
-**Issue 3:** The Wordfence firewall installs a file called `.user.ini` that includes `wordfence-waf.php` from the absolute path which uses the application container's ID. These paths will change from time to time due to routine platform maintenance. When a container is migrated and when this plugin is deployed to another environment the absolute path is no longer valid resulting in a WSOD. This has been [reported as an issue](https://wordpress.org/support/topic/set-auto_prepend_file-path-relatively/) within the plugin support forum.
+**Issue 2:** The Wordfence firewall installs a file called `.user.ini` that includes `wordfence-waf.php` from the absolute path which uses the application container's ID. These paths will change from time to time due to routine platform maintenance. When a container is migrated and when this plugin is deployed to another environment the absolute path is no longer valid resulting in a WSOD. This has been [reported as an issue](https://wordpress.org/support/topic/set-auto_prepend_file-path-relatively/) within the plugin support forum.
 
 ___
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -716,7 +716,7 @@ export ENV=dev
   ln -s ../files/private/.user.ini ./.user.ini
   ```
 
-1. Open `pantheon.yml` and add a protected web path for `.user.ini`:
+1. Open `pantheon.yml` and add a [protected web path](/private-paths) for `.user.ini`:
 
   ```yml:title=pantheon.yml
   protected_web_paths:
@@ -736,8 +736,7 @@ export ENV=dev
 1. Create the empty files `wordfence-waf.php` and `.user.ini` to push to the site. In this example, we're using [`touch`](https://man7.org/linux/man-pages/man1/touch.1.html) to create them in the `/tmp` directory:
 
   ```bash{promptUser: user}
-  touch /tmp/wordfence-waf.php
-  touch /tmp/.user.ini
+  touch /tmp/wordfence-waf.php /tmp/.user.ini
   ```
 
 1. Connect to your environment over SFTP, create the required directories, and push the new files. You can get the SFTP path from the Site Dashboard under **Connection Info**:
@@ -758,13 +757,13 @@ export ENV=dev
   exit
   ```
 
-1. Set the environment connection mode to SFTP, then installand activate Wordfence. You can do both with Terminus:
+1. Set the environment connection mode to SFTP, then install and activate Wordfence. You can do both with Terminus:
 
   ```bash{outputLines: 2,4-25}
-  terminus connection:set wordpress-docs-testbed.waf5 sftp
-  [notice] Enabled on-server development via SFTP for "waf5"
-  terminus wp wordpress-docs-testbed.waf5 -- plugin install --activate wordfence
-  Installing Wordfence Security – Firewall & Malware Scan (7.4.8)
+  terminus connection:set $SITE.$ENV sftp
+  [notice] Enabled on-server development via SFTP for "env"
+  terminus wp $SITE.$ENV -- plugin install --activate wordfence
+  Installing Wordfence Security – Firewall & Malware Scan (7.4.9)
   Warning: Failed to create directory '/.wp-cli/cache/': mkdir(): Read-only file system.
   Downloading installation package from https://downloads.wordpress.org/plugin/wordfence.7.4.8.zip...
   Unpacking the package...
@@ -784,7 +783,7 @@ export ENV=dev
 
   You can safely ignore the warning messages.
 
-1. After clicking on **CLICK HERE TO CONFIGURE**, the plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete after downloading.
+1. Navigate to the **Wordfence** plugin in the site's WordPress Admin and **Resume Installation** if prompted, or click **CLICK HERE TO CONFIGURE**. The plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete it after downloading.
 
 ___
 

--- a/src/styles/codeBlocks.css
+++ b/src/styles/codeBlocks.css
@@ -33,6 +33,11 @@
   letter-spacing: -2px;
 }
 
+.command-line-prompt > span[data-user="sftp"]::before {
+  content: "sftp> ";
+  letter-spacing: -2px;
+}
+
 .command-line-prompt > span[data-prompt]:before {
 	content: attr(data-prompt);
 }


### PR DESCRIPTION
Closes: #5591 

## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues/#wordfence)** - Updated the section on Wordfence with instructions to enable the Wordfence WAF on Pantheon.

Also introduces an SFTP prompt for code blocks.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
