### PR TITLE
add link to manual migration notes

### DIFF
--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -8,7 +8,7 @@ tags: [dashboard, migrate, site]
 
 To ensure a successful migration, complete the following tasks on the source site first:
 
-- Read [Platform Considerations](/platform-considerations)
+- Read [Platform Considerations](/platform-considerations) and review [manual migration considerations](/migrate#manually-migrate)
 - Upgrade to the latest version of WordPress or Drupal core
 - Reference your plugins and/or modules against [Modules and Plugins with Known Issues](/modules-plugins-known-issues)
 - Make sure your code is compatible with the latest recommended version of PHP for your CMS. If not, be prepared to [adjust PHP versions](/php-versions/#configure-php-version)


### PR DESCRIPTION

## Summary

**[Migrate Sites to Pantheon](https://pantheon.io/docs/migrate)** - Add a **Before You Begin** section link to the **Manual Migration** notes section.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
