### PR TITLE
Adding a section for most recent video for LW4

### DIFF
--- a/source/partials/additionalResources/lw4.md
+++ b/source/partials/additionalResources/lw4.md
@@ -1,6 +1,8 @@
-## Congratulations on completing Website Performance with Varnish, Redis, and New Relic! 🎉
+## More resources for Website Performance with Varnish, Redis, and New Relic
 
 Speed ahead to the next class! Sign up for workshop #5: [Going Live Best Practices](https://pantheon.io/live-workshops/going-live-best-practices). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
+
+- <Youtube src="j1v2gAV7R_A"  start="12" />
 
 ### Your Feedback Helps
 
@@ -20,6 +22,7 @@ We sincerely want this training to be useful. Please help us improve by [sharing
 
 ### Keep Learning After Today
 
+- [Discuss this class and ask questions[(https://discuss.pantheon.io/c/pantheon-training/performance-varnish-redis-new-relic/55)
 - [Pantheon Community (Slack + forum)](/pantheon-community)
 - [Pantheon Support](/support)
 - [Pantheon Office Hours](https://pantheon.io/agencies/office-hours)

--- a/source/partials/additionalResources/lw4.md
+++ b/source/partials/additionalResources/lw4.md
@@ -22,7 +22,7 @@ We sincerely want this training to be useful. Please help us improve by [sharing
 
 ### Keep Learning After Today
 
-- [Discuss this class and ask questions[(https://discuss.pantheon.io/c/pantheon-training/performance-varnish-redis-new-relic/55)
+- [Discuss this class and ask questions](https://discuss.pantheon.io/c/pantheon-training/performance-varnish-redis-new-relic/55)
 - [Pantheon Community (Slack + forum)](/pantheon-community)
 - [Pantheon Support](/support)
 - [Pantheon Office Hours](https://pantheon.io/agencies/office-hours)


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources - LW4](https://pantheon.io/docs/live-workshop-resources?resource=lw4)** - Updated the more resources page for Live Workshop 4 to include the previous YouTube video, less specific title, and a link to ask questions in the class forum.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
