### PR TITLE
remove references to varnishcheck

### DIFF
--- a/source/content/guides/edt/08-going-live.md
+++ b/source/content/guides/edt/08-going-live.md
@@ -34,7 +34,6 @@ All links from the video are provided below.
 
  - [Pricing Comparison](https://pantheon.io/plans/pricing-comparison)
  - [Performance and load testing](/load-and-performance-testing)
- - [Varnish Checker](https://varnishcheck.pantheon.io/)
  - [Performance guide](/guides/frontend-performance)
  - [Google Page Speed](https://developers.google.com/speed/pagespeed/insights/)
  - [Webpagetest.org](https://www.webpagetest.org)

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -11,59 +11,48 @@ tags: [cache, cdn]
 1. Enter the following command with your full Pantheon domain URL.
     - The `-I` flag sends a HEAD request to fetch only the HTTP headers for the specified URL.
     - The `-H 'accept-encoding: gzip, deflate, br'` flag and header forces curl to more closely simulate a typical browser request, resulting in typical cache behavior.
+    - The `egrep '(HTTP|cache-control|age:)'` command limits the output to include only the relevant information.
 
-  ```bash{outputLines:2-20}
-  curl -I -H "accept-encoding: gzip, deflate, br" https://scalewp.io
+  ```bash{outputLines: 2-7}
+  curl -I -H "accept-encoding: gzip, deflate, br" https://scalewp.io | egrep '(HTTP|cache-control|age:)'
+    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+  0 14801    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
   HTTP/2 200
   cache-control: public, max-age=86400
-  content-encoding: gzip
-  content-type: text/html; charset=UTF-8
-  link: <https://scalewp.io/wp-json/>; rel="https://api.w.org/"
-  link: <https://scalewp.io/>; rel=shortlink
-  server: nginx
-  x-pantheon-styx-hostname: styx-fe3-a-906849904-7zhv4
-  x-styx-req-id: styx-460041beb0cbd966edfdeac5f09e8c50
-  via: 1.1 varnish
-  accept-ranges: bytes
-  date: Mon, 16 Apr 2018 16:30:18 GMT
-  via: 1.1 varnish
-  age: 44742 //highlight-line
-  x-served-by: cache-mdw17344-MDW, cache-jfk8146-JFK
-  x-cache: HIT, HIT
-  x-cache-hits: 1, 1
-  x-timer: S1523896219.500596,VS0,VE1
-  vary: Accept-Encoding, Cookie, Cookie
-  content-length: 41369
+  age: 65772
   ```
 
   To view the `Surrogate-Key-Raw` header, add the `Pantheon-Debug: 1` header to your request:
 
-  ```bash{outputLines:2-21}
-  curl -Is -H "accept-encoding: gzip, deflate, br" -H "Pantheon-Debug:1" https://scalewp.io
+  ```bash{outputLines: 2-5}
+  curl -Is -H "accept-encoding: gzip, deflate, br" -H "Pantheon-Debug:1" https://scalewp.io | egrep '(HTTP|cache-control|age:|surrogate-key-raw)'
   HTTP/2 200
   cache-control: public, max-age=86400
-  content-encoding: gzip
-  content-type: text/html; charset=UTF-8
-  link: <https://scalewp.io/wp-json/>; rel="https://api.w.org/"
-  link: <https://scalewp.io/>; rel=shortlink
-  server: nginx
-  surrogate-key-raw: front post-7 post-user-6 single //highlight-line
-  x-pantheon-styx-hostname: styx-fe3-a-906849904-7zhv4
-  x-styx-req-id: styx-460041beb0cbd966edfdeac5f09e8c50
-  via: 1.1 varnish
-  accept-ranges: bytes
-  date: Mon, 16 Apr 2018 16:30:24 GMT
-  via: 1.1 varnish
-  age: 44747
-  x-served-by: cache-mdw17344-MDW, cache-jfk8132-JFK
-  x-cache: HIT, HIT
-  x-cache-hits: 1, 2
-  x-timer: S1523896225.507911,VS0,VE0
-  vary: Accept-Encoding, Cookie, Cookie
-  content-length: 41369
+  surrogate-key-raw: front post-7 post-user-6 single
+  age: 71611
   ```
 
 ## Test Global CDN with Browser Headers
+
+### View HTTPS Headers with Chrome
+
+1. Open [DevTools](https://developers.google.com/web/tools/chrome-devtools) and click on the **Network** tab.
+1. Load a page on your site.
+1. Click on the URL of the request, under the **Name** column of the Requests table.
+1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#headers) tab.
+
+### View HTTPS Headers with Firefox
+
+1. Open the [Network Monitor](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor).
+1. Load a page on your site.
+1. In the Network Monitor window, click on the URL of the request, under the **File** column of the Requests table.
+1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor#Headers) tab.
+
+### View HTTPS Headers with Internet Explorer
+
+1. Use the developer tools by pressing **F12** or by clicking **Settings**, then **Developer Tools**.
+1. Click the **Start Capturing** button to begin reading the headers from the HTTP request. If headers aren't displaying, refresh the page.
 
 ### How to Read HTTP Headers
 
@@ -100,25 +89,6 @@ Every HTTP response served by Pantheon is accompanied by a number of headers. T
   - Via is used by proxies to indicate the intermediate protocol and recipient; the request went through Varnish (which is part of the technology behind Global CDN). This header will always be shown, regardless of whether the CDN served cached content.
 
 Two of the headers listed above are Drupal-specific. By default, WordPress does not send any additional HTTP headers. However, it is possible for plugins and themes to send them.
-
-### View HTTPS Headers with Chrome
-
-1. Open [DevTools](https://developers.google.com/web/tools/chrome-devtools) and click on the **Network** tab.
-1. Load a page on your site.
-1. Click on the URL of the request, under the **Name** column of the Requests table.
-1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#headers) tab.
-
-### View HTTPS Headers with Firefox
-
-1. Open the [Network Monitor](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor).
-1. Load a page on your site.
-1. In the Network Monitor window, click on the URL of the request, under the **File** column of the Requests table.
-1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor#Headers) tab.
-
-### View HTTPS Headers with Internet Explorer
-
-1. Use the developer tools by pressing **F12** or by clicking **Settings**, then **Developer Tools**.
-1. Click the **Start Capturing** button to begin reading the headers from the HTTP request. If headers aren't displaying, refresh the page.
 
 ## See Also
 

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -4,9 +4,6 @@ description: Detailed information on how to determine if CDN caching is working 
 categories: [performance]
 tags: [cache, cdn]
 ---
-## Verify the Global CDN is Working on Your Pantheon Site
-
-Use the [web utility](https://varnishcheck.pantheon.io/) to check to see if caching is working on your Pantheon-hosted website. This tool performs up to two web requests to your site and will check the headers to determine if the CDN can cache your site. If not, it will make recommendations specific to your site configuration. Please note that this utility does not check for cookies that are set in your frontend code (i.e. JavaScript). If you have any feedback, let us know by [contacting support](/support).
 
 ## Test If Global CDN Caching Is Working by Reading HTTP Headers
 
@@ -14,7 +11,7 @@ Every HTTP response served by Pantheon is accompanied by a number of headers. T
 
 - **Cache-Control: public, max-age=900**
   - Set from Drupal's performance settings.
-  - max-age is the number of seconds that content can remain in cache; if set to 0, content will not be cached.
+  - max-age is the number of seconds that content can remain in cache; if set to 0, content willmlv.asasdasdasdasd not be cached.
   - If "no-cache, must-revalidate, post-check=0, pre-check=0"; this is Drupal's default header and typically indicates that there is a conflict.
   - **All static assets** (images, etc) on production environments (Test and Live) are set with a max-age of 366 days; we recommend using new file names or appending a changable query string if content needs to change earlier. Development environments (Dev and Multidevs) intentionally do not cache static assets.
 
@@ -25,7 +22,7 @@ Every HTTP response served by Pantheon is accompanied by a number of headers. T
   - A Pantheon webserver generated the original page content. This will always be shown, even if a page is served from the a Global CDN cache.
 
 - **X-Drupal-Cache: HIT**
-  - Drupal's internal page cache served the content. See  [\_drupal\_bootstrap\_page\_cache](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/_drupal_bootstrap_page_cache/7) for more information.  **Drupal Only**
+  - Drupal's internal page cache served the content. See  [\_drupal\_bootstrap\_page\_cache](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/_drupal_bootstrap_page_cache/7) for more information. **Drupal Only**
 
 - **X-Generator: Drupal 7 (https://www.drupal.org/)**
   - Drupal built the page. **Drupal Only**
@@ -120,7 +117,6 @@ Two of the headers listed above are Drupal-specific. By default, WordPress does 
 
 1. Use the developer tools by pressing **F12** or by clicking **Settings**, then **Developer Tools**.
 1. Click the **Start Capturing** button to begin reading the headers from the HTTP request. If headers aren't displaying, refresh the page.
-
 
 ## See Also
 - [Drupal Performance and Caching Settings](/drupal-cache)

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -33,6 +33,8 @@ tags: [cache, cdn]
   age: 71611
   ```
 
+To see all headers, remove the pipe (`|`) and everything following it from these commands.
+
 ## Test Global CDN with Browser Headers
 
 ### View HTTPS Headers with Chrome
@@ -54,7 +56,7 @@ tags: [cache, cdn]
 1. Use the developer tools by pressing **F12** or by clicking **Settings**, then **Developer Tools**.
 1. Click the **Start Capturing** button to begin reading the headers from the HTTP request. If headers aren't displaying, refresh the page.
 
-### How to Read HTTP Headers
+## How to Read HTTP Headers
 
 Every HTTP response served by Pantheon is accompanied by a number of headers. These are the same headers that the CDN uses when determining if and for how long to cache content.
 

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -5,43 +5,7 @@ categories: [performance]
 tags: [cache, cdn]
 ---
 
-## Test If Global CDN Caching Is Working by Reading HTTP Headers
-
-Every HTTP response served by Pantheon is accompanied by a number of headers. These are the same headers that the CDN uses when determining if and for how long to cache content.
-
-- **Cache-Control: public, max-age=900**
-  - Set from Drupal's performance settings.
-  - max-age is the number of seconds that content can remain in cache; if set to 0, content willmlv.asasdasdasdasd not be cached.
-  - If "no-cache, must-revalidate, post-check=0, pre-check=0"; this is Drupal's default header and typically indicates that there is a conflict.
-  - **All static assets** (images, etc) on production environments (Test and Live) are set with a max-age of 366 days; we recommend using new file names or appending a changable query string if content needs to change earlier. Development environments (Dev and Multidevs) intentionally do not cache static assets.
-
-- **X-Pantheon-Styx-Hostname**
-  - Hostname of the Pantheon load balancing server at the origin datacenter. There are a number of these servers, and each request may be served by a different server.
-
-- **Server: nginx**
-  - A Pantheon webserver generated the original page content. This will always be shown, even if a page is served from the a Global CDN cache.
-
-- **X-Drupal-Cache: HIT**
-  - Drupal's internal page cache served the content. See  [\_drupal\_bootstrap\_page\_cache](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/_drupal_bootstrap_page_cache/7) for more information. **Drupal Only**
-
-- **X-Generator: Drupal 7 (https://www.drupal.org/)**
-  - Drupal built the page. **Drupal Only**
-
-- **X-Served-By**
-  - Hostnames of points of presence (POPs) from the Global CDN that the request routed through. The names are typically based on the codes for nearby airports. The first entry is the POP close to the origin datacenter. The second entry (if one exists) is the POP close to the device loading the page.
-
-- **X-Cache**
-  - The hit and miss values shown here correspond to the POPs listed in X-Served-By. A request can "hit" in Global CDN either close to the device loading the page or close to the origin datacenter.
-
-- **Age: 233**
-  - How long the content has been stored in cache. If 0, it was produced at the time of the request. If you see Age: 0 after multiple requests, your site is not being cached properly.
-
-- **Via: 1.1 varnish**
-  - Via is used by proxies to indicate the intermediate protocol and recipient; the request went through Varnish (which is part of the technology behind Global CDN). This header will always be shown, regardless of whether the CDN served cached content.
-
-Two of the headers listed above are Drupal-specific. By default, WordPress does not send any additional HTTP headers. However, it is possible for plugins and themes to send them.
-
-### Test CDN Caching with curl
+## Test CDN Caching with curl
 
 1. Open a terminal.
 1. Enter the following command with your full Pantheon domain URL.
@@ -99,25 +63,64 @@ Two of the headers listed above are Drupal-specific. By default, WordPress does 
   content-length: 41369
   ```
 
-### Test Global CDN with Chrome
+## Test Global CDN with Browser Headers
+
+### How to Read HTTP Headers
+
+Every HTTP response served by Pantheon is accompanied by a number of headers. These are the same headers that the CDN uses when determining if and for how long to cache content.
+
+- **Cache-Control: public, max-age=900**
+  - Set from Drupal's performance settings.
+  - max-age is the number of seconds that content can remain in cache; if set to 0, content willmlv.asasdasdasdasd not be cached.
+  - If "no-cache, must-revalidate, post-check=0, pre-check=0"; this is Drupal's default header and typically indicates that there is a conflict.
+  - **All static assets** (images, etc) on production environments (Test and Live) are set with a max-age of 366 days; we recommend using new file names or appending a changable query string if content needs to change earlier. Development environments (Dev and Multidevs) intentionally do not cache static assets.
+
+- **X-Pantheon-Styx-Hostname**
+  - Hostname of the Pantheon load balancing server at the origin datacenter. There are a number of these servers, and each request may be served by a different server.
+
+- **Server: nginx**
+  - A Pantheon webserver generated the original page content. This will always be shown, even if a page is served from the a Global CDN cache.
+
+- **X-Drupal-Cache: HIT**
+  - Drupal's internal page cache served the content. See  [\_drupal\_bootstrap\_page\_cache](https://api.drupal.org/api/drupal/includes%21bootstrap.inc/function/_drupal_bootstrap_page_cache/7) for more information. **Drupal Only**
+
+- **X-Generator: Drupal 7 (https://www.drupal.org/)**
+  - Drupal built the page. **Drupal Only**
+
+- **X-Served-By**
+  - Hostnames of points of presence (POPs) from the Global CDN that the request routed through. The names are typically based on the codes for nearby airports. The first entry is the POP close to the origin datacenter. The second entry (if one exists) is the POP close to the device loading the page.
+
+- **X-Cache**
+  - The hit and miss values shown here correspond to the POPs listed in X-Served-By. A request can "hit" in Global CDN either close to the device loading the page or close to the origin datacenter.
+
+- **Age: 233**
+  - How long the content has been stored in cache. If 0, it was produced at the time of the request. If you see Age: 0 after multiple requests, your site is not being cached properly.
+
+- **Via: 1.1 varnish**
+  - Via is used by proxies to indicate the intermediate protocol and recipient; the request went through Varnish (which is part of the technology behind Global CDN). This header will always be shown, regardless of whether the CDN served cached content.
+
+Two of the headers listed above are Drupal-specific. By default, WordPress does not send any additional HTTP headers. However, it is possible for plugins and themes to send them.
+
+### View HTTPS Headers with Chrome
 
 1. Open [DevTools](https://developers.google.com/web/tools/chrome-devtools) and click on the **Network** tab.
 1. Load a page on your site.
 1. Click on the URL of the request, under the **Name** column of the Requests table.
 1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developers.google.com/web/tools/chrome-devtools/network-performance/reference#headers) tab.
 
-### Test Global CDN with Firefox
+### View HTTPS Headers with Firefox
 
 1. Open the [Network Monitor](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor).
 1. Load a page on your site.
 1. In the Network Monitor window, click on the URL of the request, under the **File** column of the Requests table.
 1. View HTTP response headers for this request on the right side of the window under the [**Headers**](https://developer.mozilla.org/en-US/docs/Tools/Network_Monitor#Headers) tab.
 
-### Test Global CDN with Internet Explorer
+### View HTTPS Headers with Internet Explorer
 
 1. Use the developer tools by pressing **F12** or by clicking **Settings**, then **Developer Tools**.
 1. Click the **Start Capturing** button to begin reading the headers from the HTTP request. If headers aren't displaying, refresh the page.
 
 ## See Also
+
 - [Drupal Performance and Caching Settings](/drupal-cache)
 - [WordPress Pantheon Cache Plugin Configuration](/wordpress-cache-plugin)

--- a/source/content/wordpress-sessions.md
+++ b/source/content/wordpress-sessions.md
@@ -5,6 +5,7 @@ cms: "WordPress"
 categories: [develop]
 tags: [code, users, cookies]
 ---
+
 WordPress Core [does not use sessions](https://wordpress.org/support/topic/how-does-wordpress-handle-sessions-and-session-variables/?replies=7). All "user state" is managed via cookies. This is a Core design decision.
 
 However, some plugins or themes will use `session_start()` or PHP's `$_SESSION` superglobal. On Pantheon, support for sessions requires the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin which we maintain. Sites that need to utilize PHP Sessions should install this plugin.
@@ -22,6 +23,7 @@ Prior to installing WordPress Native PHP Sessions, you might see the following e
 ```php
 Warning: session_start(): user session functions not defined
 ```
+
 Plugins with session-using code are relying on PHP's default session manager, which is temporary files on local disk. Pantheon does not support this because it will not work properly in our distributed environment.
 
 ### Varnish or caching is not working when a plugin or theme that uses `$_SESSIONS` is enabled
@@ -34,7 +36,7 @@ Symptoms of this issue shows when the header is inspected, you will see that the
 Set-Cookie: SESS1234XXXXXXXXXXXXXX path=/; domain=.example.pantheonsite.io; HttpOnly
 ```
 
-The best way to determine which plugin or theme is not allowing caching is to use our [Varnish check tool](https://varnishcheck.pantheon.io/), or by inspecting the headers using `curl -sI example.com` with each of the following steps, until you determine which component is breaking the cache:
+The best way to determine which plugin or theme is not allowing caching is to inspect the headers using `curl -sI example.com` after each of the following steps, until you determine which component is breaking the cache:
 
 1. To check your theme, use your default theme (twentynineteen for example), and check for the cookie.
 
@@ -45,41 +47,42 @@ The best way to determine which plugin or theme is not allowing caching is to us
 1. To check if a 3rd party must-use plugin or drop-in plugin is breaking the cache, temporarily remove the 3rd party must-use plugins and leave only the `Pantheon` and `WP Native PHP Sessions`. There should be no drop-ins in place.
 
 ### Install WordPress Native PHP Sessions Plugin
+
 If `$_SESSIONs` are necessary for your application, install the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) plugin:
 
 1. [Set the connection mode to SFTP](/sftp) for the Dev or Multidev environment via the Pantheon Dashboard or with [Terminus](/terminus):
 
- ```
+ ```bash{promptUser: user}
  terminus connection:set <site>.<env> sftp
  ```
 
-2. Install and activate  [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=wp+native-php-sessions`) or with Terminus:
+1. Install and activate  [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions) from within the Dev or Multidev environment's WordPress Dashboard (`/wp-admin/plugin-install.php?tab=search&s=wp+native-php-sessions`) or with Terminus:
 
- ```
+ ```bash{promptUser: user}
  terminus wp <site>.<env> -- plugin install wp-native-php-sessions --activate
  ```
 
-3. Deploy the plugin to the Test environment within the Site Dashboard or with Terminus:
+1. Deploy the plugin to the Test environment within the Site Dashboard or with Terminus:
 
- ```
+ ```bash{promptUser: user}
  terminus env:deploy <site>.test --sync-content --cc --updatedb --note="Install WordPress Native PHP Sessions plugin"
  ```
 
-4. Activate the plugin within the WordPress Dashboard on the Test environment (`/wp-admin/plugins.php`) or with Terminus:
+1. Activate the plugin within the WordPress Dashboard on the Test environment (`/wp-admin/plugins.php`) or with Terminus:
 
- ```
+ ```bash{promptUser: user}
  terminus wp <site>.test -- plugin activate wp-native-php-sessions
  ```
 
-5. Deploy the plugin to the Live environment within the Site Dashboard or with Terminus:
+1. Deploy the plugin to the Live environment within the Site Dashboard or with Terminus:
 
- ```
+ ```bash{promptUser: user}
  terminus env:deploy <site>.live --cc --note="Install WordPress Native PHP Sessions plugin"
  ```
 
-6. Activate the plugin within the WordPress Dashboard on the Live environment (`/wp-admin/plugins.php`) or with Terminus:
+1. Activate the plugin within the WordPress Dashboard on the Live environment (`/wp-admin/plugins.php`) or with Terminus:
 
- ```
+ ```bash{promptUser: user}
  terminus wp <site>.live -- plugin activate wp-native-php-sessions
  ```
 
@@ -92,8 +95,9 @@ Starting a session for _every_ user is an application anti-pattern. Serving page
 Our plugin provides an admin screen to see how many sessions have been started. You can also examine the headers being sent by your website. If you start a new incognito window and see a "PHPSESS" cookie being sent in response to a request for your site, you have some over-eager sessions code.
 
 Command line users can use this quick snippet to test:
-```bash
-curl -Is https://www.getpantheon.com|grep PHPSESS|wc -l
+
+```bash{promptUser: user}
+curl -Is https://www.getpantheon.com | grep PHPSESS|wc -l
 ```
 
 You should substitute your site URL in there, but the desired output is "0" (zero).

--- a/source/partials/additionalResources/lw4.md
+++ b/source/partials/additionalResources/lw4.md
@@ -4,11 +4,10 @@ Speed ahead to the next class! Sign up for workshop #5: [Going Live Best Practic
 
 ### Your Feedback Helps
 
-We sincerely want this training to be useful. Please help us improve by [sharing your feedback](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495040). It only takes you a moment but it makes a big difference for us. 
+We sincerely want this training to be useful. Please help us improve by [sharing your feedback](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495040). It only takes you a moment but it makes a big difference for us.
 
 ### Resources from this Workshop
 
-- [Is Varnish working on my Pantheon Site?](https://varnishcheck.pantheon.io/)
 - Drupal Module: [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache)
 - WordPress Plugin: [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache)
 - Blog post: [Caching: Advanced Topics](/caching-advanced-topics)

--- a/source/partials/additionalResources/lw5.md
+++ b/source/partials/additionalResources/lw5.md
@@ -1,18 +1,17 @@
 ## Congratulations on completing Going Live Best Practices! 🎉
 
-Double congratulations if you attended all five of the [Live Workshops](https://pantheon.io/live-workshops)! 
+Double congratulations if you attended all five of the [Live Workshops](https://pantheon.io/live-workshops)!
 
 You must be feeling really great about developer workflows, Terminus, Quicksilver, and topics around making your website fast. If not, [let us know how we can improve](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041) and consider attending [Pantheon Office Hours](https://pantheon.io/agencies/office-hours) this Wednesday to get some more assistance.
 
 ### Your Feedback Helps
 
-We sincerely want this training to be useful. Please help us improve by [sharing your feedback](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041). It only takes you a moment but it makes a big difference for us. 
+We sincerely want this training to be useful. Please help us improve by [sharing your feedback](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041). It only takes you a moment but it makes a big difference for us.
 
 ### Resources from this Workshop
 
 - [Pantheon Pricing Comparison](https://pantheon.io/plans/pricing-comparison)
 - Doc: [Load and Performance Testing](/load-and-performance-testing)
-- [Is Varnish working on my Pantheon Site?](http://varnishcheck.pantheon.io/)
 - Guide: [Frontend Performance](/guides/frontend-performance)
 - [Google PageSpeed](https://developers.google.com/speed/pagespeed/insights/)
 - [WebPageTest](https://www.webpagetest.org)


### PR DESCRIPTION
Closes: #5864 

## Summary

**[Testing Global CDN Caching](https://pantheon.io/docs/test-global-cdn-caching)** - Varnishcheck is retiring and has been removed from the docs. [PR 5867](https://github.com/pantheon-systems/documentation/pull/5867)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
