### PR TITLE
Adjust H3 weight

### DIFF
--- a/source/docs/assets/css/main.css
+++ b/source/docs/assets/css/main.css
@@ -148,9 +148,8 @@ h3 {
 h4 {
   margin-top: 25px;
   font-family: 'Open Sans', sans-serif;
-  color: #8f9192;
+  color: #747676;
   font-size: 22px;
-  font-weight: bold;
 }
 h3.changelog {
   font-family: 'Open Sans', sans-serif;
@@ -210,7 +209,7 @@ hr {
 .article-subhead {
   font-family: 'Open Sans', sans-serif;
   font-size: 25px;
-  color: #8f9192;
+  color: #747676;
   line-height: 24px;
   letter-spacing: -0.2px;
   line-height: 1.5em;

--- a/source/partials/notes/partial-composer-adoption-warning.md
+++ b/source/partials/notes/partial-composer-adoption-warning.md
@@ -1,6 +1,5 @@
-<div class="alert alert-danger">
-<h4 class="info">Warning</h4>
+<alert type="danger" title="Warning">
 
 Partial Composer adoption for Drupal 8 sites is not supported since Composer is used by core, meaning any change to `composer.json` or the `vendor` directory would result in massive merge conflicts when trying to update core via one-click updates in the Pantheon Site Dashboard. Composer with Drupal 8 is an all or nothing proposition. To use Composer to manage Drupal 8 sites, use the [Build Tools](/guides/build-tools) or [Drupal 8 and Composer on Pantheon Without Continuous Integration](/guides/drupal-8-composer-no-ci) methods.
 
-</div>
+</alert>

--- a/src/components/headerBody/style.css
+++ b/src/components/headerBody/style.css
@@ -7,7 +7,7 @@
 .article-subhead {
   font-family: "Open Sans", sans-serif;
   font-size: 25px;
-  color: #747676
+  color: #747676;
   line-height: 24px;
   letter-spacing: -0.2px;
   line-height: 1.5em;

--- a/src/components/headerBody/style.css
+++ b/src/components/headerBody/style.css
@@ -7,7 +7,7 @@
 .article-subhead {
   font-family: "Open Sans", sans-serif;
   font-size: 25px;
-  color: #8f9192;
+  color: #747676
   line-height: 24px;
   letter-spacing: -0.2px;
   line-height: 1.5em;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -90,7 +90,6 @@ pre code {
 	font-family: "Open Sans", sans-serif;
 	color: #8f9192;
 	font-size: 22px;
-	font-weight: bold;
 }
 .pantheon-docs h3.changelog {
 	font-family: "Open Sans", sans-serif;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -84,7 +84,6 @@ pre code {
 	font-family: Tablet Gothic,Frutiger,Frutiger Linotype,Univers,HelveticaNeue-Light,Helvetica Neue Light,Helvetica Neue,Helvetica,Arial,Lucida Grande,sans-serif;
 	color: #424749;
 	font-size: 25px;
-	font-weight: bold;
 }
 .pantheon-docs h4 {
 	margin-top: 25px;

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -88,7 +88,7 @@ pre code {
 .pantheon-docs h4 {
 	margin-top: 25px;
 	font-family: "Open Sans", sans-serif;
-	color: #8f9192;
+	color: #747676;
 	font-size: 22px;
 }
 .pantheon-docs h3.changelog {


### PR DESCRIPTION
## Summary

**Site Stack** - Removes the font-weight override from Docs H3 tags, so they are not greater than H2s. [PR 5933](https://github.com/pantheon-systems/documentation/pull/5933).

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
