### PR TITLE
Unrecommend PHP 7.4 for now

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -127,7 +127,7 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
 1. Modify the `pantheon.yml` file to specify PHP 7.3 or newer and Drush 8:
 
   ```yaml:title=pantheon.yml
-  php_version: 7.3
+  php_version: 7.4
   drush_version: 8
   ```
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -127,7 +127,7 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
 1. Modify the `pantheon.yml` file to specify PHP 7.3 or newer and Drush 8:
 
   ```yaml:title=pantheon.yml
-  php_version: 7.4
+  php_version: 7.3
   drush_version: 8
   ```
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -24,6 +24,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 ### Available PHP Versions
 The recommended PHP versions available on Pantheon are:
 
+- [7.4](https://v74-php-info.pantheonsite.io/) is available for sites on [COE](/platform-considerations#compute-optimized-environments-coe). Other users may experience errors uploading images.
 - [7.3](https://v73-php-info.pantheonsite.io/)
 - [7.2](https://v72-php-info.pantheonsite.io/)
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -24,7 +24,6 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 ### Available PHP Versions
 The recommended PHP versions available on Pantheon are:
 
-- [7.4](https://v74-php-info.pantheonsite.io/)
 - [7.3](https://v73-php-info.pantheonsite.io/)
 - [7.2](https://v72-php-info.pantheonsite.io/)
 


### PR DESCRIPTION
## Summary

**[Upgrade PHP Version](https://pantheon.io/docs/php-versions)** - Users reporting issues with PHP 7.4 and uploading images. BUGS-3159 [PR 5861](https://github.com/pantheon-systems/documentation/pull/5861)

## Effect

The following changes are already committed:

- remove php 7.4 for now

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] Confirmation from @greg-1-anderson and @tylerdigital 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] stage undo PR
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
