### PR TITLE
Terminus install plugin with Composer update

### DIFF
--- a/source/content/terminus/plugins.md
+++ b/source/content/terminus/plugins.md
@@ -14,7 +14,7 @@ image: terminus-thumbLarge
 searchboost: 100
 ---
 
-Extend the functionality of Terminus and add commands by installing third party plugins.
+Extend the functionality of Terminus and add commands by installing third-party plugins.
 
 <Alert title="Note" type="info">
 
@@ -24,45 +24,41 @@ If you are a plugin author, ensure your your plugin is updated for Terminus 2. S
 
 ## Install Plugins
 
-Add plugins within the <code>$HOME/.terminus/plugins</code> directory on your local workstation. You may need to create the <code>$HOME/.terminus/plugins</code> directory if it does not already exist:
+Add plugins within the `$HOME/.terminus/plugins` directory on your local workstation. You may need to create the `$HOME/.terminus/plugins` directory if it does not already exist:
 
-```bash
-  mkdir -p $HOME/.terminus/plugins
+```bash{promptUser: user}
+mkdir -p $HOME/.terminus/plugins
 ```
 
-Download a zip archive of the plugin's most recent release, then install it by unpacking the archive within <code>\$HOME/.terminus/plugins</code>:
+Download a zip archive of the plugin's most recent release, then install it by unpacking the archive within `$HOME/.terminus/plugins`:
 
-```bash
-  curl
-  https://github.com/pantheon-systems/terminus-plugin-example/archive/1.x.tar.gz
-  -L | tar -C ~/.terminus/plugins -xvz
+```bash{promptUser: user}
+curl https://github.com/pantheon-systems/terminus-plugin-example/archive/1.x.tar.gz -L | tar -C ~/.terminus/plugins -xvz
 ```
 
-<Accordion title="Explore Advanced Install Methods (Optional)" id="advance-installs" icon="lightbulb">
+<Accordion title="Composer and Git - Explore Advanced Installation Methods (Optional)" id="advance-installs" icon="lightbulb">
 
 ### Install via Composer
 
 Plugins published on Packagist are available to install via the Composer package manager. From a terminal window on your computer, use the following commands:
 
-```bash
-  composer create-project -n -d $HOME/.terminus/plugins
-  pantheon-systems/terminus-plugin-example:~1
+```bash{promptUser: user}
+composer create-project --no-dev -d ~/.terminus/plugins pantheon-systems/terminus-rsync-plugin:~1
 ```
 
 ### Install via Git
 
-Most plugins are published online as a Git repository. You can install the plugin by cloning the repository into your local plugins directory (`\$HOME/.terminus/plugins`). This will allow you to contribute to the development of the plugin and to update the plugin using Git commands. To install a plugin using Git, find the Git URL of the plugin’s repository. On GitHub you can find it by clicking **Clone or download** on the repository home page:
+Most plugins are published online as a Git repository. You can install the plugin by cloning the repository into your local plugins directory (`$HOME/.terminus/plugins`). This will allow you to contribute to the development of the plugin and to update the plugin using Git commands. To install a plugin using Git, find the Git URL of the plugin’s repository. On GitHub you can find it by clicking **Clone or download** on the repository home page:
 
 ![GitHub clone URL](../../images/terminus-plugin-install-git.png "GitHub clone URL")
 
 Then in a terminal window on your computer, use the following commands:
 
-```bash
-  cd $HOME/.terminus/plugins && git clone
-  https://github.com/pantheon-systems/terminus-plugin-example.git
+```bash{promptUser: user}
+cd $HOME/.terminus/plugins && git clone https://github.com/pantheon-systems/terminus-plugin-example.git
 ```
 
-  </Accordion>
+</Accordion>
 
 ## Update Plugins
 


### PR DESCRIPTION
Reference: [terminus-rsync-plugin issue #17](https://github.com/pantheon-systems/terminus-rsync-plugin/issues/17)
(thanks, @jenlampton!)

## Summary

**[Terminus Plugins](https://pantheon.io/docs/terminus/plugins#install-via-composer)** - Aligns the Composer plugin installation method with the [terminus-rsync-plugin readme](https://github.com/pantheon-systems/terminus-rsync-plugin/tree/1.1.0#installation) which seems to work. Also fixed the syntax of the commands in the doc so they're on one line. [PR 5879](https://github.com/pantheon-systems/documentation/pull/5879)

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] 👍  from @greg-1-anderson 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
