### PR TITLE
update EOL table for php 7.2

### DIFF
--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -3,7 +3,7 @@ title: Upgrade PHP Versions
 description: Learn how to upgrade PHP versions to resolve  compatibility issues.
 tags: [libraries, updates]
 categories: [platform]
-reviewed: "2020-05-05"
+reviewed: "2020-12-21"
 ---
 Upgrading your site's PHP version will improve the security, performance, and supportability of your site. See our blog post for an [example of 62% performance gains after upgrading](https://pantheon.io/blog/php-7-now-available-all-sites-pantheon).
 
@@ -30,7 +30,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | --------------------------------------------:| ----------- | ------ |
 | [7.4](https://v74-php-info.pantheonsite.io/) | <span style="color:green">✔</span> | Active |
 | [7.3](https://v73-php-info.pantheonsite.io/) | <span style="color:green">✔</span> | Active |
-| [7.2](https://v72-php-info.pantheonsite.io/) | <span style="color:green">✔</span> | Active |
+| [7.2](https://v72-php-info.pantheonsite.io/) | ❌           | EOL     |
 | [7.1](https://v71-php-info.pantheonsite.io/) | ❌           | EOL     |
 | [7.0](https://v70-php-info.pantheonsite.io/) | ❌           | EOL     |
 | [5.6](https://v56-php-info.pantheonsite.io/) | ❌           | EOL     |


### PR DESCRIPTION
Per pull request updating default version for [drops-7](https://github.com/pantheon-systems/drops-7/pull/164) repo.


## Summary

**[Upgrade PHP Versions](https://pantheon.io/docs/php-versions)** - Update PHP 7.2 status to reflect EOL. 


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
