### PR TITLE
Adding a section for the previous video to LW3

### DIFF
--- a/source/partials/additionalResources/lw3.md
+++ b/source/partials/additionalResources/lw3.md
@@ -1,6 +1,6 @@
 ## More resources for Automate and Integrate with Quicksilver
 
-<Youtube src="LiNSEifhKP4" />
+<Youtube src="LiNSEifhKP4" title="Automate and Integrate With Quicksilver" start="93" />
 
 If you thought that was interesting you should sign up for workshop #4: [Website Performance with Varnish, Redis, and New Relic](https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 

--- a/source/partials/additionalResources/lw3.md
+++ b/source/partials/additionalResources/lw3.md
@@ -1,4 +1,6 @@
-## Congratulations on completing Automate and Integrate with Quicksilver! 🎉
+## More resources for Automate and Integrate with Quicksilver
+
+<Youtube src="LiNSEifhKP4" />
 
 If you thought that was interesting you should sign up for workshop #4: [Website Performance with Varnish, Redis, and New Relic](https://pantheon.io/live-workshops/website-performance-varnish-redis-and-new-relic). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 
@@ -14,6 +16,7 @@ We sincerely want this training to be useful. Please help us improve by [sharing
 
 ### Keep Learning After Today
 
+- [Discuss this class and ask questions](https://discuss.pantheon.io/c/pantheon-training/automate-integrate-quicksilver/54)
 - [Pantheon Community (Slack + forum)](/pantheon-community)
 - [Pantheon Support](/support)
 - [Pantheon Office Hours](https://pantheon.io/agencies/office-hours)

--- a/src/components/youtube.js
+++ b/src/components/youtube.js
@@ -5,7 +5,7 @@ This component creates an embedded YouTube video. You can give it a video ID
 or playlist ID, and it can be customized to include start and stop times.
 
 PARAMETERS:
-title="Video title"
+title="Video title" (required for accessibility)
 src="youtubeVideoIdHash" If embedding a playlist, include only the playlist ID (starts with PL)
 start="60" integer value for start point of video clip, as number of seconds from video beginning
 end="120" integer value for end point of video clip, as number of seconds from video beginning
@@ -43,6 +43,7 @@ const Youtube = ( props ) => { //Construct our component as a function
         position: "relative",
         height: "0px",
         overflow: "hidden",
+        marginBottom: "1em",
       }}
     >
       <div className="embedVideo-container">


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources - LW3](https://pantheon.io/docs/live-workshop-resources?c=lw3)** - Updating the more resources page for Live Workshop 3 to include the previous YouTube video, less specific title, and a link to ask questions in the class forum.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
