### PR TITLE
Update Redis memory limits doc

### DIFF
--- a/source/content/redis.md
+++ b/source/content/redis.md
@@ -487,12 +487,9 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 | Plan                   | Cache Memory Limit (in MB) |
 | ---------------------- | -------------------------- |
 | Sandbox*               |               64           |
-| Performance Small      |               64           |
+| Basic                  |               64           |
+| Performance Small      |               256          |
 | Performance M, L, XL   |               512          |
-| Professional           |               256          |
-| Flagship               |               512          |
-| Business               |               512          |
-| BusinessXL             |               1024         |
 | Elite                  |               1024         |
 
 *Redis is available on free Sandbox plans for usage during development and will remain through upgrades to any other plan except for Basic. See the [Enable Redis](#enable-redis) section above for details about which account types have Redis on paid plans.


### PR DESCRIPTION

Closes: #6164 

## Summary

**[Redis](https://pantheon.io/docs/redis)** - Remove legacy plan info and correct Performance Small Cache Memory Limit. Add row for Basic to Cache Memory Limit table.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
