### PR TITLE
Sitemap Branch

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -236,7 +236,7 @@ module.exports = {
         serialize: ({site, allSitePage}) =>
           allSitePage.nodes.map(node => {
             return {
-              url: `${site.siteMetadata.siteUrl}${node.path}`,
+              url: `https://pr-6219--pantheon-docs.my.pantheonfrontend.website${node.path}`,
               changeFreq: `daily`,
               priority: 0.7,
             }

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -214,6 +214,34 @@ module.exports = {
     `gatsby-plugin-react-helmet`,
     {
       resolve: 'gatsby-plugin-sitemap',
+      options: {
+        exclude: [`/changelog/*`, `/terminus/commands/*`],
+        query: `
+        {
+          allSitePage {
+            nodes {
+              path
+            }
+          }
+          site {
+            siteMetadata {
+              siteUrl
+            }
+            pathPrefix
+          }
+        }`,
+        resolveSiteURL: ({site, allSitePage}) => {
+          return site.siteMetadata.siteUrl
+        },
+        serialize: ({site, allSitePage}) =>
+          allSitePage.nodes.map(node => {
+            return {
+              url: `${site.siteMetadata.siteUrl}${node.path}`,
+              changeFreq: `daily`,
+              priority: 0.7,
+            }
+          })
+      },
     },
     `gatsby-plugin-fontawesome-css`,
   ],

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -124,6 +124,8 @@ exports.createPages = ({ graphql, actions }) => {
               layout
               permalink
               draft
+              categories
+              tags
             }
             fields {
               slug
@@ -152,6 +154,8 @@ exports.createPages = ({ graphql, actions }) => {
               layout
               permalink
               draft
+              categories
+              tags
             }
             fields {
               slug
@@ -237,8 +241,9 @@ exports.createPages = ({ graphql, actions }) => {
     const docs = result.data.allDocs.edges
     docs.forEach(doc => {
       const template = calculateTemplate(doc.node, "doc")
+      //console.log(`Slug: ${doc.node.fields.slug}\nCategories: ${doc.node.frontmatter.categories}`) //For Debugging
       createPage({
-        path: doc.node.fields.slug,
+        path: `${doc.node.frontmatter.categories}/${doc.node.fields.slug}`,
         component: path.resolve(`./src/templates/${template}.js`),
         context: {
           slug: doc.node.fields.slug,
@@ -254,7 +259,7 @@ exports.createPages = ({ graphql, actions }) => {
         const next = calculateNext(guide);
         const template = calculateTemplate(guide.node, "guide")
         createPage({
-          path: guide.node.fields.slug,
+          path: `${guide.node.frontmatter.categories}/${guide.node.fields.slug}`,
           component: path.resolve(`./src/templates/${template}.js`),
           context: {
             slug: guide.node.fields.slug,

--- a/source/content/backups.md
+++ b/source/content/backups.md
@@ -2,7 +2,7 @@
 title: Backups Tool
 description: Learn how to backup your Drupal or WordPress site on Pantheon.
 tags: [getstarted]
-categories: []
+categories: [platform]
 ---
 
 The Backups tab is where you manage all the details for your site's backup. Each backup contains three components: code, database, and files.


### PR DESCRIPTION
## Summary

This branch adjusts the page paths to include the categories as sub-directories. This is not intended to ever go into production, it's here so we can use the sitemap generated to create a site mapping that includes our pre-defined categories.

## Remaining Work

- [ ] Incorporate tags into the site mapping.

## Post Launch (Should Never Be Launched)

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
