### PR TITLE
remove outdated multidev update/cleanup steps

### DIFF
--- a/.circleci/scripts/deploy-live.sh
+++ b/.circleci/scripts/deploy-live.sh
@@ -37,9 +37,17 @@ git branch -r --merged main | awk -F'/' '/^ *origin/{if(!match($0, /(>|main)/) &
 # Delete empty line at the end of txt file produced by awk
 sed '/^$/d' merged-branches.txt > merged-branches-clean.txt
 
+getMergedBranch() {
+    merged_branch_array=() # Clear array
+    while read -r branch # Read a line
+    do
+        # Save the first 11 chars, then remove -'s to follow multidev naming strategy
+        merged_branch_array+=( "$branch" ) # Append to the array
+    done < "$1"
+}
+getMergedBranch "merged-branches-clean.txt"
+
 # Delete merged branches from GH Repo
-  for branch in ${merged_branch_array[@]}; do
-    if [ "$branch" != "sculpin" ] ; then
-    git push origin --delete "$branch"
-    fi
-  done
+while IFS= read -r line; do
+  git push origin --delete "$branch"
+done < merged-branches-clean.txt


### PR DESCRIPTION
## Summary

**CI Upgrade** - Removes scripting to update preview site environments, since we're using new decoupled (beta) environments for previews.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
