### PR TITLE
update Terminus title and description

### DIFF
--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -168,12 +168,11 @@ class CommandsTemplate extends React.Component {
     })
     //console.log("Options: ", options) //For Debugging
 
-
     return (
       <Layout>
         <SEO
-          title={"terminus " + command.name + " | " + "Pantheon Docs"}
-          description="Terminus Command Documentation"
+          title={command.name + " | Terminus Commands"}
+          description={command.description}
           image={"/assets/images/terminus-thumbLarge.png"}
         />
         <div className="">


### PR DESCRIPTION
## Summary

**[Terminus Command Reference Pages](https://pantheon.io/docs/terminus/commands)** - For command sub-pages, the title and description passed to search engines has been updated..

## Effect

- sets the title to `{command.name} | Terminus | Pantheon Docs`
- sets the description to `{terminus.description}`

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
