### PR TITLE
Dash login session length

### DIFF
--- a/source/content/faq.md
+++ b/source/content/faq.md
@@ -167,6 +167,10 @@ See [Getting Support](/support) and explore our [support features](https://panth
 
 ## Security
 
+### Pantheon User Account Login Session Length
+
+<Partial file="dashboard-login-session-length.md" />
+
 ### PCI Compliance on Pantheon
 
 Since you can alter your code on Pantheon, you must certify your own applications. PCI compliance for applications deployed on any platform cannot be guaranteed by the platform alone. We recommend architectures designed to work with PCI SAQ-A to minimize both risk and compliance efforts.

--- a/source/content/faq.md
+++ b/source/content/faq.md
@@ -19,9 +19,11 @@ Pantheon supports Drupal 7, 8, and 9 sites. As of February 2016, the Drupal comm
 Pantheon supports the most recent release of WordPress via our [upstream](https://github.com/pantheon-systems/WordPress), which includes platform integration plugins and a pre-configured `wp-config.php`.
 
 ### How much does Pantheon cost?
+
 You can develop new sites for free on Pantheon. Billing starts when you're ready to go live and direct traffic to a site. See available plans on our [pricing page](https://pantheon.io/pricing).
 
 ### Where are the Pantheon servers located?
+
 In addition to the United States data center, [new sites can be created](/regions) in Australia, Canada, and the European Union (EU). Pantheon's [Global CDN](/global-cdn) serves content from 70+ POPs (points of presence) distributed around the world.
 
 ### Can I run other applications on Pantheon?

--- a/source/content/guides/quickstart/02-user-dashboard.md
+++ b/source/content/guides/quickstart/02-user-dashboard.md
@@ -54,4 +54,8 @@ In this lesson, we’re going to explore the User Dashboard.
 
 </Accordion>
 
+Note:
+
+- <Partial file="dashboard-login-session-length.md" />
+
 You should now be familiar with the Pantheon User Dashboard. When you’re ready, you may continue to the next lesson.

--- a/source/content/user-dashboard.md
+++ b/source/content/user-dashboard.md
@@ -9,17 +9,21 @@ Access all of your sites and manage your account information from the User Dashb
 ![Site Dashboard](../images/dashboard/pantheon-user-dashboard.png)
 
 ## Sites Tab
+
 Here you can add a new site, see every site you're a team member of, and see the number of free sites you have remaining. Return to this page by clicking the Pantheon logo.
 
 Each site displays a screenshot of the Dev environment's home page. The default image is shown for sites that have not yet begun development. These thumbnails are updated after clearing caches, deploying code, and cloning or importing database or files to Dev.
 
 ## Organizations Tab
+
 If you belong to an organization, you will see it listed here and can click it to go to that organization's Dashboard.
 
 ## Support Tab
+
 View details for open support requests or create a new one.
 
 ## Account Tab
+
 This is where you can update and manage your personal account details. Use the options on the left navigation menu to:
 
 - Update your user profile details
@@ -32,8 +36,8 @@ This is where you can update and manage your personal account details. Use the o
 - [Delete your account](/delete-account)
 
 ### Gravatar
-To associate an image with your Pantheon account, you'll need to [create a Gravatar](https://en.gravatar.com/) for the email address you use with your Pantheon account. If you already have a Gravatar set up for another email address, update your Gravatar profile to add the email address you use on Pantheon. For help, visit the [Gravatar Support](https://gravatar.com/support/) page.
 
+To associate an image with your Pantheon account, you'll need to [create a Gravatar](https://en.gravatar.com/) for the email address you use with your Pantheon account. If you already have a Gravatar set up for another email address, update your Gravatar profile to add the email address you use on Pantheon. For help, visit the [Gravatar Support](https://gravatar.com/support/) page.
 
 ## See Also
 - [Role-Based Permissions & Change Management](/change-management)

--- a/source/content/user-dashboard.md
+++ b/source/content/user-dashboard.md
@@ -35,6 +35,10 @@ This is where you can update and manage your personal account details. Use the o
 - Add [machine tokens](/machine-tokens)
 - [Delete your account](/delete-account)
 
+### Pantheon User Account Login Session Length
+
+<Partial file="dashboard-login-session-length.md" />
+
 ### Gravatar
 
 To associate an image with your Pantheon account, you'll need to [create a Gravatar](https://en.gravatar.com/) for the email address you use with your Pantheon account. If you already have a Gravatar set up for another email address, update your Gravatar profile to add the email address you use on Pantheon. For help, visit the [Gravatar Support](https://gravatar.com/support/) page.

--- a/source/partials/dashboard-login-session-length.md
+++ b/source/partials/dashboard-login-session-length.md
@@ -1,0 +1,1 @@
+The Platform logs users out after 24 hours of inactivity, and forces all users to log back into the Platform every 30 days.


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: DOC-208

## Summary

**[User Dashboard and Account](https://pantheon.io/docs/user-dashboard#pantheon-user-account-session-length)** - The Platform logs users out after 24 hours of inactivity, and forces all users to log back into the Platform every 30 days.

## Remaining Work

The following changes still need to be completed:

- [ ] copy edit (is that a list or a comma splice?)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
