### PR TITLE
pad guide-content-well

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -972,6 +972,7 @@ span#changelog-rsaquo {
 }
 .guide-content-well {
 	/*border-bottom: .1em solid #eef2f3;*/
+        padding-top: 20px;
 }
 .doc-content-well {
 	padding-bottom: 50px;


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.


## Summary

* CSS changes so that multipage guides have the same padding as single page layouts (20px)

## Effect
Before:
<img width="1193" alt="Screen Shot 2020-09-17 at 3 09 27 PM" src="https://user-images.githubusercontent.com/10119525/93524683-7ebc3f00-f8fa-11ea-8388-42e383aeeb28.png">

After:
<img width="1202" alt="Screen Shot 2020-09-17 at 3 10 15 PM" src="https://user-images.githubusercontent.com/10119525/93524702-867be380-f8fa-11ea-804d-6e98586c465d.png">


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
