### PR TITLE
Clarifications on terminus backup:restore

### DIFF
--- a/source/partials/terminus/backup-restore.md
+++ b/source/partials/terminus/backup-restore.md
@@ -1,0 +1,4 @@
+
+## Additional Context
+
+The `--file` flag for this command only accepts as a value a Pantheon environment backup on the platform, not a local backup file. Use [terminus backup:list](/terminus/commands/backup-list) to identify available backups.

--- a/source/partials/terminus/backup-restore.md
+++ b/source/partials/terminus/backup-restore.md
@@ -1,4 +1,27 @@
 
-## Additional Context
+## Example
 
-The `--file` flag for this command only accepts as a value a Pantheon environment backup on the platform, not a local backup file. Use [terminus backup:list](/terminus/commands/backup-list) to identify available backups.
+The `--file` flag for this command only accepts as a value a Pantheon environment backup on the platform, not a local backup file.
+Use [terminus backup:list](/terminus/commands/backup-list) to identify available backups:
+
+```bash{outputLines: 2-13}
+terminus backup:list anita-drupal.live
+ ----------------------------------------------------------- -------- --------------------- --------------------- -----------
+  Filename                                                    Size     Date                  Expiry                Initiator  
+ ----------------------------------------------------------- -------- --------------------- --------------------- -----------
+  anita-drupal_live_2020-12-07T02-00-00_UTC_files.tar.gz      0.1MB    2020-12-07 02:24:25   2020-12-15 02:24:25   automated  
+  anita-drupal_live_2020-12-07T02-00-00_UTC_database.sql.gz   0.9MB    2020-12-07 02:23:20   2020-12-15 02:23:20   automated  
+  anita-drupal_live_2020-12-07T02-00-00_UTC_code.tar.gz       75.3MB   2020-12-07 02:27:52   2020-12-15 02:27:52   automated  
+  anita-drupal_live_2020-12-06T02-00-00_UTC_files.tar.gz      0.1MB    2020-12-06 02:26:10   2020-12-14 02:26:10   automated  
+  anita-drupal_live_2020-12-06T02-00-00_UTC_database.sql.gz   0.9MB    2020-12-06 02:25:39   2020-12-14 02:25:39   automated  
+  anita-drupal_live_2020-12-06T02-00-00_UTC_code.tar.gz       75.3MB   2020-12-06 02:47:13   2020-12-14 02:47:13   automated  
+  anita-drupal_live_2020-12-05T02-00-00_UTC_files.tar.gz      0.1MB    2020-12-05 02:37:29   2020-12-13 02:37:29   automated  
+  anita-drupal_live_2020-12-05T02-00-00_UTC_database.sql.gz   0.9MB    2020-12-05 02:40:54   2020-12-13 02:40:54   automated  
+  anita-drupal_live_2020-12-05T02-00-00_UTC_code.tar.gz       75.3MB   2020-12-05 02:48:08   2020-12-13 02:48:08   automated
+```
+
+In this example, we could restore the environment's code from the latest backup with:
+
+```bash{promptUser: user}
+terminus backup:restore anita-drupal.live --file=anita-drupal_live_2020-12-07T02-00-00_UTC_code.tar.gz
+```


### PR DESCRIPTION
Closes: #6137 

## Summary

**[Terminus Command Reference: terminus backup:restore](https://pantheon.io/docs/terminus/commands/backup-restore)** - Added a partial file clarifying that `terminus backup:restore` uses backup files on the platform, not local backup archive files.

## Remaining Work

- [x] Input from @mcohen-impact and/or @umandalroald would be welcome.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
