### PR TITLE
Custom WordPress Login Message

### DIFF
--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -186,6 +186,16 @@ else{
 }
 ```
 
+### Custom Login Message
+
+To customize the text provided on `/wp-login.php`, add the following filter:
+
+```php
+add_filter( 'pantheon_wp_login_text', function() {
+  return 'This is my custom login message';
+});
+```
+
 ### Exclude Plugins from Redis Cache
 
 A page load with 2,000 Redis calls can be 2 full seconds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistence for the plugin's group.

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -5,6 +5,7 @@ contributors: [alexfornuto, eabquina, carlalberto]
 cms: "WordPress"
 categories: [develop]
 tags: [plugins]
+reviewed: "2020-08-12"
 ---
 
 For actions or filters you want to run even when a theme's `functions.php` isn't invoked by a request, or before plugins are loaded by WordPress, you can create a [Must-Use (**MU**) Plugin](https://codex.wordpress.org/Must_Use_Plugins).
@@ -14,6 +15,7 @@ MU-Plugins are activated by default by adding a PHP file to the `wp-content/mu-p
 MU-plugins are loaded by PHP in alphabetical order, before normal plugins. This means API hooks added in an MU-plugin apply to all other plugins even if they run hooked-functions in the global namespace.
 
 ## Why use MU Plugins?
+
 While you can add code in the `wp-config.php` file for site-wide behavior, actions and filters shouldn't be added here.
 
 If they are added above the `require_once ABSPATH . 'wp-settings.php';` statement, the WordPress site will get a Fatal PHP error because the `add_action()` and `add_filter()` functions won't be defined yet.
@@ -21,7 +23,9 @@ If they are added above the `require_once ABSPATH . 'wp-settings.php';` statemen
 If they are added below the `require_once ABSPATH . 'wp-settings.php';` statement, then the entirety of WordPress has already been loaded and the actions / filters won't be applied, or would be applied last.
 
 ## Create Your MU Plugin
+
 1. Create a PHP file (i.e. `your-file.php`) in the `mu-plugins` folder (`code/wp-content/mu-plugins/your-file.php`).
+
 1. Provide the plugin details for its name, description, etc.:
 
   ```php
@@ -112,9 +116,11 @@ If they are added below the `require_once ABSPATH . 'wp-settings.php';` statemen
   ```
 
 ## Example Code Snippets
+
 Listed below are different plugins, themes, or use cases where creating a custom MU plugin with actions and filters resolves the issue they encounter.
 
 ### Redirects
+
 In addition to [PHP redirects](/redirects), it's possible to add custom redirects, like path or domain specific redirects, in an MU-plugin.
 
 ```php
@@ -134,9 +140,10 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 ```
 
 ### Cache Control
+
 Set `Cache-Control: max-age=0` by hooking into `send_headers`. This will override `max-age` configured within the Pantheon Cache plugin for all matching requests:
 
-```
+```php
 /*
  * Set $regex_path_patterns accordingly.
  *
@@ -167,6 +174,7 @@ function add_header_nocache() {
 ```
 
 ### WP REST API (`wp-json`) Endpoints Cache
+
 For WP REST API endpoints, we can use the `rest_post_dispatch` filter and create a specific function to apply specific headers for each path or endpoint.
 
 ```php
@@ -194,6 +202,7 @@ foreach ($regex_json_path_patterns as $regex_json_path_pattern) {
 ```
 
 ### Exclude Plugins from Redis Cache
+
 A page load with 2,000 Redis calls can be 2 full seconds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistence for the plugin's group.
 
 For example, let's say you have a custom plugin that sets the cache with:
@@ -217,7 +226,7 @@ wp_cache_add_non_persistent_groups( array( 'my_plugin_group', 'woocommerce' ) );
 
 To verify, you can use the [Redis CLI](/redis#use-the-redis-command-line-client) to flush all keys and see that the related objects are no longer added to the cache:
 
-```
+```sql
 > KEYS *woocommerce:*
 1) "woocommerce:size-gallery_thumbnail"
 2) "woocommerce:size-woocommerce_thumbnail"
@@ -265,8 +274,9 @@ else{
 ```
 
 ## See Also
+
 This page intends to introduce the concept of using an MU-plugin for applying actions or filters for a site. For Site-specific or Environment-specific context, see these other documentation pages:
 
- - [Configuring wp-config.php](/wp-config-php)
- - [Environment-Specific Configuration for WordPress Sites](/environment-specific-config)
- - [WordPress Plugins and Themes with Known Issues](/plugins-known-issues)
+- [Configuring wp-config.php](/wp-config-php)
+- [Environment-Specific Configuration for WordPress Sites](/environment-specific-config)
+- [WordPress Plugins and Themes with Known Issues](/plugins-known-issues)

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -155,7 +155,7 @@ function add_header_nocache() {
 
 ### Custom Cookies
 
-Setting custom cookies can also be done from an MU-plugin like in the example below. Find more [cookie manipulation examples here](https://pantheon.io/docs/cookies/).
+Setting custom cookies can also be done from an MU-plugin like in the example below. Find more cookie manipulation examples at [Working with Cookies on Pantheon](/cookies).
 
 ```php
 if ( isset( $_COOKIE['STYXKEY_gorp'] ) ) {

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -188,13 +188,27 @@ else{
 
 ### Custom Login Message
 
-To customize the text provided on `/wp-login.php`, add the following filter:
+To customize the text provided on `/wp-login.php` (when accessing the site from a Platform Domain), add the following filter:
 
 ```php
 add_filter( 'pantheon_wp_login_text', function() {
   return 'This is my custom login message';
 });
 ```
+
+You can also disable the **Return to Pantheon** button on platform domain login pages, and overwrite the default login text:
+
+```php
+if ( ! defined( 'RETURN_TO_PANTHEON_BUTTON' ) ) {
+  define( 'RETURN_TO_PANTHEON_BUTTON', false );
+}
+
+add_filter( 'login_message', function() {
+  return "This is the default login message being overwritten.";
+});
+```
+
+Please note that overwritting `login_message` changes the text displayed on all login pages, regardless of domain used to access it.
 
 ### Exclude Plugins from Redis Cache
 

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -1,6 +1,6 @@
 ---
-title: Create a WordPress MU Plugin for Actions and Filters
-description: Learn to make a boilerplate MU Plugin for actions and filters.
+title: Create a WordPress MU-Plugin for Actions and Filters
+description: Learn to make a boilerplate MU-plugin for actions and filters.
 contributors: [alexfornuto, eabquina, carlalberto]
 cms: "WordPress"
 categories: [develop]
@@ -10,11 +10,11 @@ reviewed: "2020-08-12"
 
 For actions or filters you want to run even when a theme's `functions.php` isn't invoked by a request, or before plugins are loaded by WordPress, you can create a [Must-Use (**MU**) Plugin](https://codex.wordpress.org/Must_Use_Plugins).
 
-MU-Plugins are activated by default by adding a PHP file to the `wp-content/mu-plugins` directory. It affects the whole site, including all sites under a WordPress Multisite installation.
+MU-plugins are activated by default by adding a PHP file to the `wp-content/mu-plugins` directory. It affects the whole site, including all sites under a WordPress Multisite installation.
 
 MU-plugins are loaded by PHP in alphabetical order, before normal plugins. This means API hooks added in an MU-plugin apply to all other plugins even if they run hooked-functions in the global namespace.
 
-## Why use MU Plugins?
+## Why use MU-Plugins?
 
 While you can add code in the `wp-config.php` file for site-wide behavior, actions and filters shouldn't be added here.
 
@@ -22,7 +22,7 @@ If they are added above the `require_once ABSPATH . 'wp-settings.php';` statemen
 
 If they are added below the `require_once ABSPATH . 'wp-settings.php';` statement, then the entirety of WordPress has already been loaded and the actions / filters won't be applied, or would be applied last.
 
-## Create Your MU Plugin
+## Create Your MU-Plugin
 
 1. Create a PHP file (i.e. `your-file.php`) in the `mu-plugins` folder (`code/wp-content/mu-plugins/your-file.php`).
 
@@ -33,7 +33,7 @@ If they are added below the `require_once ABSPATH . 'wp-settings.php';` statemen
   /*
     Plugin Name: Custom Actions and Filters
     Plugin URI: https://plugin-site.example.com
-    Description: Boilerplate MU-Plugin for custom actions and filters to run for a site instead of setting in WP-config.php
+    Description: Boilerplate MU-plugin for custom actions and filters to run for a site instead of setting in WP-config.php
     Version: 0.1
     Author: Pantheon
     Author URI: https://yoursite.example.com
@@ -47,7 +47,7 @@ If they are added below the `require_once ABSPATH . 'wp-settings.php';` statemen
   /*
     Plugin Name: Custom Actions and Filters
     Plugin URI: https://plugin-site.example.com
-    Description: Boilerplate MU-Plugin for custom actions and filters to run for a site instead of setting in WP-config.php
+    Description: Boilerplate MU-plugin for custom actions and filters to run for a site instead of setting in WP-config.php
     Version: 0.1
     Author: Pantheon
     Author URI: https://yoursite.example.com
@@ -117,7 +117,7 @@ If they are added below the `require_once ABSPATH . 'wp-settings.php';` statemen
 
 ## Example Code Snippets
 
-Listed below are different plugins, themes, or use cases where creating a custom MU plugin with actions and filters resolves the issue they encounter.
+Create a custom MU-plugin with actions or filters to resolve issues you may encounter with the following plugins, themes, or use cases.
 
 ### Cache Control
 
@@ -188,7 +188,7 @@ else{
 
 ### Custom Login Message
 
-To customize the text provided on `/wp-login.php` (when accessing the site from a Platform Domain), add the following filter:
+To customize the text displayed on `/wp-login.php` when accessing the site from a Platform Domain, add the following filter:
 
 ```php
 add_filter( 'pantheon_wp_login_text', function() {
@@ -208,11 +208,11 @@ add_filter( 'login_message', function() {
 });
 ```
 
-Please note that overwritting `login_message` changes the text displayed on all login pages, regardless of domain used to access it.
+Please note that overwriting `login_message` changes the text displayed on all login pages, regardless of domain used to access them.
 
 ### Exclude Plugins from Redis Cache
 
-A page load with 2,000 Redis calls can be 2 full seconds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistence for the plugin's group.
+A page load with 2,000 Redis calls can be two full seconds of object cache transactions. If a plugin you're using is erroneously creating a huge number of cache keys, you might be able to mitigate the problem by disabling cache persistence for the plugin's group.
 
 For example, let's say you have a custom plugin that sets the cache with:
 


### PR DESCRIPTION
Closes: #5791 

## Summary

**[Create a WordPress MU Plugin for Actions and Filters](https://pantheon.io/docs/mu-plugin)** - Documents how to set a custom login message in an MU-plugin. PR [5925](https://github.com/pantheon-systems/documentation/pull/5925)

## Remaining Work

The following changes still need to be completed:

- [x] Identify if a user can also remove the "Return to Pantheon" button while keeping a custom login message.

## Post Launch

- [x] Update Status Report
- [x] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
