### PR TITLE
Adding a method for clearing database cache tables.

### DIFF
--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -175,23 +175,23 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
 
 1. On your dev site, navigate to `/admin/reports/status` and confirm that the **REDIS** line says "Connected, using the PhpRedis client."
 
-<Accordion title="Database Cleanup (optional)" id="database-cleanup" icon="lightbulb">
+<Accordion title="Database Cleanup (optional)" id="database-cleanup-d8" icon="lightbulb">
 
-After enabling Redis via this method, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For some sites, this could be significant amounts of data in these tables and it may be worth running a few commands to remove this data to increase the speed of cloning, exporting and backing up the database.
+After enabling Redis via this method, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting and backing up the database.
 
-To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run this command:
+To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run the command:
 
 ```sql
 SHOW TABLES LIKE 'cache%';
 ```
 
-This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
+This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
+
+To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
 
 ```sql
 TRUNCATE TABLE `<tablename>`;
 ```
-
-Now your database wil no longer have that old, unused cache data while using Redis.
 
 </Accordion>
 
@@ -251,23 +251,23 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 1. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
 
-<Accordion title="Database Cleanup (optional)" id="database-cleanup" icon="lightbulb">
+<Accordion title="Database Cleanup (optional)" id="database-cleanup-d7" icon="lightbulb">
 
-After enabling Redis via this method, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For some sites, this could be significant amounts of data in these tables and it may be worth running a few commands to remove this data to increase the speed of cloning, exporting and backing up the database.
+After enabling Redis, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting and backing up the database.
 
-To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run this command:
+To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run the command:
 
 ```sql
 SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
 ```
 
-This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
+This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
+
+To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
 
 ```sql
 TRUNCATE TABLE `<tablename>`;
 ```
-
-Now your database wil no longer have that old, unused cache data while using Redis.
 
 </Accordion>
 

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -175,6 +175,26 @@ All plans except for the Basic plan can use Redis. Sandbox site plans can enable
 
 1. On your dev site, navigate to `/admin/reports/status` and confirm that the **REDIS** line says "Connected, using the PhpRedis client."
 
+<Accordion title="Database Cleanup (optional)" id="database-cleanup" icon="lightbulb">
+
+After enabling Redis via this method, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For some sites, this could be significant amounts of data in these tables and it may be worth running a few commands to remove this data to increase the speed of cloning, exporting and backing up the database.
+
+To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run this command:
+
+```sql
+SHOW TABLES LIKE 'cache%';
+```
+
+This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing "<tablename>" with the name of the cache table:
+
+```sql
+TRUNCATE TABLE `<tablename>`;
+```
+
+Now your database wil no longer have that old, unused cache data while using Redis.
+
+</Accordion>
+
 </Tab>
 
 <Tab title="Drupal 7" id={"d7-install"}>

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -185,10 +185,10 @@ To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) a
 SHOW TABLES LIKE 'cache%';
 ```
 
-This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing "<tablename>" with the name of the cache table:
+This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
 
 ```sql
-TRUNCATE TABLE `<tablename>`;
+TRUNCATE TABLE '<tablename>';
 ```
 
 Now your database wil no longer have that old, unused cache data while using Redis.

--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -188,7 +188,7 @@ SHOW TABLES LIKE 'cache%';
 This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
 
 ```sql
-TRUNCATE TABLE '<tablename>';
+TRUNCATE TABLE `<tablename>`;
 ```
 
 Now your database wil no longer have that old, unused cache data while using Redis.
@@ -250,6 +250,26 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 1. Verify Redis is enabled by going to the Dashboard and clicking **Connection Info**. If you see the Redis cache connection string, Redis is enabled.
 
 1. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
+
+<Accordion title="Database Cleanup (optional)" id="database-cleanup" icon="lightbulb">
+
+After enabling Redis via this method, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For some sites, this could be significant amounts of data in these tables and it may be worth running a few commands to remove this data to increase the speed of cloning, exporting and backing up the database.
+
+To do this, [connect directly to MySQL](https://pantheon.io/docs/mysql-access) and run this command:
+
+```sql
+SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
+```
+
+This returns a list of all the cache tables in the database. These are safe to empty and at some future point when Redis is not enabled, then Drupal will default to storing and reading cache data from these tables. To empty them, run this command on each table, replacing `<tablename>` with the name of the cache table:
+
+```sql
+TRUNCATE TABLE `<tablename>`;
+```
+
+Now your database wil no longer have that old, unused cache data while using Redis.
+
+</Accordion>
 
 </Tab>
 


### PR DESCRIPTION
## Summary

**[Installing Redis](https://pantheon.io/docs/redis)** - After Redis is enabled in at least Drupal 8, the database keeps old cache data. It could be helpful to instruct how to remove it manually.

## Effect
The following changes are already committed:

- Add a note to the end of the Drupal 8 install that cache data in db tables is still around.
- Provide a few MySQL queries to remove these tables. Depending on modules installed, the amount and names of tables may be different, but they will follow that pattern.

## Remaining Work
The following changes still need to be completed:

- [x] Does this also happen on Drupal 7? If so, add Docs for this as well.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
