### PR TITLE
quicksilver scripts run commands in order, waiting for end or timeout

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -47,7 +47,7 @@ Quicksilver scripts that trigger on the deploy hook operate on the state of the 
 
 ## Script Type and Location
 
-Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types.
+Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will be run in order, and only execute the next when the previous has finished or timed out.
 
 We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`).
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -47,7 +47,7 @@ Quicksilver scripts that trigger on the deploy hook operate on the state of the 
 
 ## Script Type and Location
 
-Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will be run in order, and only execute the next when the previous has finished or timed out.
+Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will run in order, and only execute the next when the previous has finished or timed out.
 
 We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`).
 


### PR DESCRIPTION
## Summary

**[Quicksilver](https://pantheon.io/docs/quicksilver#script-type-and-location)** - Quicksilver scripts run commands in order, waiting for each to finish or timeout before continuing. [PR 5930](https://github.com/pantheon-systems/documentation/pull/5930)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [x] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
