### PR TITLE
Use try3 function to increase link check resiliency

### DIFF
--- a/.circleci/tests/link-checker.sh
+++ b/.circleci/tests/link-checker.sh
@@ -1,8 +1,9 @@
 #! /bin/bash
-
 # This script takes as an argument a target URL to test, then checks recursively for broken (relative) links.
-
 set -e
+
+# Import Functions
+source $BUILD_PATH/.circleci/scripts/functions.sh
 
 # Exits if no target is provided as an argument.
 if [ "$1" = "" ]; then
@@ -12,7 +13,7 @@ fi
 
 echo "Checking for broken links on ${1} .."
 
-if blc -q -r -e -o $1
+if try3 blc -q -r -e -o $1
 then
   echo "No broken internal links!"
 else


### PR DESCRIPTION
## Summary

**CI upgrade** - The link check has been failing with false positives more frequently. This change tries the test 3 times before failing.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
