### PR TITLE
Replace wording

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1094,7 +1094,7 @@ ___
 
 **Solution 1:**
 
-1. In `wp-config.php`, add the following after the `define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp');` line:
+1. In `wp-config.php`, add the following above the line `/* That's all, stop editing! Happy Pressing. */`:
 
   ```php:title=wp-config.php
   define('WP_LANG_DIR', $_SERVER['HOME'] .'/files/languages');


### PR DESCRIPTION
**Note:** Please fill out the PR Template to ensure proper processing.

Closes: #

## Summary

**[WordPress Plugins and Themes with Known Issues - WPML](https://pantheon.io/docs/plugins-known-issues#wpml---the-wordpress-multilingual-plugin)** - Direct users to the correct place in `wp-config.php` since previous section was moved to `wp-config-pantheon.php`.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

- WPML documentation, modified `add the following after the define('WP_TEMP_DIR', $_SERVER['HOME'] .'/tmp'); line:` changed to `add the following above the line /* That's all, stop editing! Happy Pressing. */:`

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
