### PR TITLE
Wordpress include wrapped with Redis check first

### DIFF
--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -51,7 +51,9 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
     ```php:title="object-cache.php"
     <?php
     # This is a Windows-friendly symlink
-    require_once WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
+    if (!empty($_ENV['CACHE_HOST'])) {
+      require_once WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
+    }
     ```
 
     This file is a symlink to the `/plugins/wp-redis/object-cache.php` file. Using SFTP or Git, commit the new file to the Dev environment.


### PR DESCRIPTION
Upstreams that try to launch a Basic site get an error downstream because Redis is not available to those plans and breaks WordPress. Wrapping a quick conditional check should prevent that.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

Upstreams that try to launch a Basic site get an error downstream because Redis is not available to those plans and breaks WordPress. Wrapping a quick conditional check should prevent that.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- WordPress 'Basic' sites breaks when this include is part of an upstream, copied as-is from our docs

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] Gut check from anyone else on the team. Or, suggestions/feedback.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
