### PR TITLE
Remove references to d9 preview plugin

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -60,56 +60,6 @@ $node = Node::load(1);
 
 Since most of these changes are relatively minor, there are a number of [deprecation checking and correction tools](https://www.drupal.org/docs/9/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9/deprecation-checking-and-correction-tools) available.
 
-## Test-upgrade an Existing Pantheon Drupal 8 Site to Drupal 9
-
-Are you already running a Pantheon site using our [Drupal 8 upstream](https://github.com/pantheon-systems/drops-8)? Use our [Multidev](/multidev) feature to test Drupal 9 in a new branch.
-
-1. Clone your Drupal 8 site’s codebase [to your computer](/local-development#get-the-code) and change directory to it. You can create a new Drupal 8 site or use an existing Drupal 8 site:
-
-  ```bash{promptUser: user}
-  git clone <url for site repo>
-  cd <site-name>
-  ```
-
-1. Install the [Terminus D9 Preview plugin](https://github.com/pantheon-systems/terminus-d9-preview) to create a Multidev environment called `preview-d9` on your Drupal 8 site for testing:
-
-  ```bash{promptUser: user}
-  composer create-project -d ~/.terminus/plugins pantheon-systems/terminus-d9-preview:^0.1
-  ```
-
-1. Create and switch to a new testing Multidev:
-
-  ```bash{promptUser: user}
-  terminus preview:d9
-  ```
-
-1. Modify the `pantheon.yml` file to specify PHP 7.3 or newer and Drush 8:
-
-  ```yaml:title=pantheon.yml
-  php_version: 7.4
-  drush_version: 8
-  ```
-
-  Note that Drupal 9 is not yet compatible with the pre-installed Drush 10 on Pantheon.
-
-1. Commit and push your changes:
-
-  ```bash{promptUser: user}
-  git commit -am "test upgrade to Drupal 9"
-  git push origin preview-d9
-  ```
-
-You should not attempt to merge your Drupal 9 preview Multidev into the dev environment until Drupal 9 is officially supported on Pantheon.
-
-### Refresh Existing preview-d9 Multidev With Latest Dev Environment
-
-This destroys the code, database and files on the existing `preview-d9` Multidev and re-creates it from the latest dev environment. Save any changes you made on this environment to your local computer before refreshing the environment.
-
-If you make changes to your dev environment that you want to test in Drupal 9, run `terminus preview:d9` again to update the existing Multidev:
-
-```bash{promptUser: user}
-terminus preview:d9
-```
 
 ## FAQ
 


### PR DESCRIPTION
## Summary

**[Doc Title](https://pantheon.io/docs/doc-title)** - Remove references to d9 preview plugin



## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
