### PR TITLE
Clarify Secure Integration Add-on

### DIFF
--- a/source/content/secure-integration.md
+++ b/source/content/secure-integration.md
@@ -4,7 +4,7 @@ description: Configuring your Drupal or WordPress site to use Secure Integration
 categories: [platform]
 tags: [database, professional-services, redis, security]
 ---
-[Pantheon Secure Integration](https://pantheon.io/features/secure-integration), formerly known as Pantheon Enterprise Gateway (PEG), creates a secure tunnel between your firewall and your public facing website. This is available for contract customers. [Contact us](https://pantheon.io/contact-us) for more information.
+[Pantheon Secure Integration](https://pantheon.io/features/secure-integration), formerly known as Pantheon Enterprise Gateway (PEG), creates a secure tunnel between your firewall and your public facing website. This is an available add-on service for contract customers. [Contact us](https://pantheon.io/contact-us) for more information.
 
 One of the effects of the elastic nature of Pantheon's platform is that sites have a [dynamic outgoing IP](/outgoing-ips). Container IP addresses are not constant, so direct connections aren't sustainable. This can be a problem if your site needs to communicate with another service that restricts traffic by source IP. Secure Integration provides a solution.
 


### PR DESCRIPTION
Closes: #6217 

## Summary

**[Pantheon Secure Integration](https://pantheon.io/docs/secure-integration)** - Clarified that SI is an add-on service available to contact customers.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
