### PR TITLE
move services.yml step to faq

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -78,6 +78,27 @@ Since most of these changes are relatively minor, there are a number of [depreca
 
 ## FAQ
 
+### Can I upgrade my existing Drupal site to Drupal 9?
+
+Not yet. While Drupal 9 on Pantheon is in Limited Availability, there is no supported upgrade path yet.
+
+### Pantheon Launch Check Status Error: services.yml does not exist
+
+After you set up Drupal 9, you might see this error in the **Best practices** section of the Pantheon Launch Check:
+
+```none
+services.yml does not exist! Copy the default.service.yml to services.yml and see https://www.drupal.org/documentation/install/settings-file for details.
+
+Create services.yml file inside sites/default directory by copying default/services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.
+```
+
+Use the terminal on the local machine where you cloned the site, and from the project's root directory, copy the `default.services.yml` to its own file:
+
+```bash{promptUser: user}
+cp web/sites/default/default.services.yml web/sites/default/services.yml
+```
+
+Learn more about the [service configuration](/services-yml#create-and-modify-servicesyml) file.
 ### Pantheon Drupal 8 Modules Being Upgraded to Drupal 9
 
 | Module Name                                                                                 | Drupal 8 Version? | Drupal 9 Version? |

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -92,11 +92,20 @@ services.yml does not exist! Copy the default.service.yml to services.yml and se
 Create services.yml file inside sites/default directory by copying default/services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.
 ```
 
-Use the terminal on the local machine where you cloned the site, and from the project's root directory, copy `default.services.yml` to its own file:
+Ensure your site's [Development Mode](/guides/quickstart/connection-modes/) is set to **Git**, then use the terminal on the local machine where you cloned the site, and from the project's root directory:
 
-```bash{promptUser: user}
-cp web/sites/default/default.services.yml web/sites/default/services.yml
-```
+1. Copy `default.services.yml` to its own file:
+
+ ```bash{promptUser: user}
+ cp web/sites/default/default.services.yml web/sites/default/services.yml
+ ```
+
+1. Commit and push:
+
+ ```bash{promptUser: user}
+ git add web/sites/default/services.yml && git commit -m "copy over services.yml"
+ git push origin master
+  ```
 
 Learn more about the [service configuration](/services-yml#create-and-modify-servicesyml) file.
 ### Pantheon Drupal 8 Modules Being Upgraded to Drupal 9

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -92,7 +92,7 @@ services.yml does not exist! Copy the default.service.yml to services.yml and se
 Create services.yml file inside sites/default directory by copying default/services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.
 ```
 
-Use the terminal on the local machine where you cloned the site, and from the project's root directory, copy the `default.services.yml` to its own file:
+Use the terminal on the local machine where you cloned the site, and from the project's root directory, copy `default.services.yml` to its own file:
 
 ```bash{promptUser: user}
 cp web/sites/default/default.services.yml web/sites/default/services.yml

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -86,15 +86,15 @@ Not yet. While Drupal 9 on Pantheon is in Limited Availability, there is no supp
 
 After you set up Drupal 9, you might see this error in the **Best practices** section of the Pantheon Launch Check:
 
-```none
-services.yml does not exist! Copy the default.service.yml to services.yml and see https://www.drupal.org/documentation/install/settings-file for details.
-
-Create services.yml file inside sites/default directory by copying default/services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.
-```
+> <span  style="color:red">x <strong>sites/default/services.yml:</strong></span> services.yml does not exist! Copy the default.service.yml to services.yml and see https://www.drupal.org/documentation/install/settings-file for details.
+><br />
+><br />
+>
+> *Create services.yml file inside sites/default directory by copying default/services.yml file. See https://www.drupal.org/documentation/install/settings-file for details.*
 
 Ensure your site's [Development Mode](/guides/quickstart/connection-modes/) is set to **Git**, then use the terminal on the local machine where you cloned the site, and from the project's root directory:
 
-1. Copy `default.services.yml` to its own file:
+1. Copy `default.services.yml` to `services.yml`:
 
  ```bash{promptUser: user}
  cp web/sites/default/default.services.yml web/sites/default/services.yml
@@ -103,11 +103,12 @@ Ensure your site's [Development Mode](/guides/quickstart/connection-modes/) is s
 1. Commit and push:
 
  ```bash{promptUser: user}
- git add web/sites/default/services.yml && git commit -m "copy over services.yml"
+ git add web/sites/default/services.yml && git commit -m "init services.yml"
  git push origin master
   ```
 
 Learn more about the [service configuration](/services-yml#create-and-modify-servicesyml) file.
+
 ### Pantheon Drupal 8 Modules Being Upgraded to Drupal 9
 
 | Module Name                                                                                 | Drupal 8 Version? | Drupal 9 Version? |

--- a/source/content/guides/quickstart/04-site-dashboard.md
+++ b/source/content/guides/quickstart/04-site-dashboard.md
@@ -30,7 +30,7 @@ Every Pantheon site comes with 3 separate environments— Dev, Test, Live—whic
 
 <Alert title="Note" type="info">
 
-Agencies have access to additional development environments under the{" "} <Icon icon={"cloud"} text={"Multidev"} /> tab.
+Agencies have access to additional development environments under the <Icon icon={"cloud"} text={"Multidev"} /> tab.
 
 </Alert>
 

--- a/source/partials/drupal-9-upstream-install.md
+++ b/source/partials/drupal-9-upstream-install.md
@@ -16,14 +16,6 @@
 
 1. In your local terminal, from the project root directory, run `composer install`.
 
-1. Copy the default `services.yml`:
-
-   ```bash{promptUser: user}
-   cp web/sites/default/default.services.yml web/sites/default/services.yml
-   ```
-
-   Learn more about the [service configuration](/services-yml#create-and-modify-servicesyml) file.
-
 1. Commit and push:
 
    ```bash{promptUser: user}

--- a/source/partials/drupal-9-upstream-install.md
+++ b/source/partials/drupal-9-upstream-install.md
@@ -15,10 +15,3 @@
 1. Return to the Dev tab, set the site's Development Mode to Git, and [clone the site locally](/local-development#get-the-code).
 
 1. In your local terminal, from the project root directory, run `composer install`.
-
-1. Commit and push:
-
-   ```bash{promptUser: user}
-   git add web/sites/default/services.yml && git commit -m "copy over services.yml"
-   git push origin master
-   ```


### PR DESCRIPTION
Relates to CORE-2243 - once that is complete and this step is automated, we can remove the step from the D9 FAQ

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [x] copy edit

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
