### PR TITLE
fallback to tag_name when name is empty

### DIFF
--- a/src/components/buildToolsChangelog.js
+++ b/src/components/buildToolsChangelog.js
@@ -11,7 +11,7 @@ const BuildToolsChangelog = ({ data }) => (
       )
       return (
         <div key={i}>
-          <h3 className="toc-ignore">{buildtools.node.name}</h3>
+          <h3 className="toc-ignore">{buildtools.node.name ? buildtools.node.name : buildtools.node.tag_name}</h3>
           <MDXProvider>
             <MDXRenderer>
               {buildtools.node.fields.markdownBody.childMdx.body.replace(


### PR DESCRIPTION
Follows up #6016 

## Summary

**[Build Tools Introduction](https://pantheon.io/docs/guides/build-tools)** - Updated the buildToolsChangelog component to fall back on the `tag_name` when the `name` value is empty.

## Post Launch

none