### PR TITLE
Refactor Dashboard Link Report to query at Runtime

### DIFF
--- a/src/reports/components/searchField.js
+++ b/src/reports/components/searchField.js
@@ -1,0 +1,37 @@
+import React from "react"
+
+/* This function creates a search field  component. it accepts as arguments
+the object and object setter used to represent the data it's filtering on,*/
+const SearchField = props => {
+  const title = props.title
+  const data = props.data
+  const dataSetter = props.dataSetter
+
+  return (
+    <div className="form-group">
+      <div className="input-group">
+        <div className="input-group-addon">
+          <i className="fa fa-search" />
+        </div>
+        <input
+          type="text"
+          id={`command-search-${title}`}
+          className="form-control"
+          placeholder={`Filter by ${title}`}
+          onChange={e => dataSetter(e.target.value)}
+          value={data}
+        />
+        <div
+          style={{ background: "#fff; cursor:pointer" }}
+          className="input-group-addon"
+          id="clear-filter"
+          onClick={e => dataSetter("")}
+        >
+          <span className="fa fa-times" />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default SearchField

--- a/src/reports/dashLinks.js
+++ b/src/reports/dashLinks.js
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from "react"
 import { useStaticQuery, graphql, Link } from "gatsby"
 import Layout from "../layout/layout"
+import SearchField from "./components/searchField"
 //import newGitHubIssueUrl from "new-github-issue-url"
 
 /*
@@ -8,8 +9,8 @@ This report provides all links to Dashboard pages and features, for quick
 reference when they are updates or changed in the product.
 */
 
-// Helper / Builder Functions //
 
+// Helper / Builder Functions //
 /* This function filters an array to unique entities, without changing the
 object type to a set. */
 function uniq(a) {
@@ -19,84 +20,59 @@ function uniq(a) {
   })
 }
 
-/* This function creates a search field  component. it accepts as arguments
-the object and object setter used to represent the data it's filtering on,*/
-const SearchField = props => {
-  const title = props.title
-  const data = props.data
-  const dataSetter = props.dataSetter
-
-  return (
-    <div className="form-group">
-      <div className="input-group">
-        <div className="input-group-addon">
-          <i className="fa fa-search" />
-        </div>
-        <input
-          type="text"
-          id={`command-search-${title}`}
-          className="form-control"
-          placeholder={`Filter by ${title}`}
-          onChange={e => dataSetter(e.target.value)}
-          value={data}
-        />
-        <div
-          style={{ background: "#fff; cursor:pointer" }}
-          className="input-group-addon"
-          id="clear-filter"
-          onClick={e => dataSetter("")}
-        >
-          <span className="fa fa-times" />
-        </div>
-      </div>
-    </div>
-  )
-}
-
 // Main Page Component //
-
 // Create the React Component as a function
 const DashLinks = () => {
-  // Data
+  // Data objects
+  const [pages, setPages] = useState([]);
+  var tertiaryPages = []
 
-  /* Create a function to query all pages that include a dashboard link,
-  excluding the base domain dashboard.pantheon.io. */
-  const queryData = useStaticQuery(graphql`
-    query {
-      allMdx(filter: { body: { regex: "/dashboard.pantheon.io/[a-z]/" } }) {
-        edges {
-          node {
-            fields {
-              slug
+  /* Query all pages that include a dashboard link, excluding the base domain dashboard.pantheon.io. */
+  useEffect(() => {
+    const body = {
+      query: `
+        query DashLinks{
+          allMdx(filter: { body: { regex: "/dashboard.pantheon.io/[a-z]/" } }) {
+            edges {
+              node {
+                fields {
+                  slug
+                }
+                frontmatter {
+                  title
+                }
+                body
+              }
             }
-            frontmatter {
-              title
-            }
-            body
           }
-        }
-      }
-    }
-  `)
+      }`,
+    };
+    fetch(`http://localhost:8000/___graphql`, {
+      body: JSON.stringify(body),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      method: 'POST',
+    })
+      .then(response => response.json()) // parse JSON from request
+      .then(resultData => {
+        setPages(resultData.data.allMdx.edges);
+        tertiaryPages = resultData.data.allMdx.edges.filter( //All guide sub-pages
+          page => {
+            return page.node.fields.slug.match(/\/guides(\/[a-z,\-]*){2}/)
+          }
+        )
+      })
+  }, [setPages])
 
-  //These objects are shorthand references to data in the query.
-  const pages = queryData.allMdx.edges //All Pages
-  const tertiaryPages = queryData.allMdx.edges.filter( //All guide sub-pages
-    page => {
-      return page.node.fields.slug.match(/\/guides(\/[a-z,\-]*){2}/)
-    }
-  )
-
-  /* These objects contain the data used in the search fields on the page to
-  filter the results */
+  /* These objects contain the data used in the search fields to filter the results */
   const [searchTitle, setSearchTitle] = useState("")
   const [searchLinks, setSearchLinks] = useState("")
 
   // And one for the table data, filtered by the search fields
   const [filteredPages, setFilteredPages] = useState(pages)
 
-  /* This call to the useEffect hook applies the filtering to our results table
-  if either search term has a value.*/
+  /* This call to the useEffect hook applies the filtering to our results table if either search term has a value.*/
   useEffect(() => {
     if (searchTitle || searchLinks) { //If either search field has a value...
       const applyFilter = data => // Define a function to filter the table, using data as a placeholder value,
@@ -119,24 +95,23 @@ const DashLinks = () => {
     }
   }, [pages, searchTitle, searchLinks, setFilteredPages]) //If the data in any of these objects changes, the useEffect hook is called.
 
-  /* Component to construct the table body by mapping on the pages data, after
-  it's been filtered by the search terms*/
+  /* Component to construct the table body by mapping on the pages data, after it's been filtered by the search terms*/
   const ResultsTable = () => {
     return (
       //Construct a table body
       <tbody>
         {filteredPages.map((page, i) => { // Map over each page and,
           return (
-            <tr key={i}> {/*Create a table row*/}
-              <td>{page.node.frontmatter.title || "Partial File"}</td> {/*Provide the page title, or specify a partial file if there isn't one*/}
-              <td>{page.node.fields.slug}</td> {/*Provide the path to the page*/}
-              <td>
-                {uniq( //Return only one unique instance where,
-                  page.node.body //in the body
-                    .match(RegExp(/dashboard.pantheon.io\/[a-z-\/]+/g)) // there's a reference to a dashboard page,
-                    .map((link, i) => link + "\n") // and list each one on a new line.
-                )}
-              </td>
+            <tr key={i}>{/*Create a table row*/}
+              <td>{page.node.frontmatter.title || "Partial File"}</td>{/*Provide the page title, or specify a partial file if there isn't one*/}
+              <td>{page.node.fields.slug}</td>{/*Provide the path to the page*/}
+              <td>{
+                uniq( //Return only one unique instance where,
+                    page.node.body //in the body
+                      .match(RegExp(/dashboard.pantheon.io\/[a-z-\/]+/g)) // there's a reference to a dashboard page,
+                      .map((link, i) => link + "\n") // and list each one on a new line.
+                  )
+                }</td>
             </tr>
           )
         })}

--- a/src/reports/dashLinks.js
+++ b/src/reports/dashLinks.js
@@ -122,6 +122,7 @@ const DashLinks = () => {
   // Render
   return (
     <Layout>
+      <h1>Links to Dashboard Features in Docs</h1>
       <SearchField
         title="Doc Title"
         data={searchTitle}


### PR DESCRIPTION
## Summary

**[Dashboard Feature Links Report](http://localhost:8000/dashLinks)** (dev server only) - Reduced overall site build time by setting up the large query in this report to run client-side instead of at build time. All glory to @puglyfe for `<frampton>`showing me the way`</frampton>`.

## Effect

-This will reduce this report's cost to total build time for the site.
- Additionally, I've abstraced the SearchField into a re-usable component, to eventually use in the other reports.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
