### PR TITLE
Update and correct the style guide

### DIFF
--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -211,7 +211,7 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 <Example>
 
 A <dfn id="dfn">dfn</dfn> tag is used to indicate that a paragraph is defining a new term.
-New terms should only be defined once throughout the doc, and then cross-referenced.
+New terms should only be defined once throughout the docs, and then cross-referenced.
 Definitions and Definition Lists are automatically added to the [Glossary](/glossary).
 
 <hr className="source-code" /> <br/>

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -14,6 +14,8 @@ You can also reference the [Pantheon Documentation Template](/doc-template) to s
 
 The site features two distinct content types; **docs** and **guides**. We define docs as reference materials used to explain the behavior and intended use of Pantheon's platform features and service offerings. Guides are generally paginated and designed to walk the reader through a specific concept or task.
 
+___
+
 ## Voice, Style, and Flow
 
 Some General Rules:
@@ -21,6 +23,8 @@ Some General Rules:
 - [Avoid be verbs](http://writing.rocks/to-be-or-not-to-be/).
 - Avoid colloquialisms and personal opinions, feelings, or anecdotes. Use an informal but succinct tone.
 - Only assume as much knowledge from the reader as specified in the Before You Begin section. Otherwise explain everything.
+
+___
 
 ## Frontmatter
 
@@ -89,6 +93,14 @@ The content type for this content. Defaults to `doc`, overwritten for other cont
 <dt><code>subtitle</code></dt>
 <dd>Used in multipage guides to define a title for that page of the guide.</dd>
 
+<dt><code>cms</code></dt>
+
+<dd>
+
+If a page is specificially written for a single CMS or CMS version, it's tagged as `"WordPress"`, `"Drupal"`, `"Drupal 7"`, `"Drupal 8"`, or `"Drupal 9"`.
+
+</dd>
+
 </dl>
 
 </Accordion>
@@ -97,7 +109,7 @@ The content type for this content. Defaults to `doc`, overwritten for other cont
 
 This section should outline any steps or services required before starting those in the doc. If there are other docs that should be completed first, list them here.
 
-Of particular note, any documentation that uses Terminus should reference it in this section, and link to the [Terminus Manual](/terminus). 
+Of particular note, any documentation that uses Terminus should reference it in this section, and link to the [Terminus Manual](/terminus).
 
 <Example>
 
@@ -126,8 +138,10 @@ Be sure that you have:
 </Example>
 
 ### Export Local Environment Variables
+
 Be kind. If you're writing a guide that will use one or more example variables the reader must replace when following along, you should walk them through exporting them to local environment variables. See the [Variables](#variables) section below for more details.
 
+___
 
 ## Typography
 
@@ -174,20 +188,6 @@ Go to **Account** > **Security** > **Personal Access Tokens**.
 
 </Example>
 
-Bold is also used when defining new terms, in cases where the [Definition List](#definition-list) doesn't fit:
-
-<Example>
-
-**Transport Layer Security** (TLS) refers to a set of cryptographic security protocols used to encrypt network traffic.
-
-<hr className="source-code" /> <br/>
-
-```markdown
-**Transport Layer Security** (TLS) refers to a set of cryptographic security protocols used to encrypt network traffic.
-```
-
-</Example>
-
 ### Italics
 
 <Example>
@@ -198,6 +198,24 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 
 ```markdown
 Emphasis should *always* be stressed with italics, and *never* with bold.
+```
+
+</Example>
+
+### Definitions
+
+<Example>
+
+A <dfn id="dfn">dfn</dfn> tag is used to indicate that a paragraph is defining a new term.
+New terms should only be defined once throughout the doc, and then cross-referenced.
+Definitions and definition Lists also are automatically added to the [Glossary](/glossary).
+
+<hr className="source-code" /> <br/>
+
+```html
+A <dfn id="dfn">dfn</dfn> tag is used to indicate that a paragraph is defining a new term.
+New terms should only be defined once throughout the doc, and then cross-referenced.
+Definitions and definition Lists also are automatically added to the [Glossary](/glossary).
 ```
 
 </Example>
@@ -220,13 +238,37 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 
 <dt>Term</dt>
 
-<dd>Definition.</dd>
+<dd>
+
+Definition.
+
+</dd>
 
 <dt>Another Term</dt>
 
-<dd>Description of the new term.</dd>
+<dd>
+
+Description of the new term.
+
+</dd>
 
 </dl>
+```
+
+</Example>
+
+Note that a newline is required between HTML elements and content, so that the MarkDown renderer knows to format the content.
+
+### Abbreviations
+
+<Example>
+
+The <abbr title="Abbreviation">abbr</abbr> tag is used to provide the full name of an abbreviated term on mouse hover.
+
+<hr className="source-code" /> <br/>
+
+```html
+The <abbr title="Abbreviation">abbr</abbr> tag is used to provide the full name of an abbreviated term on mouse hover.
 ```
 
 </Example>
@@ -264,6 +306,8 @@ Use relative paths when linking to other pages of the docs site.
 ```
 
 </Example>
+
+___
 
 ## Code
 
@@ -417,6 +461,8 @@ Vary: Accept-Encoding, Cookie
 
 </Example>
 
+___
+
 ## File Excerpts
 
 File excerpts are [code blocks](#blocks) with a file name specified after the syntax as `:title=FILENAME`:
@@ -450,6 +496,8 @@ wp-content/upgrade/
 
 </Example>
 
+___
+
 ## Variables
 
 When writing multi-step processes, repeated variables and constants should be defined before providing the first set of commands. If the doc has a "Before You Begin" section, define varables here. Provide them using the callout below, and follow common conventions (lowercase for variables, uppercase for constants).
@@ -460,7 +508,7 @@ When writing multi-step processes, repeated variables and constants should be de
 
 This process uses [Terminus](/terminus) extensively. Before we begin, set the variables `$site` and `$env` in your terminal session to match your site name and the Dev environment:
 
-```bash
+```bash{promptUser: user}
 export site=yoursitename
 export env=dev
 ```
@@ -474,7 +522,7 @@ export env=dev
 
 This process uses [Terminus](/terminus) extensively. Before we begin, set the variables `$site` and `$env` in your terminal session to match your site name and the Dev environment:
 
-```bash
+```bash{promptUser: user}
 export site=yoursitename
 export env=dev
 ```
@@ -484,9 +532,11 @@ export env=dev
 
 </Example>
 
+___
+
 ## Callouts
 
-There are two types of callouts used in our docs, notes and warnings:
+There are several types of callouts commonly used in our docs:
 
 ### Notes
 
@@ -569,6 +619,8 @@ Success callouts are used infrequently, usually in guides with specific end resu
 
 </Example>
 
+___
+
 ## Tabs
 
 When working on a document that will cover steps for multiple CMSs, use tabs when possible to condense instructions that need duplication for the different applications.
@@ -626,60 +678,64 @@ Some code.
 
 <hr className="source-code" /> <br/>
 
-    <TabList>
-    
-    <Tab title="WordPress" id="wp-example" active={true}>
-    
-    Here's our WordPress specific copy, and an example snippet:
-    
-    ```php
-    /**
-      * Some WordPress specific thing
-      *
-      */
- 
-    Some code.
-    ```
-    
-    </Tab>
-    
-    <Tab title="Drupal 8" id="d8-example">
-    
-    Here's our Drupal 8 specific copy, and an example snippet:
-    
-    ```php
-    /**
-      * Some Drupal 8 specific thing
-      *
-      */
+````markdown
+<TabList>
 
-    Some code.
-    ```
-    
-    </Tab>
-    
-    <Tab title="Drupal 7" id="d7-example">
-    
-    Here's our Drupal 7 specific copy, and an example snippet:
-    
-    ```php
-    /**
-      * Some Drupal 7 specific thing
-      *
-      */
+<Tab title="WordPress" id="wp-example" active={true}>
 
-    Some code.
-    ```
-    
-    </Tab>
-    
-    </TabList>
+Here's our WordPress specific copy, and an example snippet:
+
+```php
+/**
+  * Some WordPress specific thing
+  *
+  */
+
+Some code.
+```
+
+</Tab>
+
+<Tab title="Drupal 8" id="d8-example">
+
+Here's our Drupal 8 specific copy, and an example snippet:
+
+```php
+/**
+  * Some Drupal 8 specific thing
+  *
+  */
+
+Some code.
+```
+
+</Tab>
+
+<Tab title="Drupal 7" id="d7-example">
+
+Here's our Drupal 7 specific copy, and an example snippet:
+
+```php
+/**
+  * Some Drupal 7 specific thing
+  *
+  */
+
+Some code.
+```
+
+</Tab>
+
+</TabList>
+````
 
 </Example>
 
+___
+
 ## Screenshots
 
-Submit screenshots without additional markup. Don't use Skitch to add an arrow, for example.
+Submit screenshots without additional markup. For example, don't use Skitch to add an arrow.
 
 ### GUI
 
@@ -713,6 +769,8 @@ Terminal screenshots should only be used to demonstrate intended output:
 
 </Example>
 
+___
+
 ## Error Messages
 
 Document error messages verbatim as H3s within a **Troubleshooting** section. Using the exact copy of the error message helps to improve SEO, and making the header an H3 allows the section to be linkable within the table of contents for easy sharing.
@@ -744,6 +802,8 @@ Enable Redis via the Pantheon Site Dashboard by going to **Settings** > **Add On
 
 </Example>
 
+___
+
 ## Panels
 
 Use panels for extraneous but useful information such as troubleshooting sections or pro tips that would be distracting or can be skipped over by a large portion of readers. This is primarily used in an effort to promote readability of a page.
@@ -772,13 +832,15 @@ This Panel contains additional context, or advanced instructions.
 
 </Example>
 
+___
+
 ## Tables
 
 You can use markdown tables to describe availability based on service levels before providing instructions on how to enable or use a given feature. For example:
 
 <Example>
 
-## Enable Redis 
+<h2 class="toc-ignore">Enable Redis</h2>
 
 All plans except for a Basic plan can use Redis. Redis is available to Sandbox site plans for developmental purposes, but Redis will not be available going live on a Basic plan.
 
@@ -866,6 +928,8 @@ Standard markdown tables don't allow for cells to span multiple rows or columns,
 
 </Accordion>
 
+___
+
 ## Tooltips
 
 Tooltips are a great way to add additional information without cluttering up a section. For example, you can define jargon and even link out to an external resource without being distracting to the reader:
@@ -887,6 +951,8 @@ Given two new sites with slugs <Popover title="Slugs" content="Generally, are UR
 ```
 
 </Example>
+
+___
 
 ## See Also
 

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -23,6 +23,7 @@ Some General Rules:
 - [Avoid be verbs](http://writing.rocks/to-be-or-not-to-be/).
 - Avoid colloquialisms and personal opinions, feelings, or anecdotes. Use an informal but succinct tone.
 - Only assume as much knowledge from the reader as specified in the Before You Begin section. Otherwise explain everything.
+- Review our [Inclusive Language](https://pantheon.io/docs/inclusive-language) doc, and review your writing for inaccessible language.
 
 ___
 

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -2,7 +2,7 @@
 title: Style Guide
 description: Formatting rules and guidelines for Pantheon's open-source documentation.
 contributors: [alexfornuto, rachelwhitton]
-reviewed: "2020-04-28"
+reviewed: "2020-11-04"
 ---
 <!-- markdownlint-disable -->
 
@@ -145,7 +145,11 @@ ___
 
 ## Typography
 
+All documentation uses MarkDown to render headings and typographic elements like bold and italic. Note that a newline is required between HTML elements and content, so the MarkDown renderer knows to format the content.
+
 ### Headings
+
+Give heading levels a meaningful hierarchy to ensure accessible navigation and structure.
 
 <Example>
 
@@ -208,14 +212,14 @@ Emphasis should *always* be stressed with italics, and *never* with bold.
 
 A <dfn id="dfn">dfn</dfn> tag is used to indicate that a paragraph is defining a new term.
 New terms should only be defined once throughout the doc, and then cross-referenced.
-Definitions and definition Lists also are automatically added to the [Glossary](/glossary).
+Definitions and Definition Lists are automatically added to the [Glossary](/glossary).
 
 <hr className="source-code" /> <br/>
 
 ```html
 A <dfn id="dfn">dfn</dfn> tag is used to indicate that a paragraph is defining a new term.
 New terms should only be defined once throughout the doc, and then cross-referenced.
-Definitions and definition Lists also are automatically added to the [Glossary](/glossary).
+Definitions and Definition Lists are automatically added to the [Glossary](/glossary).
 ```
 
 </Example>
@@ -256,8 +260,6 @@ Description of the new term.
 ```
 
 </Example>
-
-Note that a newline is required between HTML elements and content, so that the MarkDown renderer knows to format the content.
 
 ### Abbreviations
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2828,6 +2828,11 @@ article > div > dfn {
 	color: #44525e;
 }
 
+dt {
+	font-weight: 700;
+	margin-top: .5em;
+}
+
 /* Was this helpful widget */
 /* .helpful {
 	margin: 60px 0;


### PR DESCRIPTION
## Summary

**[Style Guide](https://pantheon.io/docs/style-guide)** - Updates and improvements.

## Effect

- Clarified definition lists and added `dfn` and `abbr` tags.
- Added `hr` lines between H2 sections, as they can all sort of melt into each other.
- Removed bold for definitions.
- Improved MarkDown formatting, various small copy edits.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
