### PR TITLE
Add link to collaborator roles

### DIFF
--- a/source/content/organizations.md
+++ b/source/content/organizations.md
@@ -49,7 +49,7 @@ For more details on the Sites tab, see
 ### People
 
 View all of your collaborators, filter them by role, manage their roles, and add new users to your organization.
-[Learn how to add users to the organization](/organization-dashboard/#add-users-to-your-organization).
+[Learn how to add users to the organization](/organization-dashboard/#add-users-to-your-organization) and [role-based permissions & change management](/change-management). 
 
 ### Upstreams
 


### PR DESCRIPTION
## Summary

**[Organizations: People](https://pantheon.io/docs/organizations#people)** - Add link to collaborator roles to the People section.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
In the course of directing customers on how to set up their organizations, we include a link to add users to an org but don't include a link to the different roles. 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
