### PR TITLE
Preceding slashes in log path

### DIFF
--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -147,7 +147,7 @@ Configure a temporary path that uses a private subdirectory of Pantheon's networ
 * Replace SOME_TMP_SETTING
 */
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-  define('SOME_TMP_SETTING', 'wp-content/uploads/private/tmp');
+  define('SOME_TMP_SETTING', '/wp-content/uploads/private/tmp');
 }
 ```
 The `private` and `tmp` directories do not exist by default; you must create the folders via SFTP if you have not done so already. We do not recommend using a public path since core treats the temporary path as non-web-accessible by default.

--- a/source/content/wp-config-php.md
+++ b/source/content/wp-config-php.md
@@ -91,7 +91,7 @@ ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );
 As of WP version 5.1 and newer:
 
 ```php:title=wp-config.php
-define( 'WP_DEBUG_LOG', __DIR__ . 'wp-content/uploads/debug.log'
+define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/uploads/debug.log'
 ```
 
 ### Where do I specify database credentials?


### PR DESCRIPTION
Closes: #5776 

## Summary

**[Configuring wp-config.php](https://pantheon.io/docs/wp-config-php) and [Temporary File Management](https://pantheon.io/docs/tmp)** - Fixes PHP code to include preceding slash when pointing to the wp-content directory.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
