### PR TITLE
Update core-updates.md

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -300,7 +300,14 @@ Whenever there's a new release of WordPress or Drupal core, updates will be avai
 
 <Partial file="drupal-8-8-warning.md" />
 
-</Alert>
+## Supress WordPress Admin Notice
+
+By default WordPress admin will test for new releases every 2 minutes from admin screens. You can disable this by setting the `PANTHEON_UPDATE_NOTICES` constant to `false` in your `wp-config.php` file. This only disabled the test and notice from the WordPress admin, you will still see updates in the Panntheon dashboard.
+
+```
+define( 'PANTHEON_UPDATE_NOTICES', false );
+```
+
 
 ## Troubleshooting
 

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -302,10 +302,10 @@ Whenever there's a new release of WordPress or Drupal core, updates will be avai
 
 ## Supress WordPress Admin Notice
 
-By default WordPress admin will test for new releases every 2 minutes from admin screens. You can disable this by setting the `PANTHEON_UPDATE_NOTICES` constant to `false` in your `wp-config.php` file. This only disabled the test and notice from the WordPress admin, you will still see updates in the Panntheon dashboard.
+By default WordPress admin will check for new upstream updates instead of the default WordPress update nag. You can disable this by setting the `DISABLE_PANTHEON_UPDATE_NOTICES` constant to `true` in your `wp-config.php` file. This only disabled the test and notice from the WordPress admin, you will still see updates in the Pantheon dashboard.
 
 ```
-define( 'PANTHEON_UPDATE_NOTICES', false );
+define( 'DISABLE_PANTHEON_UPDATE_NOTICES', true );
 ```
 
 

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -302,12 +302,11 @@ Whenever there's a new release of WordPress or Drupal core, updates will be avai
 
 ## Supress WordPress Admin Notice
 
-By default WordPress admin will check for new upstream updates instead of the default WordPress update nag. You can disable this by setting the `DISABLE_PANTHEON_UPDATE_NOTICES` constant to `true` in your `wp-config.php` file. This only disabled the test and notice from the WordPress admin, you will still see updates in the Pantheon dashboard.
+By default WordPress admin will check for new upstream updates instead of the default WordPress update nag. You can disable this by setting the `DISABLE_PANTHEON_UPDATE_NOTICES` constant to `true` in your `wp-config.php` file. This only disables the text and notice in the WordPress admin, you will still see upstream updates in the Pantheon dashboard.
 
-```
+```php:title=wp-config.php
 define( 'DISABLE_PANTHEON_UPDATE_NOTICES', true );
 ```
-
 
 ## Troubleshooting
 

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -300,6 +300,8 @@ Whenever there's a new release of WordPress or Drupal core, updates will be avai
 
 <Partial file="drupal-8-8-warning.md" />
 
+</Alert>
+
 ## Supress WordPress Admin Notice
 
 By default WordPress admin will check for new upstream updates instead of the default WordPress update nag. You can disable this by setting the `DISABLE_PANTHEON_UPDATE_NOTICES` constant to `true` in your `wp-config.php` file. This only disables the text and notice in the WordPress admin, you will still see upstream updates in the Pantheon dashboard.


### PR DESCRIPTION
Adds instructions to disable WordPress admin notices

Only applies if https://github.com/pantheon-systems/WordPress/pull/264 is merged.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[WordPress and Drupal Core Updates](https://pantheon.io/docs/core-updates)** - Adds instructions to disable WordPress admin notices


## Remaining Work
The following changes still need to be completed:
pantheon-systems/WordPress/pull/264 should be merged before this is added.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
