### PR TITLE
Update redis.md

### DIFF
--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -217,9 +217,6 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
     $conf['cache_default_class'] = 'Redis_CacheCompressed';
     $conf['cache_prefix'] = array('default' => 'pantheon-redis');
 
-    // Do not use Redis for cache_form (no performance difference).
-    $conf['cache_class_cache_form'] = 'DrupalDatabaseCache';
-
     // Use Redis for Drupal locks (semaphore).
     $conf['lock_inc'] = 'sites/all/modules/redis/redis.lock.inc';
     // Or if you've installed the redis module in a contrib subdirectory, use:


### PR DESCRIPTION
In D8, the cache_form no longer exists: https://drupal.stackexchange.com/a/226698

## Summary

**[Installing Redis on Drupal or WordPress](https://pantheon.io/docs/redis)** - In D8, the cache_form no longer exists: https://drupal.stackexchange.com/a/226698

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
