### PR TITLE
clarify XL metrics

### DIFF
--- a/source/content/site-plans-faq.md
+++ b/source/content/site-plans-faq.md
@@ -83,7 +83,7 @@ Yes. If you are interested in bulk pricing, [Contact our sales team](https://pan
 
 The Performance Extra Large Plan allows for 300,000 monthly visits and 1.5 million monthly page views. High traffic sites should be moved to an Elite plan. To learn about moving to an [Elite Plan](https://pantheon.io/plans/elite?docsplanFAQ), please [contact us](https://pantheon.io/contact-us?docsplanFAQ).
 
-If you need time or are unable to commit to an annual contract, sites that exceed the Performance Extra Large limits will be upgraded to a Performance 2X Large Plan, which has a limit of 600,000 monthly visits and 3 million monthly page views. The 2X Large plan is not available for purchase via the Dashboard, but can be applied by our Support team. Prices for the 2X Large plan are as follows:
+If you exceed the Performance Extra Large plan limits of 300,000 monthly visits or 1.5 million page views, your site will be upgraded to a Performance 2X Large Plan, which has a limit of 600,000 monthly visits and 3 million monthly page views. The 2X Large plan is not available for purchase via the Dashboard, but can be applied by our Support team. Prices for the 2X Large plan are as follows:
 
 | Payment Type      | Price            |
 |:----------------- |:---------------- |


### PR DESCRIPTION
## Summary

**[Site Plans FAQs](https://pantheon.io/docs/site-plans-faq)** - Clarifies metrics limits for Performance XL Plans.


