### PR TITLE
5769 mixed case dns

### DIFF
--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -158,7 +158,7 @@ Replace `http://` in the site's database and configure your CMS to assume users 
 
 ### Mixed Case DNS Is Not Supported
 
-The Pantheon Dashboard standardizes mixed case domain entries to be completely lowercase. If you have your name server configured to use a mixed case domain, users might not be able to access your site.
+If you have your name server configured to use a mixed case domain, visitors might not be able to access your site.
 
 Configure your DNS to accept an entirely lowercase domain to avoid this issue.
 

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -156,6 +156,12 @@ When troubleshooting a redirect loop, you may want to deactivate any module or p
 
 Replace `http://` in the site's database and configure your CMS to assume users are visiting via HTTPS and the site’s primary domain. Templates for example should reference HTTPS in absolute CSS and Javascript sources, even when accessed with HTTP.
 
+### Mixed Case DNS Is Not Supported
+
+The Pantheon Dashboard standardizes mixed case domain entries to be completely lowercase. If you have your name server configured to use a mixed case domain, users might not be able to access your site.
+
+Configure your DNS to accept an entirely lowercase domain to avoid this issue.
+
 ### Test Domain Names Before DNS
 
 You can modify your local `hosts` file to validate domain-specific settings before DNS is in place.

--- a/source/content/domains.md
+++ b/source/content/domains.md
@@ -17,6 +17,7 @@ Optimize your dev team and streamline internal workflows. Pantheon delivers cust
 </Enablement>
 
 ## Platform Domains
+
 Pantheon issues platform domains for all environments. Each environment (Dev, Test, Live, each Multidev) is accessible via the platform domain, matching the following patterns:
 
 - dev-site-name.pantheonsite.io
@@ -27,11 +28,13 @@ Pantheon issues platform domains for all environments. Each environment (Dev, Te
 All platform domains are available over HTTPS. Redirecting to HTTPS during development and testing is a good best practice to ensure you are ready to go live with HTTPS. See [Redirect to HTTPS](/redirects/#redirect-to-https) for more information.
 
 ### robots.txt
+
 Pantheon serves a default `robots.txt` that disallows crawlers on platform domains (`/*.pantheonsite.io`, `/*.pantheon.io`, `/*.gotpantheon.com`, and `/*.sites.my-agency.com`). Crawlers are allowed on the Live environment for requests served with a custom domain (e.g., `www.example.com`). If you attempt to access your Live environment with a platform domain, even if you have a domain associated with the environment, the default `robots.txt` will be served.
 
 Pantheon does not allow crawlers on Dev, Test, or Multidev environments. Adding a custom domain to an environment other than Live will not permit crawlers to that environment.
 
 ## Custom Domains
+
 If you don't already own a domain name, register one with a third-party provider. Pantheon is not a domain registrar, but we've created documentation for several popular DNS managers:
 
 <Accordion title="DNS Host-Specific Instructions" id="host-specific2" icon="info-sign">
@@ -83,6 +86,7 @@ Add all domains (`example.com` and `www.example.com` are different domains!) you
   ![Set the primary domain in the Site Dashboard](../images/dashboard/choose-primary-domain.png)
 
 ## Choose Primary Domain
+
 Pantheon uses the term **primary domain** to refer to a single domain used to serve all traffic from a site. For example, configuring `www.example.com` as the primary domain means that requests to `example.com` (or any other custom domain connected to the environment) all get redirected to `www.example.com`. This assumes that you have added **both** `example.com` and `www.example.com` to the Site Dashboard.
 
 Redirecting all traffic to a primary domain is a best practice for SEO since it avoids duplicate content. It also prevents session strangeness, where a user can be logged in to one domain but logged out of other domains at the same time, and it can make it easier to measure and monitor website traffic.
@@ -98,9 +102,11 @@ Redirects cannot be managed via `.htaccess`, which is ignored on our platform. F
 <Partial file="remove-primary-domain.md" />
 
 ### Redirect to HTTPS
+
 It's a best practice for SEO and security to standardize all traffic on HTTPS and choose a primary domain. Configure redirects to the primary domain with HTTPS in [pantheon.yml](/pantheon-yml#enforce-https--hsts)
 
 ### Redirect with PHP
+
 If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects:
 
 <Accordion title="PHP Redirection" >
@@ -112,6 +118,7 @@ If your site configuration prevents you from setting the primary domain from the
 For more redirect scenarios, see [Configure Redirects](/redirects).
 
 ## Vanity Domains for Organizations
+
 Pantheon Partners, Strategic Partners, Enterprise accounts, Resellers, and OEM Partners have the ability to provision a custom vanity domain for each environment on every site running on the platform, in addition to the default platform domain (`pantheonsite.io`).
 
 For details, see [Vanity Domains](/vanity-domains).
@@ -119,6 +126,7 @@ For details, see [Vanity Domains](/vanity-domains).
 ## Troubleshooting
 
 ### Failed cache clears, search and replace, or Drush and WP-CLI operations
+
 All redirect logic should include the `php_sapi_name() != "cli"` conditional statement to see if WordPress or Drupal is running via the command line. Drush and WP-CLI are used by the platform for operations like cache clearing and search and replace, so it is important to only redirect web requests, otherwise the redirect will kill the PHP process before Drush or WP-CLI is executed, resulting in a silent failure:
 
 ```bash
@@ -127,12 +135,15 @@ All redirect logic should include the `php_sapi_name() != "cli"` conditional sta
 ```
 
 ### Infinite Redirect Loops
+
 #### HTTP_X_FORWARDED_PROTO
+
 Errors referencing too many redirects may be a result of using the ` $_SERVER['HTTP_X_FORWARDED_PROTO']` variable within redirect logic located in your site's `wp-config.php` or `settings.php` file.
 
 Resolve this error by replacing the offending redirect logic with the [recommended code samples in the above section](#redirect-to-https-and-the-primary-domain) and for your specific use case.
 
 #### Modules and Plugins
+
 Modules and plugins that support managing redirects in the Site Admin interface can produce redirect errors when repeating or conflicting with redirects managed via PHP in your site's configuration file. Some examples include:
 
 WordPress plugins: Redirection, Quick Page/Post Redirect, Safe Redirect Manager, Simple 301 Redirects
@@ -142,14 +153,17 @@ Drupal modules: Language (when using URL detection), Securepages, Redirect
 When troubleshooting a redirect loop, you may want to deactivate any module or plugin that may be providing its own redirect logic.
 
 ### Mixed-mode Browser Warnings
+
 Replace `http://` in the site's database and configure your CMS to assume users are visiting via HTTPS and the site’s primary domain. Templates for example should reference HTTPS in absolute CSS and Javascript sources, even when accessed with HTTP.
 
 ### Test Domain Names Before DNS
+
 You can modify your local `hosts` file to validate domain-specific settings before DNS is in place.
 
 <Partial file="_hosts-file.md" />
 
 ## See Also
+
 - [Configure Redirects](/redirects)
 - [Launch Essentials](/guides/launch)
 - [Relaunch Existing Pantheon Site](/relaunch)


### PR DESCRIPTION
Closes: #5769 

## Summary

**[Domains](https://pantheon.io/docs/domains)** - Some users have DNS configured with mixed case in order to provide a slight boost in spoofing resistance ([interesting explanation from Google](https://developers.google.com/speed/public-dns/docs/security?csw=1#randomize_case)). This isn't supported by the platform, so now the doc suggests that users configure DNS to be lowercase only. [PR 5856](https://github.com/pantheon-systems/documentation/pull/5856)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- troubleshooting: configure dns to be lowercase

## Remaining Work

The following changes still need to be completed:

- [x] @ari-gold to confirm: dashboard doesn't allow mixed case, but does Terminus?

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
