### PR TITLE
Add Integrated Composer Troubleshooting details

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -139,6 +139,7 @@ All Composer commands are available through the **Commit Log** in the Site Dashb
 ### Can I view live logs?
 
 Composer build logs are only available after the task or action completes (or fails).
+
 ### How do I view Composer's changes?
 
 Use `git diff` to view changes, excluding composer.lock
@@ -167,3 +168,10 @@ Features that are still in development:
 
  - Integrated Composer and [Build Tools](/guides/build-tools)
  - Upgrade an existing site to use Integrated Composer
+
+### Why is my site no longer including the files that should be added by Integrated Composer? The Workflow shows an error during Sync Code or Deploying to a new Environment.
+
+On the most recent commit, click "View Log" to see the Composer command that was run and the output that was given by the Composer command. If there is an error in the output, it is likely due to some error in your site's `composer.json` or `composer.lock` file or an issue with a Composer library you are using.
+
+To resolve, try to understand the log message to pinpoint what needs to change in your Composer files or code. It may be a syntax/parse error of the JSON files, or some sort of error loading a library via Composer. You can also try running the same command on your local Git checkout of the site's code and see if you can update the `composer.json` and `composer.lock` files to run the command successfully.
+


### PR DESCRIPTION
Customers sometimes get errors in their Integrated Composer log when they do not use Integrated Composer as expected. This change aims to encourage them to view the logs and try to understand the issue.

I am certainly open to ideas on how to better word or expound on this change to be most helpful.

Closes: #

## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Trying to gives some general guidelines about troubleshooting Integrated Composer deployment errors.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

-
-

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
