### PR TITLE
Product Page link in Review Component

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -117,9 +117,9 @@ function is_mobile() {
 
 ___
 
-## [Autoptimize](https://wordpress.org/plugins/autoptimize/)
+## Autoptimize
 
-<ReviewDate date="2020-02-10" />
+<ReviewDate date="2020-02-10" link="https://wordpress.org/plugins/autoptimize/"/>
 
 **Issue:** Autoptimize assumes write access to the site's codebase within the `wp-content/resources` directory, which is not granted on Test and Live environments on Pantheon by design. For additional details, see [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
 

--- a/src/components/reviewDate/index.js
+++ b/src/components/reviewDate/index.js
@@ -1,13 +1,18 @@
 import React from "react"
 import './style.css';
 
-const reviewDate = ({ date }) => {
+const reviewDate = ({ date, link }) => {
   var formattedDate = new Date(`${date}`)
   formattedDate.setMinutes(formattedDate.getMinutes() + formattedDate.getTimezoneOffset() )
+  var thisLink = link ? `| <a href=${link}>Product Page</a>` : null
   return (
     <>
       <h4 className="review-date toc-ignore" >
-        Last reviewed: {formattedDate.toDateString().replace(/^\S+\s/,'')}
+        Last reviewed: {formattedDate.toDateString().replace(/^\S+\s/,'')} {link ? 
+          <>
+          | <a href={link}>Product Page</a>
+          </>
+          : null}
       </h4>
     </>
   )


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[Plugins with Known Issues](https://pantheon.io/docs/plugins-known-issues)** and **[Modules with Known Issues](https://pantheon.io/docs/modules-known-issues)**- Now that all headers link to their anchors, we can link to the module / plugin / theme page in the ReviewDate component underneath.

## Remaining Work
The following changes still need to be completed:

- [ ] Adjust component copy
- [ ] Complete link replacement

## Post Launch

- [ ] Update Status Report
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
