### PR TITLE
Add PRESSFLOW_SETTINGS unset to D7 snippet

### DIFF
--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -25,7 +25,15 @@ Pantheon configures an appropriate temporary path for [WordPress](https://github
  * Define appropriate location for tmp directory
  */
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+  if (isset($_SERVER['PRESSFLOW_SETTINGS'])) { 
+    // It's necessary to unset the injected PRESSFLOW_SETTINGS to override the values.
+    $pressflow_settings = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE); 
+    unset($pressflow_settings['conf']['file_temporary_path']); 
+    unset($pressflow_settings['conf']['file_directory_temp']); 
+    $_SERVER['PRESSFLOW_SETTINGS'] = json_encode($pressflow_settings); 
+  } 
   $conf['file_temporary_path'] = $_SERVER['HOME'] .'/tmp';
+  $conf['file_directory_temp'] = $_SERVER['HOME'] .'/tmp';
 }
 ```
 

--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -37,6 +37,8 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 ```
 
+**Note:** Changing the temporary settings path for Drupal 7 is not recommended. While the changes above would allow temporary files to be shared across application containers, it comes with a heavy performance penalty. 
+
 ## Fix Unsupported Temporary Path
 
 Errors caused by an unsupported temporary path typically surface as permission errors for `.tmp` files and can be replicated on any environment.


### PR DESCRIPTION
## Summary

It's necessary to unset PRESSFLOW_SETTINGS to override temp directory locations in D7. This clarifies that.

## Steps to test:
- Spin up vanilla D7, with existing snippet in settings.php, using a custom path e.g. `$conf['file_temporary_path'] = 'sites/default/files/foo';`
- Check variable through filesystem or echo out somewhere, observe it is not changed
- Use new snippet to unset `PRESSFLOW_SETTINGS['file_temporary_path']`, and check again to confirm the custom path is now honored.