### PR TITLE
Remove note on SMTP module for D8

### DIFF
--- a/source/content/email.md
+++ b/source/content/email.md
@@ -45,7 +45,7 @@ Use the following integration methods for Drupal and WordPress to configure an e
 
 <TabList>
 
-<Tab title="Drupal 7/8/9" id="$" active={true}>
+<Tab title="Drupal" id="$" active={true}>
 
 Once you have chosen your SMTP provider, install and configure Drupal's [SMTP Authentication Support](https://drupal.org/project/smtp) module.
 

--- a/source/content/email.md
+++ b/source/content/email.md
@@ -45,7 +45,7 @@ Use the following integration methods for Drupal and WordPress to configure an e
 
 <TabList>
 
-<Tab title="Drupal" id="$" active={true}>
+<Tab title="Drupal" id="drupal" active={true}>
 
 Once you have chosen your SMTP provider, install and configure Drupal's [SMTP Authentication Support](https://drupal.org/project/smtp) module.
 

--- a/source/content/email.md
+++ b/source/content/email.md
@@ -45,7 +45,7 @@ Use the following integration methods for Drupal and WordPress to configure an e
 
 <TabList>
 
-<Tab title="Drupal 7/8" id="$" active={true}>
+<Tab title="Drupal 7/8/9" id="$" active={true}>
 
 Once you have chosen your SMTP provider, install and configure Drupal's [SMTP Authentication Support](https://drupal.org/project/smtp) module.
 

--- a/source/content/email.md
+++ b/source/content/email.md
@@ -49,12 +49,6 @@ Use the following integration methods for Drupal and WordPress to configure an e
 
 Once you have chosen your SMTP provider, install and configure Drupal's [SMTP Authentication Support](https://drupal.org/project/smtp) module.
 
-<Alert title="Note" type="info">
-
-The SMTP Authentication Support module for Drupal 8 is currently in Beta, support may be limited. 
-
-</Alert>
-
 </Tab>
 
 <Tab title="WordPress" id="wp">


### PR DESCRIPTION
## Summary

**[Email on Pantheon](https://pantheon.io/docs/email#smtp-providers--configurations)** 

- Removes note about the SMTP module being in beta for D8. As of Sept 2020, the SMTP module has a stable release for D8/D9: https://www.drupal.org/project/smtp/releases/8.x-1.0
- Adds "D9" to the Drupal tab in the "SMTP Providers & Configurations" section.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
