### PR TITLE
Added cache lifetime for static assets in dev and multidev environments

### DIFF
--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -3,6 +3,7 @@ title: 'Caching: Advanced Topics'
 description: Advanced details about Pantheon's edge caching layer, cookies, and PHP sessions.
 categories: [performance]
 tags: [cache, cookies, security, webops]
+reviewed: "2020-10-15"
 ---
 ## Allow a User to Bypass the Cache
 
@@ -39,7 +40,7 @@ If your site or application requires Facebook authentication, we have added exce
 
 ## Manually Expiring Cache for Static Assets
 
-Pantheon sets a cache lifetime of 1 year for static assets (e.g. CSS, JS, Images, PDFs) per industry standard best practices. Either of the following options should ensure a client's browser receives a new version of any static asset after clearing a site's cache:
+Pantheon sets a cache lifetime of 1 year for static assets (e.g. CSS, JS, Images, PDFs) on production and test environments, per industry standard best practices. Either of the following options should ensure a client's browser receives a new version of any static asset after clearing a site's cache:
 
 - Rename the file
 - Request the file with an updated query parameter. For example, you can version a css file by linking to it as `style.css?v=1.1`
@@ -50,7 +51,7 @@ For CSS or JavaScript changes, Drupal and WordPress each offer methods to ensure
 
 - **WordPress:** install a plugin like [Autoptimize](https://wordpress.org/plugins/autoptimize/) to add a similar option in the WordPress admin dashboard. Be aware, Autoptimize requires [additional configuration](/plugins-known-issues/#autoptimize) to write files within the standard `wp-content/uploads` path.
 
-Cache lifetime of 1 year for static assets only applies to test and live environments. Dev and multidev environments are intended for development purposes only so static assets for these environments will not be cached.
+Dev and Multidev environments do not cache static assets.
 
 ## Using Your Own Session-Style Cookies
 

--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -50,6 +50,8 @@ For CSS or JavaScript changes, Drupal and WordPress each offer methods to ensure
 
 - **WordPress:** install a plugin like [Autoptimize](https://wordpress.org/plugins/autoptimize/) to add a similar option in the WordPress admin dashboard. Be aware, Autoptimize requires [additional configuration](/plugins-known-issues/#autoptimize) to write files within the standard `wp-content/uploads` path.
 
+Cache lifetime of 1 year only applies to test and live environments. Dev and multidev environments are intended for development purposes only so static assets for these environments will not be cached.
+
 ## Using Your Own Session-Style Cookies
 
 Pantheon passes all cookies beginning with SESS that are followed by numbers and lowercase characters back to the application. When at least one of these cookies is present, the Global CDN will not try to respond to the request from its cache or store the response.

--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -23,7 +23,6 @@ Pantheon does not support manually editing and updating the Varnish Configuratio
 
 </Alert>
 
-
 ## Ignoring GET Parameters
 
 For the purpose of optimizing cache hits for identical content, the Global CDN ignores any GET parameter prefixed with `__` (two underscores) or `utm_` in determining the cache key. This optimization is compatible with services such as Google Analytics and AdWords that use these query parameters solely for tracking and do not alter the page content returned by the application container. The double-underscore prefix for parameter keys and cookie names is a standard convention used by frontend code to indicate a value that can be safely ignored on the back-end.
@@ -58,6 +57,7 @@ Dev and Multidev environments do not cache static assets.
 Pantheon passes all cookies beginning with SESS that are followed by numbers and lowercase characters back to the application. When at least one of these cookies is present, the Global CDN will not try to respond to the request from its cache or store the response.
 
 ### Drupal Sites
+
 Drupal uses SESS-prefixed cookies for its own session tracking, so be sure to name yours differently if you choose to use one. Generally, SESS followed by a few words will work.
 
 **Correct:** SESSmysessioncookie, SESShello123, SESSletsgo
@@ -65,9 +65,11 @@ Drupal uses SESS-prefixed cookies for its own session tracking, so be sure to na
 **Incorrect:** SESS\_hello, SESS-12345, mycustomSESS, Sessone, sess123testing, SESSFIVE
 
 ### WordPress Sites
+
 WordPress does not use PHP session cookies; however, some themes and plugins do. If you are using a theme or plugin that requires PHP sessions, you can install the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/ "Pantheon Session WordPress plugin") plugin. It is designed to handle the naming properly.
 
 ### Session and Cookie Lifetime
+
 Pantheon allows developers to control the length of sessions. There are two pieces: the lifetime of the cookie and the lifetime of the session itself.
 
 Session cookie lifetime is configured using the [session.cookie\_lifetime](https://secure.php.net/manual/en/session.configuration.php#ini.session.cookie-lifetime) PHP setting. If set to 0, the cookie is deleted when the user closes their browser. Session cookie lifetime is set to 2,000,000 seconds in Drupal's default.settings.php and in Pantheon's PHP configuration.
@@ -77,9 +79,11 @@ Drupal's [session garbage collection](https://api.drupal.org/api/drupal/includes
 For additional details and examples on how to set cookie lifetimes and garbage collection manually, see the [documentation within default.settings.php](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php#L314-L336).
 
 #### Drupal 7
+
 Session cookie lifetime and session garbage collection can be overriden in your `settings.php` file. For additional details and examples on how to set cookie lifetimes and garbage collection manually, see ​​the [documentation within default.settings.php](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php#L314-L336).
 
 #### Drupal 8
+
 Session cookie lifetime and session garbage collection can be configured as `session.storage.options` parameters in a services.yml file. To override core session behavior, create a copy of the services.yml file (see [Creating a services.yml File for Drupal 8](/services-yml)), and adjust the `gc_maxlifetime` and `cookie_lifetime` values as needed.
 
 ## Geolocation, Referral Tracking, Content Customization, and Cache Segmentation
@@ -87,6 +91,7 @@ Session cookie lifetime and session garbage collection can be configured as `ses
 A site may need to deliver different content to different users without them logging in or starting a full session (either of which will cause them to bypass the page cache entirely). Pantheon recommends doing this on the client side using browser detection, orientation, or features like aspect ratio using HTML5, CSS3, and JavaScript. Advanced developers can also use STYXKEY.
 
 ### Using Modernizr
+
 [Modernizr](https://modernizr.com/) is a JavaScript library that detects HTML5 and CSS3 features in the user's browser. This will also allow requests to have the benefit of being saved in the Global CDN and rendering correctly, depending on the requirements. Modernizr is available as a [Drupal module](https://www.drupal.org/project/modernizr) or a [WordPress plugin](https://wordpress.stackexchange.com/questions/62340/loading-modernizr-or-other-javascript-libraries-for-use-in-a-plugin/62362#62362).
 
 ### Device Detection
@@ -111,10 +116,10 @@ More information on mobile site best practices can be found in the Google offici
 
 A full list of the devices and their support for HTML5 is available on [https://html5test.com](https://html5test.com):
 
- - [Desktop browsers](https://html5test.com/results/desktop.html)
- - [Tablet browsers](https://html5test.com/results/tablet.html)
- - [Mobile browsers](https://html5test.com/results/mobile.html)
- - [Other browsers](https://html5test.com/results/other.html)
+- [Desktop browsers](https://html5test.com/results/desktop.html)
+- [Tablet browsers](https://html5test.com/results/tablet.html)
+- [Mobile browsers](https://html5test.com/results/mobile.html)
+- [Other browsers](https://html5test.com/results/other.html)
 
 ### Using STYXKEY
 
@@ -132,41 +137,44 @@ In your code, remember to first check whether the incoming request has the `STYX
 
 **Examples of `STYXKEY` cookie names:**
 
-&#8211; `STYXKEY-mobile-ios`: Delivers different stylesheets and content for iOS devices
+- `STYXKEY-mobile-ios`: Delivers different stylesheets and content for iOS devices
 
-&#8211; `STYXKEY_european_user`: Presents different privacy options to E.U. users
+- `STYXKEY_european_user`: Presents different privacy options to E.U. users
 
-&#8211; `STYXKEY-under21`: Part of your site markets alcohol and you want to change the content for minors
+- `STYXKEY-under21`: Part of your site markets alcohol and you want to change the content for minors
 
-&#8211; `STYXKEY-school`: Your site changes content depending on the user's school affiliation
+- `STYXKEY-school`: Your site changes content depending on the user's school affiliation
 
 **Invalid names that won't work:**
 
-&#8211; `STYXKEY`: Needs something after the `STYXKEY` text
+- `STYXKEY`: Needs something after the `STYXKEY` text
 
-&#8211; `styxkey-android`: The text `STYXKEY` must be uppercase
+- `styxkey-android`: The text `STYXKEY` must be uppercase
 
-&#8211; `STYX-KEY-android`: The text `STYXKEY` cannot be hyphenated or contain other punctuation
+- `STYX-KEY-android`: The text `STYXKEY` cannot be hyphenated or contain other punctuation
 
-&#8211; `STYXKEY.tablet`: The only valid characters are a-z, A-Z, 0-9, hyphens ("-"), and underscores ("\_")
+- `STYXKEY.tablet`: The only valid characters are a-z, A-Z, 0-9, hyphens ("-"), and underscores ("\_")
 
-&#8211; `tablet-STYXKEY`: The cookie name must start with `STYXKEY`
-
-
+- `tablet-STYXKEY`: The cookie name must start with `STYXKEY`
 
 ## Public Files and Cookies
+
 Pantheon strips cookies from requests made to public files served from `sites/default/files` in Drupal and `wp-content/uploads` in WordPress. This allows the Global CDN to cache the response.
 
 ## 404s
+
 Pantheon’s default is to not cache 404s, but if your application sets `Cache-Control:max-age headers`, the Global CDN will respect them. Depending on your use case, that may be the desired result.
 
 ### Drupal Sites
+
 Drupal’s `404_fast_*` configuration does not set caching headers. Some contributed 404 modules include cache-friendly headers, which will cause a 404 response to be cached.
 
 ### WordPress Sites
+
 WordPress does not set cache headers by default, 404 or otherwise. If your site has a Permalinks option set other than default, WordPress will return your theme's 404 page. Unless a plugin sets cache friendly headers, your 404 page will not be cached.
 
 ## Environment Access Locked
+
 If you're using the [Security tool](/security) within the Pantheon Site Dashboard to lock an environment, the Global CDN will not cache responses. Disable basic authentication by setting environment access to **Public**.
 
 ## Cookie Handling

--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -50,7 +50,7 @@ For CSS or JavaScript changes, Drupal and WordPress each offer methods to ensure
 
 - **WordPress:** install a plugin like [Autoptimize](https://wordpress.org/plugins/autoptimize/) to add a similar option in the WordPress admin dashboard. Be aware, Autoptimize requires [additional configuration](/plugins-known-issues/#autoptimize) to write files within the standard `wp-content/uploads` path.
 
-Cache lifetime of 1 year only applies to test and live environments. Dev and multidev environments are intended for development purposes only so static assets for these environments will not be cached.
+Cache lifetime of 1 year for static assets only applies to test and live environments. Dev and multidev environments are intended for development purposes only so static assets for these environments will not be cached.
 
 ## Using Your Own Session-Style Cookies
 


### PR DESCRIPTION
Closes: #

## Summary

**Caching: Advanced Topics** - Added cache lifetime for static assets in dev and multidev environments

## Effect
- Static assets in dev and multidev environments are never cached so its good to have this included in this page.

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
