### PR TITLE
Don't specify an exact PHP version in migration pre-reqs

### DIFF
--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -11,7 +11,7 @@ To ensure a successful migration, complete the following tasks on the source sit
 - Read [Platform Considerations](/platform-considerations)
 - Upgrade to the latest version of WordPress or Drupal core
 - Reference your plugins and/or modules against [Modules and Plugins with Known Issues](/modules-plugins-known-issues)
-- Make sure your code is compatible with PHP 7.2. If not, be prepared to [adjust PHP versions](/php-versions/#configure-php-version)
+- Make sure your code is compatible with the latest recommended version of PHP for your CMS. If not, be prepared to [adjust PHP versions](/php-versions/#configure-php-version)
 - Clear all caches
 - Remove unneeded code, database tables, and files
 - [Configure SSH keys](/ssh-keys)


### PR DESCRIPTION
## Summary

**[Migrate Sites to Pantheon](https://pantheon.io/docs/migrate)** - 

Don't specify an exact PHP version here since this changes somewhat frequently and varies by CMS/upstream. Referring people to the main PHP versions doc is more maintainable.

PHP 7.2 is EOL as of Nov 30: https://www.php.net/eol.php

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
