### PR TITLE
Fix Terminus Script Downloader

### DIFF
--- a/source/content/terminus/plugins/create.md
+++ b/source/content/terminus/plugins/create.md
@@ -36,14 +36,7 @@ mkdir $HOME/.terminus/plugins/hello-world
 
 In order for Terminus to recognize the directory as a plugin, the directory must contain a valid `composer.json` file. Download the following file and move it to your plugin's root directory (e.g. `$HOME/.terminus/plugins/hello-world`):
 
-<div class="script-file-header">
-  composer.json
-  <a id="downloadLink">
-    <button class="btn btn-default btn-download">
-      <i class="fa fa-download" aria-hidden="true" /> Download File
-    </button>
-  </a>
-</div>
+<Download file="composer.json" />
 
 ```json
 {
@@ -52,7 +45,7 @@ In order for Terminus to recognize the directory as a plugin, the directory must
   "type": "terminus-plugin",
   "extra": {
     "terminus": {
-      "compatible-version": "1.*"
+      "compatible-version": "2.*"
     }
   }
 }
@@ -76,14 +69,7 @@ mkdir $HOME/.terminus/plugins/hello-world/src
 
 Download the following file and move it to your plugin's `src` directory (e.g. `$HOME/.terminus/plugins/hello-world/src/HelloCommand.php`):
 
-<div class="script-file-header">
-  HelloCommand.php
-  <a id="downloadLinkb">
-    <button class="btn btn-default btn-download">
-      <i class="fa fa-download" aria-hidden="true" /> Download File
-    </button>
-  </a>
-</div>
+<Download file="HelloCommand.php" />
 
 ```php
 use Pantheon\Terminus\Commands\TerminusCommand;

--- a/source/scripts/HelloCommand.php.txt
+++ b/source/scripts/HelloCommand.php.txt
@@ -1,0 +1,14 @@
+use Pantheon\Terminus\Commands\TerminusCommand;
+
+class HelloCommand extends TerminusCommand
+{
+    /**
+     * Print the classic message to the log.
+     *
+     * @command hello
+     */
+    public function sayHello()
+    {
+        $this->log()->notice("Hello, World!");
+    }
+}

--- a/source/scripts/composer.json.txt
+++ b/source/scripts/composer.json.txt
@@ -1,0 +1,10 @@
+{
+  "name": "my-username/terminus-hello-world",
+  "description": "An Hello, World Terminus command",
+  "type": "terminus-plugin",
+  "extra": {
+    "terminus": {
+      "compatible-version": "2.*"
+    }
+  }
+}


### PR DESCRIPTION
Closes: #

## Summary

**[Terminus Manual - Create Plugins](https://pantheon.io/docs/terminus/plugins/create)** - Fixes the option to download example scripts, which were not updated for the conversion to Gatsby.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
