### PR TITLE
no date set for mariadb upgrade

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -157,7 +157,7 @@ Are you already running a Pantheon site using our [Drupal 8 upstream](https://gi
 
 ### Does Pantheon have plans to upgrade MariaDB?
 
-Yes, Pantheon has plans to upgrade MariaDB platform-wide before September 30, 2020.
+Yes, Pantheon has plans to upgrade MariaDB platform-wide with the official platform release of Drupal 9.
 
 ### When will Drupal 9 be officially supported for production sites on Pantheon?
 


### PR DESCRIPTION
## Summary

**[Drupal 9 Early Access](https://pantheon.io/docs/drupal-9#does-pantheon-have-plans-to-upgrade-mariadb)** - It's unlikely that MariaDB is going live on the platform by the end of September. Changed the promised date to a "at the same time as D9, which is more likely. [PR 5981](https://github.com/pantheon-systems/documentation/pull/5981)

Thanks, @desl !

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
