### PR TITLE
Update CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ contributors: [mrfelton]
 Review our [Style Guide](https://pantheon.io/docs/style-guide/) for more detailed information on the Pantheon voice and style, and examples of the formatting we use for notes & warnings, code blocks, etc.
 
 ### Contributors
-Create a contributor profile within your **first** contribution. Fill out the information below and add it to the [`contributors.yaml`](/source/data/contributor.yaml) file. Commit this change alongside your new guide.
+Create a contributor profile within your **first** contribution. Fill out the information below and add it to the [`contributor.yaml`](/source/data/contributor.yaml) file. Commit this change alongside your new guide.
 
 ```
 - id: alexfornuto


### PR DESCRIPTION
Small typo in file name - contributors.yaml does not exist.

**Note:** Please fill out the PR Template to ensure proper processing.

Closes: n/a

## Summary

The doc referenced contributors.yaml, which should be contributor.yaml.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
