### PR TITLE
pressflow for D8

### DIFF
--- a/source/content/start-state.md
+++ b/source/content/start-state.md
@@ -8,7 +8,7 @@ The site's framework is selected during the creation process. Pantheon Upstreams
 
 ## Pantheon Upstreams
 
-We base our Drupal 7 repository on the canonical source from drupal.org, and then extend it with [Pressflow](http://pressflow.org/) modifications and additional features to take advantage of the Pantheon runtime environment. The WordPress repository includes platform integration plugins and a pre-configured `wp-config.php`.
+We base our Drupal 7 & 8 repositories on the canonical source from drupal.org, and then extend it with [Pressflow](http://pressflow.org/) modifications and additional features to take advantage of the Pantheon runtime environment. The WordPress repository includes platform integration plugins and a pre-configured `wp-config.php`.
 
 - [WordPress](https://dashboard.pantheon.io/sites/create?upstream_id=e8fe8550-1ab9-4964-8838-2b9abdccf4bf)
 - [Drupal 8](https://dashboard.pantheon.io/sites/create?upstream_id=8a129104-9d37-4082-aaf8-e6f31154644e) <Popover content="Install Requires SFTP Mode" />


### PR DESCRIPTION
Closes: #6107 

## Summary

**[Choosing Your Start State](https://pantheon.io/docs/start-state)** - Updated language to not imply that D8 isn't extended with Pressflow settings..

## Remaining Work
- [x] (optional) :+1: from @ksenour 

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
