### PR TITLE
Temporary File Management -> Default Temporary Path: Fixed temp path D8

### DIFF
--- a/source/content/tmp.md
+++ b/source/content/tmp.md
@@ -17,7 +17,7 @@ export env=dev
 
 ## Default Temporary Path
 
-Pantheon configures an appropriate temporary path for [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/wp-config-pantheon.php#L67) and [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/8.5.3/sites/default/settings.pantheon.php#L146-L154). Drupal 7 sites can achieve the same configuration by adding the following to `settings.php`:
+Pantheon configures an appropriate temporary path for [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/wp-config-pantheon.php#L67) and [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L142-L150). Drupal 7 sites can achieve the same configuration by adding the following to `settings.php`:
 
 ```php
 /**


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Temporary File Management -> Default Temporary Path](https://pantheon.io/docs/tmp#default-temporary-path)** - Fixed link to pantheon.settings.php (Drupal 8 Link)

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

- Fixed link to go to the latest changes in default branch -> https://github.com/pantheon-systems/drops-8/blob/default/sites/default/settings.pantheon.php#L142-L150

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
