### PR TITLE
direct users from kalabox to localdev; clarify lando/localdev support

### DIFF
--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -20,7 +20,9 @@ Dev/Test/Live, Multidev, local development, and more! Learn how Pantheon's WebOp
 
 </Enablement>
 
-Pantheon cannot troubleshoot or support local development solutions; however, we can provide some suggestions and known working solutions. For large teams/sites, we recommend using [Multidev](/multidev) instead of local development.
+Pantheon cannot troubleshoot or [support local development](/support#local-development) solutions; however, we can provide some suggestions and known working solutions. For large teams/sites, we recommend using [Multidev](/multidev) instead of local development.
+
+If you encounter any issues, visit the [Lando GitHub repository](https://github.com/lando/lando#help-troubleshooting--support).
 
 ## Before You Begin
 

--- a/source/content/videos/local.md
+++ b/source/content/videos/local.md
@@ -20,7 +20,7 @@ Pantheon [encourages on-server development](/support#local-development). However
 
 Let’s explore how to sync your code, database, and files back-and-forth between Pantheon and a local environment.
 
-To sync code from Pantheon to your local environment, we suggest [Git](git) for speed and simplicity. Just clone the codebase using the command provided in your site dashboard. By default, this sets Pantheon as the origin remote destination, which makes it easier to push changes.
+To sync code from Pantheon to your local environment, we suggest [Git](/git) for speed and simplicity. Just clone the codebase using the command provided in your site dashboard. By default, this sets Pantheon as the origin remote destination, which makes it easier to push changes.
 
 Now we still need the files and database. On your site dashboard, select Database/Files, then Export. Alternatively, you can download a recent backup. Or you can use Terminus, our command line interface, to automate both this download and the subsequent import to your local environment. Just follow the directions of your preferred method. That’s it. Now you’re ready to start developing locally.
 

--- a/source/content/videos/local.md
+++ b/source/content/videos/local.md
@@ -14,8 +14,7 @@ type: video
 
 <Partial file="deprecate-kalabox.md" />
 
-Pantheon encourages on-server development. However, many developers prefer the speed and convenience of [local development](/local-development) where sites run in virtual machines and don’t require Internet access.
-
+Pantheon [encourages on-server development](/support#local-development). However, many developers prefer the speed and convenience of [local development](/local-development) where sites run in virtual machines and don’t require Internet access.
 
 Sync from Pantheon to local
 
@@ -25,13 +24,6 @@ To sync code from Pantheon to your local, we suggest Git for speed and simplicit
 
 Now we still need the files and database. On your site dashboard, select Database/Files, then Export. Alternatively, you can download a recent backup. Or you can use Terminus, our command line interface, to automate both this download and the subsequent import to your local environment. Just follow the directions of your preferred method. That’s it. Now you’re ready to start developing locally.
 
-
 Sync from local to Pantheon
 
 Use Git to add, commit, and push code changes up to Pantheon from your local development environment. Remember, you also need to sync the changes made to your database and media files. Since this can be tricky, we recommend using a configuration management solution, such as WP-CFM for WordPress or the Features module for Drupal 7. These tools help you push configuration separately, as part of your code base, without disturbing database content.
-
-Kalabox
-
-One application we highly recommend for local development is Kalabox from Tandem. It’s pre-configured for Pantheon, and it automates many of the tasks we just covered.
-
-This was a quick introduction to local development and Pantheon. Check out Kalabox, and try it yourself.

--- a/source/content/videos/local.md
+++ b/source/content/videos/local.md
@@ -16,14 +16,14 @@ type: video
 
 Pantheon [encourages on-server development](/support#local-development). However, many developers prefer the speed and convenience of [local development](/local-development) where sites run in virtual machines and don’t require Internet access.
 
-Sync from Pantheon to local
+### Sync from Pantheon to local
 
 Let’s explore how to sync your code, database, and files back-and-forth between Pantheon and a local environment.
 
-To sync code from Pantheon to your local, we suggest Git for speed and simplicity. Just clone the codebase using the command provided in your site dashboard. By default, this sets Pantheon as the origin remote destination, which makes it easier to push changes.
+To sync code from Pantheon to your local environment, we suggest [Git](git) for speed and simplicity. Just clone the codebase using the command provided in your site dashboard. By default, this sets Pantheon as the origin remote destination, which makes it easier to push changes.
 
 Now we still need the files and database. On your site dashboard, select Database/Files, then Export. Alternatively, you can download a recent backup. Or you can use Terminus, our command line interface, to automate both this download and the subsequent import to your local environment. Just follow the directions of your preferred method. That’s it. Now you’re ready to start developing locally.
 
-Sync from local to Pantheon
+### Sync from local to Pantheon
 
 Use Git to add, commit, and push code changes up to Pantheon from your local development environment. Remember, you also need to sync the changes made to your database and media files. Since this can be tricky, we recommend using a configuration management solution, such as WP-CFM for WordPress or the Features module for Drupal 7. These tools help you push configuration separately, as part of your code base, without disturbing database content.

--- a/source/partials/deprecate-kalabox.md
+++ b/source/partials/deprecate-kalabox.md
@@ -1,5 +1,5 @@
 <Alert title="Warning" type="danger">
 
-This video references Kalabox, which is no longer under active development. We suggest [Lando](https://github.com/lando/lando) as an alternative.
+This video references Kalabox, which is no longer under active development. We suggest [Localdev](/localdev) as an alternative.
 
 </Alert>


### PR DESCRIPTION
Closes: #5903 
Closes: #5904 

## Summary

**[Local Development](https://pantheon.io/docs/local-development)** - Clarify Pantheon's scope of support for local development. Update the link from Kalabox to Localdev instead of Lando. [PR 5905](https://github.com/pantheon-systems/documentation/pull/5905)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
