### PR TITLE
list wp-ban as known issue due to 200-level responses

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1046,6 +1046,14 @@ The optimal number of records to process at one time depends on how many post_me
 
 ___
 
+## [WP-Ban](https://wordpress.org/plugins/wp-ban/)
+
+<ReviewDate date="2021-02-23" />
+
+**Issue:** This plugin works on the platform but might not perform the function that users expect. IPs banned using WP-Ban will return a [200-level](/metrics#available-metrics) response code which does count towards Site Visits.
+
+___
+
 ## [WP Migrate DB](https://wordpress.org/plugins/wp-migrate-db/)
 
 <ReviewDate date="2018-10-17" />

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1050,7 +1050,9 @@ ___
 
 <ReviewDate date="2021-02-23" />
 
-**Issue:** This plugin works on the platform but might not perform the function that users expect. IPs banned using WP-Ban will return a [200-level](/metrics#available-metrics) response code which does count towards Site Visits.
+**Issue:** This plugin works on the platform but might not perform the function that users expect. WP-Ban returns a [200-level](/metrics#available-metrics) response code to banned IPs. These responses are cached and count towards Site Visits.
+
+**Solution:** See the doc on how to [Investigate and Remedy Traffic Events](/optimize-site-traffic) for alternative methods.
 
 ___
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1050,7 +1050,7 @@ ___
 
 <ReviewDate date="2021-02-23" />
 
-**Issue:** This plugin works on the platform but might not perform the function that users expect. WP-Ban returns a [200-level](/metrics#available-metrics) response code to banned IPs. These responses are cached and count towards Site Visits.
+**Issue:** WP-Ban returns a [200-level](/metrics#available-metrics) response code to banned IPs. These responses are cached and count towards Site Visits. In addition, the Pantheon [Global CDN](/global-cdn) may cache the result as successful, leading future visitors to think they've also been banned.
 
 **Solution:** See the doc on how to [Investigate and Remedy Traffic Events](/optimize-site-traffic) for alternative methods.
 


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #6247 

## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues#wp-ban)** - WP-Ban bans traffic to uncached pages, but it uses a 200 status code when returning those pages which causes the platform to cache the banned message for future users and count the traffic as a Site Visit.

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] copy edit

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
