### PR TITLE
Updating video URL to most recent recording

### DIFF
--- a/source/partials/additionalResources/lw2.md
+++ b/source/partials/additionalResources/lw2.md
@@ -2,7 +2,7 @@
 
 You're on a roll! Sign up for workshop #3: [Integrate and Automate with Quicksilver](https://pantheon.io/live-workshops/integrate-and-automate-quicksilver). Or you could pick one of our other [Live Workshops](https://pantheon.io/live-workshops) happening every Thursday.
 
-<Youtube src="vMNPa89xIv4" title="Command Line Interface with Terminus" start="16" />
+<Youtube src="vr2NsjQZzIg" title="Command Line Interface with Terminus" start="16" />
 
 ### Your Feedback Helps
 


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Live Workshop Resources - LW2](https://pantheon.io/docs/live-workshop-resources?resource=lw2)** - Swapped out the YouTube URL of the workshop recording to the most recent (from 3/4)

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
