### PR TITLE
Add info on MySQL binlogs for troubleshooting quota issues

### DIFF
--- a/source/content/logs.md
+++ b/source/content/logs.md
@@ -20,6 +20,7 @@ The server timezone and all log timestamps are in UTC (Coordinated Universal Tim
 | **php-fpm-error.log**     | 1MB of log data       | PHP-FPM generated collection of stack traces of slow executions, similar to MySQL's slow query log. See [PHP Slow Log](/php-slow-log) |
 | **mysqld-slow-query.log** | 10MB of log data      | Log of MySQL queries that took more than 120 seconds to execute. Located in the database's `logs/` directory. |
 | **mysqld.log**            | 1MB of log data       | Log of established MySQL client connections and statements received from clients. Also Located in the database's `logs/` directory. |
+| **mysql-bin.0001**        |                       | MySQL [binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html). Located in the database's `data/` directory. |
 
 Rotated log files are archived within the `/logs` directory on application containers and database servers.
 

--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -123,6 +123,10 @@ Can’t connect to local MySQL server through socket '/var/lib/mysql/mysql.sock'
 
 Pantheon logs underperforming database queries using the [MySQL Slow Query Log](https://dev.mysql.com/doc/refman/5.5/en/slow-query-log.html). To access the log for your database, get the SFTP connection info for the environment in question. Then, replace the word "appserver" with "dbserver" in the connection string. The MySQL slow query logs are in the `logs` subdirectory.
 
+## How can I access MySQL binary logs?
+
+To access MySQL [binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html) ("binlogs"), connect to the database server as described above for the slow query logs. Binlogs are stored in the `data` subdirectory. These logs are generally not used for development but may be useful to troubleshoot disk quota issues.
+
 ### Are table prefixes supported?
 
 Table prefixes are not supported or recommended by Pantheon. While the server will not prevent their creation or use, managing and supporting tables with prefixes is the developer's responsibility.

--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -3,6 +3,7 @@ title: Accessing MySQL Databases
 description: Configure and troubleshoot your Pantheon website's MySQL database connections.
 categories: [develop]
 tags: [database, local, ssh]
+reviewed: "2020-07-30"
 ---
 Pantheon provides direct access for your MySQL databases, both for debugging and for importing large databases. Each site environment (Dev, Test and Live) has a separate database, so credentials for one cannot be used on another. The credentials are automatically included in your site configuration.
 
@@ -123,9 +124,9 @@ Can’t connect to local MySQL server through socket '/var/lib/mysql/mysql.sock'
 
 Pantheon logs underperforming database queries using the [MySQL Slow Query Log](https://dev.mysql.com/doc/refman/5.5/en/slow-query-log.html). To access the log for your database, get the SFTP connection info for the environment in question. Then, replace the word "appserver" with "dbserver" in the connection string. The MySQL slow query logs are in the `logs` subdirectory.
 
-## How can I access MySQL binary logs?
+### How can I access MySQL binary logs?
 
-To access MySQL [binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html) ("binlogs"), connect to the database server as described above for the slow query logs. Binlogs are stored in the `data` subdirectory. These logs are generally not used for development but may be useful to troubleshoot disk quota issues.
+To access [MySQL binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html) ("binlogs"), connect to the database server as described above for the slow query logs. Binlogs are stored in the `data` subdirectory. These logs are generally not used for development but may be useful to troubleshoot disk quota issues.
 
 ### Are table prefixes supported?
 


### PR DESCRIPTION
## Summary

**[Log Files](https://pantheon.io/docs/logs)** and **[Accessing MySQL Databases](https://pantheon.io/docs/mysql-access)** - Add information on the availability of MySQL binlogs, and how to access them. [PR 5894](https://github.com/pantheon-systems/documentation/pull/5894)

Occasionally site devs may need to review MySQL binlogs (generally when troubleshooting disk quota issues). These are available via SFTP, similar to MySQL slow logs, but we do not currently have this documented.

## Effect
The following changes are already committed:
- Add binlogs to our [list of available logs](https://pantheon.io/docs/logs)
- Mention binlogs on "Accessing MySQL Databases"

## Remaining Work
- technical review
- copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
