### PR TITLE
Update solr-drupal-8.md

### DIFF
--- a/source/content/solr-drupal-8.md
+++ b/source/content/solr-drupal-8.md
@@ -16,7 +16,7 @@ contributors: [peter-pantheon, cityofoaksdesign]
 
 If your search needs include geospatial search, emojis, or multilingual search, consider [OpenSolr](/opensolr) or another alternative search.
 
-Pantheon Search supports [Search API Solr 8.x-1.x](https://www.drupal.org/project/search_api_solr), which will reach end-of-life in December 2020. Search API Solr 8.x-1.x should continue to work as long as the Search API Pantheon module is also being used, following the installation directions below.
+Pantheon Search supports [Search API Solr 8.x-1.x](https://www.drupal.org/project/search_api_solr), which will reach end-of-life in December 2021. Search API Solr 8.x-1.x should continue to work as long as the Search API Pantheon module is also being used, following the installation directions below.
 
 </Alert>
 


### PR DESCRIPTION
Closes: NA

## Summary

**[Enabling Solr on Drupal 8](https://pantheon.io/docs/solr-drupal-8)** - Updated the EOL date for the 8.x branch of Search API Solr, as listed on the [module page](https://www.drupal.org/project/search_api_solr).

## Effect

- At minimum the date should be updated to reflect the new End of Life date of December 2021 (click through to the Search API Solr page). Personally, I don't love the "should continue to work" wording as it doesn't instill confidence but technically it's accurate.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
