### PR TITLE
Add localdev support for nested docroot

### DIFF
--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -48,7 +48,7 @@ Help improve Localdev by sharing bug reports and feedback in the [GitHub issue q
 
 Select a site and click **Pull for local development** to clone the site locally and boot the local environment.
 
-Each site is cloned to its own directory within `~/Localdev/` by default.
+Each site is cloned to its own directory within `~/Localdev/` by default. If your site specifies `web_docroot: true` in its [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) or [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) file (a nested docroot) the site's code will be located in the `web` subdirectory.
 
 ![Localdev clones the site code](../images/localdev/localdev-cloning-site.png)
 

--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -190,15 +190,15 @@ After using one of these commands, verify the new file locations with `git statu
 
 ## FAQ and Troubleshooting
 
-#### Quicksilver Script Location
+### Quicksilver Script Location
 If you are using a Quicksilver platform hook with the type `webphp`, make sure that the path to the script is relative to the `web` docroot and not the project root.
 
 For example, if your `pantheon.yml` has a script location definition of `private/scripts/my_quicksilver_script.php`, the file needs to be located at `web/private/scripts/my_quicksilver_script.php`. This is because `webphp` scripts are run with Nginx, which is serving from the nested docroot.
 
-#### Can I specify a subdirectory other than web?
+### Can I specify a subdirectory other than web?
 
 The directory name is not configurable, but you can [create a symlink](/symlinks-assumed-write-access#create-a-symbolic-link) from some other directory to `web`.
 
-#### Can I use Localdev for local development of nested docroot sites?
+### Can I use Localdev for local development of nested docroot sites?
 
 Yes, Pantheon's [Localdev](/localdev) pulls configuration information from your site's [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) and [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) files.

--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -188,7 +188,7 @@ You'll need to move the CMS code into the `web` subdirectory, either manually or
 
 After using one of these commands, verify the new file locations with `git status` before committing and pushing.
 
-## Troubleshooting
+## FAQ and Troubleshooting
 
 #### Quicksilver Script Location
 If you are using a Quicksilver platform hook with the type `webphp`, make sure that the path to the script is relative to the `web` docroot and not the project root.
@@ -198,3 +198,7 @@ For example, if your `pantheon.yml` has a script location definition of `private
 #### Can I specify a subdirectory other than web?
 
 The directory name is not configurable, but you can [create a symlink](/symlinks-assumed-write-access#create-a-symbolic-link) from some other directory to `web`.
+
+#### Can I use Localdev for local development of nested docroot sites?
+
+Yes, Pantheon's [Localdev](/localdev) pulls configuration information from your site's `pantheon.yml` file.

--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -201,4 +201,4 @@ The directory name is not configurable, but you can [create a symlink](/symlinks
 
 #### Can I use Localdev for local development of nested docroot sites?
 
-Yes, Pantheon's [Localdev](/localdev) pulls configuration information from your site's `pantheon.yml` file.
+Yes, Pantheon's [Localdev](/localdev) pulls configuration information from your site's [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) and [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) files.


### PR DESCRIPTION
## Summary

**[Serving Sites from the Web Subdirectory](https://pantheon.io/docs/nested-docroot)** and **[Localdev](https://pantheon.io/docs/localdev)** - Adds note about Localdev support for nested docroots.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
