### PR TITLE
fills in missing links

### DIFF
--- a/source/content/git-faq.md
+++ b/source/content/git-faq.md
@@ -6,7 +6,7 @@ tags: [git, iterate, local, workflow]
 contributors: [mrfelton, alexfornuto]
 reviewed: "2020-03-16"
 ---
-[Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
+[Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](/local-development), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
 
 <Enablement title="Get WebOps Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 

--- a/source/content/git-resolve-merge-conflicts.md
+++ b/source/content/git-resolve-merge-conflicts.md
@@ -6,7 +6,7 @@ tags: [git, local, webops]
 contributors: [alexfornuto]
 reviewed: "2020-02-11"
 ---
-[Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
+[Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](/local-development), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
 
 Conflicts can occur when modified file(s) within your site's codebase do not align with changes made to the same file(s) in the site's upstream.
 


### PR DESCRIPTION
## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- fixes two empty links that should've been /local-development

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [x] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
