### PR TITLE
Added sample code to make the WP CFM work in multidev

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           deployment-path: docs
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
-          gatsby-cache-version: "v1.5"
+          gatsby-cache-version: "v1.6"
           pre-steps:
             - checkout
             - run:

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -276,6 +276,23 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 }
 ```
 
+### WP CFM Compatibility
+
+WP CFM works on multidev but a Must Use plugin needs to be setuped with this sample code.
+
+```php
+add_filter( 'wpcfm_multi_env', function( $pantheon_envs ) {
+	if ( !( in_array( PANTHEON_ENVIRONMENT, $pantheon_envs ) ) ) {
+		$pantheon_envs[] = PANTHEON_ENVIRONMENT;
+	}
+return $pantheon_envs;
+} );
+
+add_filter( 'wpcfm_current_env', function( $pantheon_env ) {
+    return PANTHEON_ENVIRONMENT;
+} );
+```
+
 ### WP REST API (`wp-json`) Endpoints Cache
 
 For WP REST API endpoints, we can use the `rest_post_dispatch` filter and create a specific function to apply specific headers for each path or endpoint.

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -276,15 +276,15 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 }
 ```
 
-### WP CFM Compatibility
+### WP-CFM Compatibility
 
-WP CFM works on multidev but a Must Use plugin needs to be setuped with this sample code.
+[WP-CFM](https://wordpress.org/plugins/wp-cfm/) can work with [Multidev](/multidev) environments, but a Must Use plugin needs to be configured:
 
 ```php
 add_filter( 'wpcfm_multi_env', function( $pantheon_envs ) {
-	if ( !( in_array( PANTHEON_ENVIRONMENT, $pantheon_envs ) ) ) {
-		$pantheon_envs[] = PANTHEON_ENVIRONMENT;
-	}
+  if ( !( in_array( PANTHEON_ENVIRONMENT, $pantheon_envs ) ) ) {
+    $pantheon_envs[] = PANTHEON_ENVIRONMENT;
+  }
 return $pantheon_envs;
 } );
 

--- a/source/content/wp-cfm.md
+++ b/source/content/wp-cfm.md
@@ -146,8 +146,9 @@ You can review values on the [All Settings Screen](https://codex.wordpress.org/O
 
 If you want to track configurations in more tables, you must do so using the `wpcfm_configuration_items` hook. For details, see [WP-CFM documentation](https://forumone.github.io/wp-cfm/).
 
-### Will this work in multidev?
-Yes, for the multidev to appear as the choices, you will need hook into the plugin's `wpcfm_current_env` and set it up as a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
+### Will WP-CFM work with Multidev?
+
+Yes. For the Multidev to appear as a config option, you will need hook into the plugin's `wpcfm_current_env` and set it up as a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
 
 ### What's not tracked?
 

--- a/source/content/wp-cfm.md
+++ b/source/content/wp-cfm.md
@@ -146,6 +146,9 @@ You can review values on the [All Settings Screen](https://codex.wordpress.org/O
 
 If you want to track configurations in more tables, you must do so using the `wpcfm_configuration_items` hook. For details, see [WP-CFM documentation](https://forumone.github.io/wp-cfm/).
 
+### Will this work in multidev?
+Yes, for the multidev to appear as the choices, you will need hook into the plugin's `wpcfm_current_env` and set it up as a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
+
 ### What's not tracked?
 
 Site content, posts, users, taxonomy, etc. Review all queries for a page request using the Queries tab of the [Debug Bar](https://wordpress.org/plugins/debug-bar/) plugin to help identify more settings you want to track. This plugin requires that you enable [debugging via `wp-config.php`](/wp-config-php/#frequently-asked-questions).

--- a/source/content/wp-cfm.md
+++ b/source/content/wp-cfm.md
@@ -148,7 +148,7 @@ If you want to track configurations in more tables, you must do so using the `wp
 
 ### Will WP-CFM work with Multidev?
 
-Yes. For the Multidev to appear as a config option, you will need hook into the plugin's [`wpcfm_current_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_current_env) and [`wpcfm_multi_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_multi_env) functions, in a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
+Yes. For the Multidev to appear as a config option, you will need hook into the plugin's [`wpcfm_multi_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_multi_env) and [`wpcfm_current_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_current_env) functions in a Must Use Plugin like the example in [Create a WordPress MU-Plugin for Actions and Filters](/mu-plugin/#wp-cfm-compatibility).
 
 ### What's not tracked?
 

--- a/source/content/wp-cfm.md
+++ b/source/content/wp-cfm.md
@@ -148,7 +148,7 @@ If you want to track configurations in more tables, you must do so using the `wp
 
 ### Will WP-CFM work with Multidev?
 
-Yes. For the Multidev to appear as a config option, you will need hook into the plugin's `wpcfm_current_env` and set it up as a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
+Yes. For the Multidev to appear as a config option, you will need hook into the plugin's [`wpcfm_current_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_current_env) and [`wpcfm_multi_env`](https://github.com/forumone/wp-cfm/wiki/Filters-Reference#wpcfm_multi_env) functions, in a Must Use Plugin like the examples here setup [MU Plugin Bar](/mu-plugin/#example-code-snippets).
 
 ### What's not tracked?
 


### PR DESCRIPTION
Closes: #5865

## Summary

**[Create a WordPress MU-Plugin for Actions and Filters](https://pantheon.io/docs/mu-plugin#wp-cfm-compatibility)** - Added sample code to enable WP-CFM support for Multidev environments. Referenced and crosslinked in [WordPress Configuration Management (WP-CFM)](https://pantheon.io/docs/wp-cfm#will-wp-cfm-work-with-multidev)


## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
