### PR TITLE
Update D8 Configuration Management Content

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -296,7 +296,11 @@ This process lets you manually resolve the conflict using the command line and a
 
 Whenever there's a new release of WordPress or Drupal core, updates will be available within 72 hours of upstream availability. Security related updates will be made available within 24 hours.
 
+<Alert title="Warning" type="danger">
+
 <Partial file="drupal-8-8-warning.md" />
+
+</Alert>
 
 ## Troubleshooting
 

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -341,7 +341,9 @@ There are multiple reasons that 503 errors might occur when updating:
 This issue happens when you attempt to update very outdated core files from the Dashboard. Perform the following to resolve:
 
 1. Modify `.gitignore` and add a `#` at the beginning of the `pantheon.upstream.yml` line to comment it out
+
 1. Set the Site Connection Mode to SFTP
+
 1. Reupload the `pantheon.upstream.yml` file if missing:
 
  <TabList>
@@ -373,5 +375,7 @@ This issue happens when you attempt to update very outdated core files from the 
  </TabList>
 
 1. Return to the Commit in dashboard, and note that `pantheon.upstream.yml` can now be committed
+
 1. Set the Site Connection Mode to Git and reapply updates
+
 1. Modify `.gitignore` and remove the `#` before the `pantheon.upstream.yml` line to instruct Git to ignore the file again

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -22,23 +22,27 @@ You can export your configuration into that directory directly using Drush's `co
 
 1. With the Development environment in SFTP mode, export your configuration to code:
 
-   ```bash
+   ```bash{promptUser: user}
    drush config:export -y
    ```
 
 1. Return to the Dashboard and commit the configuration changes.
+
 1. Deploy the code to Test.
+
 1. Import the configuration from code into the test environment database:
 
-   ```bash
+   ```bash{promptUser: user}
    drush config:import -y
    ```
 
 1. Test the site.
+
 1. Deploy the code to Live.
+
 1. Import the configuration from code into the live environment database:
 
-   ```bash
+   ```bash{promptUser: user}
    drush config:import -y
    ```
 

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -8,7 +8,7 @@ reviewed: "2020-10-21"
 ---
 Managing configuration is an extremely important part of any team website project, but in many cases, this area of the project does not receive as much attention as it deserves. The tools for Drupal 7 do not provide complete coverage of all configuration settings, leading to inconsistencies in configuration handling and inconvenient workarounds. This has led to configuration management becoming a real thorn in the side for many projects.
 
-Pantheon supports the [Drupal 8 Configuration Management system](https://www.drupal.org/documentation/administer/config) and defaults configuration into the `config` directory for each Pantheon Drupal 8.8+ site. Drupal versions before 8.8 store configurations in `sites/default/config`.
+Pantheon supports the [Drupal 8 Configuration Management system](https://www.drupal.org/documentation/administer/config) and defaults configuration into the `sites/default/config` directory for each Pantheon Drupal site.
 
 You can export your configuration into that directory directly using Drush's `config-export` command or indirectly using Drupal's UI to download the configuration, and then use SFTP/Git to place the configuration in `config` or `sites/default/config`. For more information, check out the [Managing Content, Configuration, and Code Across Environments](/guides/drupal8-commandline#managing-content-configuration-and-code-across-environments) section of [Create a Drupal 8 Site From the Command Line Using Terminus and Drush](/guides/drupal8-commandline).
 

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -4,10 +4,13 @@ description: Commit your Drupal configuration to version control.
 cms: "Drupal"
 categories: [develop]
 tags: [drush, workflow, webops]
+reviewed: "2020-10-21"
 ---
 Managing configuration is an extremely important part of any team website project, but in many cases, this area of the project does not receive as much attention as it deserves. The tools for Drupal 7 do not provide complete coverage of all configuration settings, leading to inconsistencies in configuration handling and inconvenient workarounds. This has led to configuration management becoming a real thorn in the side for many projects.
 
-Pantheon supports the [Drupal 8 Configuration Management system](https://www.drupal.org/documentation/administer/config) and defaults configuration into the `sites/default/config` directory for each Pantheon Drupal 8 site. You can export your configuration into that directory directly using Drush's config-export command or indirectly using Drupal's UI to download the configuration and then use SFTP/Git to place the configuration in `sites/default/config`. For more information on how this all works, check out Matt Cheney and David Strauss' presentation on [Drupal 8 CMI on Managed Workflow at Drupalcon Amsterdam](https://www.youtube.com/watch?v=eg2dtPFyGxs).
+Pantheon supports the [Drupal 8 Configuration Management system](https://www.drupal.org/documentation/administer/config) and defaults configuration into the `config` directory for each Pantheon Drupal 8.8+ site. Drupal versions before 8.8 store configurations in `sites/default/config`.
+
+You can export your configuration into that directory directly using Drush's `config-export` command or indirectly using Drupal's UI to download the configuration, and then use SFTP/Git to place the configuration in `config` or `sites/default/config`. For more information, check out the [Managing Content, Configuration, and Code Across Environments](/guides/drupal8-commandline#managing-content-configuration-and-code-across-environments) section of [Create a Drupal 8 Site From the Command Line Using Terminus and Drush](/guides/drupal8-commandline).
 
 <Accordion title="Watch: Configuration Management in Drupal" id="d8-config-video" icon="facetime-video">
 

--- a/source/content/drupal-8-configuration-management.md
+++ b/source/content/drupal-8-configuration-management.md
@@ -6,6 +6,7 @@ categories: [develop]
 tags: [drush, workflow, webops]
 reviewed: "2020-10-21"
 ---
+
 Managing configuration is an extremely important part of any team website project, but in many cases, this area of the project does not receive as much attention as it deserves. The tools for Drupal 7 do not provide complete coverage of all configuration settings, leading to inconsistencies in configuration handling and inconvenient workarounds. This has led to configuration management becoming a real thorn in the side for many projects.
 
 Pantheon supports the [Drupal 8 Configuration Management system](https://www.drupal.org/documentation/administer/config) and defaults configuration into the `sites/default/config` directory for each Pantheon Drupal site.

--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -229,7 +229,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 
 ## Managing Content, Configuration, and Code Across Environments
 
-[Configuration management is a complex topic with its own detailed recommendations](/drupal-8-configuration-management). For this guide, all you need to know is that by default, Drupal 8 configuration is stored in the database and can be cleanly exported to `yml` files. Once exported to files and committed to git, these configuration changes can be deployed to different environments (like Test and Live) where they can then be imported to the database.
+[Configuration management is a complex topic with its own detailed recommendations](/drupal-8-configuration-management). For this guide, all you need to know is that by default, Drupal 8 configuration is stored in the database and can be cleanly exported to `yml` files. Once exported to files and committed to Git, these configuration changes can be deployed to different environments (like Test and Live) where they can then be imported to the database.
 
 In the lifecycle of managing a site, you can expect content editors to add new material to the Live environment. That content needs to be brought down into the Test and Dev environments from time to time so you can build and test features with fresh material from Live.
 

--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -175,8 +175,6 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
   terminus drush $TERMINUS_SITE.dev -- config-export -y
   ```
 
-  [Configuration management is a complex topic with its own detailed recommendations](/drupal-8-configuration-management). For this guide, all you need to know is that by default, Drupal 8 configuration is stored in the database and can be cleanly exported to `yml` files. Once exported to files and committed to git, these configuration changes can be deployed to different environments (like Test and Live) where they can then be imported to the database.
-
 1. Commit the changes:
 
   ```bash{promptUser: user}
@@ -230,6 +228,8 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
   Once this command completes you will be able to refresh the Live environment in your browser and see the development footer.
 
 ## Managing Content, Configuration, and Code Across Environments
+
+[Configuration management is a complex topic with its own detailed recommendations](/drupal-8-configuration-management). For this guide, all you need to know is that by default, Drupal 8 configuration is stored in the database and can be cleanly exported to `yml` files. Once exported to files and committed to git, these configuration changes can be deployed to different environments (like Test and Live) where they can then be imported to the database.
 
 In the lifecycle of managing a site, you can expect content editors to add new material to the Live environment. That content needs to be brought down into the Test and Dev environments from time to time so you can build and test features with fresh material from Live.
 

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -7,6 +7,7 @@ categories: [develop]
 tags: [site, database]
 reviewed: "2020-10-21"
 ---
+
 The Drupal system configuration in code is set in the `sites/default/settings.php` file.
 
 ## Drupal 8

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -21,7 +21,6 @@ Drupal 8 sites on Pantheon run an unmodified version of core, bundled with a cus
 
 For Drupal 7 and earlier, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing `settings.php`. Permissions are handled automatically by Pantheon, so you can customize `settings.php` like any other site code.
 
-
 ## Pantheon Articles on settings.php
 
 The following articles include techniques and configurations for `settings.php` on Pantheon:
@@ -43,6 +42,7 @@ You should never put the database connection information for a Pantheon database
 Use these configuration snippets to specify a local configuration that will be ignored by Pantheon, such as database credentials.
 
 ### Drupal 8
+
 Configure environment-specific settings within the `settings.local.php` file, which is ignored by git in our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8). Modifying the bundled `settings.php` file is not necessary, as it already includes `settings.local.php` if one exists.
 
 ```php
@@ -222,7 +222,7 @@ Pantheon automatically injects database credentials into the site environment; i
 
 There can be an occasion when you may need to set the hash salt to a specific value. If you install Drupal 7, it will create a `drupal_hash_salt` value for you, but if you want to use a different one, you can edit `settings.php` before installation. Pantheon uses Pressflow to automatically read the environmental configuration and the Drupal 7 hash salt is stored as part of the Pressflow settings.
 
-```php
+```php:title=settings.php
 // All Pantheon Environments.
 if (defined('PANTHEON_ENVIRONMENT')) {
   // Set your custom hash salt value.
@@ -264,7 +264,7 @@ No; `settings.pantheon.php` is for Pantheon's use only and you should only modif
 
 If you are using a licensed plugin that requires IonCube Decoder support, first ensure you are running [PHP 7.1](/php-versions) or later. Then, enable IonCube Decoder support site-wide by adding a single line to `settings.php`:
 
-```php
+```php:title=settings.php
 ini_set('ioncube.loader.encoded_paths', '/');
 ```
 
@@ -278,13 +278,13 @@ The PHP 5.5 default is `&` and the PHP 5.3 default is `&amp;`.
 
 If the API expects `&` as an argument separator but receives `&amp;` (for example, when using http_build_query), you can override the default arg_separator.output value by adding the following line to `settings.php`:
 
-```php
+```php:title=settings.php
 ini_set('arg_separator.output', '&');
 ```
 
 ### Drush Error: "No Drupal site found", "Could not find a Drupal settings.php file", or missing system information from status
 
-```bash
+```none
 Could not find a Drupal settings.php file at ./sites/default/settings.php
 ```
 
@@ -298,4 +298,4 @@ If you see this error, you need to update your [trusted host patterns](#trusted-
 
 By default, Pantheon's environment is configured to not allow any non-trusted hosts. Trusted hosts are added via the `PANTHEON_ENVIRONMENT` variable in `settings.php` [here](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L184):
 
-GITHUB-EMBED https://github.com/pantheon-systems/drops-8/blob/master/sites/default/settings.pantheon.php php 184-190 GITHUB-EMBED
+GITHUB-EMBED https://github.com/pantheon-systems/drops-8/blob/master/sites/default/settings.pantheon.php php:title=settings.php 179-187 GITHUB-EMBED

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -5,14 +5,22 @@ contributors: [mmenavas, andrewmallis]
 cms: "Drupal"
 categories: [develop]
 tags: [site, database]
+reviewed: "2020-10-21"
 ---
 The Drupal system configuration in code is set in the `sites/default/settings.php` file.
 
+## Drupal 8
+
 Drupal 8 sites on Pantheon run an unmodified version of core, bundled with a custom `settings.php` file that includes the necessary `settings.pantheon.php`. If the stock `settings.php` file is used in place of the bundled file, the site will stop working on Pantheon.
 
-For Drupal 6/7, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing `settings.php`. Permissions are handled automatically by Pantheon, so you can customize `settings.php` like any other site code.
+### Drupal 8.8
 
 <Partial file="drupal-8-8-warning.md" />
+
+## Drupal 7 and Earlier
+
+For Drupal 7 and earlier, Pantheon uses a variant of Pressflow Drupal to allow the server to automatically specify configuration settings, such as the database configuration without editing `settings.php`. Permissions are handled automatically by Pantheon, so you can customize `settings.php` like any other site code.
+
 
 ## Pantheon Articles on settings.php
 

--- a/source/partials/drupal-8-8-warning.md
+++ b/source/partials/drupal-8-8-warning.md
@@ -22,5 +22,4 @@ To resolve (or avoid before upgrading), update the modified code as follows:
   $settings['config_sync_directory'] = dirname(DRUPAL_ROOT) . '/config';
   ```
 
-**Note:** `example-drops-8-composer` (the starting template for all Composer-managed sites on Pantheon) includes this configuration in `settings.php`. Any site built from this example (e.g. using either the No CI workflow or the Build Tools workflow) will need to be updated.
-
+**Note:** `example-drops-8-composer` (the starting template for all Composer-managed sites on Pantheon) includes this configuration in `settings.php`. Any site built from this example (e.g., using either the No CI workflow or the Build Tools workflow) will need to be updated.

--- a/source/partials/drupal-8-8-warning.md
+++ b/source/partials/drupal-8-8-warning.md
@@ -1,14 +1,10 @@
-<Alert title="Warning" type="danger">
-
 Drupal 8.7.x sites that have modified the `config_sync_directory` value in `settings.php` may see this error when upgrading to Drupal 8.8.x:
 
-<br/>
-
-**`CONFIGURATION SYNC DIRECTORY`**
-
-The directory *sites/default/config* does not exist.
-
-<br/>
+> **`CONFIGURATION SYNC DIRECTORY`**
+>
+> The directory *sites/default/config* does not exist.
+>
+>
 
 To resolve (or avoid before upgrading), update the modified code as follows:
 
@@ -28,4 +24,3 @@ To resolve (or avoid before upgrading), update the modified code as follows:
 
 **Note:** `example-drops-8-composer` (the starting template for all Composer-managed sites on Pantheon) includes this configuration in `settings.php`. Any site built from this example (e.g. using either the No CI workflow or the Build Tools workflow) will need to be updated.
 
-</Alert>


### PR DESCRIPTION
Closes: #5965 

## Summary

**[Configuration Workflow for Drupal 8 Sites](https://pantheon.io/docs/drupal-8-configuration-management/)**, **[Create a Drupal 8 Site From the Command Line Using Terminus and Drush](https://pantheon.io/docs/guides/drupal8-commandline/#managing-content-configuration-and-code-across-environments)**,  - Updated content around configuration management in D8 to account for changes introduced in Drupal 8.8

## Remaining Work
The following changes still need to be completed:

- [x] Review from @tgillstar 
- [x] Review from @greg-1-anderson 

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
