### PR TITLE
Glossary

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           deployment-path: docs
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
-          gatsby-cache-version: "v1.4.12"
+          gatsby-cache-version: "v1.4.13"
           pre-steps:
             - checkout
             - run:

--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -6,15 +6,19 @@
   "MD029": false,
   "MD033": {
     "allowed_elements": [
-      "Alert",
+      "abbr",
       "Accordion",
+      "Alert",
+      "Check",
       "dd",
       "dl",
+      "DNSProviderDocs",
       "Download",
       "DrushChangelog",
       "dt",
       "Enablement",
       "ExternalLink",
+      "Icon",
       "LocaldevChangelog",
       "Partial",
       "Partial",
@@ -23,11 +27,7 @@
       "Span",
       "Tab",
       "TabList",
-      "DNSProviderDocs",
-      "Check",
-      "abbr",
-      "Youtube",
-      "Icon"
+      "Youtube"
     ]
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -19902,16 +19902,26 @@
       "integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A=="
     },
     "html-to-react": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.2.tgz",
-      "integrity": "sha512-TdTfxd95sRCo6QL8admCkE7mvNNrXtGoVr1dyS+7uvc8XCqAymnf/6ckclvnVbQNUo2Nh21VPwtfEHd0khiV7g==",
+      "version": "1.4.3",
+      "resolved": "https://registry.npmjs.org/html-to-react/-/html-to-react-1.4.3.tgz",
+      "integrity": "sha512-txe09A3vxW8yEZGJXJ1is5gGDfBEVACmZDSgwDyH5EsfRdOubBwBCg63ZThZP0xBn0UE4FyvMXZXmohusCxDcg==",
       "requires": {
         "domhandler": "^3.0",
-        "htmlparser2": "^4.0",
+        "htmlparser2": "^4.1.0",
         "lodash.camelcase": "^4.3.0",
-        "ramda": "^0.26"
+        "ramda": "^0.27"
       },
       "dependencies": {
+        "dom-serializer": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-1.0.1.tgz",
+          "integrity": "sha512-1Aj1Qy3YLbdslkI75QEOfdp9TkQ3o8LRISAzxOibjBs/xWwr1WxZFOQphFkZuepHFGo+kB8e5FVJSS0faAJ4Rw==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^3.0.0",
+            "entities": "^2.0.0"
+          }
+        },
         "domelementtype": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.0.1.tgz",
@@ -19926,11 +19936,11 @@
           }
         },
         "domutils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.0.0.tgz",
-          "integrity": "sha512-n5SelJ1axbO636c2yUtOGia/IcJtVtlhQbFiVDBZHKV5ReJO1ViX7sFEemtuyoAnBxk5meNSYgA8V4s0271efg==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/domutils/-/domutils-2.2.0.tgz",
+          "integrity": "sha512-0haAxVr1PR0SqYwCH7mxMpHZUwjih9oPPedqpR/KufsnxPyZ9dyVw1R5093qnJF3WXSbjBkdzRWLw/knJV/fAg==",
           "requires": {
-            "dom-serializer": "^0.2.1",
+            "dom-serializer": "^1.0.1",
             "domelementtype": "^2.0.1",
             "domhandler": "^3.0.0"
           }
@@ -26834,9 +26844,9 @@
       "integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA=="
     },
     "ramda": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.26.1.tgz",
-      "integrity": "sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ=="
+      "version": "0.27.1",
+      "resolved": "https://registry.npmjs.org/ramda/-/ramda-0.27.1.tgz",
+      "integrity": "sha512-PgIdVpn5y5Yns8vqb8FzBUEYn98V3xcPgawAkkgj0YJ0qDsnHCiNmZYfOGMgOvoB0eWFLpYbhxUR3mxfDIMvpw=="
     },
     "randombytes": {
       "version": "2.1.0",

--- a/source/content/code.md
+++ b/source/content/code.md
@@ -89,9 +89,20 @@ The Dev environment provides [one-click updates](/core-updates) for your site's 
 
   <dl>
   <dt>Upstream</dt>
-  <dd>A code repository that serves as a common package for your web application.</dd>
+
+  <dd>
+  
+  A code repository that serves as a common package for your web application.
+  
+  </dd>
+  
   <dt>Repository</dt>
-  <dd>Centralized location of code intended for distribution.</dd>
+
+  <dd>
+  
+  Centralized location of code intended for distribution.
+  </dd>
+  
   </dl>
 
 <Alert title="Note" type="info">

--- a/source/content/guides/frontend-performance.md
+++ b/source/content/guides/frontend-performance.md
@@ -97,16 +97,28 @@ Pantheon is designed to store cached copies of the full HTML pages coming out of
 The following describes the expected cache behavior for sites running the Pantheon Advanced Page Cache [WordPress plugin](https://wordpress.org/plugins/pantheon-advanced-page-cache/) or [Drupal module](https://www.drupal.org/project/pantheon_advanced_page_cache). If you find that your page is not served from cache with similar headers and values, examine the response using Google's Developer tools and consult the next section for common cache busters and potential culprits.
 
 <dt>age</dt>
-<dd >The number of seconds cache has been available to serve the request. Any number greater than zero indicates that this response was served to the browser from cache.</dd>
-<br />
+
+<dd>
+
+The number of seconds cache has been available to serve the request. Any number greater than zero indicates that this response was served to the browser from cache.
+
+</dd>
+
 <dt>cache-control</dt>
-<dd >This header should include a `max-age` that is the maximum number of seconds that the cache can be kept.</dd>
-<br />
+
+<dd>
+
+This header should include a `max-age` that is the maximum number of seconds that the cache can be kept.
+
+</dd>
+
 <dt>surrogate-key-raw</dt>
-<dd>Metadata including the the content IDs for what was displayed on this page. This metadata instructs this page to be cleared from cache when any of those posts are saved again. This header is only present when you specifically add a debugging header (`Pantheon-Debug:1`) to your request. You can use a browser extension to add the debugging header (here are some extensions for [Chrome](https://chrome.google.com/webstore/search/modify%20header) and [Firefox](https://addons.mozilla.org/en-US/firefox/search/?q=modify+header)).</dd>
-<br />
+
+surrogate-key-raw<dd>Metadata including the the content IDs for what was displayed on this page. This metadata instructs this page to be cleared from cache when any of those posts are saved again. This header is only present when you specifically add a debugging header (`Pantheon-Debug:1`) to your request. You can use a browser extension to add the debugging header (here are some extensions for [Chrome](https://chrome.google.com/webstore/search/modify%20header) and [Firefox](https://addons.mozilla.org/en-US/firefox/search/?q=modify+header)).</dd>
+
 <dt>x-served-by</dt>
-<dd>This header indicates which POP your response came from. Our primary infrastructure is in the Midwest of the United States so the first item you will probably see on this list will include "ORD" for the O'Hare airport in Chicago. If you're physically located in Austin you will also see DFW, indicating the response went from the primary datacenter to a cached copy in Chicago to a cached copy in Dallas.</dd>
+
+x-served-by<dd>This header indicates which POP your response came from. Our primary infrastructure is in the Midwest of the United States so the first item you will probably see on this list will include "ORD" for the O'Hare airport in Chicago. If you're physically located in Austin you will also see DFW, indicating the response went from the primary datacenter to a cached copy in Chicago to a cached copy in Dallas.</dd>
 
 ![Chrome network headers](../../images/guides/front-end-performance/chrome-network-headers.png)
 

--- a/source/content/guides/wordpress-google-sso/01-introduction.md
+++ b/source/content/guides/wordpress-google-sso/01-introduction.md
@@ -26,12 +26,23 @@ This guide will help you install the WP SAML Auth plugin, create a SAML App with
 - As you work through this process, there are two key SAML authentication terms to keep in mind:
 
   <dl title="SAML Providers">
+
   <dt>Identity Provider</dt>
 
-  <dd>Where user information is housed (e.g. Google Apps).</dd>
+  <dd>
+
+  In SAML architecture, the <abbr title="Identity Provider">IP</abbr> is where user information is housed (e.g. Google Apps).
+
+  </dd>
+
   <dt>Service Provider</dt>
 
-  <dd>Application depending on user information provided by the Identity Provider (e.g. WordPress).</dd>
+  <dd>
+
+  Application depending on user information provided by the Identity Provider (e.g. WordPress).
+
+  </dd>
+
   </dl>
 
 You’ll see these in reference documentation, so it’s important to keep them straight so you know what configuration goes where.

--- a/source/content/guides/wordpress-google-sso/01-introduction.md
+++ b/source/content/guides/wordpress-google-sso/01-introduction.md
@@ -27,8 +27,10 @@ This guide will help you install the WP SAML Auth plugin, create a SAML App with
 
   <dl title="SAML Providers">
   <dt>Identity Provider</dt>
+
   <dd>Where user information is housed (e.g. Google Apps).</dd>
   <dt>Service Provider</dt>
+
   <dd>Application depending on user information provided by the Identity Provider (e.g. WordPress).</dd>
   </dl>
 

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -57,37 +57,29 @@ contributors: [alexfornuto, rachelwhitton]
 
 <dl>
 
-<dt><code>title</code></dt>
-<dd>The title of the content.</dd>
+<dt><code>title</code></dt><dd>The title of the content.</dd>
 
-<dt><code>description</code></dt>
-<dd>A brief description displayed under the title.</dd>
+<dt><code>description</code></dt><dd>A brief description displayed under the title.</dd>
 
-<dt><code>contributors</code></dt>
-<dd>
+<dt><code>contributors</code></dt><dd>
 
 An array of IDs for contributors to the content. The ID must correspond to an entry in [contributor.yaml](https://github.com/pantheon-systems/documentation/blob/main/source/data/contributor.yaml).
 
 </dd>
 
-<dt><code>reviewed</code></dt>
-<dd>The last date when the content was updated or reviewed for accuracy.</dd>
+<dt><code>reviewed</code></dt><dd>The last date when the content was updated or reviewed for accuracy.</dd>
 
-<dt><code>tags</code></dt>
-<dd>An array of tags used by our search engine to quickly identify the primary topics found in the content.</dd>
+<dt><code>tags</code></dt><dd>An array of tags used by our search engine to quickly identify the primary topics found in the content.</dd>
 
-<dt><code>category</code></dt>
-<dd>A value corresponding to the content's position in the site architecture and (sometimes) corresponding category landing page.</dd>
+<dt><code>category</code></dt><dd>A value corresponding to the content's position in the site architecture and (sometimes) corresponding category landing page.</dd>
 
-<dt><code>type</code></dt>
-<dd>
+<dt><code>type</code></dt><dd>
 
 The content type for this content. Defaults to `doc`, overwritten for other content types like `guide`, `video`, or `resource`.
 
 </dd>
 
-<dt><code>subtitle</code></dt>
-<dd>Used in multipage guides to define a title for that page of the guide.</dd>
+<dt><code>subtitle</code></dt><dd>Used in multipage guides to define a title for that page of the guide.</dd>
 
 </dl>
 
@@ -207,10 +199,8 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 <Example>
 
 <dl>
-<dt>Term</dt>
-<dd>Definition.</dd>
-<dt>Another Term</dt>
-<dd>Description of the new term.</dd>
+<dt>Term</dt><dd>Definition.</dd>
+<dt>Another Term</dt><dd>Description of the new term.</dd>
 </dl>
 
 <hr className="source-code" /> <br/>

--- a/source/content/terminus/examples.md
+++ b/source/content/terminus/examples.md
@@ -54,7 +54,6 @@ Human readable, such as "Your Awesome Site", entered during site creation and di
 
 </dd>
 
-
 <dt>Site Name</dt>
 
 <dd>
@@ -63,7 +62,6 @@ Machine readable, such as "your-awesome-site", either derived automatically by t
 
 </dd>
 
-
 <dt>Environment Name</dt>
 
 <dd>
@@ -71,7 +69,6 @@ Machine readable, such as "your-awesome-site", either derived automatically by t
 Machine readable, such as "dev", "test", "live", or "bug123", which refers to the target site environment on Pantheon.
 
 </dd>
-
 
 </dl>
 

--- a/source/style-guide.md
+++ b/source/style-guide.md
@@ -140,18 +140,18 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 ### Definition List
 <div class="style-example" >
 <dl>
-<dt>Term</dt>
-<dd>Definition.</dd>
-<dt>Another Term</dt>
-<dd>Description of the new term.</dd>
+<dt>Term</dt><dd>Definition.</dd>
+<dt>Another Term</dt><dd>Description of the new term.</dd>
 </dl>
 <hr class="source-code">
 ```html
 <dl>
   <dt>Term</dt>
-    <dd>Definition.</dd>
+
+  <dd>Definition.</dd>
   <dt>Another Term</dt>
-    <dd>Description of the new term.</dd>
+
+  <dd>Description of the new term.</dd>
 </dl>
 ```
 </div>

--- a/src/components/toc/index.js
+++ b/src/components/toc/index.js
@@ -30,7 +30,7 @@ const TOC = ({ title }) => {
 
   return (
     <nav aria-labelledby="toc-nav" className="pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top">
-    <div id="toc" className="tocbot">
+    <div key={title} id="toc" className="tocbot">
       <h4 id="toc-nav">{title || "Table of Contents"}</h4>
       <div className="toc-placeholder" />
     </div>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -88,7 +88,7 @@ class Glossary extends React.Component {
                         <>
                           <section key={title}>
                             <hr />
-                            <h3 id={title.replaceAll(" ", "-").toLowerCase()}><dt key={`${title}-term`}>
+                            <h3 id={title.toLowerCase()}><dt key={`${title}-term`}>
                               {title.charAt(0).toUpperCase() + title.slice(1)}
                             </dt></h3>
                             <dd key={`${title}-definition`}>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -20,106 +20,107 @@ const previewFlexPanelItem = {
 class Glossary extends React.Component {
 
   render () {
-  let allDefs = []
+    let allDefs = []
 
-  const bodies = this.props.data.bodies
+    const bodies = this.props.data.bodies
 
-  console.log("Bodies: ", bodies) // For Debugging
+    //console.log("Bodies: ", bodies) // For Debugging
 
-  bodies.edges.map(({ node }) => {
-  
-    const matches = node.fileInfo.childMdx.rawBody.match(
-      /<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim
-    )
-    //console.log("Match Title: ", node.frontmatter.title) // For Debugging
-    //console.log("match: ", matches) // For Debugging
-    if (matches && matches.length) {
-      matches.forEach(term => {
-        allDefs.push({
-          from: node.frontmatter.title,
-          slug: node.fields.slug,
-          title: term.match(/<dt>(.*?)<\/dt>/)[1],
-          definition: term.match(/<dd>\n\n(.*?)\n\n<\/dd>/)[1],
-          letter: term.match(/<dt>(.*?)<\/dt>/)[1][0].toUpperCase()
+    bodies.edges.map(({ node }) => {
+
+      const matches = node.fileInfo.childMdx.rawBody.match(
+        /<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim
+      )
+      //console.log("Match Title: ", node.frontmatter.title) // For Debugging
+      //console.log("match: ", matches) // For Debugging
+      if (matches && matches.length) {
+        matches.forEach(term => {
+          allDefs.push({
+            from: node.frontmatter.title,
+            slug: node.fields.slug,
+            title: term.match(/<dt>(.*?)<\/dt>/)[1],
+            definition: term.match(/<dd>\n\n(.*?)\n\n<\/dd>/)[1],
+            letter: term.match(/<dt>(.*?)<\/dt>/)[1][0].toUpperCase()
+          })
         })
-      })
-    }
-  })
+      }
+    })
 
-  allDefs.sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase()) ? 1 : -1)
-  allDefs.sort(function(a, b) {
-    return a.title[0].localeCompare(b.title[0]);
-  });
+    allDefs.sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase()) ? 1 : -1)
+    allDefs.sort(function(a, b) {
+      return a.title[0].localeCompare(b.title[0]);
+    });
 
-  console.log("AllDefs: ", allDefs) // For debugging
+    console.log("AllDefs: ", allDefs) // For debugging
 
-  const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
+    const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
-  return (
-    <>
-      <Layout>
-        <SEO
-          title="Glossary"
-          description="A collection of terms and definitions through Pantheon's Documentation"
-        />
-        <main id="doc">
-          <div className="container doc-content-well">
-            <article className="doc article col-md-9 md-70">
-              <HeaderBody
-                title="Glossary"
-                description="A collection of terms and definitions through Pantheon's Documentation"
-              />
-              <div style={{ marginTop: "15px", marginBottom: "45px" }}>
-                This page dynamically displays all defined terms in the Pantheon Documentation project.
+    return (
+      <>
+        <Layout>
+          <SEO
+            title="Glossary"
+            description="A collection of terms and definitions through Pantheon's Documentation"
+          />
+          <main id="doc">
+            <div className="container doc-content-well">
+              <article className="doc article col-md-9 md-70">
+                <HeaderBody
+                  title="Glossary"
+                  description="A collection of terms and definitions through Pantheon's Documentation"
+                />
+                <div style={{ marginTop: "15px", marginBottom: "45px" }}>
+                  This page dynamically displays all defined terms in the Pantheon Documentation project.
 
-                {letters.map( index =>(
-                  <>
-                  <h2 key={index} className="tocify-item" id={index.toLowerCase()}>
-                    {index}
-                  </h2>
+                  {letters.map( index =>(
+                    <>
+                    <h2 key={index} className="tocify-item" id={index.toLowerCase()}>
+                      {index}
+                    </h2>
 
-                  {allDefs
-                    .filter(def => {
-                      return (
-                        def.letter.toUpperCase() === index.toUpperCase()
-                      )
-                    })
-                    .map(({ from, slug, title, definition}) => (                 
-                      <>
-                        <section key={title}>
-                          <hr />
-                          <h3 id={title.replaceAll(" ", "-").toLowerCase()}><dt key={`${title}-term`}>
-                            {title.charAt(0).toUpperCase() + title.slice(1)}
-                          </dt></h3>
-                          <dd key={`${title}-definition`}>
-                            <ReactMarkdown skipHtml={true} source={definition} />
-                          </dd>
+                    {allDefs
+                      .filter(def => {
+                        return (
+                          def.letter.toUpperCase() === index.toUpperCase()
+                        )
+                      })
+                      .map(({ from, slug, title, definition}) => (
+                        <>
+                          <section key={title}>
+                            <hr />
+                            <h3 id={title.replaceAll(" ", "-").toLowerCase()}><dt key={`${title}-term`}>
+                              {title.charAt(0).toUpperCase() + title.slice(1)}
+                            </dt></h3>
+                            <dd key={`${title}-definition`}>
+                              <ReactMarkdown skipHtml={true} source={definition} />
+                            </dd>
 
-                          {from.length > 0 ? (
-                            <>
-                              <br />
-                              Excerpt from:{" "}
-                              <Link key={`${title}-reference`} to={`/${slug}`}>
-                                {from}
-                              </Link>
-                            </>
-                          ) : null}
-
-                          <br />
-                        </section>
-                      </>
+                            {from.length > 0 ? (
+                              <>
+                                <br />
+                                Excerpt from:{" "}
+                                <Link key={`${title}-reference`} to={`/${slug}`}>
+                                  {from}
+                                </Link>
+                              </>
+                            ) : null}
+                            <br />
+                          </section>
+                        </>
+                      ))
+                    }
+                    </>
                   ))}
-                  </>
-                ))}
-              </div>
-            </article>
-            <TOC title="Contents" />
-          </div>
-        </main>
-      </Layout>
-    </>
-  )
-}}
+                </div>
+              </article>
+              <TOC title="Contents" />
+            </div>
+          </main>
+        </Layout>
+      </>
+    )
+  }
+}
 
 export default Glossary
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -24,6 +24,8 @@ class Glossary extends React.Component {
 
   const bodies = this.props.data.bodies
 
+  console.log("Bodies: ", bodies) // For Debugging
+
   bodies.edges.map(({ node }) => {
   
     const matches = node.fileInfo.childMdx.rawBody.match(
@@ -48,7 +50,9 @@ class Glossary extends React.Component {
   allDefs.sort(function(a, b) {
     return a.title[0].localeCompare(b.title[0]);
   });
-  console.log("AllDefs: ", JSON.stringify(allDefs, null, 2))
+
+  console.log("AllDefs: ", allDefs) // For debugging
+
   const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
   return (

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -48,7 +48,7 @@ class Glossary extends React.Component {
   allDefs.sort(function(a, b) {
     return a.title[0].localeCompare(b.title[0]);
   });
-  console.log("AllDefs: ", allDefs)
+  console.log("AllDefs: ", JSON.stringify(allDefs, null, 2))
   const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
   return (
@@ -88,7 +88,7 @@ class Glossary extends React.Component {
                             {title.charAt(0).toUpperCase() + title.slice(1)}
                           </dt></h3>
                           <dd key={`${title}-definition`}>
-                            {definition}
+                            <ReactMarkdown skipHtml={true} source={definition} />
                           </dd>
 
                           {from.length > 0 ? (

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -1,0 +1,112 @@
+import React from "react"
+import { Link, graphql } from "gatsby"
+import Layout from "../layout/layout"
+import SEO from "../layout/seo"
+import ReactMarkdown from "react-markdown"
+import TOC from "../components/toc"
+import HeaderBody from "../components/headerBody"
+
+{
+  /* @TODO Convert to a React Component */
+}
+const previewFlexPanelItem = {
+  flex: "1 46%",
+  margin: "0px 0px 15px 15px",
+  color: "#333",
+}
+
+
+
+
+const Glossary = ({data: {bodies}}) => {
+
+  let allDefs = [];
+
+
+  bodies.edges.map(({node}) => {
+    //const allDefs = node.fileInfo.childMdx.rawBody.match(/(<dt>.+?<\/dt>)\n\n(<dd>.+?<\/dd>)/gim)
+    const matches = node.fileInfo.childMdx.rawBody.match(/<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim)
+    console.log("Match Title: ", node.frontmatter.title)
+    console.log("match: ", matches)
+    if (matches && matches.length) {
+      matches.forEach(term => {
+        allDefs.push({
+          from: node.frontmatter.title,
+          slug: node.fields.slug,
+          title: term.match(/<dt>(.*?)<\/dt>/)[1],
+          definition: term.match(/<dd>\n\n(.*?)\n\n<\/dd>/)[1],
+        });
+      })
+    }
+  })
+  
+  return (
+    <>
+      <Layout>
+        <SEO
+          title="Glossary"
+          description="A collection of terms and definitions through Pantheon's Documentation"
+        />
+        <main id="doc">
+          <div className="container doc-content-well">
+            <article className="doc article col-md-9 md-70">
+              <HeaderBody
+                title="Glossary"
+                description="A collection of terms and definitions through Pantheon's Documentation"
+              />
+              <div style={{ marginTop: "15px", marginBottom: "45px" }}>
+                  {allDefs.map(({from, slug, title, definition}) => 
+
+                    <>
+
+                    <p id={title}>
+
+                      <dt><h2>{title}</h2></dt>
+
+                      <dd>
+                      <ReactMarkdown source={definition} />
+                      </dd>
+
+                      <br />
+
+                      Excerpt from: <Link to={slug}>{from}</Link>
+
+                    <br />
+
+                    </p>
+                    </>
+                    )}
+              </div>
+            </article>
+            <TOC title="Contents" />
+          </div>
+        </main>
+      </Layout>
+    </>
+  );
+};
+
+
+export default Glossary
+
+export const pageQuery = graphql`
+  {
+    bodies: allMdx(filter: {frontmatter: {changelog: {ne: true}, title: {ne: ""}}, fileInfo: {childMdx: {rawBody: {regex: "/<dt>/"}}}}) {
+      edges {
+        node {
+          fields {
+            slug
+          }
+          frontmatter {
+            title
+          }
+          fileInfo {
+            childMdx {
+              rawBody
+            }
+          }
+        }
+      }
+    }
+  }
+`

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -17,7 +17,7 @@ const previewFlexPanelItem = {
   color: "#333",
 }
 
-class Glossary  extends React.Component {
+class Glossary extends React.Component {
 
   render () {
   let allDefs = []
@@ -25,7 +25,7 @@ class Glossary  extends React.Component {
   const bodies = this.props.data.bodies
 
   bodies.edges.map(({ node }) => {
-    //const allDefs = node.fileInfo.childMdx.rawBody.match(/(<dt>.+?<\/dt>)\n\n(<dd>.+?<\/dd>)/gim)
+  
     const matches = node.fileInfo.childMdx.rawBody.match(
       /<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim
     )
@@ -48,7 +48,7 @@ class Glossary  extends React.Component {
   allDefs.sort(function(a, b) {
     return a.title[0].localeCompare(b.title[0]);
   });
-
+  console.log("AllDefs: ", allDefs)
   const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]
 
   return (
@@ -88,7 +88,7 @@ class Glossary  extends React.Component {
                             {title.charAt(0).toUpperCase() + title.slice(1)}
                           </dt></h3>
                           <dd key={`${title}-definition`}>
-                            <ReactMarkdown skipHtml="true" source={definition} />
+                            {definition}
                           </dd>
 
                           {from.length > 0 ? (

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -70,7 +70,7 @@ class Glossary  extends React.Component {
 
                 {letters.map( index =>(
                   <>
-                  <h2 key={index}>
+                  <h2 key={index} className="tocify-item" id={index.toLowerCase()}>
                     {index}
                   </h2>
 
@@ -84,7 +84,7 @@ class Glossary  extends React.Component {
                       <>
                         <section key={title}>
                           <hr />
-                          <h3><dt key={`${title}-term`}>
+                          <h3 id={title.replaceAll(" ", "-").toLowerCase()}><dt key={`${title}-term`}>
                             {title}
                           </dt></h3>
                           <dd key={`${title}-definition`}>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -1,10 +1,12 @@
-import React from "react"
 import { Link, graphql } from "gatsby"
-import Layout from "../layout/layout"
-import SEO from "../layout/seo"
-import ReactMarkdown from "react-markdown"
-import TOC from "../components/toc"
+
 import HeaderBody from "../components/headerBody"
+import Layout from "../layout/layout"
+import Popover from "../components/popover"
+import React from "react"
+import ReactMarkdown from "react-markdown"
+import SEO from "../layout/seo"
+import TOC from "../components/toc"
 
 {
   /* @TODO Convert to a React Component */
@@ -82,14 +84,14 @@ const Glossary = ({ data: { bodies } }) => {
                             {title}
                           </dt></h3>
                           <dd key={`${title}-definition`}>
-                            <ReactMarkdown source={definition} />
+                            <ReactMarkdown skipHtml="true" source={definition} />
                           </dd>
 
                           {from.length > 0 ? (
                             <>
                               <br />
                               Excerpt from:{" "}
-                              <Link key={`${title}-reference`} to={slug}>
+                              <Link key={`${title}-reference`} to={`/${slug}`}>
                                 {from}
                               </Link>
                             </>

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -85,7 +85,7 @@ class Glossary  extends React.Component {
                         <section key={title}>
                           <hr />
                           <h3 id={title.replaceAll(" ", "-").toLowerCase()}><dt key={`${title}-term`}>
-                            {title}
+                            {title.charAt(0).toUpperCase() + title.slice(1)}
                           </dt></h3>
                           <dd key={`${title}-definition`}>
                             <ReactMarkdown skipHtml="true" source={definition} />

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -17,8 +17,12 @@ const previewFlexPanelItem = {
   color: "#333",
 }
 
-const Glossary = ({ data: { bodies } }) => {
+class Glossary  extends React.Component {
+
+  render () {
   let allDefs = []
+
+  const bodies = this.props.data.bodies
 
   bodies.edges.map(({ node }) => {
     //const allDefs = node.fileInfo.childMdx.rawBody.match(/(<dt>.+?<\/dt>)\n\n(<dd>.+?<\/dd>)/gim)
@@ -103,9 +107,6 @@ const Glossary = ({ data: { bodies } }) => {
                   ))}
                   </>
                 ))}
-
-
-
               </div>
             </article>
             <TOC title="Contents" />
@@ -114,7 +115,7 @@ const Glossary = ({ data: { bodies } }) => {
       </Layout>
     </>
   )
-}
+}}
 
 export default Glossary
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -22,12 +22,11 @@ const Glossary = ({data: {bodies}}) => {
 
   let allDefs = [];
 
-
   bodies.edges.map(({node}) => {
     //const allDefs = node.fileInfo.childMdx.rawBody.match(/(<dt>.+?<\/dt>)\n\n(<dd>.+?<\/dd>)/gim)
     const matches = node.fileInfo.childMdx.rawBody.match(/<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim)
-    console.log("Match Title: ", node.frontmatter.title)
-    console.log("match: ", matches)
+    //console.log("Match Title: ", node.frontmatter.title) // For Debugging
+    //console.log("match: ", matches) // For Debugging
     if (matches && matches.length) {
       matches.forEach(term => {
         allDefs.push({
@@ -39,7 +38,9 @@ const Glossary = ({data: {bodies}}) => {
       })
     }
   })
-  
+
+  console.log("allDefs:", allDefs) // For Debugging
+
   return (
     <>
       <Layout>
@@ -56,24 +57,22 @@ const Glossary = ({data: {bodies}}) => {
               />
               <div style={{ marginTop: "15px", marginBottom: "45px" }}>
                   {allDefs.map(({from, slug, title, definition}) => 
-
                     <>
-
-                    <p id={title}>
-
-                      <dt><h2>{title}</h2></dt>
-
-                      <dd>
+                    <div key={title}>
+                      <dt key={`${title}-term`}><h2>{title}</h2></dt>
+                      <dd key={`${title}-definition`}>
                       <ReactMarkdown source={definition} />
                       </dd>
-
                       <br />
 
-                      Excerpt from: <Link to={slug}>{from}</Link>
+                      {from.length > 0 ? (
+                      <>Excerpt from: <Link key={`${title}-reference`} to={slug}>{from}</Link></>
+                      ): null
+                      }
 
                     <br />
-
-                    </p>
+                    <hr />
+                    </div>
                     </>
                     )}
               </div>
@@ -91,7 +90,7 @@ export default Glossary
 
 export const pageQuery = graphql`
   {
-    bodies: allMdx(filter: {frontmatter: {changelog: {ne: true}, title: {ne: ""}}, fileInfo: {childMdx: {rawBody: {regex: "/<dt>/"}}}}) {
+    bodies: allMdx(filter: {frontmatter: {changelog: {ne: true}, title: {ne: "Style Guide"}}, fileInfo: {childMdx: {rawBody: {regex: "/<dt>/"}}}}) {
       edges {
         node {
           fields {

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -1,64 +1,62 @@
-import React from "react"
-import { graphql } from "gatsby"
-import { MDXRenderer } from "gatsby-plugin-mdx"
-import { MDXProvider } from "@mdx-js/react"
-
-import Layout from "../layout/layout"
-import HeaderBody from "../components/headerBody"
-
-import Callout from "../components/callout"
-import Alert from "../components/alert"
 import Accordion from "../components/accordion"
-import ExternalLink from "../components/externalLink"
-import Icon from "../components/icon"
-import Popover from "../components/popover"
-import TabList from "../components/tabList"
-import Tab from "../components/tab"
-import TOC from "../components/toc"
-import GetFeedback from "../components/getFeedback"
+import Alert from "../components/alert"
+import Callout from "../components/callout"
 import Card from "../components/card"
 import CardGroup from "../components/cardGroup"
-import SEO from "../layout/seo"
-import Enablement from "../components/enablement"
-import Color from "../components/color.js"
-import Download from "../components/download"
-import Partial from "../components/partial"
-import Image from "../layout/image"
-import ChecklistItem from "../components/checklistItem"
-import Example from "../components/styleExample"
-import LocaldevChangelog from "../components/localdevChangelog"
-import DrushChangelog from "../components/drushChangelog"
-import ReviewDate from "../components/reviewDate"
-import Youtube from "../components/youtube"
-import ResourceSelector from "../components/resourceSelector"
-import DNSProviderDocs from "../components/dns-provider-docs.js"
 import Check from "../components/check.js"
+import ChecklistItem from "../components/checklistItem"
+import Color from "../components/color.js"
+import DNSProviderDocs from "../components/dns-provider-docs.js"
+import Download from "../components/download"
+import DrushChangelog from "../components/drushChangelog"
+import Enablement from "../components/enablement"
+import Example from "../components/styleExample"
+import ExternalLink from "../components/externalLink"
+import GetFeedback from "../components/getFeedback"
+import HeaderBody from "../components/headerBody"
+import Icon from "../components/icon"
+import Image from "../layout/image"
+import Layout from "../layout/layout"
+import LocaldevChangelog from "../components/localdevChangelog"
+import { MDXProvider } from "@mdx-js/react"
+import { MDXRenderer } from "gatsby-plugin-mdx"
+import Partial from "../components/partial"
+import Popover from "../components/popover"
+import React from "react"
+import ResourceSelector from "../components/resourceSelector"
+import ReviewDate from "../components/reviewDate"
+import SEO from "../layout/seo"
+import TOC from "../components/toc"
+import Tab from "../components/tab"
+import TabList from "../components/tabList"
+import Youtube from "../components/youtube"
+import { graphql } from "gatsby"
 
 const shortcodes = {
-  Callout,
-  Alert,
   Accordion,
-  ExternalLink,
-  Icon,
-  Popover,
-  TabList,
-  Tab,
+  Alert,
+  Callout,
   Card,
   CardGroup,
-  Enablement,
-  Color,
-  Download,
-  Partial,
-  ChecklistItem,
-  Image,
-  Example,
-  LocaldevChangelog,
-  DrushChangelog,
-  ReviewDate,
-  Youtube,
-  ResourceSelector,
-  DNSProviderDocs,
   Check,
+  ChecklistItem,
+  Color,
+  DNSProviderDocs,
+  Download,
+  DrushChangelog,
+  Enablement,
+  Example,
+  ExternalLink,
+  Icon,
+  Image,
+  LocaldevChangelog,
+  Partial,
+  Popover,
+  ResourceSelector,
+  ReviewDate,
+  Tab,
+  TabList,
+  Youtube,
 }
 
 class DocTemplate extends React.Component {


### PR DESCRIPTION
Closes: #

## Summary

**[Glossary](https://pantheon.io/docs/glossary)** - Created a dynamic glossary page that pulls all definitions from all docs and partials.

## Remaining Work

- [ ] Expand to include `<dfn>` tags.

## Post Launch

- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
