### PR TITLE
remove twig escaping

### DIFF
--- a/source/content/guides/drupal-8-advanced-page-cache.md
+++ b/source/content/guides/drupal-8-advanced-page-cache.md
@@ -396,7 +396,7 @@ The code we added clears all references to each taxonomy term every time a node 
 
   ![Views edit screen](../../images/guides/drupal-8-advanced-page-cache/img11-view-taxonomy-term.png)
 
-4. For the custom tag, use `{% verbatim %}taxonomy-listing:{{ raw_arguments.tid }}{% endverbatim %}`. Save the View:
+4. For the custom tag, use `taxonomy-listing:{{ raw_arguments.tid }}`. Save the View:
 
  ![Views caching config form](../../images/guides/drupal-8-advanced-page-cache/img12-page-caching-option.png)
 


### PR DESCRIPTION
Closes: Conversation in #docs.

## Summary

**[Setting and Clearing Custom Cache Tags in Drupal 8](https://pantheon.io/docs/guides/drupal-8-advanced-page-cache#set-a-custom-cache-tag)** - Removed Twig escape tags, a relic from our Sculpin days,

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
