### PR TITLE
note zsh breaking command paste

### DIFF
--- a/source/content/terminus/install.md
+++ b/source/content/terminus/install.md
@@ -48,6 +48,8 @@ The following commands will:
   sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
   ```
 
+**Note:** If you're using ZSH and get `parse error near ')'`, ZSH is inserting escape characters (`\`) into the command on paste. consider [disabling magic functions](https://github.com/ohmyzsh/ohmyzsh/blob/master/templates/zshrc.zsh-template#L35-L36) if you don't want this behavior.
+
 <Alert type="info" title="Note">
 
 There is an unofficial third-party installer script which will download `terminus.phar` and attempt to update the appropriate `rc` files, available [on GitHub](https://github.com/alexfornuto/terminus-installer). Note that this script is *not* supported directly by Pantheon.


### PR DESCRIPTION
## Summary

**[Terminus Manual: Install](https://pantheon.io/docs/terminus/install)** - Noted that ZSH inserts escape characters into pasted commands, which breaks our install steps. Includes a link to disable the functionality.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
