### PR TITLE
small terminal windows cut off upstream ID

### DIFF
--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -57,7 +57,7 @@ Now let's create a new site.
  21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
  ```
 
-- If the the output you see is shorter than 36 characters (including hyphens), enlarge your terminal window and run the command again. Otherwise, you might encounter the following error:
+- If the output you see is shorter than 36 characters (including hyphens), enlarge your terminal window and run the command again. Otherwise, you might encounter the following error:
 
    ```bash
    Could not find an upstream identified by 21e1fada-199c-492b.

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -48,29 +48,41 @@ terminus site:list
 
 ### Create a Brand New Site
 
-Now let's create a new site:
+Now let's create a new site.
 
-```bash{outputLines:2}
-terminus upstream:list | grep "Drupal 7" | grep "core"
-21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
-```
+1. List the available Upstreams:
 
-```bash{outputLines:2-4}
-terminus site:create terminus-cli-create "Terminus CLI Create" 21e1fada-199c-492b-97bd-0b36b53a9da0
-[notice] Creating a new site...
-```
+ ```bash{outputLines:2}
+ terminus upstream:list | grep "Drupal 7" | grep "core"
+ 21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
+ ```
 
-```bash{outputLines:1-8}
-terminus site:list
-+--------------------------+-----------+---------------+--------------------------+
-| Site                     | Framework | Service Level | UUID                     |
-+--------------------------+-----------+---------------+--------------------------+
-| terminus-cli-create      | drupal    | free          | terminus-cli-create      |
-| terminus-create          | drupal8   | free          | terminus-create          |
-| git-import-example       | drupal    | free          | git-import-example       |
-+--------------------------+-----------+---------------+--------------------------+
+- If the the output you see is shorter than 36 characters (including hyphens), enlarge your terminal window and run the command again. Otherwise, you might encounter the following error:
 
-```
+   ```bash
+   Could not find an upstream identified by 21e1fada-199c-492b.
+   ```
+
+1. Create a site using the Upstream:
+
+ ```bash{outputLines:2-4}
+ terminus site:create terminus-cli-create "Terminus CLI Create" 21e1fada-199c-492b-97bd-0b36b53a9da0
+ [notice] Creating a new site...
+ ```
+
+1. See the new site listed:
+
+ ```bash{outputLines:1-8}
+ terminus site:list
+ +--------------------------+-----------+---------------+--------------------------+
+ | Site                     | Framework | Service Level | UUID                     |
+ +--------------------------+-----------+---------------+--------------------------+
+ | terminus-cli-create      | drupal    | free          | terminus-cli-create      |
+ | terminus-create          | drupal8   | free          | terminus-create          |
+ | git-import-example       | drupal    | free          | git-import-example       |
+ +--------------------------+-----------+---------------+--------------------------+
+
+ ```
 
 ### Update the Code
 Now that the site is created, the next step is to run a Drush install command to get a fully functional Drupal site ready  for development. Terminus will run most available Drush commands by simply adding the word "drush" to the command directly afterward, along with the site's Pantheon machine name.

--- a/source/content/guides/terminus-drupal-site-management.md
+++ b/source/content/guides/terminus-drupal-site-management.md
@@ -54,25 +54,25 @@ Now let's create a new site.
 
  ```bash{outputLines:2}
  terminus upstream:list | grep "Drupal 7" | grep "core"
- 21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                                                                  vanilla      core          drupal
+ 21e1fada-199c-492b-97bd-0b36b53a9da0   Drupal 7                               drupal7                                         core     drupal
  ```
 
-- If the output you see is shorter than 36 characters (including hyphens), enlarge your terminal window and run the command again. Otherwise, you might encounter the following error:
+   - If the Upstream ID in the output you receive is shorter than 36 characters (including hyphens), enlarge your terminal window and run the command again. Otherwise, you might encounter an error similar to:
 
-   ```bash
-   Could not find an upstream identified by 21e1fada-199c-492b.
-   ```
+  ```bash
+  Could not find an upstream identified by 21e1fada-199c-492b.
+  ```
 
 1. Create a site using the Upstream:
 
- ```bash{outputLines:2-4}
+ ```bash{outputLines:2}
  terminus site:create terminus-cli-create "Terminus CLI Create" 21e1fada-199c-492b-97bd-0b36b53a9da0
  [notice] Creating a new site...
  ```
 
-1. See the new site listed:
+1. View the new site list:
 
- ```bash{outputLines:1-8}
+ ```bash{outputLines:2-8}
  terminus site:list
  +--------------------------+-----------+---------------+--------------------------+
  | Site                     | Framework | Service Level | UUID                     |
@@ -81,7 +81,6 @@ Now let's create a new site.
  | terminus-create          | drupal8   | free          | terminus-create          |
  | git-import-example       | drupal    | free          | git-import-example       |
  +--------------------------+-----------+---------------+--------------------------+
-
  ```
 
 ### Update the Code


### PR DESCRIPTION
that was a fun one to figure out

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Using Terminus to Create and Update Drupal Sites on Pantheon](https://pantheon.io/docs/guides/terminus-drupal-site-management)** - Warn users that small terminal windows cut off the full upstream ID. PR.

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] check the md

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
