### PR TITLE
Fix header link

### DIFF
--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -68,7 +68,7 @@ const Header = ({ data, page }) => (
           </li>
           <li className="dropdown">
             <a
-              href="#"
+              href="/docs"
               className="dropdown-toggle active-trail"
               role="button"
               aria-haspopup="true"


### PR DESCRIPTION
## Summary

**Site Header** - Fixes the Documentation link in the header to point to the docs site index.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
