### PR TITLE
integrated composer is composer 2

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -126,6 +126,12 @@ Click **Check Now**. If updates are available, click **Apply Updates**.
   composer remove drupal/pkg-name
   ```
 
+## Pantheon Supports Composer 2
+
+The version of Composer on the platform is Composer 2.
+
+Some packages are not compatible with Composer 2. If you encounter a build error that instructs you to contact [Support](/support), validate the package version's compatibility locally first, and check Drupal's [Preparing your site for Composer 2](https://www.drupal.org/docs/develop/using-composer/preparing-your-site-for-composer-2#s-composer-plugins) documentation for packages that have already been identified.
+
 ## Pantheon's Scope of Support for Composer
 
 <Partial file="composer-support-scope.md" />


### PR DESCRIPTION
Closes: #6178 

## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer#pantheon-supports-composer-2)** - Specify that Pantheon supports Composer 2 and link to Drupal's documentation on what packages have already been identified as needing an upgrade for compatibility.

## Effect
(Use this section to detail the changes summarized above, or remove if not needed)
The following changes are already committed:

-
-

## Remaining Work
(Remove if not needed)
The following changes still need to be completed:

- [x] 👍 
- [ ] copy review

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
