### PR TITLE
Fix check for frozen sites in our example Terminus script

### DIFF
--- a/source/content/terminus/scripting.md
+++ b/source/content/terminus/scripting.md
@@ -70,7 +70,7 @@ while read -r PANTHEON_SITE_NAME; do
     IS_FROZEN="$(terminus site:info $PANTHEON_SITE_NAME --field=frozen)"
 
     # If the site is frozen
-    if [[ "true" == "${IS_FROZEN}" ]]
+    if [[ "1" == "${IS_FROZEN}" ]]
     then
         # Then skip it
         echo -e "Skipping a backup of the site '$PANTHEON_SITE_NAME' because it is frozen...\n"


### PR DESCRIPTION
## Summary

https://pantheon.io/docs/terminus/scripting

## Effect
The following changes are already committed:
- Adjust the check for "IS_FROZEN" in our example. If a site is frozen, "terminus site:info <sitename> --field=frozen" returns a 1, not "true."

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
