### PR TITLE
Adding sample security headers code for WP

### DIFF
--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -276,30 +276,6 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 }
 ```
 
-### Security Headers
-
-Pantheon's Nginx configuration cannot be modified to add security headers, and most solutions written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms. Adding code like the example below in an mu-plugin can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform.
-
-These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
-
-The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
-
-```php
-function additional_securityheaders( $headers ) {
-  if ( ! is_admin() ) {
-    $headers['Referrer-Policy']             = 'no-referrer-when-downgrade';
-    $headers['X-Content-Type-Options']      = 'nosniff';
-    $headers['XX-XSS-Protection']           = '1; mode=block';
-    $headers['Permissions-Policy']         = 'geolocation=(self "https://example.com") microphone=() camera=()';
-    $headers['Content-Security-Policy']    = 'script-src "self"';
-    $headers['X-Frame-Options']            = 'SAMEORIGIN';
-  }
-
-  return $headers;
-}
-add_filter( 'wp_headers', 'additional_securityheaders' );
-```
-
 ### WP-CFM Compatibility
 
 [WP-CFM](https://wordpress.org/plugins/wp-cfm/) can work with [Multidev](/multidev) environments, but a Must Use plugin needs to be configured:

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -276,6 +276,30 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 }
 ```
 
+### Security Headers
+
+Since Pantheon's Nginx config cannot be modified to add security headers and most of the results from search engines are solutions modifying the `.htaccess` file for Apache-based platforms, so adding the code below in an mu-plugin can help our in adding security headers in Nginx-based sites.
+
+This is applicably mainly when accessing the REST API of WordPress but not when directly accessing assets like https://example.com/wp-content/uploads/2020/01/sample.json
+
+Sample code below is only and example to get you started and you'll need to modify it to match your needs especially the Content Security Policy. You can use [this](https://securityheaders.com) to check your security headers.
+
+```php
+function additional_securityheaders( $headers ) {
+	if ( ! is_admin() ) {
+		$headers['Referrer-Policy']             = 'no-referrer-when-downgrade';
+		$headers['X-Content-Type-Options']      = 'nosniff';
+		$headers['XX-XSS-Protection']           = '1; mode=block';
+		$headers['Feature-Policy: geolocation'] = 'geolocation "none" ; camera "none"';
+		$headers['Content-Security-Policy:']    = 'script-src "self"';
+		$headers['X-Frame-Options:']            = 'SAMEORIGIN';
+	}
+
+	return $headers;
+}
+add_filter( 'wp_headers', 'additional_securityheaders' );
+```
+
 ### WP-CFM Compatibility
 
 [WP-CFM](https://wordpress.org/plugins/wp-cfm/) can work with [Multidev](/multidev) environments, but a Must Use plugin needs to be configured:

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -280,7 +280,7 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 
 Pantheon's Nginx configuration cannot be modified to add security headers, and most solutions written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms. Adding code like the example below in an mu-plugin can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform.
 
-These headers apply when accessing the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
+These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
 
 The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
 

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -290,9 +290,9 @@ function additional_securityheaders( $headers ) {
     $headers['Referrer-Policy']             = 'no-referrer-when-downgrade';
     $headers['X-Content-Type-Options']      = 'nosniff';
     $headers['XX-XSS-Protection']           = '1; mode=block';
-    $headers['Feature-Policy: geolocation'] = 'geolocation "none" ; camera "none"';
-    $headers['Content-Security-Policy:']    = 'script-src "self"';
-    $headers['X-Frame-Options:']            = 'SAMEORIGIN';
+    $headers['Permissions-Policy']         = 'geolocation=(self "https://example.com") microphone=() camera=()';
+    $headers['Content-Security-Policy']    = 'script-src "self"';
+    $headers['X-Frame-Options']            = 'SAMEORIGIN';
   }
 
   return $headers;

--- a/source/content/mu-plugin.md
+++ b/source/content/mu-plugin.md
@@ -278,24 +278,24 @@ if (($_SERVER['REQUEST_URI'] == '/old') && (php_sapi_name() != "cli")) {
 
 ### Security Headers
 
-Since Pantheon's Nginx config cannot be modified to add security headers and most of the results from search engines are solutions modifying the `.htaccess` file for Apache-based platforms, so adding the code below in an mu-plugin can help our in adding security headers in Nginx-based sites.
+Pantheon's Nginx configuration cannot be modified to add security headers, and most solutions written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms. Adding code like the example below in an mu-plugin can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform.
 
-This is applicably mainly when accessing the REST API of WordPress but not when directly accessing assets like https://example.com/wp-content/uploads/2020/01/sample.json
+These headers apply when accessing the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
 
-Sample code below is only and example to get you started and you'll need to modify it to match your needs especially the Content Security Policy. You can use [this](https://securityheaders.com) to check your security headers.
+The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
 
 ```php
 function additional_securityheaders( $headers ) {
-	if ( ! is_admin() ) {
-		$headers['Referrer-Policy']             = 'no-referrer-when-downgrade';
-		$headers['X-Content-Type-Options']      = 'nosniff';
-		$headers['XX-XSS-Protection']           = '1; mode=block';
-		$headers['Feature-Policy: geolocation'] = 'geolocation "none" ; camera "none"';
-		$headers['Content-Security-Policy:']    = 'script-src "self"';
-		$headers['X-Frame-Options:']            = 'SAMEORIGIN';
-	}
+  if ( ! is_admin() ) {
+    $headers['Referrer-Policy']             = 'no-referrer-when-downgrade';
+    $headers['X-Content-Type-Options']      = 'nosniff';
+    $headers['XX-XSS-Protection']           = '1; mode=block';
+    $headers['Feature-Policy: geolocation'] = 'geolocation "none" ; camera "none"';
+    $headers['Content-Security-Policy:']    = 'script-src "self"';
+    $headers['X-Frame-Options:']            = 'SAMEORIGIN';
+  }
 
-	return $headers;
+  return $headers;
 }
 add_filter( 'wp_headers', 'additional_securityheaders' );
 ```

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -117,3 +117,29 @@ This method has the advantage of being toggleable without deploying code, by act
   ```
 
 1. Commit your work, deploy code changes then activate the plugin on Test and Live environments.
+
+## Security Headers
+
+Pantheon's Nginx configuration cannot be modified to add security headers, and most solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
+
+Adding code like the example below in a plugin or to your theme can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform.
+
+These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
+
+The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
+
+```php
+function additional_securityheaders( $headers ) {
+  if ( ! is_admin() ) {
+    $headers['Referrer-Policy']             = 'no-referrer-when-downgrade'; //This is the default value, the same as if it were not set.
+    $headers['X-Content-Type-Options']      = 'nosniff';
+    $headers['X-XSS-Protection']           = '1; mode=block';
+    $headers['Permissions-Policy']         = 'geolocation=(self "https://example.com") microphone=() camera=()';
+    $headers['Content-Security-Policy']    = 'script-src "self"';
+    $headers['X-Frame-Options']            = 'SAMEORIGIN';
+  }
+
+  return $headers;
+}
+add_filter( 'wp_headers', 'additional_securityheaders' );
+```

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -120,11 +120,11 @@ This method has the advantage of being toggleable without deploying code, by act
 
 ## Security Headers
 
-Pantheon's Nginx configuration cannot be modified to add security headers, and most solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
+Pantheon's Nginx configuration cannot be modified to add security headers, and many solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
 
-Adding code like the example below in a plugin or to your theme can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform.
+There are plugins for WordPress that do not require `.htaccess` to set security headers (like [GD Security Headers](https://wordpress.org/plugins/gd-security-headers/) or [HTTP headers to improve web site security](https://wordpress.org/plugins/http-security/)), but header specifications may change more rapidly than the plugins can keep up with. In those cases, you may want to define the headers yourself.
 
-These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
+Adding code like the example below in a plugin or to your theme can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform. These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
 
 The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
 

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -133,10 +133,10 @@ function additional_securityheaders( $headers ) {
   if ( ! is_admin() ) {
     $headers['Referrer-Policy']             = 'no-referrer-when-downgrade'; //This is the default value, the same as if it were not set.
     $headers['X-Content-Type-Options']      = 'nosniff';
-    $headers['X-XSS-Protection']           = '1; mode=block';
-    $headers['Permissions-Policy']         = 'geolocation=(self "https://example.com") microphone=() camera=()';
-    $headers['Content-Security-Policy']    = 'script-src "self"';
-    $headers['X-Frame-Options']            = 'SAMEORIGIN';
+    $headers['X-XSS-Protection']            = '1; mode=block';
+    $headers['Permissions-Policy']          = 'geolocation=(self "https://example.com") microphone=() camera=()';
+    $headers['Content-Security-Policy']     = 'script-src "self"';
+    $headers['X-Frame-Options']             = 'SAMEORIGIN';
   }
 
   return $headers;

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -124,9 +124,9 @@ Pantheon's Nginx configuration cannot be modified to add security headers, and m
 
 There are plugins for WordPress that do not require `.htaccess` to set security headers (like [GD Security Headers](https://wordpress.org/plugins/gd-security-headers/) or [HTTP headers to improve web site security](https://wordpress.org/plugins/http-security/)), but header specifications may change more rapidly than the plugins can keep up with. In those cases, you may want to define the headers yourself.
 
-Adding code like the example below in a plugin or to your theme can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform. These headers apply when accessing site pages or the REST API of WordPress, but not when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
+Adding code like the example below in a plugin (or [mu-plugin](/mu-plugin)) can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform. Do not add this to your theme's `functions.php` file, as it will not be executed for calls to the REST API.
 
-The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers and links to additional information on where to improve your security header profile.
+The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers, and links to additional information on how to improve your security header profile.
 
 ```php
 function additional_securityheaders( $headers ) {
@@ -143,3 +143,5 @@ function additional_securityheaders( $headers ) {
 }
 add_filter( 'wp_headers', 'additional_securityheaders' );
 ```
+
+**Note:** Because the headers are applied by php code when WordPress is invoked, they will not be added when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -126,7 +126,7 @@ There are plugins for WordPress that do not require `.htaccess` to set security 
 
 Adding code like the example below in a plugin (or [mu-plugin](/mu-plugin)) can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform. Do not add this to your theme's `functions.php` file, as it will not be executed for calls to the REST API.
 
-The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers, and links to additional information on how to improve your security header profile.
+The code below is only an example to get you started. You'll need to modify it to match your needs, especially the Content Security Policy. Tools like [SecurityHeaders.com](https://securityheaders.com) can help to check your security headers, and link to additional information on how to improve your security header profile.
 
 ```php
 function additional_securityheaders( $headers ) {
@@ -144,4 +144,4 @@ function additional_securityheaders( $headers ) {
 add_filter( 'wp_headers', 'additional_securityheaders' );
 ```
 
-**Note:** Because the headers are applied by php code when WordPress is invoked, they will not be added when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.
+**Note:** Because the headers are applied by PHP code when WordPress is invoked, they will not be added when directly accessing assets like `https://example.com/wp-content/uploads/2020/01/sample.json`.

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -120,7 +120,7 @@ This method has the advantage of being toggleable without deploying code, by act
 
 ## Security Headers
 
-Pantheon's Nginx configuration cannot be modified to add security headers, and many solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
+Pantheon's Nginx configuration [cannot be modified](/platform-considerations#htaccess) to add security headers, and many solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
 
 There are plugins for WordPress that do not require `.htaccess` to set security headers (like [GD Security Headers](https://wordpress.org/plugins/gd-security-headers/) or [HTTP headers to improve web site security](https://wordpress.org/plugins/http-security/)), but header specifications may change more rapidly than the plugins can keep up with. In those cases, you may want to define the headers yourself.
 


### PR DESCRIPTION
Closes: #6158

## Summary

**[WordPress Best Practices](https://pantheon.io/docs/wordpress-best-practices#security-headers)** - Added a new section on security headers including plugins that can create them without `.htaccess`, and example code to set them yourself.

## Effect

Since Pantheon is Nginx based and the config cannot be modified to add security headers, it might be a good idea to have some sample code on how to do it in the platform since most of the results from search engines are solutions modifying .htaccess files and for Apache-based platforms

- Adding sample code for security headers in WP
- Some links to help users check their security headers

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
