### PR TITLE
Adding a section for the most recent video for LW5

### DIFF
--- a/source/partials/additionalResources/lw5.md
+++ b/source/partials/additionalResources/lw5.md
@@ -1,4 +1,4 @@
-## More resources for Going Live Best Practices! 🎉
+## More Resources for Going Live Best Practices! 🎉
 
 This is the final of the five [Live Workshops](https://pantheon.io/live-workshops)!
 
@@ -10,7 +10,7 @@ You must be feeling really great about developer workflows, Terminus, Quicksilve
 
 We sincerely want this training to be useful. Please help us improve by [sharing your feedback](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041). It only takes you a moment but it makes a big difference for us.
 
-### Resources from this Workshop
+### Resources From This Workshop
 
 - [Pantheon Pricing Comparison](https://pantheon.io/plans/pricing-comparison)
 - Doc: [Load and Performance Testing](/load-and-performance-testing)

--- a/source/partials/additionalResources/lw5.md
+++ b/source/partials/additionalResources/lw5.md
@@ -1,6 +1,8 @@
-## Congratulations on completing Going Live Best Practices! 🎉
+## More resources for Going Live Best Practices! 🎉
 
-Double congratulations if you attended all five of the [Live Workshops](https://pantheon.io/live-workshops)!
+This is the final of the five [Live Workshops](https://pantheon.io/live-workshops)!
+
+- <Youtube src="QzCf8VO002s"  start="17" />
 
 You must be feeling really great about developer workflows, Terminus, Quicksilver, and topics around making your website fast. If not, [let us know how we can improve](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041) and consider attending [Pantheon Office Hours](https://pantheon.io/agencies/office-hours) this Wednesday to get some more assistance.
 
@@ -27,6 +29,7 @@ We sincerely want this training to be useful. Please help us improve by [sharing
 
 ### Keep Learning After Today
 
+- [Discuss this class and ask questions](https://discuss.pantheon.io/c/pantheon-training/going-live-best-practices/56)
 - [Pantheon Community (Slack + forum)](/pantheon-community)
 - [Pantheon Support](/support)
 - [Pantheon Office Hours](https://pantheon.io/agencies/office-hours)


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources LW5](https://pantheon.io/docs/live-workshop-resources?resource=lw5)** - Updating the more resources page for Live Workshop 5 to include the most recent YouTube video, less specific title, and a link to ask questions in the class forum.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
