### PR TITLE
Fixes: relative Plugin URI and Description typo

### DIFF
--- a/source/content/environment-specific-config.md
+++ b/source/content/environment-specific-config.md
@@ -46,9 +46,9 @@ Copy this plugin file to `wp-content/mu-plugins/site-config.php` and edit accord
 <?php
 /*
   Plugin Name: Site Config
-  Plugin URI: /docs/environment-specific-config
-  Description: Activating and deactivates plugins based on environment.
-  Version: 0.1
+  Plugin URI: https://pantheon.io/docs/environment-specific-config
+  Description: Activates and deactivates plugins based on environment.
+  Version: 0.1.1
   Author: Pantheon
   Author URI: https://pantheon.io/docs/contributors
 */


### PR DESCRIPTION
Correct a typo and an invalid relative URI

Closes: # n/a

## Summary

**[Environment-Specific Configuration for WordPress Sites](https://pantheon.io/docs/environment-specific-config)** - Fixes a typo and fixes a relative URI path that leads to a 404 error in many cases.

## Effect

The following changes are already committed:

* Updated the Plugin URI to point to an absolute URI at pantheon.io. The current URI is relative to each hosted site, so it causes a 404 error in most cases.
* Fixed a typo involving different verb tenses.
* Small bump of the version number to reflect these changes.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
