### PR TITLE
To note that wp eval command is not working in Pantheon

### DIFF
--- a/source/content/wp-cli.md
+++ b/source/content/wp-cli.md
@@ -61,6 +61,15 @@ Use the `wp db query` command via [Terminus](/terminus) to run SQL queries again
 terminus wp <site>.<env> -- db query "SELECT * FROM wp_users WHERE ID=1"
 ```
 
+## Execute PHP Code Using WP-CLI on Pantheon
+
+The [`wp eval`](https://developer.wordpress.org/cli/commands/eval/) command is not supported on Pantheon but you can still run the interactive shell [`wp shell`](https://developer.wordpress.org/cli/commands/eval/) to execute php commands.
+
+```bash
+terminus <site>.<env> -- wp shell
+var_dump($_ENV);
+```
+
 ## Extending WP-CLI With Subcommands
 
 WP-CLI has a framework for users to write their own commands. Learn about the [anatomy of a subcommand](https://make.wordpress.org/cli/handbook/commands-cookbook/#anatomy-of-a-command) to solve your thorny problems with WP-CLI.

--- a/source/content/wp-cli.md
+++ b/source/content/wp-cli.md
@@ -15,6 +15,17 @@ Once you've installed Terminus locally, and verified it's working correctly, you
 
 If you have a [Composer-based site](/composer), Terminus will use the version of WP-CLI that it finds in `vendor/wp-cli` when running WP-CLI commands on the platform.
 
+<Alert title="Exports" type="export">
+
+This doc demonstrates [Terminus](/terminus) commands which require site and environment values. Before we begin, set the variables `$site` and `$env` in your terminal session to match your site name and the Dev environment, so that the example commands will work in your local terminal:
+
+```bash{promptUser: user}
+export site=yoursitename
+export env=dev # Or a multidev test environment
+```
+
+</Alert>
+
 ## Getting Started With WP-CLI
 
 When working on the command-line, it's worth remembering the adage: "with great power comes great responsibility". WP-CLI will let you perform incredible operations on your WordPress site (including dropping your database), for better or for worse. Only you know the true intention of the command you're invoking.
@@ -30,7 +41,7 @@ Each of these global parameters define the **context** under which the command i
 Now that we've covered the most important basics, let's run a command:
 
 ```bash{outputLines:2-7}
-terminus wp pantheon-demo.dev -- option get home
+terminus wp $site.$env -- option get home
   [2015-11-25 02:42:12] [info] Running wp option get home  on pantheon-demo
       cmd: 'option get home'
       flags: ''
@@ -43,7 +54,7 @@ From the example above:
 
 * `terminus wp` tells Terminus we'd like to execute a WP-CLI command.
 * `option get` is the command itself ([docs](https://developer.wordpress.org/cli/commands/option/get/)). `home` is the key for the option we're requesting.
-* `<site>` and `<env>` tell Terminus which site and environment to run the command in, respectively. These arguments can be provided automatically if you execute Terminus commands from a directory containing a [`.env`](https://github.com/pantheon-systems/cli/blob/master/.env.example) file.
+* `$site` and `$env` tell Terminus which site and environment to run the command in, respectively. These arguments can be provided automatically if you execute Terminus commands from a directory containing a [`.env`](https://github.com/pantheon-systems/cli/blob/master/.env.example) file.
 
 The first part of the output is Terminus telling you which command it's running, and where. The last line, `https://pantheon-demo.pantheonsite.io`, is the response of `wp option get`.
 
@@ -58,15 +69,15 @@ Feeling comfortable with WP-CLI? Here are a [few of the many commands](https://d
 Use the `wp db query` command via [Terminus](/terminus) to run SQL queries against the database on Pantheon:
 
 ```bash{promptUser: user}
-terminus wp <site>.<env> -- db query "SELECT * FROM wp_users WHERE ID=1"
+terminus wp $site.$env -- db query "SELECT * FROM wp_users WHERE ID=1"
 ```
 
 ## Execute PHP Code Using WP-CLI on Pantheon
 
-The [`wp eval`](https://developer.wordpress.org/cli/commands/eval/) command is not supported on Pantheon but you can still run the interactive shell [`wp shell`](https://developer.wordpress.org/cli/commands/eval/) to execute php commands.
+The [`wp eval`](https://developer.wordpress.org/cli/commands/eval/) command is not supported on Pantheon, but you can still run the interactive shell [`wp shell`](https://developer.wordpress.org/cli/commands/eval/) to execute PHP commands:
 
 ```bash
-terminus <site>.<env> -- wp shell
+terminus wp $site.$env -- shell
 var_dump($_ENV);
 ```
 
@@ -79,10 +90,11 @@ Keep in mind that WP-CLI commands are subject to platform PHP memory limits, whi
 ## Troubleshooting
 
 ### Terminus WP-CLI Silent Failure
+
 The following silent failure occurs when executing `terminus remote:wp` commands on environments that use redirect logic without checking to see if WordPress is running via the command line:
 
 ```bash
-[notice] Command: <site>.<env> -- 'wp <command>' [Exit: 0]
+[notice] Command: $site.$env -- 'wp <command>' [Exit: 0]
 ```
 
 Redirects kill the PHP process before WP-CLI is executed. You can resolve this error by adding `php_sapi_name() != "cli"` as a conditional statement to all redirect logic within `wp-config.php`:


### PR DESCRIPTION
Closes #5650 

## Summary

**[Using WP-CLI On The Pantheon Platform](https://pantheon.io/docs/wp-cli)** - Documented using `wp shell` over Pantheon to execute PHP commands.

## Effect
- To note that wp eval command is not working in Pantheon

Should be the equivalent of this in drush https://pantheon.io/docs/drush#execute-php-code-using-drush-on-pantheon

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
