### PR TITLE
apply latest upstream if no wp-config-pantheon.php

### DIFF
--- a/source/content/wp-config-php.md
+++ b/source/content/wp-config-php.md
@@ -44,6 +44,8 @@ GITHUB-EMBED https://github.com/pantheon-systems/WordPress/blob/default/wp-confi
 
 In order to get the latest WordPress upstream updates while avoiding merge conflicts, Pantheon includes `wp-config-pantheon.php`.
 
+If you don’t see `wp-config-pantheon.php` in your [WP code directory](/code#wordpress-code-structure), apply the latest upstream updates as shown in the [WordPress and Drupal Core Updates](/core-updates) doc
+
 Do not edit `wp-config-pantheon.php`. It includes database and environment configuration settings that the platform uses and that Pantheon maintains.
 
 ## Environment-specific Configuration

--- a/source/content/wp-config-php.md
+++ b/source/content/wp-config-php.md
@@ -44,7 +44,7 @@ GITHUB-EMBED https://github.com/pantheon-systems/WordPress/blob/default/wp-confi
 
 In order to get the latest WordPress upstream updates while avoiding merge conflicts, Pantheon includes `wp-config-pantheon.php`.
 
-If you don’t see `wp-config-pantheon.php` in your [WP code directory](/code#wordpress-code-structure), apply the latest upstream updates as shown in the [WordPress and Drupal Core Updates](/core-updates) doc
+If you don’t see `wp-config-pantheon.php` in your [WP code directory](/code#wordpress-code-structure), apply the latest upstream updates as shown in [WordPress and Drupal Core Updates](/core-updates).
 
 Do not edit `wp-config-pantheon.php`. It includes database and environment configuration settings that the platform uses and that Pantheon maintains.
 


### PR DESCRIPTION
Closes: DOC-258

## Summary

**[Pantheon Platform Settings in wp-config-pantheon.php](https://pantheon.io/docs/wp-config-php#pantheon-platform-settings-in-wp-config-pantheonphp)** - Add a reminder for users who haven't pulled the latest WP upstream in a while won't have Pantheon's wp-config.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
