### PR TITLE
Add FAQ item to Integrated Composer doc

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -152,6 +152,13 @@ Try [composer-lock-diff](https://github.com/davidrjonas/composer-lock-diff) to s
 ### Can I use a Composer GUI?
 
 Pantheon does not offer support for Composer GUIs or any conflicts that might be cause by one.
+
+### Why are contrib modules placed in /modules/composer instead of /modules/contrib?
+
+Integrated Composer needs to consider the use-case where a site might already have non-Composer-managed modules in the standard `/modules/contrib` directory. To support this, we create the `modules/composer` directory for modules added by Integrated Composer.
+
+If your site does not fall into this category, it is safe to rename the `composer` directory back to the standard `contrib`.
+
 ### What features are planned for Integrated Composer on Pantheon?
 
 Pantheon's devs are working hard to make the Integrated Composer experience on Pantheon better.

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -155,7 +155,7 @@ Pantheon does not offer support for Composer GUIs or any conflicts that might be
 
 ### Why are contrib modules placed in /modules/composer instead of /modules/contrib?
 
-Integrated Composer needs to consider the use-case where a site might already have non-Composer-managed modules in the standard `/modules/contrib` directory. To support this, we create the `modules/composer` directory for modules added by Integrated Composer.
+Integrated Composer needs to consider the use case where a site might already have non-Composer-managed modules in the standard `/modules/contrib` directory. To support this, we create the `/modules/composer` directory for modules added by Integrated Composer.
 
 If your site does not fall into this category, it is safe to rename the `composer` directory back to the standard `contrib`.
 


### PR DESCRIPTION
## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Add an item to the the FAQ section

## Effect
Adds an explanation for why Integrated Composer places contrib modules in a non-standard location. This question came up on [Community Slack](https://pantheon-community.slack.com/archives/CTA1621KK/p1608666454169400?thread_ts=1608655406.168900&cid=CTA1621KK) yesterday and has also come through Support.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
