### PR TITLE
Note another method to block xmlrpc.php attacks.

### DIFF
--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -69,12 +69,7 @@ Hits Vis.     %   Bandwidth Avg. T.S. Cum. T.S. Max. T.S. Data
 
 Pantheon recommends disabling XML-RPC, given the WordPress Rest API is a stronger and more secure method for interacting with WordPress via external services.
 
-
-<Alert type="info" title="Note">
-
-Pantheon blocked requests to `xmlrpc.php` by default in the [WordPress 5.4.2 core release](/changelog/#changelog/2020/07). If your version of WordPress is older than this, you can block `xmlrpc.php` attacks by simply applying your upstream updates. 
-
-</Alert>
+Pantheon blocked requests to `xmlrpc.php` by default in the [WordPress 5.4.2 core release](/changelog/2020/07#wordpress-542). If your version of WordPress is older than this, you can block `xmlrpc.php` attacks by simply applying your [upstream updates](/core-updates).
 
 ### Disable XML-RPC via Pantheon.yml
 

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -69,6 +69,13 @@ Hits Vis.     %   Bandwidth Avg. T.S. Cum. T.S. Max. T.S. Data
 
 Pantheon recommends disabling XML-RPC, given the WordPress Rest API is a stronger and more secure method for interacting with WordPress via external services.
 
+
+<Alert type="info" title="Note">
+
+Pantheon blocked requests to `xmlrpc.php` by default in the [WordPress 5.4.2 core release](/changelog/#changelog/2020/07). If your version of WordPress is older than this, you can block `xmlrpc.php` attacks by simply applying your upstream updates. 
+
+</Alert>
+
 ### Disable XML-RPC via Pantheon.yml
 
 This method is more performant than disabling via a plugin since this won't involve bootstrapping WordPress. The result of this configuration is that requests to `/xmlrpc.php` will return a 403 status code.

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -4,7 +4,7 @@ description: A list of suggestions for developing WordPress sites on Pantheon.
 cms: "WordPress"
 categories: [develop]
 tags: [workflow, security, composer]
-reviewed: "2019-11-21"
+reviewed: "2020-10-15"
 ---
 
 This article provides suggestions, tips, and best practices for developing and managing WordPress sites on the Pantheon platform.
@@ -55,6 +55,7 @@ This article provides suggestions, tips, and best practices for developing and m
 * Follow our [Frontend Performance](/guides/frontend-performance) guide to tune your WordPress site.
 
 ## Avoid XML-RPC Attacks
+
 The `/xmlrpc.php` script is a potential security risk for WordPress sites. It can be used by bad actors to brute force administrative usernames and passwords, for example. This can be surfaced by reviewing your site's `nginx-access.log` for the Live environment. If you leverage [GoAccess](/nginx-access-log), you might see something similar to the following:
 
 ```none
@@ -69,7 +70,7 @@ Hits Vis.     %   Bandwidth Avg. T.S. Cum. T.S. Max. T.S. Data
 
 Pantheon recommends disabling XML-RPC, given the WordPress Rest API is a stronger and more secure method for interacting with WordPress via external services.
 
-Pantheon blocked requests to `xmlrpc.php` by default in the [WordPress 5.4.2 core release](/changelog/2020/07#wordpress-542). If your version of WordPress is older than this, you can block `xmlrpc.php` attacks by simply applying your [upstream updates](/core-updates).
+Pantheon blocked requests to `xmlrpc.php` by default in the [WordPress 5.4.2 core release](/changelog/2020/07#wordpress-542). If your version of WordPress is older than this, you can block `xmlrpc.php` attacks by applying your [upstream updates](/core-updates).
 
 ### Disable XML-RPC via Pantheon.yml
 
@@ -81,7 +82,6 @@ Add the following configuration to your [`pantheon.yml`](/pantheon-yml) file:
   protected_web_paths:
     - /xmlrpc.php
   ```
-
 
 ### Disable XML-RPC via a Custom Plugin
 


### PR DESCRIPTION

**Note:** Please fill out the PR Template to ensure proper processing.

## Summary

**[WordPress Best Practices](https://pantheon.io/docs/wordpress-best-practices#avoid-xml-rpc-attacks)** - Note that updating WP core is another way to protect your site from xmlrpc.php shenanigans.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
