### PR TITLE
rename database descriptions

### DIFF
--- a/source/content/hyperdb.md
+++ b/source/content/hyperdb.md
@@ -13,7 +13,7 @@ Replica MySQL databases are available for sites on the [Elite service level](htt
 </Alert>
 
 ## Advantages of MySQL Replication
-Typical WordPress sites are limited to the capacity of a single database to serve read and write requests. As a result, high traffic sites can experience latency as requests are fulfilled. MySQL replication rapidly copies content from the "master" database to one or more "replica" databases. This allows you to spread requests across multiple databases to improve site performance and load times.
+Typical WordPress sites are limited to the capacity of a single database to serve read and write requests. As a result, high traffic sites can experience latency as requests are fulfilled. MySQL replication rapidly copies content from the "primary" database to one or more "replica" databases. This allows you to spread requests across multiple databases to improve site performance and load times.
 
 ## About HyperDB
 The [HyperDB](https://wordpress.org/support/plugin/hyperdb) plugin replaces the standard [`wpdb`](https://codex.wordpress.org/Class_Reference/wpdb) class so that WordPress is able to write and read from additional database servers. The drop-in plugin supports database replication, failover, load balancing, and partitioning — all tools for scaling WordPress.
@@ -22,30 +22,30 @@ Keep in mind, HyperDB is a powerful tool with several tuning options based on da
 
 ## Install and Configure HyperDB
 
-Before you begin, a Customer Success Manager (**CSM**) must change your site service level to "Elite". The platform will automatically configure and manage your master and replica databases. [Contact us](https://pantheon.io/contact-us) to learn more about service levels and how a CSM can help.
+Before you begin, a Customer Success Manager (**CSM**) must change your site service level to "Elite". The platform will automatically configure and manage your primary and replica databases. [Contact us](https://pantheon.io/contact-us) to learn more about service levels and how a CSM can help.
 
 Download the archive of [HyperDB from the WordPress plugin repository](https://wordpress.org/support/plugin/hyperdb) and move the `db.php` file into the `/wp-content` directory. This is a drop-in plugin and does not require activation at any time.
 
-Next, configure the master/replica databases within `db-config.php`. This file should be stored within the same directory as the site's `wp-config.php` file.
+Next, configure the primary/replica databases within `db-config.php`. This file should be stored within the same directory as the site's `wp-config.php` file.
 
 When the `db.php` database drop-in is deployed to production, WordPress will begin allocating MySQL database reads and writes based on the configuration details you’ve provided in `db-config.php`.
 
 The following sample configurations can be used in place of the `dp-config.php` file provided within the plugin archive. These examples require no additional edits for sites running on Pantheon. For more advanced options, refer to the `db-config.php` file provided in the HyperDB plugin archive.
 
-### Split Reads Between Master and Replica
-Split reads between the master and the replica, to simply distribute the load between two servers.
+### Split Reads Between Primary and Replica
+Split reads between the primary and the replica, to simply distribute the load between two servers.
 
 ```php
 <?php
 /**
- * Register the master server to HyperDB
+ * Register the primary server to HyperDB
  */
 $wpdb->add_database( array(
         'host'     => DB_HOST,
         'user'     => DB_USER,
         'password' => DB_PASSWORD,
         'name'     => DB_NAME,
-        'write'    => 1, // master server takes write queries
+        'write'    => 1, // primary server takes write queries
         'read'     => 1, // ... and read queries
 ) );
 /**
@@ -65,21 +65,21 @@ if ( ! empty( $_ENV['REPLICA_DB_HOST'] ) ) {
 ```
 
 
-### Pass Frontend Read Queries to Replica, WordPress Dashboard Reads and Writes to Master
-Pass all frontend database read queries to the replica, leaving the master dedicated to WordPress dashboard reads and writes. This can better ensure WordPress dashboard availability during high frontend load.
+### Pass Frontend Read Queries to Replica, WordPress Dashboard Reads and Writes to Primary
+Pass all frontend database read queries to the replica, leaving the primary dedicated to WordPress dashboard reads and writes. This can better ensure WordPress dashboard availability during high frontend load.
 
 ```php
 <?php
 /**
  * Use HyperDB to just use the replica for frontend reads.
- * Register the master server to HyperDB
+ * Register the primary server to HyperDB
  */
 $wpdb->add_database( array(
         'host'     => DB_HOST,
         'user'     => DB_USER,
         'password' => DB_PASSWORD,
         'name'     => DB_NAME,
-        'write'    => 1, // master server takes write queries
+        'write'    => 1, // primary server takes write queries
         'read'     => is_admin() || empty( $_ENV['REPLICA_DB_HOST'] ) ? 1 : 0, // ... but only takes read queries in the admin if the replica is available
 ) );
 /**


### PR DESCRIPTION
Replace instances of "master" with "primary"

Closes: n/a

## Summary

**[Scaling WordPress with MySQL Replicas and HyperDB](https://pantheon.io/docs/hyperdb)** - replace "master" language with "primary"

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [x] copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
