### PR TITLE
Explicitly call bash

### DIFF
--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -31,7 +31,7 @@ There's a wide array of MySQL clients that can be used, including [MySQL Workben
 Drupal users can create [`spf-template.spf`](https://gist.github.com/aaronbauman/f50cc691eb3ed60a358c#file-spf-template-spf) and use the following script to establish a database connection in Sequel Pro via [Terminus](/terminus) and [Drush](/drush):
 
 ```bash
-#!/bin/sh
+#!/bin/bash
 
 # exit on any errors:
 set -e

--- a/source/scripts/pantheon-backup-to-s3.sh.txt
+++ b/source/scripts/pantheon-backup-to-s3.sh.txt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 # pantheon-backup-to-s3.sh
 # Script to backup Pantheon sites and copy to Amazon s3 bucket


### PR DESCRIPTION
Closes: #5779 

## Summary

**[Backups Tool](https://pantheon.io/docs/backups)** and **[Accessing MySQL Databases](https://pantheon.io/docs/mysql-access)** - Updates scripts to explicitly call Bash, since they are both using bash-specific operators.

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
