### PR TITLE
Glossary title capitalization

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -2833,6 +2833,10 @@ dt {
 	margin-top: .5em;
 }
 
+.glossary-term {
+	text-transform: capitalize;
+}
+
 /* Was this helpful widget */
 /* .helpful {
 	margin: 60px 0;


### PR DESCRIPTION

## Summary

**[Glossary](https://pantheon.io/docs/glossary)** - Ensure consistent capitalization for glossary titles.

