### PR TITLE
Document failure to clone un-initialized site

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           deployment-path: docs
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
-          gatsby-cache-version: "v1.8.6"
+          gatsby-cache-version: "v1.8.7"
           pre-steps:
             - checkout
             - run:

--- a/source/content/guides/localdev/04-troubleshoot-support.md
+++ b/source/content/guides/localdev/04-troubleshoot-support.md
@@ -48,6 +48,19 @@ The contents of `wp-contents/uploads` should be symlinked to files, in keeping w
 
 You can [contact support](#contact-support) for help moving your files out of the codebase.
 
+### Clone of a New Site Failed
+
+If you attempt to clone a site before opening the admin panel to initialize the database, Localdev will fail to pull it locally. The logs under **show detail (beta)** will show:
+
+```docker
+Pulling your database... This miiiiight take a minute
+ [notice] Command: anita-wordpress.dev -- wp db export [Exit: 0]
+Checking db pull for expected tables...
+Database pull failed...
+```
+
+See step 9 of [Create a Site](/create-sites#create-a-site).
+
 ### Log out and Reset to Defaults
 
 The steps in this section should only be used as a last resort. This resets Localdev and will remove the machine token and all local copies of your connected sites.

--- a/source/content/guides/localdev/04-troubleshoot-support.md
+++ b/source/content/guides/localdev/04-troubleshoot-support.md
@@ -50,7 +50,7 @@ You can [contact support](#contact-support) for help moving your files out of th
 
 ### Clone of a New Site Failed
 
-If you attempt to clone a site before opening the admin panel to initialize the database, Localdev will fail to pull it locally. The logs under **show detail (beta)** will show:
+If you attempt to initialize a site within Localdev before you've completed the CMS install on Pantheon, it will fail when attempting to pull the (non-existent) database from the platform. The logs under **show detail (beta)** will show:
 
 ```docker
 Pulling your database... This miiiiight take a minute

--- a/source/content/guides/localdev/04-troubleshoot-support.md
+++ b/source/content/guides/localdev/04-troubleshoot-support.md
@@ -14,7 +14,7 @@ editpath: localdev/04-troubleshoot-support.md
 
 ## Contact Support
 
-Before contacting support, review the [support request best practices](/support#best-practices) to help our team help you resolve the issue, or to report any potential issues in Localdev itself.
+Before contacting Support, review the [support request best practices](/support#best-practices) to help our team help you resolve the issue, or to report any potential issues in Localdev itself.
 
 1. Navigate to the **Settings** menu and confirm that *Usage and Crash Data* is set to **Allow reports**. This allows the application to automatically submit crash data to Pantheon Support.
 
@@ -95,4 +95,4 @@ You can verify which version of PHP your site is using by clicking **Launch Term
 
 ### Can I create Multidev environments from Localdev?
 
-No, new multidev environments must still be created from the Site Dashboard or [Terminus](/terminus/commands/multidev-create).
+No, new Multidev environments must still be created from the Site Dashboard or [Terminus](/terminus/commands/multidev-create).


### PR DESCRIPTION
## Summary

**[Support & Troubleshooting - Pantheon Localdev](https://pantheon.io/docs/guides/localdev/troubleshoot-support)** - Documented the failure of Localdev to clone un-initialized sites.

## Remaining Work
The following changes still need to be completed:

- [x] Confirm this is expected behavior (CC @fergusofarrell @dustinleblanc)

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
