### PR TITLE
remove wp_get_environment_type info and partial and revert to wp_debug

### DIFF
--- a/source/content/environment-specific-config.md
+++ b/source/content/environment-specific-config.md
@@ -22,12 +22,9 @@ To conditionally set `WP_DEBUG` based on the given Pantheon environment, change 
  * Sets WP_DEBUG to true on if on a development environment.
  *
  */
+
 if (!defined('WP_DEBUG') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-    if(in_array( $_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live'))) {
-      define('WP_DEBUG', false);
-    } else {
-      define( 'WP_DEBUG', true );
-    }
+    define( 'WP_DEBUG', !in_array( $_ENV['PANTHEON_ENVIRONMENT'], ['test', 'live']) );
 }
 ```
 

--- a/source/content/environment-specific-config.md
+++ b/source/content/environment-specific-config.md
@@ -35,7 +35,11 @@ For more options when editing `wp-config.php` for debugging, see [Configure Erro
 
 ## Configuration in an mu-plugin
 
-Filters or functions running in an mu-plugin can enable development plugins that should be active in Dev and/or Test, but disable them in Live, present extra work to reactivate them after a database clone from the Live environment. To achieve this goal, we can use an mu-plugin that checks which environment we're on, and then activates or deactivates plugins that were deactivated or activated when the database clone completed.
+Filters or functions running in an mu-plugin can enable development plugins that should be active in Dev and/or Test, but disabled in Live. To achieve this, use an mu-plugin that checks which environment you're on, and then activates or deactivates plugins that were deactivated or activated when the database clone completed.
+
+### Use the WP_ENVIRONMENT_TYPE Function to Define the Environment for a Plugin
+
+<Partial file="wp_get_environment_type.md" />
 
 ### Create the Plugin
 

--- a/source/content/environment-specific-config.md
+++ b/source/content/environment-specific-config.md
@@ -11,17 +11,23 @@ In order to improve the development and debugging processes, you might use setti
 
 This doc shows how to use the same codebase with different settings for each environment, using values for the [PANTHEON_ENVIRONMENT variable](/read-environment-config). To quickly see which environment you are on, consider installing the [Pantheon HUD plugin](https://wordpress.org/plugins/pantheon-hud/).
 
-## Use the WP_ENVIRONMENT_TYPE Function to Perform Actions Based on Environment
+## Define WP_DEBUG to Perform Actions Based on Environment
 
-<Partial file="wp_get_environment_type.md" />
-
-### Configure WP_DEBUG in wp-config.php
-
-To conditionally set `WP_DEBUG` based on the given Pantheon environment, change the [existing code block](https://github.com/pantheon-systems/WordPress/blob/default/wp-config.php#L72-L74) defining it:
+To conditionally set `WP_DEBUG` based on the given Pantheon environment, change the [existing code block](https://github.com/pantheon-systems/WordPress/blob/default/wp-config.php#L72-L74) defining it. This example configuration enables `WP_DEBUG` for development environments (Dev and Multidevs), while disabling it on production environments (Test and Live):
 
 ```php:title=wp-config.php
-if ( ! defined( 'WP_DEBUG' ) ) {
-    define('WP_DEBUG', (wp_get_environment_type() == "development"));
+/**
+ * WordPress debugging mode.
+ *
+ * Sets WP_DEBUG to true on if on a development environment.
+ *
+ */
+if (!defined('WP_DEBUG') && isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    if(in_array( $_ENV['PANTHEON_ENVIRONMENT'], array('test', 'live'))) {
+      define('WP_DEBUG', false);
+    } else {
+      define( 'WP_DEBUG', true );
+    }
 }
 ```
 

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -20,12 +20,6 @@ If they are added above the `require_once ABSPATH . 'wp-settings.php';` statemen
 
 If they are added below the `require_once ABSPATH . 'wp-settings.php';` statement, then the entirety of WordPress has already been loaded and the actions / filters won't be applied, or would be applied last.
 
-### Use wp_get_environment_type for Environment-specific Actions
-
-<Partial file="wp_get_environment_type.md" />
-
-An MU-plugin can be instructed to run or perform environment-specific actions. Use `wp_get_environment_type` to look up the current environment in a platform-neutral way.
-
 ## Create Your MU Plugin
 1. Create a PHP file (i.e. `your-file.php`) in the `mu-plugins` folder (`code/wp-content/mu-plugins/your-file.php`).
 1. Provide the plugin details for its name, description, etc.:
@@ -116,6 +110,12 @@ An MU-plugin can be instructed to run or perform environment-specific actions. U
   }
   // End of File
   ```
+
+### Use wp_get_environment_type for Environment-specific Actions
+
+<Partial file="wp_get_environment_type.md" />
+
+An MU-plugin can be instructed to run or perform environment-specific actions. Use `wp_get_environment_type` to look up the current environment in a platform-neutral way.
 
 ## Example Code Snippets
 Listed below are different plugins, themes, or use cases where creating a custom MU plugin with actions and filters resolves the issue they encounter.

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -24,7 +24,7 @@ If they are added below the `require_once ABSPATH . 'wp-settings.php';` statemen
 
 <Partial file="wp_get_environment_type.md" />
 
-An MU-plugin can be instructed to run or perform environment-specific actions. Use `wp_get_environment_type` to pass the environment to the plugin.
+An MU-plugin can be instructed to run or perform environment-specific actions. Use `wp_get_environment_type` to look up the current environment in a platform-neutral way.
 
 ## Create Your MU Plugin
 1. Create a PHP file (i.e. `your-file.php`) in the `mu-plugins` folder (`code/wp-content/mu-plugins/your-file.php`).

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -9,7 +9,7 @@ tags: [plugins]
 
 For actions or filters you want to run even when a theme's `functions.php` isn't invoked by a request, or before plugins are loaded by WordPress, you can create a [Must-Use (**MU**) Plugin](https://codex.wordpress.org/Must_Use_Plugins).
 
-MU-Plugins are activated by default by adding a PHP file to the `wp-content/mu-plugins` directory. It affects the whole site, including all sites under a WordPress Multisite installation.
+MU-plugins are activated by default by adding a PHP file to the `wp-content/mu-plugins` directory. It affects the whole site, including all sites under a WordPress Multisite installation.
 
 MU-plugins are loaded by PHP in alphabetical order, before normal plugins. This means API hooks added in an MU-plugin apply to all other plugins even if they run hooked-functions in the global namespace.
 
@@ -19,6 +19,12 @@ While you can add code in the `wp-config.php` file for site-wide behavior, actio
 If they are added above the `require_once ABSPATH . 'wp-settings.php';` statement, the WordPress site will get a Fatal PHP error because the `add_action()` and `add_filter()` functions won't be defined yet.
 
 If they are added below the `require_once ABSPATH . 'wp-settings.php';` statement, then the entirety of WordPress has already been loaded and the actions / filters won't be applied, or would be applied last.
+
+### Use wp_get_environment_type for Environment-specific Actions
+
+<Partial file="wp_get_environment_type.md" />
+
+An MU-plugin can be instructed to run or perform environment-specific actions. Use `wp_get_environment_type` to pass the environment to the plugin.
 
 ## Create Your MU Plugin
 1. Create a PHP file (i.e. `your-file.php`) in the `mu-plugins` folder (`code/wp-content/mu-plugins/your-file.php`).

--- a/source/content/wp-config-php.md
+++ b/source/content/wp-config-php.md
@@ -48,13 +48,9 @@ Do not edit `wp-config-pantheon.php`. It includes database and environment confi
 
 ## Environment-specific Configuration
 
-### Use the WP_ENVIRONMENT_TYPE Function to Perform Actions Based on Environment
-
-<Partial file="wp_get_environment_type.md" />
-
 ### Write Logic Based on the Pantheon Server Environment
 
-In addition to `wp_get_environment_type`, you can still use the PHP methods shown here. Depending on your use case, there are two possibilities:
+Depending on your use case, there are two possibilities:
 
 - For web only actions, like [redirects](/domains#primary-domain), check if `$_ENV['PANTHEON_ENVIRONMENT']` exists. If it does, it will contain a string with the current environment (Dev, Test, or Live):
 

--- a/source/partials/wp_get_environment_type.md
+++ b/source/partials/wp_get_environment_type.md
@@ -1,9 +1,0 @@
-WordPress 5.5 [introduced the `wp_get_environment_type` function](https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/). The Platform automatically defines `wp_get_environment_type` based on the environment variables set by the platform.
-
-Note that the environment variables used by WordPress differ from the names used on Pantheon:
-
-| Pantheon Environment | `wp_get_environment_type` |
-|----------------------|---------------------------|
-| dev / Multidev       | development               |
-| test                 | staging                   |
-| live                 | production                |

--- a/source/partials/wp_get_environment_type.md
+++ b/source/partials/wp_get_environment_type.md
@@ -1,0 +1,9 @@
+WordPress 5.5 [introduced the `wp_get_environment_type` function](https://make.wordpress.org/core/2020/07/24/new-wp_get_environment_type-function-in-wordpress-5-5/). The Platform automatically defines `wp_get_environment_type` based on the environment variables set by the platform.
+
+Note that the environment variables used by WordPress differ from the names used on Pantheon:
+
+| Pantheon Environment | `wp_get_environment_type` |
+|----------------------|---------------------------|
+| dev / Multidev       | development               |
+| test                 | staging                   |
+| live                 | production                |


### PR DESCRIPTION
Closes: #5922 

## Summary

(Updating the copy in the status report)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- one commit to remove information about `wp_get_environment_type`
- another commit to put it (and the partial) back into the docs as useful for plugins, themes, or mu-plugins

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
