### PR TITLE
Document Index Size Issue Coming From utf8mb3 to utf8mb4

### DIFF
--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -293,7 +293,7 @@ Go the to files directory of your existing site and check if the site archive wa
 
 ### Maximum Index Size
 
-From the [MySQL reference manual](https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-conversion.html):
+From the [MySQL reference manual](https://dev.mysql.com/doc/refman/8.0/en/charset-unicode-conversion.html):
 
 > InnoDB has a maximum index length of 767 bytes for tables that use COMPACT or REDUNDANT row format, so for utf8mb3 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. If you currently have utf8mb3 columns with indexes longer than 191 characters, you must index a smaller number of characters.
 

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -303,7 +303,7 @@ Sites migrated from hosts using `utf8mb3` are upgraded to `utf8mb4`. If those si
 Index column size too large. The maximum column size is 767 bytes
 ```
 
-The offending tables will need to be updated. One method to update index length uses the `ALTER TABLE` command:
+These tables will need to be updated. One method to update index length uses the `ALTER TABLE` command:
 
 ```sql
 ALTER TABLE tableName DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -291,6 +291,20 @@ If you have an existing archive (tgz) file in `sites/default/files` the `drush a
 
 Go the to files directory of your existing site and check if the site archive was generated successfully. If you're hosting the archive on a third party like Dropbox or Google Drive, confirm that it was uploaded successfully. Visiting the archive link with a browser should download the files automatically. You may need to run the `drush ard` command again if you can't find the site archive.
 
+### Maximum Index Size
+
+From the [MySQL reference manual](https://dev.mysql.com/doc/refman/5.7/en/charset-unicode-conversion.html):
+
+> InnoDB has a maximum index length of 767 bytes for tables that use COMPACT or REDUNDANT row format, so for utf8mb3 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. If you currently have utf8mb3 columns with indexes longer than 191 characters, you must index a smaller number of characters.
+
+Sites migrated from hosts using `utf8mb3` are upgraded to `utf8mb4`. If those sites have indexes larger than 191 characters, they will beed to be updated. One method to update index length uses the `ALTER TABLE` command:
+
+```sql
+ALTER TABLE tableName DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+```
+
+This command can be used as part of a script to find and update large indexes.
+
 ## Frequently Asked Questions (FAQs)
 
 ### How do I clone an existing Pantheon site?

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -297,7 +297,13 @@ From the [MySQL reference manual](https://dev.mysql.com/doc/refman/8.0/en/charse
 
 > InnoDB has a maximum index length of 767 bytes for tables that use COMPACT or REDUNDANT row format, so for utf8mb3 or utf8mb4 columns, you can index a maximum of 255 or 191 characters, respectively. If you currently have utf8mb3 columns with indexes longer than 191 characters, you must index a smaller number of characters.
 
-Sites migrated from hosts using `utf8mb3` are upgraded to `utf8mb4`. If those sites have indexes larger than 191 characters, they will beed to be updated. One method to update index length uses the `ALTER TABLE` command:
+Sites migrated from hosts using `utf8mb3` are upgraded to `utf8mb4`. If those sites have indexes larger than 191 characters MySQL will return the following error on import:
+
+```none
+Index column size too large. The maximum column size is 767 bytes
+```
+
+The offending tables will need to be updated. One method to update index length uses the `ALTER TABLE` command:
 
 ```sql
 ALTER TABLE tableName DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -537,11 +537,11 @@ See the [plugin documentation](https://polylang.pro/doc/php-constants/) for more
 
 ___
 
-## [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/)
+## Posts 2 Posts
 
-<ReviewDate date="2020-10-12" />
+<ReviewDate date="2020-12-10" />
 
-**Issue:** This plugin sets an incompatible index value for meta_key when creating new database tables.
+**Issue:** [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/) sets an incompatible index value for meta_key when creating new database tables.
 
 **Solution:** You can apply [this patch](https://gist.github.com/rachelwhitton/a348b3aff2aabf867dccd8188bcddb12) to ensure new tables created by the plugin use the supported `meta_key(191)` index value. You can fix existing tables via the MySQL commandline, for example:
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -541,7 +541,7 @@ ___
 
 <ReviewDate date="2020-12-10" />
 
-**Issue:** [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/) sets an incompatible index value for meta_key when creating new database tables.
+**Issue:** [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/) can have incompatible index values for `meta_key` on database tables when installed on a site imported from a host using [3-byte character sets](/migrate#maximum-index-size).
 
 **Solution:** You can apply [this patch](https://gist.github.com/rachelwhitton/a348b3aff2aabf867dccd8188bcddb12) to ensure new tables created by the plugin use the supported `meta_key(191)` index value. You can fix existing tables via the MySQL commandline, for example:
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -537,6 +537,24 @@ See the [plugin documentation](https://polylang.pro/doc/php-constants/) for more
 
 ___
 
+## [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/)
+
+<ReviewDate date="2020-10-12" />
+
+**Issue:** This plugin sets an incompatible index value for meta_key when creating new database tables.
+
+**Solution:** You can apply [this patch](https://gist.github.com/rachelwhitton/a348b3aff2aabf867dccd8188bcddb12) to ensure new tables created by the plugin use the supported `meta_key(191)` index value. You can fix existing tables via the MySQL commandline, for example:
+
+```sql
+ALTER TABLE wp_18_p2pmeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+ALTER TABLE wp_29_p2pmeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+ALTER TABLE wp_30_p2pmeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+ALTER TABLE wp_31_p2pmeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+ALTER TABLE wp_33_p2pmeta DROP INDEX meta_key, ADD INDEX meta_key(meta_key(191));
+```
+
+___
+
 ## [Query Monitor](https://wordpress.org/plugins/query-monitor/)
 
 **Issue:** Creates a symlink with an absolute path, which will only work on the appserver where the plugin was installed. The plugin is not fully designed for cloud or multi server environments.

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -541,7 +541,11 @@ ___
 
 <ReviewDate date="2020-12-10" />
 
-**Issue:** [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/) can have incompatible index values for `meta_key` on database tables when installed on a site imported from a host using [3-byte character sets](/migrate#maximum-index-size).
+**Issue:** [Posts 2 Posts](https://wordpress.org/plugins/posts-to-posts/) can have incompatible index values for `meta_key` on database tables when installed on a site imported from a host using [3-byte character sets](/migrate#maximum-index-size), resulting in the following error on import:
+
+```none
+Index column size too large. The maximum column size is 767 bytes
+```
 
 **Solution:** You can apply [this patch](https://gist.github.com/rachelwhitton/a348b3aff2aabf867dccd8188bcddb12) to ensure new tables created by the plugin use the supported `meta_key(191)` index value. You can fix existing tables via the MySQL commandline, for example:
 


### PR DESCRIPTION
Close #6054 

## Summary

**[Migrate Sites to Pantheon](https://pantheon.io/docs/migrate#maximum-index-size)** - Documented the issue with overlarge index sizes for databases imported from hosts using `utf8mb4`.

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Captured known issue with posts 2 posts plugin, relating to conversion to `utf8mb4`.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
