### PR TITLE
link to slack invite

### DIFF
--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -40,7 +40,7 @@ Download Edge versions to get the latest features, bug fixes, instructions, and 
 
 <Alert type="info" title="Note">
 
-Help improve Localdev by sharing bug reports and feedback on the [Localdev Slack channel](https://pantheon-community.slack.com/messages/CB2H8065D) or [GitHub issue queue](https://github.com/pantheon-systems/localdev-issues).
+Help improve Localdev by sharing bug reports and feedback in the [GitHub issue queue](https://github.com/pantheon-systems/localdev-issues), or join the [Pantheon Community](/pantheon-community) to post in the [Localdev Slack channel](https://pantheon-community.slack.com/messages/CB2H8065D). Get your [Slack invite here](https://slackin.pantheon.io/).
 
 </Alert>
 


### PR DESCRIPTION
Closes: #5896 

## Summary

**[Localdev](https://pantheon.io/docs/localdev)** - Added a link to the [Community Slack invite](https://pantheon.io/docs/localdev) for those who aren't already signed up. [PR 5897](https://github.com/pantheon-systems/documentation/pull/5897)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
