### PR TITLE
Adding a section for the previous video to LW2

### DIFF
--- a/source/partials/additionalResources/lw2.md
+++ b/source/partials/additionalResources/lw2.md
@@ -2,7 +2,7 @@
 
 You're on a roll! Sign up for workshop #3: [Integrate and Automate with Quicksilver](https://pantheon.io/live-workshops/integrate-and-automate-quicksilver). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 
-<Youtube src="vMNPa89xIv4" start="16" />
+<Youtube src="vMNPa89xIv4" title="Command Line Interface with Terminus" start="16" />
 
 ### Your Feedback Helps
 

--- a/source/partials/additionalResources/lw2.md
+++ b/source/partials/additionalResources/lw2.md
@@ -1,8 +1,8 @@
 ## More resources for Command Line Interface with Terminus 
 
-<Youtube src="vMNPa89xIv4" />
-
 You're on a roll! Sign up for workshop #3: [Integrate and Automate with Quicksilver](https://pantheon.io/live-workshops/integrate-and-automate-quicksilver). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
+
+<Youtube src="vMNPa89xIv4" start="16" />
 
 ### Your Feedback Helps
 

--- a/source/partials/additionalResources/lw2.md
+++ b/source/partials/additionalResources/lw2.md
@@ -1,4 +1,4 @@
-## More resources for Command Line Interface with Terminus 
+## More Resources for Command Line Interface with Terminus 
 
 You're on a roll! Sign up for workshop #3: [Integrate and Automate with Quicksilver](https://pantheon.io/live-workshops/integrate-and-automate-quicksilver). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 

--- a/source/partials/additionalResources/lw2.md
+++ b/source/partials/additionalResources/lw2.md
@@ -1,4 +1,6 @@
-## Congratulations on completing Command Line Interface with Terminus! 🎉
+## More resources for Command Line Interface with Terminus 
+
+<Youtube src="vMNPa89xIv4" />
 
 You're on a roll! Sign up for workshop #3: [Integrate and Automate with Quicksilver](https://pantheon.io/live-workshops/integrate-and-automate-quicksilver). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 
@@ -14,6 +16,7 @@ We sincerely want this training to be useful. Please help us improve by [sharing
 
 ### Keep Learning After Today
 
+- [Discuss this class and ask questions](https://discuss.pantheon.io/c/pantheon-training/command-line-interface-terminus/53)
 - [Pantheon Community (Slack + forum)](/pantheon-community)
 - [Pantheon Support](/support)
 - [Pantheon Office Hours](https://pantheon.io/agencies/office-hours)


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources - LW2](https://pantheon.io/docs/live-workshop-resources?resource=lw2)** -  Updating the more resources page for Live Workshop 2 to include the previous YouTube video, less specific title, and a link to ask questions in the class forum.



## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
