### PR TITLE
Add snippet to list ssh key fingerprints

### DIFF
--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -113,7 +113,7 @@ This error occurs when a user is attempting to make a direct connection to Panth
 
 ### Authentication Prompts
 
-Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. Verify by listing the SSH fingerprints already loaded in your device's ssh-agent using the command below:
+Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. Verify by listing the SSH fingerprints already loaded in your device's ssh-agent:
 
 ```bash{promptUser: user}
 ssh-add -L | ssh-keygen -l -E md5 -f - | awk '{print substr($2,5)}'

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -113,7 +113,13 @@ This error occurs when a user is attempting to make a direct connection to Panth
 
 ### Authentication Prompts
 
-Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
+Password requests may still occur after adding an SSH key to your Pantheon account if the corresponding key is not found by your local ssh-agent. Verify by listing the SSH fingerprints already loaded in your device's ssh-agent using the command below:
+
+```bash{promptUser: user}
+ssh-add -L | ssh-keygen -l -E md5 -f - | awk '{print substr($2,5)}'
+```
+
+To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
 
 ```bash{promptUser: user}
 ssh-add ~/.ssh/id_rsa

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -119,6 +119,8 @@ Password requests may still occur after adding an SSH key to your Pantheon accou
 ssh-add -L | ssh-keygen -l -E md5 -f - | awk '{print substr($2,5)}'
 ```
 
+The resulting string should match one of the keys [listed in your User Dashboard](https://dashboard.pantheon.io/users/#account/ssh-keys).
+
 To resolve, add your SSH key to the ssh-agent using the following command, replacing `id_rsa` with the name of your private key, if different:
 
 ```bash{promptUser: user}


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

## Summary

**[Doc Title](https://pantheon.io/docs/ssh-keys)** - In Troubleshooting - Authentication Prompts [section](https://pantheon.io/docs/ssh-keys#authentication-prompts), add command to list fingerprint of loaded ssh keys.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

-
-

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
