### PR TITLE
Upstreams other option

### DIFF
--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -123,9 +123,10 @@ You can [sign up](https://gitlab.com/users/sign_in) for a GitLab.com account, or
 
 <Tab title="Other" id="other">
 
-Other Git based providers can be used like Azure DevOps or an On-Prem Bitbucket. You will need to create a new project in that system. Contact support and we can try to work it out with you.
+Other Git hosting providers (like Azure DevOps or a self-hosted Bitbucket server) can be used, but we cannot detail specific instructions for each and every provider. You will need to create a new project in that system. Contact support and we can try to work it out with you.
 
 </Tab>
+
 </TabList>
 
 ## Pull in Core from Pantheon's Upstream
@@ -307,18 +308,21 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
 
 <Tab title="Other" id="other-auth">
 
-  Custom Upstreams from other repositories must be created for you by Pantheon Support. Contact support and we can try to work it out with you.
+Custom Upstreams from other repository hosts must be created for you by Pantheon Support.
   
 These are common steps needed for most Git Providers:
-  1. Prepare a new user specifically for Pantheon access.
 
-  1. This new account will need to be accessable via API for Pantheon, it must also have access to the repository created in the earlier step.
+1. Prepare a new user specifically for Pantheon access.
 
-  1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
+1. This new account will need to be accessible via API for Pantheon, it must also have access to the repository created in the earlier step.
 
-     - A name for the custom upstream
-     - The `https` clone URL (ending in `.git`)
-     - The Access Token for the new user.
+1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
+
+    - A name for the custom upstream
+
+    - The `https` clone URL (ending in `.git`)
+
+    - The Access Token for the new user.
 
 </Tab>
 

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -121,6 +121,11 @@ You can [sign up](https://gitlab.com/users/sign_in) for a GitLab.com account, or
 
 </Tab>
 
+<Tab title="Other" id="other">
+
+Other Git based providers can be used like Azure DevOps or an On-Prem Bitbucket. You will need to create a new project in that system. Contact support and we can try to work it out with you.
+
+</Tab>
 </TabList>
 
 ## Pull in Core from Pantheon's Upstream
@@ -291,6 +296,23 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
   1. From the GitLab account that maintains the repository, add the new user to the repo under **Members** with **Reporter** access.
 
       ![GitLab reporter permission](../images/gitlab-reporter.png)
+
+  1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
+
+     - A name for the custom upstream
+     - The `https` clone URL (ending in `.git`)
+     - The Access Token for the new user.
+
+</Tab>
+
+<Tab title="Other" id="other-auth">
+
+  Custom Upstreams from other repositories must be created for you by Pantheon Support. Contact support and we can try to work it out with you.
+  
+These are common steps needed for most Git Providers:
+  1. Prepare a new user specifically for Pantheon access.
+
+  1. This new account will need to be accessable via API for Pantheon, it must also have access to the repository created in the earlier step.
 
   1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
 

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -123,7 +123,9 @@ You can [sign up](https://gitlab.com/users/sign_in) for a GitLab.com account, or
 
 <Tab title="Other" id="other">
 
-Other Git hosting providers (like Azure DevOps or a self-hosted Bitbucket server) can be used, but we cannot detail specific instructions for each and every provider. You will need to create a new project in that system. Contact support and we can try to work it out with you.
+Other Git hosting providers (like Azure DevOps or a self-hosted Bitbucket server) can be used, but we cannot detail specific instructions for each and every provider. You will need to create a new project in that system.
+
+As detailed below, [Pantheon Support](/support) will need to add this Custom Upstream for you from a support ticket.
 
 </Tab>
 
@@ -333,11 +335,15 @@ These are common steps needed for most Git Providers:
 
 1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
 
-    - A name for the custom upstream
+    - A name for the custom upstream,
 
-    - The `https` clone URL (ending in `.git`)
+    - The CMS within (WordPress, Drupal 7/8/9),
 
-    - The Access Token for the new user.
+    - The `https` clone URL (ending in `.git`),
+
+    - The username and Access Token for the new user,
+
+    - The name of the branch to be used by Pantheon (usually `master`).
 
 </Tab>
 

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -213,34 +213,43 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
   ![Organization Dashboard](../images/dashboard/organizations.png)
 
 1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
 1. Click the **<span class="glyphicons glyphicons-plus"></span> Add New Upstream** button. You must be an Organization Administrator to add a new upstream.
+
 1. Enter the following information about the Custom Upstream:
 
-   * **Name**
-   * **Upstream Repository URL**:
+   - **Name**
+   - **Upstream Repository URL**:
 
     ![GitHub HTTPS Repo URL](../images/github-https-url.png)
 
-     * **Authenticate (private repositories only)**: If you provided the URL to a private repository, a new field will appear:
+     - **Authenticate (private repositories only)**: If you provided the URL to a private repository, a new field will appear:
 
      ![GitHub Upstream Authentication](../images/dashboard/create-upstream-auth-gh.png)
 
      For privately hosted repositories, create a dedicated user with repository access. If your repository is publicly accessible, you can skip this step.
 
-       1. Go to GitHub to [generate a personal access token](https://github.com/settings/tokens).
-       1. Click **Generate new token**.
-       1. Confirm your password if prompted.
-       1. Enter a token description, such as "pantheon read my Custom Upstream"
-       1. Select "repo" as the scope:
+      1. Go to GitHub to [generate a personal access token](https://github.com/settings/tokens).
 
-           ![GitHub generate token](../images/github-token.png)
+      1. Click **Generate new token**.
 
-       1. Click **Generate token** and copy the new token to your clipboard.
-       1. Return to the Pantheon Organization Dashboard, where you are creating the Custom Upstream.
-       1. Paste your new GitHub access token.
+      1. Confirm your password if prompted.
 
-   * **Framework**: Drupal 7, Drupal 8, or WordPress
-   * **Description**: (Optional) Less than 200 characters, plain text and markdown supported
+      1. Enter a token description, such as "pantheon read my Custom Upstream"
+
+      1. Select "repo" as the scope:
+
+          ![GitHub generate token](../images/github-token.png)
+
+      1. Click **Generate token** and copy the new token to your clipboard.
+
+      1. Return to the Pantheon Organization Dashboard, where you are creating the Custom Upstream.
+
+      1. Paste your new GitHub access token.
+
+   - **Framework**: Drupal 7, Drupal 8, or WordPress
+
+   - **Description**: (Optional) Less than 200 characters, plain text and markdown supported
 
 1. Click **Create**.
 
@@ -253,32 +262,38 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
   ![Organization Dashboard](../images/dashboard/organizations.png)
 
 1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
 1. Click the **<span class="glyphicons glyphicons-plus"></span> Add New Upstream** button. You must be an administrator of the organization to add a new upstream.
+
 1. Enter the following information about the Custom Upstream:
 
-    * **Name**
-    * **Upstream Repository URL**:
+   - **Name**
+   - **Upstream Repository URL**:
 
        ![Bitbucket HTTPS Repo URL](../images/bitbucket-https-url.png)
 
-    * **Authenticate (private repositories only)**: If you provided the URL to a private repository, a new field will appear:
+   - **Authenticate (private repositories only)**: If you provided the URL to a private repository, a new field will appear:
 
       ![BitBucket Upstream Authentication](../images/dashboard/create-upstream-auth-bb.png)
 
       For privately hosted repositories, create a dedicated user with repository access. If your repository is publicly accessible, you can skip this step.
 
         1. Go to Bitbucket to generate an [app password](https://bitbucket.org/account/admin/app-passwords).
+
         1. Click **Create app password**.
+
         1. Enter a label and select the `"Repositories:Read"` permission:
 
-          ![Bitbucket app password](../images/bitbucket-app-password.png)
+           ![Bitbucket app password](../images/bitbucket-app-password.png)
 
         1. Click **Create** and copy the new password.
+
         1. Return to the Pantheon Organization Dashboard, where you are creating the Custom Upstream.
+
         1. The username field should already be populated, based on the repository URL. Paste your new Bitbucket app password.
 
-    * **Framework**: Drupal 7, Drupal 8, or WordPress
-    * **Description**: (Optional) Less than 200 characters, plain text and markdown supported
+   - **Framework**: Drupal 7, Drupal 8, or WordPress
+   - **Description**: (Optional) Less than 200 characters, plain text and markdown supported
 
 1. Click **Create**.
 
@@ -286,23 +301,23 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
 
 <Tab title="GitLab" id="gitlab-auth">
 
-  Custom Upstreams from GitLab repositories must be created for you by Pantheon Support.
+Custom Upstreams from GitLab repositories must be created for you by Pantheon Support.
 
-  1. Prepare a new GitLab user specifically for Pantheon access.
+1. Prepare a new GitLab user specifically for Pantheon access.
 
-  1. From this new account, [generate an Access Token](https://gitlab.com/profile/personal_access_tokens) with the `API` scope:
+1. From this new account, [generate an Access Token](https://gitlab.com/profile/personal_access_tokens) with the `API` scope:
 
-      ![GitLab Personal Access Token](../images/gitlab-api.png)
+    ![GitLab Personal Access Token](../images/gitlab-api.png)
 
-  1. From the GitLab account that maintains the repository, add the new user to the repo under **Members** with **Reporter** access.
+1. From the GitLab account that maintains the repository, add the new user to the repo under **Members** with **Reporter** access.
 
-      ![GitLab reporter permission](../images/gitlab-reporter.png)
+    ![GitLab reporter permission](../images/gitlab-reporter.png)
 
-  1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
+1. [Contact support](/support) to add the Custom Upstream to your org. You must provide:
 
-     - A name for the custom upstream
-     - The `https` clone URL (ending in `.git`)
-     - The Access Token for the new user.
+   - A name for the custom upstream,
+   - The `https` clone URL (ending in `.git`),
+   - The Access Token for the new user.
 
 </Tab>
 
@@ -333,8 +348,11 @@ These are common steps needed for most Git Providers:
 If you would like to change the name or description of your Custom Upstream:
 
 1. Navigate to the **[<span class="glyphicons glyphicons-group"></span> Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
+
 1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
 1. Click **Settings** next to the existing upstream requiring an update.
+
 1. Make desired changes, then click **Update**.
 
 ### Initial Connection Mode
@@ -344,8 +362,11 @@ The default connection mode for new sites created from a Custom Upstream is Git 
 Configure this setting after connecting your Custom Upstream to Pantheon if new sites need to use an initial connection mode other than the default:
 
 1. Navigate to the **[<span class="glyphicons glyphicons-group"></span> Organizations](https://dashboard.pantheon.io/#organizations" )** tab within the Pantheon Dashboard and select your organization.
+
 1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
 1. Click **Settings** next to the existing upstream requiring an update.
+
 1. Select the desired connection mode, then click **Update**:
 
   ![Modify initial connection mode](../images/dashboard/initial-connection-mode.png)
@@ -365,7 +386,9 @@ You must be a site owner to switch a site's upstream. After a site's upstream ha
 Once all sites have been updated to track the new Custom Upstream, you can safely delete the old one:
 
 1. Navigate to the **[<span class="glyphicons glyphicons-group"></span> Organizations](https://dashboard.pantheon.io/#organizations" )** tab within the Pantheon Dashboard and select your organization.
+
 1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
 1. Click **Settings** next to the existing upstream, then click **Delete**.
 
 ## Switch an Existing Site to a Custom Upstream

--- a/source/content/custom-upstream.md
+++ b/source/content/custom-upstream.md
@@ -85,7 +85,7 @@ The top level repository will be one of Pantheon's core upstreams (either [WordP
 
 The second level repository is a Custom Upstream, where core updates from Pantheon are pulled in and modifications to your common codebase are distributed (e.g. parent theme and plugin/module version updates).
 
-The Custom Upstream repository is hosted outside of Pantheon using a provider like [GitHub](https://github.com/), [Bitbucket](https://bitbucket.org/) or other Git based provider <Popover content="Contact support to try and create any other Git based custom upstream." />. It's connected to Pantheon and associated with your organization, allowing fellow team members the option to select this repository as a starting point when creating new sites.
+The Custom Upstream repository is hosted outside of Pantheon using a provider like [GitHub](https://github.com/), [Bitbucket](https://bitbucket.org/) or other Git repository host <Popover content="Contact support to create a custom upstream from another host." />. It's connected to Pantheon and associated with your organization, allowing fellow team members the option to select this repository as a starting point when creating new sites.
 
 </div>
 </div>

--- a/source/content/custom-upstream.md
+++ b/source/content/custom-upstream.md
@@ -85,7 +85,7 @@ The top level repository will be one of Pantheon's core upstreams (either [WordP
 
 The second level repository is a Custom Upstream, where core updates from Pantheon are pulled in and modifications to your common codebase are distributed (e.g. parent theme and plugin/module version updates).
 
-The Custom Upstream repository is hosted outside of Pantheon using a provider like [GitHub](https://github.com/), [Bitbucket](https://bitbucket.org/) or [GitLab](https://about.gitlab.com/) <Popover content="Contact support to create a GitLab based custom upstream." />. It's connected to Pantheon and associated with your organization, allowing fellow team members the option to select this repository as a starting point when creating new sites.
+The Custom Upstream repository is hosted outside of Pantheon using a provider like [GitHub](https://github.com/), [Bitbucket](https://bitbucket.org/) or other Git based provider <Popover content="Contact support to try and create any other Git based custom upstream." />. It's connected to Pantheon and associated with your organization, allowing fellow team members the option to select this repository as a starting point when creating new sites.
 
 </div>
 </div>


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #6135

## Summary

**[Create a Custom Upstream](https://pantheon.io/docs/create-custom-upstream)** - Added instruction tabs for setting up custom upstream from other Git hosts like Azure or self-hosted BitBucket.

## We mention supporting 3 git methods: GitHub, Bitbucket or GitLab.

We really support just 2, GitHub & Bitbucket, out of the box and then a large range of other git based providers using a manual setup. The workflow for all these other Git providers is very similar to what we have now for GitLab. It involves creating a user account that gives pantheon access to it, and then contacting support to set it up. The URL validator for creating custom upstreams only accepts GitHub, Bitbucket but we can use just about anything using Git, it just needs a person to validate it.

**Expand the Git-based repository support definition here to include a wide range of other Git based providers.**


## Remaining Work
Review:
- [x] I'm sure the wording could be improved
- [ ] Should we provide less detail and jut say contact support or try and give some direction?

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
