### PR TITLE
use HTML comments for PR instructions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-**Note:** Please fill out the PR Template to ensure proper processing.
+<!--
+**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
+-->
 
 Closes: #
 
@@ -14,7 +16,7 @@ The following changes are already committed:
 -
 
 ## Remaining Work
-(Remove if not needed)
+<!-- Remove if not needed -->
 The following changes still need to be completed:
 
 - [ ] List any outstanding work here


### PR DESCRIPTION
<!-- comments don't show? cool
-->

## Summary

This removes the PR template instructions from being visible in the final PR. They are still visible to the author while making the PR.

## Post Launch

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
