### PR TITLE
build_step directive is not temporary

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -51,7 +51,7 @@ core/
 - `composer.json`: The two different `composer.json` files allow customization of individual sites without inherent merge conflicts and enable one-click updates.
   - Root-level: Site-level customizations.
   - `upstream-config/composer.json`: Composer automatically updates `composer.json` with customizations for the upstream. Avoid manually modifying this file.
-- `pantheon.upstream.yml`: The `build_step: true` directive in `pantheon.upstream.yml` enables the build step. This name is temporary and will change.
+- `pantheon.upstream.yml`: The `build_step: true` directive in `pantheon.upstream.yml` enables the build step.
 
 When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file and commits it back to the site’s code repository.
 


### PR DESCRIPTION
## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Removes the leftover text that claims that the `build_step` directive in `pantheon.upstream.yml` is temporary.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- removes leftover text from when the directive was `build_step_demo`

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [x] 👍  from @ari-gold or @mbaynton 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
