### PR TITLE
Glossary with dfns

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           deployment-path: docs
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
-          gatsby-cache-version: "v1.6"
+          gatsby-cache-version: "v1.7"
           pre-steps:
             - checkout
             - run:

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -23,49 +23,29 @@ While Pantheon does not offer DNS management services, we can help you to unders
 
 ## DNS Terminology
 
-<dl>
+### TLD
 
-<dt>TLD</dt>
+<dfn id="tld">
 
-<dd>
+The <abbr title="Top Level Domain">TLD</abbr> is the last piece of your website URL (`.com`, `.net`, `.org`, etc)
 
-Stands for **Top Level Domain**. This is the last piece of your website URL (`.com`, `.net`, `.org`, etc)
+</dfn>
 
-</dd>
+### Registrar
 
-<dt>Registrar</dt>
+A <dfn id="registrar">Registrar</dfn> is the service through which you purchase a domain name. Most registrars also offer DNS management services.
 
-<dd>
+### Domain
 
-The service through which you purchase a domain name. Most registrars also offer DNS management services.
+The last section of your website name before the [TLD](#tld), the <dfn>domain</dfn> is what you purchase from the [Registrar](#registrar).
 
-</dd>
+### Subdomain
 
-<dt>Domain</dt>
+Separates by periods (`.`), <dfn>subdomains</dfn> precede the domain name. `www` is the most commonly seen subdomain. Subdomains can also stack (example: `www.something.example.com`).
 
-<dd>
+### Authoritative Name Server
 
-The last section of your website name before the TLD, the domain is what you purchase from the Registrar.
-
-</dd>
-
-<dt>Subdomain</dt>
-
-<dd>
-
-Separate by periods (`.`), subdomains precede the domain name. `www` is the most commonly seen subdomain. Subdomains can also stack (example: `www.something.example.com`).
-
-</dd>
-
-<dt>Authoritative Name Server</dt>
-
-<dd>
-
-The service that publishes your domain's DNS records
-
-</dd>
-
-</dl>
+An <dfn>Authoritative Name Server</dfn> publishes your domain's DNS records
 
 ## DNS Record Types
 

--- a/source/content/dns.md
+++ b/source/content/dns.md
@@ -41,11 +41,11 @@ The last section of your website name before the [TLD](#tld), the <dfn>domain</d
 
 ### Subdomain
 
-Separates by periods (`.`), <dfn>subdomains</dfn> precede the domain name. `www` is the most commonly seen subdomain. Subdomains can also stack (example: `www.something.example.com`).
+Separates by periods (`.`), <dfn id="subdomain">subdomains</dfn> precede the domain name. `www` is the most commonly seen subdomain. Subdomains can also stack (example: `www.something.example.com`).
 
 ### Authoritative Name Server
 
-An <dfn>Authoritative Name Server</dfn> publishes your domain's DNS records
+An <dfn id="authoritative name server">Authoritative Name Server</dfn> publishes your domain's DNS records
 
 ## DNS Record Types
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -69,6 +69,10 @@ class Glossary extends React.Component {
         })
       }
     })
+    allDfns.sort((a, b) => (a.title.toLowerCase() > b.title.toLowerCase()) ? 1 : -1)
+    allDfns.sort(function(a, b) {
+      return a.title[0].localeCompare(b.title[0]);
+    });
     console.log("allDfns: ", allDfns) //For Debugging
 
     const letters = ["A", "B", "C", "D", "E", "F", "G", "H", "I", "J", "K", "L", "M", "N", "O", "P", "Q", "R", "S", "T", "U", "V", "W", "X", "Y", "Z"]

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -18,9 +18,9 @@ class Glossary extends React.Component {
 
   render () {
 
-    const {
-      data: { docsWithDefLists, docsWithDFNs },
-    } = this.props
+    const docsWithDefLists = this.props.data.docsWithDefLists
+    const docsWithDFNs = this.props.data.docsWithDFNs
+
     console.log("docsWithDFNS: ", docsWithDFNs) //For Debugging
     console.log("docsWithDefLists", docsWithDefLists)
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -22,6 +22,7 @@ class Glossary extends React.Component {
       data: { docsWithDefLists, docsWithDFNs },
     } = this.props
     console.log("docsWithDFNS: ", docsWithDFNs) //For Debugging
+    console.log("docsWithDefLists", docsWithDefLists)
 
     let defLists = []
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -22,13 +22,13 @@ class Glossary extends React.Component {
   render () {
 
     const {
-      data: { allMdx },
+      data: { docsWithDefLists, docsWithDFNs },
     } = this.props
     //console.log("allMdx: ", allMdx) //For Debugging
 
     let defLists = []
 
-    this.props.data.DocsWithDefLists.edges.map(({ node }) => {
+    docsWithDefLists.edges.map(({ node }) => {
       const matches = node.fileInfo.childMdx.rawBody.match(
         /<dt>(.+?)<\/dt>\n\n<dd>\n\n(.+?)\n\n<\/dd>/gim
       )
@@ -55,7 +55,7 @@ class Glossary extends React.Component {
 
     const allDfns = []
 
-    this.props.data.DocsWithDFNs.edges.map(({ node }) => {
+    docsWithDFNs.edges.map(({ node }) => {
       const isDfn = node.fileInfo.childMdx.rawBody.match(
         /.*<dfn(?: id=".+?")*>\n*.*\n*<\/dfn>.*\n/gim
       )
@@ -119,7 +119,7 @@ class Glossary extends React.Component {
                             <h3 key={`${title}-header`} id={title.toLowerCase()}>
                               {title.charAt(0).toUpperCase() + title.slice(1)}
                             </h3>
-                            
+
                               <ReactMarkdown skipHtml={true} source={definition} />
 
                             {from.length > 0 ? (
@@ -151,8 +151,8 @@ class Glossary extends React.Component {
 export default Glossary
 
 export const pageQuery = graphql`
-  {
-    DocsWithDefLists: allMdx(
+  query definitionsInDocs {
+    docsWithDefLists: allMdx(
       filter: {
         frontmatter: { changelog: { ne: true }, title: { ne: "Style Guide" } }
         fileInfo: { childMdx: { rawBody: { regex: "/<dt>/" } } }
@@ -174,7 +174,7 @@ export const pageQuery = graphql`
         }
       }
     }
-    DocsWithDFNs: allMdx(
+    docsWithDFNs: allMdx(
       filter: {
         frontmatter: { changelog: { ne: true }, title: { ne: "Style Guide" } }
         fileInfo: { childMdx: { rawBody: { regex: "/<dfn/" } } }

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -21,7 +21,7 @@ class Glossary extends React.Component {
     const {
       data: { docsWithDefLists, docsWithDFNs },
     } = this.props
-    //console.log("allMdx: ", allMdx) //For Debugging
+    console.log("docsWithDFNS: ", docsWithDFNs) //For Debugging
 
     let defLists = []
 

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -8,9 +8,6 @@ import ReactMarkdown from "react-markdown"
 import SEO from "../layout/seo"
 import TOC from "../components/toc"
 
-{
-  /* @TODO Convert to a React Component */
-}
 const previewFlexPanelItem = {
   flex: "1 46%",
   margin: "0px 0px 15px 15px",
@@ -66,7 +63,7 @@ class Glossary extends React.Component {
             slug: node.fields.slug,
             title: def.match(/<abbr title="(.+?)"/) ? def.match(/<abbr title="(.+?)"/)[1] : def.match(/<dfn(?: id=".+?")*>(.+?)<\/dfn>/)[1],
             definition: def,
-            letter: def.match(/<abbr title="(.+?)"/) ? def.match(/<abbr title="(.+?)"/)[1][0] : def.match(/<dfn(?: id=".+?")*>(.+?)<\/dfn>/)[1][0],
+            letter: def.match(/<abbr title="(.+?)"/) ? def.match(/<abbr title="(.+?)"/)[1][0] : def.match(/<dfn(?: id=".+?")*>(.+?)<\/dfn>/)[1][0].toUpperCase(),
             id: def.match(/<dfn id=/) ? def.match(/<dfn id="(.+?)"/)[1] : null
           })
         })

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2822,6 +2822,12 @@ a:focus {
 	padding-bottom: 2rem;
 }
 
+article > div > dfn {
+	font-style: inherit;
+	font-size: 18px;
+	color: #44525e;
+}
+
 /* Was this helpful widget */
 /* .helpful {
 	margin: 60px 0;


### PR DESCRIPTION
## Summary

Continued work on a glossary page, using DFN tags.

## Post Launch

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)

