### PR TITLE
Add method to find the source of a PHP session

### DIFF
--- a/source/content/wordpress-sessions.md
+++ b/source/content/wordpress-sessions.md
@@ -36,7 +36,14 @@ Symptoms of this issue shows when the header is inspected, you will see that the
 Set-Cookie: SESS1234XXXXXXXXXXXXXX path=/; domain=.example.pantheonsite.io; HttpOnly
 ```
 
-The best way to determine which plugin or theme is not allowing caching is to inspect the headers using `curl -sI example.com` after each of the following steps, until you determine which component is breaking the cache:
+The best way to determine which plugin or theme is not allowing caching is to search your site's plugin and theme code for the `session_start()` PHP function:
+
+```
+cd wp-content
+grep -rnw . -e 'session_start'
+```
+
+Alternatively, you can inspect the headers using `curl -sI example.com` after each of the following steps, until you determine which component is breaking the cache:
 
 1. To check your theme, use your default theme (twentynineteen for example), and check for the cookie.
 

--- a/source/content/wordpress-sessions.md
+++ b/source/content/wordpress-sessions.md
@@ -38,7 +38,7 @@ Set-Cookie: SESS1234XXXXXXXXXXXXXX path=/; domain=.example.pantheonsite.io; Http
 
 The best way to determine which plugin or theme is not allowing caching is to search your site's plugin and theme code for the `session_start()` PHP function:
 
-```
+```bash{promptUser: user}
 cd wp-content
 grep -rnw . -e 'session_start'
 ```


### PR DESCRIPTION
## Summary

**[WordPress and PHP Sessions](https://pantheon.io/docs/wordpress-sessions)** - Add another method to find the source of a PHP session.

## Remaining Work
The following changes still need to be completed:

- [ ] copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
