### PR TITLE
NS doc fixes

### DIFF
--- a/source/content/dns-providers/network-solutions.md
+++ b/source/content/dns-providers/network-solutions.md
@@ -65,12 +65,12 @@ An A record is required to configure a subdomain (e.g., `www.example.com`).
 4. Click **Save Changes**.
 
 ### AAAA Records
-AAAA records can be set via the [Adding an IPv6 record](http://www.networksolutions.com/support/Adding-an-IPv6-record/) instructions on the Network Solutions docs and require an email to their support to complete.
+AAAA records can be set via the [Adding an IPv6 AAAA record](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS) instructions on the Network Solutions docs and require an email to their support to complete.
 
 ## Network Solutions Docs
 
-* [Managing Advanced DNS Records](http://www.networksolutions.com/support/how-to-manage-advanced-dns-records/)
-* [Adding an IPv6 record](http://www.networksolutions.com/support/Adding-an-IPv6-record/)
+* [Managing Advanced DNS Records](https://knowledge.web.com/subjects/article/KA-01111/en-us#Network%20Solutions)
+* [Adding an IPv6 AAAA record](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS)
 
 ## Next Steps
 

--- a/source/content/dns-providers/network-solutions.md
+++ b/source/content/dns-providers/network-solutions.md
@@ -16,6 +16,7 @@ Network Solutions does not host AAAA records for IPv6 traffic which can negative
 </Alert>
 
 ## Before You Begin
+
 Be sure that you have a:
 
 - Registered domain name using Network Solutions to host DNS
@@ -23,25 +24,32 @@ Be sure that you have a:
 - [Domain connected](/guides/launch/domains) to the target Pantheon environment (typically Live)
 
 ## Locate Pantheon's DNS Values
+
 Identify DNS values to point your domain to Pantheon:
 
 1. Navigate to the Site Dashboard and select the target environment (typically <span class="glyphicons glyphicons-cardio"></span> Live) then click **<span class="glyphicons glyphicons-global"></span> Domains / HTTPS**.
-2. Click the **Details** button next to your domain.
+
+1. Click the **Details** button next to your domain.
 
 Keep this page open and login to your [Network Solutions account](https://www.networksolutions.com) in a new tab before you continue.
 
 ## Configure DNS Records on Network Solutions
 
 ### A Record
+
 1. Navigate to **Account Manager** > **My Domain Names**
-2. Select the domain you want to point to Pantheon, then click **Manage**.
-3. Click **Change Where Domain Points**, then select **Advanced DNS**.
-4. In the IP Address (A records) section, click **Edit A Records**.
-5. The domain likely has a few default values for `www` and the bare domain. Paste the IP address provided by Pantheon in the Numeric IP field for the existing `@ (None)` record, then delete any default records like so:
+
+1. Select the domain you want to point to Pantheon, then click **Manage**.
+
+1. Click **Change Where Domain Points**, then select **Advanced DNS**.
+
+1. In the IP Address (A records) section, click **Edit A Records**.
+
+1. The domain likely has a few default values for `www` and the bare domain. Paste the IP address provided by Pantheon in the Numeric IP field for the existing `@ (None)` record, then delete any default records like so:
 
   ![Network Solutions Edit A Records](../../images/dns/networksolutions/default-a-records.png)
 
-6. Select desired Time to Live (TTL).
+1. Select desired Time to Live (TTL).
 
     <Accordion title="Learn More" id="ttl" icon="info-sign">
 
@@ -53,16 +61,21 @@ Keep this page open and login to your [Network Solutions account](https://www.ne
 
     </Accordion>
 
-7. Click **Save Changes**.
-8. Once changes are saved, the section of the Advanced DNS interface for A records should look like this:
+1. Click **Save Changes**.
+
+1. Once changes are saved, the section of the Advanced DNS interface for A records should look like this:
 
 ### A Record for Subdomain
+
 An A record is required to configure a subdomain (e.g., `www.example.com`).
 
 1. In the IP Address (A records) section, click **Edit A Records**.
-2. Edit the **www** record field and enter the A record value provided by Pantheon (e.g. `23.185.0.2`) in the **Numeric IP** field.
-3. Select desired Time to Live (TTL).
-4. Click **Save Changes**.
+
+1. Edit the **www** record field and enter the A record value provided by Pantheon (e.g. `23.185.0.2`) in the **Numeric IP** field.
+
+1. Select desired Time to Live (TTL).
+
+1. Click **Save Changes**.
 
 ### AAAA Records
 
@@ -70,10 +83,10 @@ Glue records to a name server that hosts AAAA records can be set via the [How Do
 
 ## Network Solutions Docs
 
-* [Managing Advanced DNS Records](https://knowledge.web.com/subjects/article/KA-01111/en-us#Network%20Solutions)
-* [Adding an IPv6 AAAA record](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS)
+- [Managing Advanced DNS Records](https://knowledge.web.com/subjects/article/KA-01111/en-us#Network%20Solutions)
+- [Adding an IPv6 AAAA record](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS)
 
 ## Next Steps
 
-* [Launch Essentials: Domains & HTTPS](/guides/launch/domains)
-* [Launch Essentials: Redirect to a Primary Domain](/guides/launch/redirects)
+- [Launch Essentials: Domains & HTTPS](/guides/launch/domains)
+- [Launch Essentials: Redirect to a Primary Domain](/guides/launch/redirects)

--- a/source/content/dns-providers/network-solutions.md
+++ b/source/content/dns-providers/network-solutions.md
@@ -11,7 +11,7 @@ editpath: dns-providers/network-solutions.md/
 
 <Alert type="danger" title="Warning">
 
-Network Solutions does not support AAAA records for IPv6 traffic which can negatively impact performance, especially on mobile devices. We recommend transferring DNS services to a provider that supports IPv6.
+Network Solutions does not host AAAA records for IPv6 traffic which can negatively impact performance, especially on mobile devices. They support glue records pointing to another authoritative name server. We recommend transferring DNS services to a provider that hosts IPv6 records directly.
 
 </Alert>
 
@@ -65,7 +65,8 @@ An A record is required to configure a subdomain (e.g., `www.example.com`).
 4. Click **Save Changes**.
 
 ### AAAA Records
-AAAA records can be set via the [Adding an IPv6 AAAA record](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS) instructions on the Network Solutions docs and require an email to their support to complete.
+
+Glue records to a name server that hosts AAAA records can be set via the [How Do I Modify IPv6 Records?](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS) instructions on the Network Solutions docs, and require an email to their support to complete.
 
 ## Network Solutions Docs
 


### PR DESCRIPTION
Closes: #5968

## Summary

**[Network Solutions Domain Configuration](https://pantheon.io/docs/network-solutions)** - link fixes (+ maybe info improvements)

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- fixed two broken links b/c Network Solutions documentation moved to web.com

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] (not sure if needed/desired?) Add how to get the host name, maybe something like live-example.pantheonsite.io
  * from the [other issue](https://github.com/pantheon-systems/documentation/issues/6009) submitted for this doc page (closed as duplicate, but the author suggested this ^^ improvement)
    * not sure if should be part of same PR, or if it should be its own issue + PR?
    * FWIW, I **_think_** the "send us your host name" isn't a requirement -- my reading of [the doc](https://knowledge.web.com/subjects/article/KA-01100/en-us#NS), anyway, is that it's optional (in a callout box that says "Advanced Users").

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
