### PR TITLE
Added New Issue for Autoptimize Plugin

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -153,14 +153,18 @@ Be sure to add this configuration _above_ the comment to stop editing:
 
 For additional details, see the [Autoptimize FAQ](https://wordpress.org/plugins/autoptimize/faq). An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link).
 
-**Issue 2:** Autoptimize generates a php file upon activation "wp-content/autoptimize_404_handler.php" if not present autoptimize will throw a php warning
-and enabling this setting requires write access and a [location directive](https://wordpress.org/plugins/autoptimize/#%0Awhat%20does%20%E2%80%9Cenable%20404%20fallbacks%E2%80%9D%20do%3F%20why%20would%20i%20need%20this%3F%0A) not configured in platform's Nginx configuration. 
-```
-Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php): failed to open stream: Permission denied in /code/wp-content/plugins/autoptimize/classes/autoptimizeCache.php on line 642
+**Issue 2:** Autoptimize attempts to generate the file `wp-content/autoptimize_404_handler.php` upon activation, and if not present will throw a php warning.
+
+Enabling this setting requires write access and a [location directive](https://wordpress.org/plugins/autoptimize/#%0Awhat%20does%20%E2%80%9Cenable%20404%20fallbacks%E2%80%9D%20do%3F%20why%20would%20i%20need%20this%3F%0A) not configured in platform's Nginx configuration, generating the error:
+
+```php
+Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php):
+failed to open stream: Permission denied in /code/wp-content/plugins/autoptimize/classes/autoptimizeCache.php on line 642
 ```
 
-**Solution:** Uncheck *Enable 404 fallbacks* in Autoptimize settings page `wp-admin/options-general.php?page=autoptimize`.
-The Pantheon Platform does not provide support for custom configuration, hence file redirects will not work. More information can be found in [here.](https://pantheon.io/docs/advanced-redirects#redirect-files)
+**Solution:** Uncheck **Enable 404 fallbacks** in the Autoptimize settings page `wp-admin/options-general.php?page=autoptimize`.
+The Pantheon Platform does not provide support for custom HTTP server configurations, so file redirects will not work. More information can be found in the [redirect files](/advanced-redirects#redirect-files) section of [Advanced Redirects and Restrictions](/advanced-redirects).
+
 ___
 
 ## [Better Search And Replace](https://wordpress.org/plugins/better-search-replace/)

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -154,7 +154,7 @@ Be sure to add this configuration _above_ the comment to stop editing:
 For additional details, see the [Autoptimize FAQ](https://wordpress.org/plugins/autoptimize/faq). An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link).
 
 **Issue 2:** Autoptimize generates a php file upon activation "wp-content/autoptimize_404_handler.php" if not present autoptimize will throw a php warning
-and enabling this setting requires write access and specific location directive not configured in platform's Nginx configuration. 
+and enabling this setting requires write access and a [location directive](https://wordpress.org/plugins/autoptimize/#%0Awhat%20does%20%E2%80%9Cenable%20404%20fallbacks%E2%80%9D%20do%3F%20why%20would%20i%20need%20this%3F%0A) not configured in platform's Nginx configuration. 
 ```
 Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php): failed to open stream: Permission denied in /code/wp-content/plugins/autoptimize/classes/autoptimizeCache.php on line 642
 ```

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -154,16 +154,13 @@ Be sure to add this configuration _above_ the comment to stop editing:
 For additional details, see the [Autoptimize FAQ](https://wordpress.org/plugins/autoptimize/faq). An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link).
 
 **Issue 2:** Autoptimize generates a php file upon activation "wp-content/autoptimize_404_handler.php" if not present autoptimize will throw a php warning
-
+and enabling this setting requires write access and specific location directive not configured in platform's Nginx configuration. 
 ```
 Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php): failed to open stream: Permission denied in /code/wp-content/plugins/autoptimize/classes/autoptimizeCache.php on line 642
 ```
 
-**Solution 1:** Activate the plugin to generate autoptimize_404_handler.php the file from Dev before committing.
-
-**Solution 2:** An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link)
- for autoptimize_404_handler.php, This will also future proof any changes the plugin might do with every update.
-
+**Solution:** Uncheck *Enable 404 fallbacks* in Autoptimize settings page `wp-admin/options-general.php?page=autoptimize`.
+The Pantheon Platform does not provide support for custom configuration, Hence file redirects will not work. More information can be found in [here.](https://pantheon.io/docs/advanced-redirects#redirect-files)
 ___
 
 ## [Better Search And Replace](https://wordpress.org/plugins/better-search-replace/)

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -160,7 +160,7 @@ Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php): failed
 ```
 
 **Solution:** Uncheck *Enable 404 fallbacks* in Autoptimize settings page `wp-admin/options-general.php?page=autoptimize`.
-The Pantheon Platform does not provide support for custom configuration, Hence file redirects will not work. More information can be found in [here.](https://pantheon.io/docs/advanced-redirects#redirect-files)
+The Pantheon Platform does not provide support for custom configuration, hence file redirects will not work. More information can be found in [here.](https://pantheon.io/docs/advanced-redirects#redirect-files)
 ___
 
 ## [Better Search And Replace](https://wordpress.org/plugins/better-search-replace/)

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -138,7 +138,7 @@ ___
 
 <ReviewDate date="2020-02-10" />
 
-**Issue:** Autoptimize assumes write access to the site's codebase within the `wp-content/resources` directory, which is not granted on Test and Live environments on Pantheon by design. For additional details, see [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
+**Issue 1:** Autoptimize assumes write access to the site's codebase within the `wp-content/resources` directory, which is not granted on Test and Live environments on Pantheon by design. For additional details, see [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
 
 **Solution:** Configure Autoptimize to write files within the standard `wp-content/uploads` path for WordPress (`wp-content/uploads/autoptimize`) by adding the following to `wp-config.php`:
 
@@ -152,6 +152,17 @@ Be sure to add this configuration _above_ the comment to stop editing:
 ![Example of Autoptimize configuration above the stop editing comment](../images/autoptimize-config.png)
 
 For additional details, see the [Autoptimize FAQ](https://wordpress.org/plugins/autoptimize/faq). An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link).
+
+**Issue 2:** Autoptimize generates a php file upon activation "wp-content/autoptimize_404_handler.php" if not present autoptimize will throw a php warning
+
+```
+Warning: file_put_contents(/code/wp-content/autoptimize_404_handler.php): failed to open stream: Permission denied in /code/wp-content/plugins/autoptimize/classes/autoptimizeCache.php on line 642
+```
+
+**Solution 1:** Activate the plugin to generate autoptimize_404_handler.php the file from Dev before committing.
+
+**Solution 2:** An alternative solution is to [create a symbolic link](/symlinks-assumed-write-access#create-a-symbolic-link)
+ for autoptimize_404_handler.php, This will also future proof any changes the plugin might do with every update.
 
 ___
 


### PR DESCRIPTION
Closes: #6022 

## Summary

**[WordPress Plugins and Themes with Known Issues
](https://pantheon.io/docs/plugins-known-issues#autoptimize)** - Documents an issue with the 404 handler in the Autoptimize plugin.

## Effect
Autoptimize will start throwing warnings about a new PHP file that seems to be required for the plugin to work properly, This file gets added upon plugin activation.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
