### PR TITLE
RSA keys are sometimes deprecated - actualize the doc

### DIFF
--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -127,7 +127,7 @@ To resolve, add your SSH key to the ssh-agent using the following command, repla
 ssh-add ~/.ssh/id_rsa
 ```
 
-Also if you use a recent Linux distribution (for example Fedora 33+), make sure RSA keys are enable in `~/.ssh/config`:
+Also if you use a recent Linux distribution (for example Fedora 33+), make sure RSA keys are enabled in `~/.ssh/config`:
 ```
 Host *.drush.in
   PubkeyAcceptedKeyTypes=ssh-rsa

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -127,7 +127,7 @@ To resolve, add your SSH key to the ssh-agent using the following command, repla
 ssh-add ~/.ssh/id_rsa
 ```
 
-If you are using a recent Linux distribution, for example Fedora 33+, make sure RSA keys are enabled in `~/.ssh/config`:
+If you are using a Linux distribution such as Fedora 33 or later, make sure RSA keys are enabled in `~/.ssh/config`:
 ```
 Host *.drush.in
   PubkeyAcceptedKeyTypes=ssh-rsa

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -126,3 +126,9 @@ To resolve, add your SSH key to the ssh-agent using the following command, repla
 ```bash{promptUser: user}
 ssh-add ~/.ssh/id_rsa
 ```
+
+Also if you use a recent Linux distribution (for example Fedora 33+), make sure RSA keys are enable in `~/.ssh/config`:
+```
+Host *.drush.in
+  PubkeyAcceptedKeyTypes=ssh-rsa
+```

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -127,7 +127,7 @@ To resolve, add your SSH key to the ssh-agent using the following command, repla
 ssh-add ~/.ssh/id_rsa
 ```
 
-Also if you use a recent Linux distribution (for example Fedora 33+), make sure RSA keys are enabled in `~/.ssh/config`:
+If you are using a recent Linux distribution, for example Fedora 33+, make sure RSA keys are enabled in `~/.ssh/config`:
 ```
 Host *.drush.in
   PubkeyAcceptedKeyTypes=ssh-rsa


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing. (Edited to conform)

Closes: NA

## Summary

**[Generate and Add SSH Keys](https://pantheon.io/docs/ssh-keys)** - Fedora 33 broke the ability to push / pull from Pantheon: https://www.reddit.com/r/Fedora/comments/jhxbdh/no_ssh_public_key_auth_after_upgrade_to_fedora_33/

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:
 - actualized the documentation with a workaround

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
