### PR TITLE
link to onboarding from load testing

### DIFF
--- a/source/content/load-and-performance-testing.md
+++ b/source/content/load-and-performance-testing.md
@@ -10,7 +10,7 @@ Load and performance tests are critical steps in going live procedures, as they 
 
 <Alert title="Note" type="info">
 
-Load testing is one of the services offered by our [Professional Services](/professional-services/#pre-launch-load-testing) team.
+Load testing is one of the services offered by our [Onboarding](/onboarding#pre-launch-load-testing) team.
 
 </Alert>
 


### PR DESCRIPTION
Closes: #5892 

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- Load testing is an Onboarding thing and the link from the doc is now 1 click instead of 3!

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
