### PR TITLE
Updates wp-config-php.md

### DIFF
--- a/source/content/wp-config-php.md
+++ b/source/content/wp-config-php.md
@@ -113,7 +113,7 @@ ini_set( 'error_log', WP_CONTENT_DIR . '/uploads/debug.log' );
 As of WP version 5.1 and newer:
 
 ```php:title=wp-config.php
-define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/uploads/debug.log'
+define( 'WP_DEBUG_LOG', __DIR__ . '/wp-content/uploads/debug.log' );
 ```
 
 ### Where do I specify database credentials?


### PR DESCRIPTION
Re: [Doc wp-config.php](https://pantheon.io/docs/wp-config-php)

Priority: Low

## Issue Description
The document currently has a PHP code example missing a closing `)`

## Suggested Resolution
The fix is to add `)` at the example
