### PR TITLE
new dashboard - clean up get access section

### DIFF
--- a/source/content/guides/new-dashboard/01-introduction.md
+++ b/source/content/guides/new-dashboard/01-introduction.md
@@ -26,9 +26,7 @@ This page refers to products and features which are currently in development or 
 
 Want to try the New Dashboard?
 
-Contact [Support](/support) or your Account Manager and ask for access to the New Dashboard and the supporting Slack Community.
-
-Once you're added to the project, navigate to your existing Dashboard, then add `/beta/workspace/` between `pantheon.io` and your [UUID](/glossary#uuid). For example: `pantheon.io/beta/workspace/de305d54-75b4-431b-adb2-eb6b9e546014`. You'll be immediately transported to the default Workspace on the New Dashboard. Click **Sites** on the left to access the Sites view.
+Navigate to your existing Dashboard, then add `/beta/workspace/` between `pantheon.io` and your [UUID](/glossary#uuid). For example: `pantheon.io/beta/workspace/de305d54-75b4-431b-adb2-eb6b9e546014`. You'll be immediately transported to the default Workspace on the New Dashboard. Click **Sites** on the left to access the Sites view.
 
 ## Features of the New Dashboard
 

--- a/source/content/guides/new-dashboard/01-introduction.md
+++ b/source/content/guides/new-dashboard/01-introduction.md
@@ -24,7 +24,7 @@ This page refers to products and features which are currently in development or 
 
 ## Get Access
 
-The New Dashboard shows long lists of sites within seconds, does this other really cool thing, and looks really nice. Want to try it?
+Want to try the New Dashboard?
 
 Contact [Support](/support) or your Account Manager and ask for access to the New Dashboard and the supporting Slack Community.
 


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[New Dashboard](https://pantheon.io/docs/guides/new-dashboard#get-access)** - Get Access section cleanup

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] @charles-lam  to confirm this is still a step we want during EA 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
