### PR TITLE
Restrict solr version to <=1.6

### DIFF
--- a/source/changelogs/2017-10-01-October.md
+++ b/source/changelogs/2017-10-01-October.md
@@ -25,7 +25,7 @@ We’ve made [PHP 7.1](http://www.php.net/ChangeLog-7.php#7.1.0) available for a
 
 <a href="/docs/guides/wordpress-git/">
 
-![WordPress Development](../images/git-sftp-wp-docs-guide.png)
+![WordPress Development](../images/assets/git-sftp-wp-docs-guide.png)
 
 </a>
 

--- a/source/content/solr-drupal-8.md
+++ b/source/content/solr-drupal-8.md
@@ -51,7 +51,7 @@ Solr on Drupal 8 requires a Composer managed workflow, as described in our [Buil
 1. Add the Search API Pantheon module as a required dependency:
 
   ```bash{promptUser: user}
-  composer require "drupal/search_api_pantheon ~1.0" --prefer-dist
+  composer require "drupal/search_api_pantheon ~1.6" --prefer-dist
   ```
 
 1. You should now have the Search API Pantheon module installed along with its dependencies. Run `git status` to make sure you see the expected result. Commit and push the changes:


### PR DESCRIPTION
Closes: #6191 

## Summary

**[Enabling Solr on Drupal 8](https://pantheon.io/docs/solr-drupal-8)** - Restrict solr module version for Drupal 8.

## Remaining Work

- [ ] Define how we're going to track when the issue described in #6191 is resolved, to revert this PR.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
