### PR TITLE
Terminus Command Pages

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  pfe: pantheon-systems/front-end@dev:master
+  pfe: pantheon-systems/front-end@0.3.0
   queue: eddiewebb/queue@1.5.0
 
 workflows:

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -295,11 +295,14 @@ exports.createPages = ({ graphql, actions }) => {
     // Create Terminus Command pages
     const terminusCommands = result.data.dataJson.commands
     terminusCommands.forEach(command => {
+      const slugRegExp = /:/g
+      const slug = command.name.replace(slugRegExp, "-")
       createPage({
-        path: `terminus/commands/${command.name}`,
+        path: `terminus/commands/${slug}`,
         component: path.resolve(`./src/templates/terminusCommand.js`),
         context: {
-          slug: command.name
+          slug: slug,
+          name: command.name
         }
       })
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -218,6 +218,15 @@ exports.createPages = ({ graphql, actions }) => {
         }
       }
 
+      dataJson {
+        commands {
+          description
+          help
+          name
+          usage
+        }
+      }
+
     }
   `).then(result => {
     if (result.errors) {
@@ -280,6 +289,18 @@ exports.createPages = ({ graphql, actions }) => {
           next: previous,
           previous: next
         },
+      })
+    })
+
+    // Create Terminus Command pages
+    const terminusCommands = result.data.dataJson.commands
+    terminusCommands.forEach(command => {
+      createPage({
+        path: `terminus/commands/${command.name}`,
+        component: path.resolve(`./src/templates/terminusCommand.js`),
+        context: {
+          slug: command.name
+        }
       })
     })
 

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -138,14 +138,14 @@ No, Pantheon is neither a domain registrar nor a DNS manager. Many platforms and
 
 <Accordion title="Learn More" id="nameservers-drop" icon="lightbulb">
 
-  Pantheon is built to support advanced website deployment needs, and that means allowing site owners to use the DNS provider of their choice. If Pantheon required specific nameservers, it would interfere with these major use cases (among others):
+Pantheon is built to support advanced website deployment needs, and that means allowing site owners to use the DNS provider of their choice. If Pantheon required specific nameservers, it would interfere with these major use cases (among others):
 
-  * **Large organizations and institutions with Information Technology departments that operate or configure DNS.** If Pantheon required use of particular DNS servers, it would interfere with the ability to use Pantheon for the organization's websites.
-  * **Digitally signing DNS records using a system like [DNSSec](https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions).** While it would be technically possible for Pantheon to host records signed offline, it's much easier for interested organizations to operate their own DNS or choose a provider that supports the desired signing methods.
-  * **Uncommon record types.** If Pantheon required use of specific nameservers, it's unlikely that all of the desired record types would be available, particularly legacy ones.
-  * **Programmatic updates.** Such use cases include domain control validation for obtaining certificates and automated responses to security events. Different DNS services support different update APIs, and it's unlikely Pantheon would ever be able to support them all.
+* **Large organizations and institutions with Information Technology departments that operate or configure DNS.** If Pantheon required use of particular DNS servers, it would interfere with the ability to use Pantheon for the organization's websites.
+* **Digitally signing DNS records using a system like [DNSSec](https://en.wikipedia.org/wiki/Domain_Name_System_Security_Extensions).** While it would be technically possible for Pantheon to host records signed offline, it's much easier for interested organizations to operate their own DNS or choose a provider that supports the desired signing methods.
+* **Uncommon record types.** If Pantheon required use of specific nameservers, it's unlikely that all of the desired record types would be available, particularly legacy ones.
+* **Programmatic updates.** Such use cases include domain control validation for obtaining certificates and automated responses to security events. Different DNS services support different update APIs, and it's unlikely Pantheon would ever be able to support them all.
 
-  If your site doesn't have these advanced needs, there are free and inexpensive options outside of Pantheon. We recommend considering your domain registrar's DNS services, [Amazon Route 53](https://aws.amazon.com/route53/), [Google Cloud DNS](https://cloud.google.com/dns/), or [Cloudflare](https://woorkup.com/cloudflare-dns/).
+If your site doesn't have these advanced needs, there are free and inexpensive options outside of Pantheon. We recommend considering your domain registrar's DNS services, [Amazon Route 53](https://aws.amazon.com/route53/), [Google Cloud DNS](https://cloud.google.com/dns/), or [Cloudflare](https://woorkup.com/cloudflare-dns/).
 
 </Accordion>
 
@@ -177,6 +177,14 @@ Pantheon provides `A` and `AAAA` values:
 
 ![DNS Values provided by the Pantheon Site Dashboard](../images/dashboard/dns-values.png)
 
+<Accordion title="Learn More" id="example-panel" icon="education">
+
+In the past, Pantheon used a mix of  `A`/`AAAA` and `CNAME` records. We've since standardized to only `A`/`AAAA`, which reduces complexity and confusion. `CNAME` records introduce an additional point of failure by requiring an additional lookup from `CNAME` to `A` before getting an IP address.
+
+Additionally, the use of an `MX` or `TXT` record prevents the use of a `CNAME`, and vice versa.
+
+</Accordion>
+
 ### Why does my domain say "Update Recommended?"
 
 The **Status** in **Domains / HTTPS** will show as <span class="glyphicons glyphicons-alert text-warning"></span> **Update Recommended** when the Platform detects a CNAME record pointed to Pantheon, or when A/AAAA records are not detected.
@@ -186,6 +194,7 @@ Click **Details** to find the values required for A and AAAA records to add, or 
 Log in to your DNS provider to make the recommended changes. We have instructions for [many popular DNS providers](/dns-providers) to help make the required adjustment.
 
 ### Can I override DNS locally?
+
 Yes! You can modify your local `hosts` file, which takes precedence over DNS:
 
 <Partial file="_hosts-file.md" />

--- a/source/content/localdev.md
+++ b/source/content/localdev.md
@@ -13,7 +13,7 @@ Pantheon offers a number of [ways to connect to your site](/guides/quickstart/co
 
 Localdev lets you [use an integrated development environment (**IDE**)](#use-a-local-ide-to-develop-your-pantheon-site) to edit files and code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview, even when you don't have an internet connection.
 
-Localdev is in active development, with new features and updates coming soon.
+Localdev is in active development, with new features and updates coming soon. Please submit feedback and feature requests through the [Pantheon Localdev Customer Feedback](https://docs.google.com/forms/d/e/1FAIpQLSdy2WU7H3bSd94YmEuTvGhzmmT_xP3LlCgORXOkTt-M8UIAXw/viewform) form.
 
 ## Install and Connect Localdev
 
@@ -121,6 +121,10 @@ While Localdev is in beta, [support request best practices](/support/#best-pract
 
 1. Report the error:
    - [Contact Support via your Dashboard](https://dashboard.pantheon.io/#support/support/all) or [via Chat](/support/#real-time-chat-support) and include the steps you took to reproduce the error.
+
+### Provide Feedback or Feature Requests
+
+Please submit feedback and feature requests through the [Pantheon Localdev Customer Feedback](https://docs.google.com/forms/d/e/1FAIpQLSdy2WU7H3bSd94YmEuTvGhzmmT_xP3LlCgORXOkTt-M8UIAXw/viewform) form.
 
 ### Log out and Reset to Defaults
 

--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -51,11 +51,13 @@ ___
 
 ___
 
-## [Basic HTTP Authentication](https://www.drupal.org/project/basic_auth) - Drupal 7 only
+## [Basic HTTP Authentication](https://www.drupal.org/project/basic_auth)
 
-**Issue**: This contrib module conflicts with [Pantheon's Security tool](/security/#password-protect-your-site%27s-environments) when both are enabled on Drupal 7 sites, resulting in 403 errors.
+<ReviewDate date="2020-08-25" />
 
-**Solution**: Lock the environment via Pantheon's Security tool or via the module, not both. For details, see [Security on the Pantheon Dashboard](/security/#troubleshoot).
+**Issue**: This module conflicts with [Pantheon's Dashboard Security Tool](/security#password-protect-your-sites-environments) when both are enabled on Drupal sites, resulting in 403 errors.
+
+**Solution**:  We suggest using Pantheon's Dashboard Security Tool if you want to set up HTTP authentication. Additionally, see [Advanced Redirects and Restrictions](/advanced-redirects) for more options to control and restrict access to some or all of your site.
 
 ___
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -17,7 +17,7 @@ If your work is already updated but still listed here, let us know so we can rem
 
 ### Assumed Write Access
 
-Some plugins and themes are built on the assumption that the CMS has write access to the entire filesystem. While this is usually true of standard LAMP/LEMP stack server configuration, Pantheon and other specialized platforms do not. This can result in runtime errors when the software can't write to locations in the code base in Test and Live environments.
+Some plugins and themes are built on the assumption that the CMS has write access to the entire filesystem. While this is usually true of standard LAMP/LEMP stack server configuration, Pantheon and other specialized platforms do not. This can result in runtime errors when the software can't write to locations in the codebase in Test and Live environments.
 
 See [Use the Pantheon WebOps Workflow](/pantheon-workflow) for more information on how Pantheon differentiates "code" from "files".
 
@@ -222,7 +222,7 @@ For more details, see [SERVER_NAME and SERVER_PORT on Pantheon](/server_name-and
 
 **Issue 2:** Local file attachments set in the admin panel cannot come from the `uploads` folder. As described in [this plugin issue](https://wordpress.org/support/topic/local-file-attachments-do-not-work-in-pantheon-hosting/), the plugin code fails for upload directories that are symlinks.
 
-**Solution:** Until the plugin is updated to allow symlink paths, you can commit your local attachment files to the code base in `wp-content` or another subdirectory thereof.
+**Solution:** Until the plugin is updated to allow symlink paths, you can commit your local attachment files to the codebase in `wp-content` or another subdirectory thereof.
 
 ___
 
@@ -643,6 +643,13 @@ ___
 
 ___
 
+## [WebP Express](https://wordpress.org/plugins/webp-express/)
+
+<ReviewDate date="2019-08-25" />
+
+**Issue:** WebP Express assumes write access to paths in the codebase that are write-only in non-dev environments. Because the plugin uses `is_dir` to check for the path, a symlink to `files/` does not resolve the issue.
+___
+
 ## [Weather Station](https://wordpress.org/plugins/live-weather-station/)
 
 **Issue:** This module uses [`php-intl`]( https://secure.php.net/manual/en/intro.intl.php), which is not currently supported by Pantheon.
@@ -689,7 +696,7 @@ ___
 
 <ReviewDate date="2020-07-15" />
 
-**Issue:** Wordfence assumes write access to several files in the code base to store configuration and log files.
+**Issue:** Wordfence assumes write access to several files in the codebase to store configuation and log files.
 
 **Solution:** Prepare your environment before installing Wordfence with the proper symlinks and configuration files:
 

--- a/source/partials/terminus/backup-automatic-enable.md
+++ b/source/partials/terminus/backup-automatic-enable.md
@@ -1,0 +1,3 @@
+## Additional Examples
+
+This section comes from a partial file, `backup-automatic-enable.md`. It lets us expand the details provided in the Terminus source code with additional content.

--- a/source/partials/terminus/backup-automatic-enable.md
+++ b/source/partials/terminus/backup-automatic-enable.md
@@ -1,3 +1,0 @@
-## Additional Examples
-
-This section comes from a partial file, `backup-automatic-enable.md`. It lets us expand the details provided in the Terminus source code with additional content.

--- a/source/partials/terminus/connection-set.md
+++ b/source/partials/terminus/connection-set.md
@@ -1,3 +1,3 @@
 ## Available Modes
 
-The connection mode for a dev or multidev environment can be set to `sftp` or `git`. For more information, see the [SFTP Mode section of Developing on Pantheon Directly with SFTP Mode](/sftp#sftp-mode)
+The connection mode for a dev or multidev environment can be set to `sftp` or `git`. For more information, see [Connection Modes](/guides/quickstart/connection-modes).

--- a/source/partials/terminus/connection-set.md
+++ b/source/partials/terminus/connection-set.md
@@ -1,0 +1,3 @@
+## Available Modes
+
+The connection mode for a dev or multidev environment can be set to `sftp` or `git`. For more information, see the [SFTP Mode section of Developing on Pantheon Directly with SFTP Mode](/sftp#sftp-mode)

--- a/source/partials/terminus/remote-drush.md
+++ b/source/partials/terminus/remote-drush.md
@@ -1,0 +1,3 @@
+## Additional Resources
+
+To learn more about Drush, see [Drupal Drush Command-Line Utility](/drush).

--- a/src/components/commands/index.js
+++ b/src/components/commands/index.js
@@ -1,5 +1,5 @@
 import React, { useState } from "react"
-import { StaticQuery, graphql } from "gatsby"
+import { StaticQuery, graphql, Link } from "gatsby"
 import './style.css';
 
 const Commands = ({ data }) => {
@@ -47,7 +47,7 @@ const Commands = ({ data }) => {
                 return (
                   <tr key={i}>
                     <td>
-                      <strong className="command-name">{command.name}</strong>
+                      <strong className="command-name"><Link to={`/terminus/commands/${command.name}`}>{command.name}</Link></strong>
                       <br />
                       <small>{command.description}</small>
                     </td>

--- a/src/components/commands/index.js
+++ b/src/components/commands/index.js
@@ -4,7 +4,7 @@ import './style.css';
 
 const Commands = ({ data }) => {
   const [search, setSearch] = useState("")
-
+  const slugRegExp = /:/g
   return (
     <div className="container col-md-12">
       <div className="form-group">
@@ -47,7 +47,7 @@ const Commands = ({ data }) => {
                 return (
                   <tr key={i}>
                     <td>
-                      <strong className="command-name"><Link to={`/terminus/commands/${command.name}`}>{command.name}</Link></strong>
+                      <strong className="command-name"><Link to={`/terminus/commands/${command.name.replace(slugRegExp, "-")}`}>{command.name}</Link></strong>
                       <br />
                       <small>{command.description}</small>
                     </td>

--- a/src/components/commands/index.js
+++ b/src/components/commands/index.js
@@ -47,7 +47,7 @@ const Commands = ({ data }) => {
                 return (
                   <tr key={i}>
                     <td>
-                      <strong className="command-name"><Link to={`/terminus/commands/${command.name.replace(slugRegExp, "-")}`}>{command.name}</Link></strong>
+                      <Link className="command-name" to={`/terminus/commands/${command.name.replace(slugRegExp, "-")}`}>{command.name}</Link>
                       <br />
                       <small>{command.description}</small>
                     </td>

--- a/src/components/commands/style.css
+++ b/src/components/commands/style.css
@@ -22,3 +22,7 @@ li.terminus-usage {
     white-space: normal !important;
   }
 }
+
+.command-name {
+  font-weight: bold;
+}

--- a/src/components/github/index.js
+++ b/src/components/github/index.js
@@ -3,6 +3,7 @@ import "./style.css"
 
 const Github = ({ pageTitle, path, editPath }) => {
   return (
+    editPath ?
     <div>
       <a
         href={`https://github.com/pantheon-systems/documentation/edit/main/${editPath}`}
@@ -18,6 +19,7 @@ const Github = ({ pageTitle, path, editPath }) => {
         <i className="fa fa-github" /> Report an issue with this doc
       </a>
     </div>
+    : null
   )
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1855,6 +1855,10 @@ pre code .hljs,
 .pio-dropzone hr {
 	width: 100px;
 }
+hr.commandHr {
+	border-top: 1px solid #DDE5E7;
+	margin: 1em;
+}
 .pio-dropzone .lead {
 	margin-bottom: 10px;
 	font-weight: normal;

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -1,0 +1,213 @@
+import React from "react"
+import { graphql, Link } from "gatsby"
+import { MDXRenderer } from "gatsby-plugin-mdx"
+import { MDXProvider } from "@mdx-js/react"
+
+import Layout from "../layout/layout"
+import HeaderBody from "../components/headerBody"
+import Callout from "../components/callout"
+import Alert from "../components/alert"
+import Accordion from "../components/accordion"
+import ExternalLink from "../components/externalLink"
+import Icon from "../components/icon"
+import Popover from "../components/popover"
+import TabList from "../components/tabList"
+import Tab from "../components/tab"
+import TOC from "../components/toc"
+import GetFeedback from "../components/getFeedback"
+import Card from "../components/card"
+import CardGroup from "../components/cardGroup"
+import Navbar from "../components/navbar"
+import NavButtons from "../components/navButtons"
+import SEO from "../layout/seo"
+import Releases from "../components/releases"
+import TerminusVersion from "../components/terminusVersion"
+import Download from "../components/download"
+import Commands from "../components/commands"
+import Partial from "../components/partial"
+import ReviewDate from "../components/reviewDate"
+import Check from "../components/check.js"
+
+const shortcodes = {
+  Callout,
+  Alert,
+  Accordion,
+  ExternalLink,
+  Icon,
+  Popover,
+  TabList,
+  Tab,
+  Card,
+  CardGroup,
+  Releases,
+  TerminusVersion,
+  Download,
+  Commands,
+  ReviewDate,
+  Check,
+  Partial,
+}
+
+// @TODO relocate this list
+// - To a YAML file and use GraphQL to pull data.
+// - To a GraphQL query order by frontmatter weight/order/index field.
+const items = [
+  {
+    id: "docs-terminus",
+    link: "/terminus",
+    title: "Get Started",
+  },
+  {
+    id: "docs-terminus-install",
+    link: "/terminus/install",
+    title: "Install",
+  },
+  {
+    id: "docs-terminus-examples",
+    link: "/terminus/examples",
+    title: "Example Usage",
+  },
+  {
+    id: "docs-terminus-commands",
+    link: "/terminus/commands",
+    title: "Commands",
+  },
+  {
+    id: "docs-terminus-scripting",
+    link: "/terminus/scripting",
+    title: "Scripting",
+  },
+  {
+    id: "docs-terminus-plugins",
+    link: "/terminus/plugins",
+    title: "Extend with Plugins",
+    items: [
+      {
+        id: "docs-terminus-directory",
+        link: "/terminus/plugins/directory",
+        title: "Directory",
+      },
+      {
+        id: "docs-terminus-create",
+        link: "/terminus/plugins/create",
+        title: "Create Plugins",
+      },
+    ],
+  },
+  {
+    id: "docs-terminus-configuration",
+    link: "/terminus/configuration",
+    title: "Configuration File",
+  },
+  {
+    id: "docs-terminus-updates",
+    link: "/terminus/updates",
+    title: "Version Updates",
+  },
+]
+
+class CommandsTemplate extends React.Component {
+  componentDidMount() {
+    $("[data-toggle=popover]").popover({
+      trigger: "click",
+    })
+
+    $("body").on("click", function(e) {
+      $('[data-toggle="popover"]').each(function() {
+        if (
+          !$(this).is(e.target) &&
+          $(this).has(e.target).length === 0 &&
+          $(".popover").has(e.target).length === 0
+        ) {
+          $(this).popover("hide")
+        }
+      })
+    })
+
+    $("body").keyup(function(e) {
+      $('[data-toggle="popover"]').each(function() {
+        if (event.which === 27) {
+          $(this).popover("hide")
+        }
+      })
+    })
+  }
+
+  render() {
+    const contentCols = 12
+    const slug = this.props.pageContext.slug
+    const commands = this.props.data.dataJson.commands
+    const getCommandBySlug = slug => commands.find(({name}) => name === slug)
+    const command = getCommandBySlug(slug)
+    //console.log("command: ", command) //For Debugging
+    //console.log("usage 1 pre cap: ", command.usage[1].replace(/[A-Z].+/, '')) //For Debugging
+    //console.log("usage 1 post cap: ", command.usage[1].replace(/[^A-Z]+/, '')) //For Debugging
+    return (
+      <Layout>
+        <SEO
+          title={command.name + " | " + "Pantheon Docs"}
+          description="Terminus Command Documentation"
+          image={"/assets/images/terminus-thumbLarge.png"}
+        />
+        <div className="">
+          <div className="container-fluid">
+            <div className="row col-md-10 guide-nav manual-guide-toc-well">
+              <Navbar
+                title={`Terminus Command Reference`}
+                items={items}
+                activePage="/terminus/commands"
+                className="manual-guide-toc"
+              />
+              <div id="doc" className="terminus col-md-9 guide-doc-body">
+                <div className="row guide-content-well">
+                  <div
+                    className={`col-xs-${contentCols} col-md-${contentCols}`}
+                  >
+                    <HeaderBody
+                      title="Terminus Command Reference"
+                      subtitle={`terminus ${command.name}`}
+                      description=""
+                      slug={slug}
+                    />
+                    <h2>Description</h2>
+                    {command.description}
+                    <br />
+                    <h2>Example Usage</h2>
+                    <pre className="language-bash"><code className="language=bash">terminus {command.usage[0].replace(/\[|\]/g, "")}</code></pre>
+                    <br />
+                    {command.usage.map( (usage, i) => {
+                      return (
+                        <>
+                        <p key={i}>
+                        <code key={`${i}-pre`}>{usage.replace(/\[|\]/g, "").replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, '')}</code> {usage.replace(/\[|\]/g, "").match(/(?!^)\b[A-Z][a-z]*\b.+/)}
+                        <hr />
+                        </p>
+                        </>
+                      )
+                    })}
+                    <Link to="/terminus/commands">Back to all commands</Link>
+                  </div>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+        <GetFeedback page={"/" + slug} />
+      </Layout>
+    )
+  }
+}
+
+export default CommandsTemplate
+
+export const pageQuery = graphql`
+  query CommandsData {
+    dataJson {
+      commands {
+        name
+        usage
+        description
+      }
+    }
+  }
+`

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -148,7 +148,7 @@ class CommandsTemplate extends React.Component {
     return (
       <Layout>
         <SEO
-          title={command.name + " | " + "Pantheon Docs"}
+          title={"terminus " + command.name + " | " + "Pantheon Docs"}
           description="Terminus Command Documentation"
           image={"/assets/images/terminus-thumbLarge.png"}
         />

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -136,12 +136,15 @@ class CommandsTemplate extends React.Component {
   render() {
     const contentCols = 12
     const slug = this.props.pageContext.slug
+    console.log("slug: ", slug) // For Debugging
+    const name = this.props.pageContext.name
+    //console.log("name: ", name) //For Debugging
     const commands = this.props.data.dataJson.commands
+    //console.log("commands: ", commands) //For Debugging
     const getCommandBySlug = slug => commands.find(({name}) => name === slug)
-    const command = getCommandBySlug(slug)
+    const command = getCommandBySlug(name)
     //console.log("command: ", command) //For Debugging
-    //console.log("usage 1 pre cap: ", command.usage[1].replace(/[A-Z].+/, '')) //For Debugging
-    //console.log("usage 1 post cap: ", command.usage[1].replace(/[^A-Z]+/, '')) //For Debugging
+
     return (
       <Layout>
         <SEO
@@ -180,11 +183,12 @@ class CommandsTemplate extends React.Component {
                         <>
                         <p key={i}>
                         <code key={`${i}-pre`}>{usage.replace(/\[|\]/g, "").replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, '')}</code> {usage.replace(/\[|\]/g, "").match(/(?!^)\b[A-Z][a-z]*\b.+/)}
-                        <hr />
                         </p>
+                        <hr />
                         </>
                       )
                     })}
+                    <Partial file={`terminus/${slug}.md`} />
                     <Link to="/terminus/commands">Back to all commands</Link>
                   </div>
                 </div>

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -136,7 +136,7 @@ class CommandsTemplate extends React.Component {
   render() {
     const contentCols = 12
     const slug = this.props.pageContext.slug
-    console.log("slug: ", slug) // For Debugging
+    //console.log("slug: ", slug) // For Debugging
     const name = this.props.pageContext.name
     //console.log("name: ", name) //For Debugging
     const commands = this.props.data.dataJson.commands

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -208,7 +208,7 @@ class CommandsTemplate extends React.Component {
                         <p key={i}>
                         <code key={`${i}-pre`}>{usage.replace(/\[|\]/g, "").replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, '')}</code> {usage.replace(/\[|\]/g, "").match(/(?!^)\b[A-Z][a-z]*\b.+/)}
                         </p>
-                        <hr />
+                        <hr className="commandHr"/>
                         </>
                       )}
                     })}

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -27,6 +27,7 @@ import Commands from "../components/commands"
 import Partial from "../components/partial"
 import ReviewDate from "../components/reviewDate"
 import Check from "../components/check.js"
+let commandsJson = require('../../source/data/commands.json')
 
 const shortcodes = {
   Callout,
@@ -135,15 +136,38 @@ class CommandsTemplate extends React.Component {
 
   render() {
     const contentCols = 12
+
     const slug = this.props.pageContext.slug
     //console.log("slug: ", slug) // For Debugging
+
     const name = this.props.pageContext.name
     //console.log("name: ", name) //For Debugging
+
     const commands = this.props.data.dataJson.commands
     //console.log("commands: ", commands) //For Debugging
+
     const getCommandBySlug = slug => commands.find(({name}) => name === slug)
+    const getCommandJSONBySlug = slug => commandsJson.commands.find(({name}) => name === slug)
+
     const command = getCommandBySlug(name)
     //console.log("command: ", command) //For Debugging
+
+    const thisCommandJson = getCommandJSONBySlug(name)
+    //console.log("thisCommandJson: ", thisCommandJson) //For Debugging
+
+    var options = Object.keys(thisCommandJson.definition.options).map(function (key) {
+      return [String(key), thisCommandJson.definition.options[key]]
+    })
+    options.forEach(option => {
+      option.shift()
+    })
+
+    options.sort((a, b) => (a[0].name > b[0].name) ? 1 : -1)
+    options.sort(function(a, b) {
+      return a[0].name.localeCompare(b[0].name);
+    })
+    //console.log("Options: ", options) //For Debugging
+
 
     return (
       <Layout>
@@ -179,15 +203,38 @@ class CommandsTemplate extends React.Component {
                     <pre className="language-bash"><code className="language=bash">terminus {command.usage[0].replace(/\[|\]/g, "")}</code></pre>
                     <br />
                     {command.usage.map( (usage, i) => {
-                      return (
+                      if (i  !== 0) { return (
                         <>
                         <p key={i}>
                         <code key={`${i}-pre`}>{usage.replace(/\[|\]/g, "").replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, '')}</code> {usage.replace(/\[|\]/g, "").match(/(?!^)\b[A-Z][a-z]*\b.+/)}
                         </p>
                         <hr />
                         </>
+                      )}
+                    })}
+
+                    <h2>Options</h2>
+                    <table>
+                    <thead>
+                      <tr>
+                        <th>Option</th>
+                        <th>Description</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                    {options.map(( option ) => {
+                      return (
+                        <>
+                        <tr key={option}>
+                          <td key={`${option}-name`}>{option[0].name}</td>
+                          <td key={`${option}-desc`}>{option[0].description}</td>
+                        </tr>
+                        </>
                       )
                     })}
+                    </tbody>
+                    </table>
+
                     <Partial file={`terminus/${slug}.md`} />
                     <Link to="/terminus/commands">Back to all commands</Link>
                   </div>


### PR DESCRIPTION
## Summary

**[Terminus Commands](https://pantheon.io/docs/terminus/commands)** - Each listed Terminus commands now links to a unique page for that command. This page has more detail from the Terminus help output for that command. These pages can be expanded with additional content from a partial file.


## Remaining Work
The following changes still need to be completed:

- [x] Remove example partial file before publishing.

## Post Launch

- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
