### PR TITLE
Updating LW5 video to most recent recording

### DIFF
--- a/source/partials/additionalResources/lw5.md
+++ b/source/partials/additionalResources/lw5.md
@@ -2,7 +2,7 @@
 
 This is the final of the five [Live Workshops](https://pantheon.io/live-workshops)!
 
-- <Youtube src="QzCf8VO002s"  start="17" />
+ <Youtube src="s6JI2xhgGD4"  start="75" />
 
 You must be feeling really great about developer workflows, Terminus, Quicksilver, and topics around making your website fast. If not, [let us know how we can improve](https://www.getfeedback.com/r/FHnfj1n8?gf_q[8821859]=17495041) and consider attending [Pantheon Office Hours](https://pantheon.io/agencies/office-hours) this Wednesday to get some more assistance.
 


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources - LW5](https://pantheon.io/docs/live-workshop-resources?resource=lw5)** - Swapped out the URL of the workshop recording to the most recent (from 2/25)

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
