### PR TITLE
Note required permissions for site-local Drush

### DIFF
--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -95,6 +95,16 @@ Do not select any major version of Drush lower than `8.3.2`, `9.7.1`, or `10.2.0
 
 For more information, see [Avoiding “Dependency Hell” with Site-Local Drush](https://pantheon.io/blog/avoiding-dependency-hell-site-local-drush).
 
+#### Permissions
+
+Site-local Drush needs executable permissions. If you encounter "permission denied" errors when running Drush commands, adjust permissions on the Drush executable:
+
+```bash
+chmod +x vendor/bin/drush
+```
+
+Then commit and push this change back up to your Pantheon site.
+
 ### Drush 5 on Older Sites
 
 Drupal sites created on Pantheon in late 2015 or earlier that do not have `drush_version` defined in `pantheon.yml` may default to Drush 5. In this case, you may see the following error:

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -99,7 +99,7 @@ For more information, see [Avoiding “Dependency Hell” with Site-Local Drush]
 
 Site-local Drush needs executable permissions. If you encounter "permission denied" errors when running Drush commands, adjust permissions on the Drush executable:
 
-```bash
+```bash{promptUser: user}
 chmod +x vendor/bin/drush
 ```
 


### PR DESCRIPTION
## Summary

**[Managing Drush Versions](https://pantheon.io/docs/drush-versions)** - Note required permissions for site-local Drush. Non-executable site-local Drush is a common cause of workflow failures.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
