### PR TITLE
add UUID to glossary

### DIFF
--- a/source/content/sites.md
+++ b/source/content/sites.md
@@ -127,7 +127,9 @@ Set a common password for accessing an environment to add an extra layer of secu
 
 ## Site UUID
 
-Every user, organization, product and site is assigned a UUID which is internal to Pantheon. The site UUID is found within the URL for the site Dashboard and resembles the following:
+Every user, organization, product, and site is assigned a <dfn id="UUID">UUID</dfn> which is internal to Pantheon. The site UUID is unique combination of 32 alphanumeric characters, found within the URL for the site Dashboard.
+
+A UUID resembles the following:
 
 ```none
 de305d54-75b4-431b-adb2-eb6b9e546014


### PR DESCRIPTION
## Summary

**[Glossary](https://pr-6206--pantheon-docs.my.pantheonfrontend.website/docs/glossary/#uuid)** - Added UUID to the glossary.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- slightly reworded and reformatted the definition of UUID in /docs/sites so that the Glossary picks it up (which I need for another doc)

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
