### PR TITLE
SITE in example must be the site ID not name

### DIFF
--- a/source/content/restore-environment-backup.md
+++ b/source/content/restore-environment-backup.md
@@ -119,6 +119,7 @@ export SITE=11111-1111-1111111-1111111
 export ENV=dev # or different environment name
 ```
 
+You can determine your site's Site ID with the `terminus site:info` command.
 </Alert>
 
 1. Download the **Files** backups using the link provided in the Site Dasboard <span class="glyphicons glyphicons-download-alt"></span> **Backups** Tab:

--- a/source/content/restore-environment-backup.md
+++ b/source/content/restore-environment-backup.md
@@ -112,10 +112,10 @@ Using [Terminus](/terminus), you can restore all or part of a site from the comm
 
 <Alert title ="Variables" type="export">
 
-The commands below assume environment variables for `SITE` which is equal to your Site Name, and `ENV` for the environment you're working with. Replace instances of `$SITE` and `$ENV` with your site name and environment, or define environment variables:
+The commands below assume environment variables for `SITE` which is equal to your Site ID, and `ENV` for the environment you're working with. Replace instances of `$SITE` and `$ENV` with your Site ID and environment, or define environment variables:
 
 ```bash{promptUser:user}
-export SITE=yourSiteName
+export SITE=11111-1111-1111111-1111111
 export ENV=dev # or different environment name
 ```
 

--- a/source/content/restore-environment-backup.md
+++ b/source/content/restore-environment-backup.md
@@ -112,14 +112,15 @@ Using [Terminus](/terminus), you can restore all or part of a site from the comm
 
 <Alert title ="Variables" type="export">
 
-The commands below assume environment variables for `SITE` which is equal to your Site ID, and `ENV` for the environment you're working with. Replace instances of `$SITE` and `$ENV` with your Site ID and environment, or define environment variables:
+The commands below assume environment variables for `SITE` which is equal to your Site ID, and `ENV` for the environment you're working with (dev|test|live). You can determine your site's Site ID with the `terminus site:info` command.
+
+Replace instances of `$SITE` and `$ENV` with your Site ID and environment, or define environment variables:
 
 ```bash{promptUser:user}
 export SITE=11111-1111-1111111-1111111
 export ENV=dev # or different environment name
 ```
 
-You can determine your site's Site ID with the `terminus site:info` command.
 </Alert>
 
 1. Download the **Files** backups using the link provided in the Site Dasboard <span class="glyphicons glyphicons-download-alt"></span> **Backups** Tab:


### PR DESCRIPTION
According to the wiki, these are site IDs, not site name: https://getpantheon.atlassian.net/wiki/spaces/VULCAN/pages/62488802/Service+drush.in+DNS

I was trying these docs but had to modify the command in this way.

