### PR TITLE
Remove References to Legacy SSL

### DIFF
--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -10,17 +10,7 @@ tags: [cdn, https, professional-services]
 
 A white glove concierge service is now available to contract customers, including Enterprise, EDU+, Pantheon One, Elite, and Resellers. For more information, please contact [Sales](https://pantheon.io/why-pantheon-enterprise).
 
-## Upgrade to the Global CDN
-
-If your site is using our Legacy SSL service, it's on deprecated legacy infrastructure served from a single server in the central US. When you upgrade to the Global CDN you'll see faster performance, with content  delivered from almost 50 points of presence (POPs) around the world.
-
-If your site uses Legacy SSL, it's also on an outdated TLS configuration. The Global CDN is configured to only use TLS 1.2 and no weak 3DES cipher. On the legacy infrastructure, your site isn't as fast, secure, or as resilient as it could be.
-
-### Option 1: Automated Certificate Management via Let's Encrypt
-
-If you just haven’t gotten around to upgrading, consider using our managed HTTPS, which includes automated certificate management, leveraging Let’s Encrypt certificates. As a convenience, when you upgrade to managed HTTPS you’ll never have to worry about an expired certificate again. As long as your domain is pointed to Pantheon, we will automatically renew the certificates required to keep your site secure. [Upgrade](/https) to get best-in-class encryption and an A+ grade from SSL Labs.
-
-### Option 2: Manually Managed Custom Certificates
+## Manually Managed Custom Certificates
 
 If you require a custom, dedicated certificate, you can now bring it to the Global CDN. This is a paid service that our Sales Team can help you with.
 
@@ -72,17 +62,17 @@ CAA records configured for the root domain (e.g., `example.com`) are inherited b
 
 ## Technical Specifications
 
-|                                                                       | Legacy                    | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
-|:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |:--------------------------------------|
-| **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt | Bring your own                        |
-| **Renewal**                                                           | Self-managed (up to you)  | Automatic                       | Self-managed (up to you)              |
-| **Inbound IP**                                                        | Static (unique)           | Static (shared)                 | Static (shared)                       |
-| **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br />Some very old browsers not supported <sup> [1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> | 95.55% of Browsers <br />Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> * |
-| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/)               | A                         | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts)     | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts) *         |
-| **Protocol**                                                          | TLS 1.1 & 1.2             | TLS 1.2 with SNI                | TLS 1.2 with SNI                      |
-| **Ciphers**                                                           | Weak 3DES Cipher          | No Weak 3DES cipher             | No Weak 3DES cipher                   |
-| **Delivery**                                                          | US Datacenter             | [Global CDN](/global-cdn)  | [Global CDN](/global-cdn)        |
-| **Encryption Endpoint**                                               | Load Balancer             | Application Container           | Application Container                 |
+|                                                                       | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
+|:--------------------------------------------------------------------- |:------------------------------- |:------------------------------------- |
+| **Certificate Type**                                                  | Shared, issued by Let's Encrypt | Bring your own                        |
+| **Renewal**                                                           | Automatic                       | Self-managed (up to you)              |
+| **Inbound IP**                                                        | Static (shared)                 | Static (shared)                       |
+| **Client Support**                                                    | 95.55% of Browsers <br />Some very old browsers not supported <sup> [1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> | 95.55% of Browsers <br />Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> * |
+| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/)               | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts)     | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts) * |
+| **Protocol**                                                          | TLS 1.2 with SNI                | TLS 1.2 with SNI                      |
+| **Ciphers**                                                           | No Weak 3DES cipher             | No Weak 3DES cipher                   |
+| **Delivery**                                                          | [Global CDN](/global-cdn)  | [Global CDN](/global-cdn)        |
+| **Encryption Endpoint**                                               | Application Container           | Application Container                 |
 
 \* The browser compatibility and SSL Labs scores are guaranteed for shared Let’s Encrypt certificates. The same results are typical for a custom certificate from a mainstream CA with mainstream attributes, but not guaranteed.  For custom certificates, compatibility and SSL Labs score depends on attributes of that certificate, such as number of SAN entries, CA and signing algorithm.
 

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -1,23 +1,27 @@
 ---
 title: 'Custom Certificates on The Pantheon Global CDN'
 description: For contract customers who require dedicated, custom TLS certificates
-reviewed: "2020-04-22"
+reviewed: "2020-12-14"
 categories: [go-live]
 tags: [cdn, https, professional-services]
 ---
 
 ## Access
+
 A white glove concierge service is now available to contract customers, including Enterprise, EDU+, Pantheon One, Elite, and Resellers. For more information, please contact [Sales](https://pantheon.io/why-pantheon-enterprise).
 
 ## Upgrade to the Global CDN
+
 If your site is using our Legacy SSL service, it's on deprecated legacy infrastructure served from a single server in the central US. When you upgrade to the Global CDN you'll see faster performance, with content  delivered from almost 50 points of presence (POPs) around the world.
 
 If your site uses Legacy SSL, it's also on an outdated TLS configuration. The Global CDN is configured to only use TLS 1.2 and no weak 3DES cipher. On the legacy infrastructure, your site isn't as fast, secure, or as resilient as it could be.
 
 ### Option 1: Automated Certificate Management via Let's Encrypt
+
 If you just haven’t gotten around to upgrading, consider using our managed HTTPS, which includes automated certificate management, leveraging Let’s Encrypt certificates. As a convenience, when you upgrade to managed HTTPS you’ll never have to worry about an expired certificate again. As long as your domain is pointed to Pantheon, we will automatically renew the certificates required to keep your site secure. [Upgrade](/https) to get best-in-class encryption and an A+ grade from SSL Labs.
 
 ### Option 2: Manually Managed Custom Certificates
+
 If you require a custom, dedicated certificate, you can now bring it to the Global CDN. This is a paid service that our Sales Team can help you with.
 
 1. Please [contact sales](https://pantheon.io/contact-us) if you are not a contract customer.
@@ -48,6 +52,7 @@ If you require a custom, dedicated certificate, you can now bring it to the Glob
 1. Update `A` and `AAAA` records provided by Pantheon Support. Note that even for subdomains, `A` and `AAAA` records are required. Do not use a `CNAME` record.
 
 ## Test Before Going Live
+
 Test production domain(s) before updating DNS by overriding DNS on your local computer from your local `hosts` file:
 
 <Partial file="_hosts-file.md" />
@@ -55,16 +60,18 @@ Test production domain(s) before updating DNS by overriding DNS on your local co
 For non-production domains, test on any environment (Dev, Test, Live or Multidev), just make sure to include the non-production domains on your certificate. We are happy to provide a new CSR if your original CSR and certificate did not initially non-production domains.
 
 ## Disable Let's Encrypt with CAA Records (Required)
+
 A **Certification Authority Authorization** (CAA) record is used to specify which certificate authorities (CAs) are allowed to issue certificates for a domain. In order to ensure your custom certificate is served for all traffic, you must prevent Let’s Encrypt from issuing certificates. You have two options to prevent Let’s Encrypt from issuing certificates for domains on your custom certificate:
 
- - An empty CAA policy,
- - CAA records permitting your CA, but not Let’s Encrypt.
+- An empty CAA policy,
+- CAA records permitting your CA, but not Let’s Encrypt.
 
 To help generate CAA records, please see the free online tool: <https://sslmate.com/caa/>
 
 CAA records configured for the root domain (e.g., `example.com`) are inherited by subdomains (e.g., `www.example.com`, `blog.example.com`, etc.). Disabling Let's Encrypt for the root domain will disable subdomains.
 
 ## Technical Specifications
+
 |                                                                       | Legacy                    | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
 |:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |:--------------------------------------|
 | **Certificate Type**                                                  | Bring your own            | Shared, issued by Let's Encrypt | Bring your own                        |
@@ -82,38 +89,47 @@ CAA records configured for the root domain (e.g., `example.com`) are inherited b
 ## Frequently Asked Questions
 
 ### Do I need a separate certificate for each site in my organization?
+
 Nope! You can use the a single certificate to cover multiple domains spread across various environments or sites. This capability is enabled because the Global CDN uses a technology called Server Name Indication (SNI), which automatically matches inbound requests with an appropriate certificate, including custom certificates.
 
 ### How long will it take to load my certificate into Pantheon?
+
 Please allow two business days to get a CSR and load the certificate.
 
 ### How do I renew or replace my custom certificate?
+
 45 days before your custom certificate expires, Pantheon will open a ticket with your team with a new CSR. You can send that CSR to the Certificate Authority to generate new certificates (as described above for [bringing a custom certificate](#option-2-manually-managed-custom-certificates)).
 
 To update a certificate with additional domains, [contact support](/support) with the following details:
 
- - The current common name (CN) and any SANs
- - A colon-separated list of domains the certificate is valid for
- - The updated certificate attached
+- The current common name (CN) and any SANs
+- A colon-separated list of domains the certificate is valid for
+- The updated certificate attached
 
 It may take up to two business days to process the request.
 
 ### What about sites purchased online?
+
 Custom certificates are available for contract customers (e.g. Elite, Enterprise, EDU+) and we have no plans to offer it for Basic or Performance sites purchased online. If bringing your own certificate for non-contract site is a requirement, please see suggestions on [how to terminate TLS through a 3rd-party](/https/#can-i-bring-my-own-certificate).
 
 ### Will custom certificates be self-serve?
+
 We have no current plans to offer a self-serve option. The concierge service is designed to quickly guide you through the steps required to deliver HTTPS on the Global CDN using your custom certificate, and we may follow-up with a self-serve option in the future.
 
 ### Which certificates do I submit?
+
 Include the end-client certificate for your named domains, as well as the intermediate certificate, in separate files.
 
 ### What is the maximum number of SAN entries?
+
 For the broadest client compatibility we recommend limiting the number of Subject Alternate Names to 100.
 
 ### Are private keys available for export?
+
 Private keys are just that, private, and not available for export. They are stored securely, server side, and it’s a security best practice to not share private keys among different deployments. If you manage multiple domains, with some on Pantheon, and some outside of Pantheon, then we recommend using separate certificates, and we are happy to provide you with a new Certificate Signing Request (CSR) so we can deploy a certificate on Pantheon that only has the domains served on Pantheon.
 
 ### What are the Global CDN IP addresses?
+
 The Global CDN currently has 4 offsets. After certificate deployment, we will provide DNS information so you can upgrade. In the examples below, `X` will be replaced with a value of `1`, `2`, `3`, or `4`:
 
 A record: `23.185.0.X`
@@ -123,6 +139,7 @@ AAAA record 2:  `2620:12a:8001::X`
 **Note:** `AAAA` records are not required, but recommended as a best practice for performance, especially for mobile devices. See [Introduction to Domain Name Services](/dns/#what-are-aaaa-records-and-do-i-need-them) for more information.
 
 ### What if my DNS manager doesn't support CAA DNS records?
+
 CAA records are required  to [prohibit Let's Encrypt from issuing certificates](#disable-lets-encrypt-with-caa-records-required). If your DNS provider does not support CAA records, consider one that does. If using a DNS provider that supports CAA records is not possible, please inform your Engagement Manager, as our [Professional Services](/professional-services) team can help.
 
 ## Caveats / Known Issues
@@ -132,12 +149,15 @@ CAA records are required  to [prohibit Let's Encrypt from issuing certificates](
 If a Let's Encrypt Certificate is deployed before the CAA record preventing it, [contact Pantheon support](/support) for assistance. Please allow at least 3 business days for Pantheon to resolve the Let's Encrypt Certificate.
 
 ### CA limitations
+
 Your CA must accept the CSR Pantheon provides. If your CA fails to accept our CSR, you will not be able to use it to generate a certificate. The CA GlobalSign does not currently meet this requirement. The workaround is to simply use another CA.
 
 ### Downgrading a Site that uses a Custom Certificate
+
 Since all sites require an encryption certificate, to downgrade a site that uses a custom certificate, use Pantheon’s [Global CDN](/https) to enable Let’s Encrypt. Alternatively, you can use another CDN like [Cloudflare](/cloudflare).
 
 ## See also
+
 - [Pantheon Global CDN](/global-cdn)
 - [HTTPS on Pantheon's Global CDN](/https)
 - [Introduction to Domain Name Services](/dns)

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -60,21 +60,7 @@ To help generate CAA records, please see the free online tool: <https://sslmate.
 
 CAA records configured for the root domain (e.g., `example.com`) are inherited by subdomains (e.g., `www.example.com`, `blog.example.com`, etc.). Disabling Let's Encrypt for the root domain will disable subdomains.
 
-## Technical Specifications
-
-|                                                                       | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
-|:--------------------------------------------------------------------- |:------------------------------- |:------------------------------------- |
-| **Certificate Type**                                                  | Shared, issued by Let's Encrypt | Bring your own                        |
-| **Renewal**                                                           | Automatic                       | Self-managed (up to you)              |
-| **Inbound IP**                                                        | Static (shared)                 | Static (shared)                       |
-| **Client Support**                                                    | 95.55% of Browsers <br />Some very old browsers not supported <sup> [1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> | 95.55% of Browsers <br />Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> * |
-| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/)               | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts)     | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts) * |
-| **Protocol**                                                          | TLS 1.2 with SNI                | TLS 1.2 with SNI                      |
-| **Ciphers**                                                           | No Weak 3DES cipher             | No Weak 3DES cipher                   |
-| **Delivery**                                                          | [Global CDN](/global-cdn)  | [Global CDN](/global-cdn)        |
-| **Encryption Endpoint**                                               | Application Container           | Application Container                 |
-
-\* The browser compatibility and SSL Labs scores are guaranteed for shared Let’s Encrypt certificates. The same results are typical for a custom certificate from a mainstream CA with mainstream attributes, but not guaranteed.  For custom certificates, compatibility and SSL Labs score depends on attributes of that certificate, such as number of SAN entries, CA and signing algorithm.
+<Partial file="tables/https-specs.md" />
 
 ## Frequently Asked Questions
 

--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -8,7 +8,7 @@ tags: [cdn, https, professional-services]
 
 ## Access
 
-A white glove concierge service is now available to contract customers, including Enterprise, EDU+, Pantheon One, Elite, and Resellers. For more information, please contact [Sales](https://pantheon.io/why-pantheon-enterprise).
+A concierge service is now available to contract customers, including Enterprise, EDU+, Pantheon One, Elite, and Resellers. For more information, please contact [Sales](https://pantheon.io/why-pantheon-enterprise).
 
 ## Manually Managed Custom Certificates
 

--- a/source/content/https.md
+++ b/source/content/https.md
@@ -40,20 +40,7 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 <Partial file="https-requirements.md" />
 
-
-## Technical Specifications
-
-|                                                                       | Legacy                    | Global CDN with Let's Encrypt   |
-|:--------------------------------------------------------------------- |:------------------------- |:------------------------------- |
-| **Certificate Type**                                                  | Bring your own            | Issued by Let's Encrypt         |
-| **Renewal**                                                           | Self-managed (up to you)  | Automatic                       |
-| **Inbound IP**                                                        | Static (unique)           | Static (shared)                 |
-| **Client Support**                                                    | 96.02% of browsers        | 95.55% of Browsers <br /> Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> |
-| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/)    | A                         | A+ [with HSTS](/pantheon-yml/#enforce-https--hsts)     |
-| **Protocol**                                                          | TLS 1.1 & 1.2             | TLS 1.2 with SNI                |
-| **Ciphers**                                                           | Weak 3DES Cipher          | No Weak 3DES cipher             |
-| **Delivery**                                                          | US Datacenter             | [Global CDN](/global-cdn)  |
-| **Encryption Endpoint**                                               | Load Balancer             | Application Container           |
+<Partial file="tables/https-specs.md" />
 
 ## Frequently Asked Questions
 

--- a/source/partials/tables/https-specs.md
+++ b/source/partials/tables/https-specs.md
@@ -1,0 +1,15 @@
+## Technical Specifications
+
+|                                                                       | Global CDN with Let's Encrypt   | Global CDN with a Custom Certificate  |
+|:--------------------------------------------------------------------- |:------------------------------- |:------------------------------------- |
+| **Certificate Type**                                                  | Issued by Let's Encrypt         | Bring your own                        |
+| **Renewal**                                                           | Automatic                       | Self-managed (up to you)              |
+| **Inbound IP**                                                        | Static (shared)                 | Static (shared)                       |
+| **Client Support**                                                    | 95.55% of Browsers <br />Some very old browsers not supported <sup> [1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> | 95.55% of Browsers <br />Some very old browsers not supported <sup>[1](https://caniuse.com/#search=TLS%201.2) [2](https://caniuse.com/#search=SNI)</sup> * |
+| [**SSL Labs Rating**](https://www.ssllabs.com/ssltest/)               | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts)     | A+ [with HSTS](/pantheon-yml/#enforce-https-+-hsts) * |
+| **Protocol**                                                          | TLS 1.2 with SNI                | TLS 1.2 with SNI                      |
+| **Ciphers**                                                           | No Weak 3DES cipher             | No Weak 3DES cipher                   |
+| **Delivery**                                                          | [Global CDN](/global-cdn)  | [Global CDN](/global-cdn)        |
+| **Encryption Endpoint**                                               | Application Container           | Application Container                 |
+
+\* The browser compatibility and SSL Labs scores are guaranteed for Pantheon-provided Let’s Encrypt certificates. The same results are typical for a custom certificate from a mainstream CA with mainstream attributes, but not guaranteed.  For custom certificates, compatibility and SSL Labs score depends on attributes of that certificate, such as number of SAN entries, CA and signing algorithm.


### PR DESCRIPTION
Closes: #6126 
Closes: #6225 

## Summary

**[Custom Certificates on The Pantheon Global CDN](https://pantheon.io/docs/custom-certificates)** - Removes information about the Legacy SSL offering, which is no longer available.

## Remaining Work

- [ ] ~@ari-gold the remaining content in the Technical Specifications table is mostly the same. Should we remove the table, or change it to just be a bulleted list of specs, or... ?~ Never mind.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
