### PR TITLE
Add New Relaunch Step: Clear Caches

### DIFF
--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -3,6 +3,7 @@ title: Relaunch Existing Pantheon Site
 description: Take a new site live by moving custom domains from one Site Dashboard to another, with minimal HTTPS interruptions.
 categories: [go-live]
 tags: [dns, https, launch, migrate]
+reviewed: "2020-09-08"
 ---
 Sites are considered launched on Pantheon once traffic is routed through custom domain(s). Relaunching a previously launched site is done by rerouting traffic from the existing Site Dashboard to an entirely new Site Dashboard.
 
@@ -15,8 +16,11 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
 ## Prepare for Relaunch
 
 1. Log in to the new Pantheon Site Dashboard as an [Admin, Team Member, or Privileged User](/change-management#roles-and-permissions).
+
 1. Open a second tab for the old Pantheon Site Dashboard.
+
 1. In a third tab, log in to the domain's DNS service provider (e.g., Cloudflare, Amazon Route 53, etc.).
+
 1. Examine existing records pointing to Pantheon.
 
   <Partial file="standard-dns-config.md" />
@@ -49,6 +53,7 @@ The relaunch process applies exclusively to live sites already hosted on Pantheo
   You can also use Google's [web implementation](https://toolbox.googleapps.com/apps/dig/) of dig.
 
 ### Roles & Permissions
+
 The permission to manage billing and plans is granted only to the role of **Site Owner** / **Organization Administrators**. Other roles do not have access as described on this page.
 
 <Alert title="Note" type="info">
@@ -66,6 +71,7 @@ The new Site Plan will be billed immediately.
 For a fast, smooth relaunch, consider having two browser tabs open, one with the old Site Dashboard, and one with the new.
 
 1. In the new Site Dashboard, [upgrade the site from free to a paid plan](/site-plan/#purchase-a-new-plan).
+
 1. In the old Site Dashboard, remove the custom domain affected by the relaunch:
 
   **<span class="glyphicons glyphicons-cardio"></span> Live** > **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS** > **Details** > **Remove Domain**
@@ -83,6 +89,7 @@ For a fast, smooth relaunch, consider having two browser tabs open, one with the
   </Alert>
   
 1. On the live environment of the Dashboard, click the "Clear Caches" button. Do this for first the old site and then the new site.
+
 1. Wait for HTTPS to provision for the newly connected domains:
 
   **<span class="glyphicons glyphicons-cardio"></span> Live** > **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS** > **Details**
@@ -96,19 +103,25 @@ For a fast, smooth relaunch, consider having two browser tabs open, one with the
   <Partial file="standard-dns-config2.md" />
 
 1. Test and confirm that the new site is accessible via the custom domain over HTTPS (e.g., `https://www.example.com/`).
+
 1. Repeat steps 2-6 above for each affected domain. Keep in mind that `www.example.com` and `example.com` are different domains.
+
 1. In the new Site Dashboard, [standardize traffic for the primary domain](/domains/#redirect-to-https-and-the-primary-domain).
+
 1. In the old Site Dashboard, [downgrade the site from a paid plan to Sandbox](/site-plan/#cancel-current-plan).
+
 1. In the old Site Dashboard, [remove the existing card as a payment method for the site](/site-billing/#do-not-bill-this-site-to-a-card). If you're a contract customer, you can skip this step.
 
 ## Frequently Asked Questions
 
 ### Why is this process needed?
+
 If you remove domains from the old site and add them to the new site, HTTPS certificates will not be immediately available for the new site. This can cause security warnings for client browsers, and potentially affect processes that require a secure connection (like commerce transactions).
 
 This procedure temporarily uses the existing HTTPS certificate until the new one is generated and ready for use.
 
 ### Will my site experience downtime?
+
 If you follow the process outlined above, downtime will be minimal and depends on the [TTL](/dns#dns-terminology) configuration.
 
 Once you complete step 2 above, the domain is unreachable until you add it to a new site in step 3. We recommend that you open the new site's Dashboard in another browser tab, then copy and paste the domain name from the old site to the new for a quick transition. You can also use [Terminus](/terminus) to run the two commands in immediate succession.
@@ -118,14 +131,17 @@ To minimize the chance to HTTPS certificate errors, set the TTL as low as possib
 Finally, the relaunch procedure should be done as a single process, as quickly as possible. Once you remove a domain from a site, the existing HTTPS certificate will be removed within a few hours and the new site's HTTPS certificate will be available within an hour. Be ready to update your DNS records as soon as the new certificate is available to minimize the chance of visitors encountering an invalid HTTPS certificate.
 
 ### Why do I need to lower my DNS TTL?
+
 DNS records propagate across many different servers and aren't refreshed until the record on *each server* up the tree expires. This means that a record with a 24 hour TTL can take several days to be updated across DNS servers globally. That's why we recommend lowering the TTL well before a site relaunch.
 
 Best practices during normal operation (e.g. not during a site relaunch) suggest a longer TTL (for example, 86400 seconds, or one day) because a long TTL helps reduce the number of DNS lookups that visitors' browsers need to perform. During a site relaunch, a long TTL can extend the time frame that return visitors are pointed to the old site, while new visitors are pointed to the new site.
 
 ### When do I switch the site from the old site to the new one?
+
 As soon as you complete step 3, visitors to your domain will see the new site. But technically, until step 5 is complete and DNS is fully propagated, your visitors may still see the new site with the old site's HTTPS certificate that will be going offline shortly.
 
 ## See Also
+
 - [Launch Essentials](/guides/launch)
 - [Manage Plans in the Site Dashboard](/site-plan)
 - [Billing in the Site Dashboard](/site-billing)

--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -81,7 +81,8 @@ For a fast, smooth relaunch, consider having two browser tabs open, one with the
   Once you make this change, traffic will be routed to the new site. However, if you do not complete the rest of the steps as outlined here, you may run into cases where the new site has an invalid HTTPS certificate.
 
   </Alert>
-
+  
+1. On the live environment of the Dashboard, click the "Clear Caches" button. Do this for first the old site and then the new site.
 1. Wait for HTTPS to provision for the newly connected domains:
 
   **<span class="glyphicons glyphicons-cardio"></span> Live** > **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS** > **Details**

--- a/source/content/relaunch.md
+++ b/source/content/relaunch.md
@@ -88,7 +88,9 @@ For a fast, smooth relaunch, consider having two browser tabs open, one with the
 
   </Alert>
   
-1. On the live environment of the Dashboard, click the "Clear Caches" button. Do this for first the old site and then the new site.
+1. On the Live environment tab of the Site Dashboard for the old site, click the "Clear Caches" button.
+
+1. Repeat on the Live environment of the new site.
 
 1. Wait for HTTPS to provision for the newly connected domains:
 


### PR DESCRIPTION
## Summary

**[Relaunch Site](https://pantheon.io/docs/relaunch)** - Add a step that instructs visitors to clear the cache of both the old site and the new site after pointing domains.

A customer came into chat with a redirect from their old site still in the CDN cache. We tried clearing the cache numerous times on the new site, but it did not clear. Finally, when the cache was finally cleared on the old site, the old redirect was gone.

So one way to resolve this would be to clear the caches after adding the domains and before the HTTPS certificate is created.

## Effect
The following changes are already committed:

- Added new step for clearing caches.
-

## Remaining Work
The following changes still need to be completed:

- [x] Maybe change it into two steps, one for the old site and one for the new site?

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
