### PR TITLE
[OTTO-911] Document Autopilot Quicksilver hooks

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -63,6 +63,7 @@ You can hook into the following workflows:
 | `deploy_product`                       | Create site                                                         | Dev                        | `after` stage valid, `before` stage invalid |
 | `sync_code`                            | Push code via Git or commit OSD/SFTP changes via Pantheon Dashboard | Dev or Multidev            |                                             |
 | `create_cloud_development_environment` | Create Multidev environment                                         | Multidev                   | `after` stage valid, `before` stage invalid |
+| `autopilot_vrt`                        | Autopilot Visual Regression test                                    | "Autopilot" Multidev       | `after` stage valid, `before` stage invalid |
 
 ## Secrets
 
@@ -113,6 +114,10 @@ remote: Successfully applied `pantheon.yml` to the 'new-feature' environment.
 remote:
 remote:
 ```
+
+### Autopilot VRT Hook Does Not Run When Expected
+
+Sometimes Quicksilver hooks are not detected due to timing issues with Multidev creation. If your Quicksilver `autopilot_vrt` scripts are not running, first make sure that your scripts are defined in the Dev environment, and then try deleting your "Autopilot" multidev from the dashboard. Be sure to also delete the "Autopilot" branch, and then create the "Autopilot" multidev again in the dashboard. Once you do this, your scripts should start running after the Visual Regression tests complete.
 
 ## See Also
 


### PR DESCRIPTION
## Summary

**[Automate and Integrate your WebOps Workflow with Quicksilver](https://pantheon.io/docs/quicksilver)** - Add documentation on the new Quicksilver hooks for Autopilot

## Effect

Updates the existing Quicksilver documentation to include the new hook.

## Remaining Work

- [ ] Determine whether we want to document the parameters that are passed to the Autopilot QS hooks. I'm not sure if there is another page that has this sort of information for other hooks.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
