### PR TITLE
basic plan overage clarification

### DIFF
--- a/source/content/horizontal-scalability.md
+++ b/source/content/horizontal-scalability.md
@@ -47,7 +47,7 @@ On Pantheon, all Performance plans include Overage Protection to prevent one-tim
 
 ### Basic Plan Sites
 
-Basic plan sites do not have overage protection. If a change in traffic behavior exceeds the 25,000 visit cap the plan will be upgraded to Performance, with a corresponding change to the bill in the applicable billing period.
+Basic Sites do not have overage protection. If a Basic Site exceeds the 25,000 visit cap in any given month, the site plan will be automatically upgraded to the [Performance plan](https://pantheon.io/plans/performance-pricing) whose visit limit accommodates the site's traffic.
 
 For more information, see [Traffic Limits and Overages](/traffic-limits).
 

--- a/source/content/horizontal-scalability.md
+++ b/source/content/horizontal-scalability.md
@@ -45,7 +45,9 @@ Pantheon customers don't need to worry about these systems, as the platform is b
 ### Performance Plans
 On Pantheon, all Performance plans include Overage Protection to prevent one-time traffic spikes from causing billing issues. If the change to traffic behavior is sustained, the site will eventually be moved to the appropriate Performance plan. This provides billing protection against externally driven spikes, or for businesses that have an annual “big event” but otherwise operate at a lower “normal” rate.
 
-Basic plan sites do not have this protective feature and are charged for traffic exceeding their allotment. The overage charge is $2.50 per 1,000 visits (no proration).
+### Basic Plan Sites
+
+Basic plan sites do not have overage protection. If a change in traffic behavior exceeds the 25,000 visit cap the plan will be upgraded to Performance, with a corresponding change to the bill in the applicable billing period.
 
 For more information, see [Traffic Limits and Overages](/traffic-limits).
 

--- a/source/content/horizontal-scalability.md
+++ b/source/content/horizontal-scalability.md
@@ -42,14 +42,14 @@ When preparing for traffic spikes manually (not on Pantheon), you need to decide
 
 Pantheon customers don't need to worry about these systems, as the platform is build to scale as needed out of the box.
 
-### Performance Plans
-On Pantheon, all Performance plans include Overage Protection to prevent one-time traffic spikes from causing billing issues. If the change to traffic behavior is sustained, the site will eventually be moved to the appropriate Performance plan. This provides billing protection against externally driven spikes, or for businesses that have an annual “big event” but otherwise operate at a lower “normal” rate.
-
-### Basic Plan Sites
+### Basic Plans
 
 Basic Sites do not have overage protection. If a Basic Site exceeds the 25,000 visit cap in any given month, the site plan will be automatically upgraded to the [Performance plan](https://pantheon.io/plans/performance-pricing) whose visit limit accommodates the site's traffic.
 
 For more information, see [Traffic Limits and Overages](/traffic-limits).
+
+### Performance Plans
+On Pantheon, all Performance plans include Overage Protection to prevent one-time traffic spikes from causing billing issues. If the change to traffic behavior is sustained, the site will eventually be moved to the appropriate Performance plan. This provides billing protection against externally driven spikes, or for businesses that have an annual “big event” but otherwise operate at a lower “normal” rate.
 
 ### Elite or Contract Plans
 We allow an increase in application containers for campaigns or peak traffic. A request can be sent to Pantheon Support with the following information:

--- a/source/partials/traffic-limits-overages.md
+++ b/source/partials/traffic-limits-overages.md
@@ -14,4 +14,6 @@ If the change to traffic behavior exceeds your plan limit for any two months of 
 
 ### Basic Plans
 
-Basic plan sites do not have this protective feature and are automatically upgraded to the appropriate [Performance plan](https://pantheon.io/plans/performance-pricing).
+Basic Sites do not have overage protection. If a Basic Site exceeds the 25,000 visit cap in any given month, the site plan will be automatically upgraded to the [Performance plan](https://pantheon.io/plans/performance-pricing) whose visit limit accommodates the site's traffic.
+
+For more information, see [Traffic Limits and Overages](/traffic-limits).

--- a/source/partials/traffic-limits-overages.md
+++ b/source/partials/traffic-limits-overages.md
@@ -14,4 +14,4 @@ If the change to traffic behavior exceeds your plan limit for any two months of 
 
 ### Basic Plan Sites
 
-Basic plan sites do not have overage protection. If a change in traffic behavior exceeds the 25,000 visit cap the plan will be upgraded to Performance, with a corresponding change to the bill in the applicable billing period.
+Basic plan sites do not have this protective feature and are automatically upgraded to the appropriate [Performance plan](https://pantheon.io/plans/performance-pricing).

--- a/source/partials/traffic-limits-overages.md
+++ b/source/partials/traffic-limits-overages.md
@@ -12,6 +12,6 @@ Pantheon designed Overage Protection for Performance sites to prevent one-time t
 
 If the change to traffic behavior exceeds your plan limit for any two months of traffic, your site will be moved to the next appropriate plan to help avoid further overages. You will receive notifications of this change ahead of time.
 
-### Basic Plan Sites
+### Basic Plans
 
 Basic plan sites do not have this protective feature and are automatically upgraded to the appropriate [Performance plan](https://pantheon.io/plans/performance-pricing).

--- a/source/partials/traffic-limits-overages.md
+++ b/source/partials/traffic-limits-overages.md
@@ -8,8 +8,10 @@ Pantheon monitors your site traffic as part of our evaluation of overall site he
 
 ### Overage Protection
 
-Pantheon designed Overage Protection to prevent one-time traffic spikes from causing billing issues. All Performance plans and higher include Overage Protection, which provides billing protection against externally driven spikes, or for businesses that have an annual “big event” but otherwise operate at a lower “normal” rate.
+Pantheon designed Overage Protection for Performance sites to prevent one-time traffic spikes from causing billing issues. All Performance plans and higher include Overage Protection, which provides billing protection against externally driven spikes, or for businesses that have an annual “big event” but otherwise operate at a lower “normal” rate.
 
 If the change to traffic behavior exceeds your plan limit for any two months of traffic, your site will be moved to the next appropriate plan to help avoid further overages. You will receive notifications of this change ahead of time.
 
-Basic plan sites do not have this protective feature and would see a change to their bill in the applicable billing period.
+### Basic Plan Sites
+
+Basic plan sites do not have overage protection. If a change in traffic behavior exceeds the 25,000 visit cap the plan will be upgraded to Performance, with a corresponding change to the bill in the applicable billing period.


### PR DESCRIPTION
## Summary

**[Traffic Limits and Overages](https://pantheon.io/docs/traffic-limits)** and **[Horizontal Scalability](https://pantheon.io/docs/horizontal-scalability)** - Modify language for basic plans to clarify that basic plans do not have overage protection, and overages result in moving to performance plan. 

## Remaining Work

- [x] Copy review M Venzon
- [x] Copy review docs
- [ ] Hold for release

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
