### PR TITLE
Replace Platform URLs During Launch

### DIFF
--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -2,23 +2,11 @@
 title: Launch Essentials
 subtitle: Configure DNS and Provision HTTPS
 description: Part four of our Launch Essentials guide covers DNS records and HTTPS provisioning.
-launch: true
 anchorid: dns
-generator: pagination
-layout: guide
 categories: [go-live]
 tags: [dns, https, launch, webops]
 type: guide
-pagination:
-    provider: data.launchpages
-use:
-    - launchpages
-    - docs_tags
 permalink: docs/guides/launch/configure-dns/
-nexturl: guides/launch/redirects/
-nextpage: Redirect to a Primary Domain
-previousurl: guides/launch/domains/
-previouspage: Connect a Domain to Live
 editpath: launch/04-configure-dns.md
 image: getting-started-Largethumb
 ---

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -24,6 +24,16 @@ Choose one of the following options to configure the primary domain.
 
 <Partial file="primary-domain.md" />
 
+## (WordPress) Update Database URLs
+
+WordPress site admins must also ensure that all URLs in the site's database are updated. This update can be performed [during a database clone](/wordpress-broken-links#update-environment-urls-on-pantheon), or at any time [using a WordPress plugin](/wordpress-broken-links#theres-a-plugin-for-that) or through [Terminus](/terminus):
+
+```bash{promptUser: user}
+terminus wp <site>.live -- search-replace live-<site>.pantheonsite.io <custom-domain> --url=live-<site>.pantheonsite.io --dry-run
+```
+
+The example code above includes `--dry-run`, which executes the command but prevents permanent changes. Remove this flag once confident that the values are correct.
+
 ### Ready to launch like the pros?
 Now that you're redirecting requests to a single, primary domain, it's the perfect time to configure a long-duration HSTS header, or set up an availability monitoring service to watch over your site like an automated hawk.
 

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -17,7 +17,7 @@ Choose one of the following options to configure the primary domain.
 
 <Partial file="primary-domain.md" />
 
-WordPress site admins must also ensure that all URLs in the site's database are updated. See [Fix WordPress Content References to the Wrong Domain After Cloning](/wordpress-broken-links#fix-wordpress-content-references-to-the-wrong-domain-after-cloning) for more information.
+WordPress site admins must ensure that all URLs in the site's database are updated. See [Fix WordPress Content References to the Wrong Domain After Cloning](/wordpress-broken-links#fix-wordpress-content-references-to-the-wrong-domain-after-cloning) for more information.
 
 ### Ready to launch like the pros?
 
@@ -30,4 +30,3 @@ Prevent cookie hijacking and get an A+ rating from SSL Labs.
 #### [Setup Availability Monitoring](/new-relic/#configure-ping-monitors-for-availability) (Optional)
 
 New Relic provides a free availability monitoring service that sends a request to designated URLs from configured locations at given intervals and alerts you via email if a response fails.
-

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -2,17 +2,10 @@
 title: Launch Essentials
 subtitle: Choose a Primary Domain for SEO
 description: Part five of our Launch Essentials guide covers redirecting users to the proper domains and paths.
-launch: true
 anchorid: redirects
-generator: pagination
-layout: guide
 categories: [go-live]
 tags: [dns, https, launch, webops]
 type: guide
-pagination:
-    provider: data.launchpages
-use:
-    - launchpages
 permalink: docs/guides/launch/redirects/
 editpath: launch/05-redirects.md
 image: getting-started-Largethumb
@@ -35,11 +28,14 @@ terminus wp <site>.live -- search-replace live-<site>.pantheonsite.io <custom-do
 The example code above includes `--dry-run`, which executes the command but prevents permanent changes. Remove this flag once confident that the values are correct.
 
 ### Ready to launch like the pros?
+
 Now that you're redirecting requests to a single, primary domain, it's the perfect time to configure a long-duration HSTS header, or set up an availability monitoring service to watch over your site like an automated hawk.
 
 #### [Send a Long-Duration HSTS Header for Increased Security](/pantheon-yml/#enforce-https--hsts)
+
 Prevent cookie hijacking and get an A+ rating from SSL Labs.
 
 #### [Setup Availability Monitoring](/new-relic/#configure-ping-monitors-for-availability) (Optional)
+
 New Relic provides a free availability monitoring service that sends a request to designated URLs from configured locations at given intervals and alerts you via email if a response fails.
 

--- a/source/content/guides/launch/05-redirects.md
+++ b/source/content/guides/launch/05-redirects.md
@@ -17,15 +17,7 @@ Choose one of the following options to configure the primary domain.
 
 <Partial file="primary-domain.md" />
 
-## (WordPress) Update Database URLs
-
-WordPress site admins must also ensure that all URLs in the site's database are updated. This update can be performed [during a database clone](/wordpress-broken-links#update-environment-urls-on-pantheon), or at any time [using a WordPress plugin](/wordpress-broken-links#theres-a-plugin-for-that) or through [Terminus](/terminus):
-
-```bash{promptUser: user}
-terminus wp <site>.live -- search-replace live-<site>.pantheonsite.io <custom-domain> --url=live-<site>.pantheonsite.io --dry-run
-```
-
-The example code above includes `--dry-run`, which executes the command but prevents permanent changes. Remove this flag once confident that the values are correct.
+WordPress site admins must also ensure that all URLs in the site's database are updated. See [Fix WordPress Content References to the Wrong Domain After Cloning](/wordpress-broken-links#fix-wordpress-content-references-to-the-wrong-domain-after-cloning) for more information.
 
 ### Ready to launch like the pros?
 

--- a/source/partials/search-replace-domains.md
+++ b/source/partials/search-replace-domains.md
@@ -21,24 +21,23 @@ Another popular search-replace plugin is [Better Search Replace](https://wordpre
 
 Using [Terminus](/terminus), you can run an additional `wp search-replace` command on the target environment after cloning. Set or replace the variables `$site` and `$env` with your site name and the correct environment:
 
-
-```bash
-terminus remote:wp $site.$env -- search-replace "://live-example.pantheonsite.io" "://test.example.com" --all-tables --verbose
+```bash{promptUser: user}
+terminus remote:wp $site.$env -- search-replace "://live-example.pantheonsite.io" "://test.example.com" --all-tables --verbose --dry-run
 ```
 
 The following example also converts the URL from HTTP to HTTPS, for situations where you might have HTTPS in one environment and not another:
 
-
-```bash
-terminus remote:wp $site.$env -- search-replace "http://live-example.pantheonsite.io" "https://test.example.com" --all-tables --verbose
+```bash{promptUser: user}
+terminus remote:wp $site.$env -- search-replace "http://live-example.pantheonsite.io" "https://test.example.com" --all-tables --verbose --dry-run
 ```
+
+**Note:** The example code above includes `--dry-run`, which executes the command but prevents permanent changes. Remove this flag once confident that the values are correct.
 
 </Tab>
 
 <Tab title="Quicksilver" id="quicksilver-replace-anchor">
 
 For those using [Quicksilver](/quicksilver) scripts, consider the following example. On each `passthru` line, replace `example#.pantheonsite.io` and `example.com` with the domains you want to find and replace, respectively:
-
 
 ```php
 <?php
@@ -61,9 +60,7 @@ if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
 
 The example above replaces three URLs when cloning to the test environment with `test-examplesite.pantheonsite.io`, and replaces that domain with the example [custom domain](/domains/#custom-domains) `example.com` when cloning to the live environment.
 
-
 You can find this example and many others in the [Quicksilver Examples](https://github.com/pantheon-systems/quicksilver-examples) repo.
-
 
 </Tab>
 


### PR DESCRIPTION
Closes: #5881 

## Summary

**[Launch Essentials - Primary Domain](https://pantheon.io/docs/guides/launch/redirects)** - Updated to instruct WordPress users to update their DB for the Primary domain.

## Remaining Work
- [x] :+1:  from @marfillaster 

## Post Launch
None