### PR TITLE
Adding .lando.yml file and README.md documentation.

### DIFF
--- a/.lando.yml
+++ b/.lando.yml
@@ -1,0 +1,26 @@
+name: pantheon-docs
+services:
+  node:
+    type: node
+    command: gatsby develop -H 0.0.0.0
+    port: 8000
+    ssl: true
+    sslExpose: true
+    globals:
+      gatsby: latest
+    build:
+      - npm ci
+proxy:
+  node:
+    - pantheon-docs.lndo.site:8000
+
+tooling:
+  npm:
+    service: node
+    cmd: npm
+  gatsby:
+    service: node
+    cmd: gatsby
+
+excludes:
+  - node_modules

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ Build Status: [![Circle CI](https://circleci.com/gh/pantheon-systems/documentati
 
 Pantheon Documentation
 ======================
+
 https://pantheon.io/docs/
 
 This repository contains the [Pantheon](https://pantheon.io) documentation, as well as the tools to build local test environments.
@@ -20,13 +21,15 @@ Read [our Style Guide](https://pantheon.io/docs/style-guide/) for our guidelines
 ## Local Installation
 
 ### Prerequisites
- - MacOS or Linux system (untested with Bash on Windows)
- - [Node.js](https://nodejs.org/en/)
- - Gatsby CLI:
+  - You can optionally use [Lando](https://docs.lando.dev)
+    - By leveraging Lando you can avoid havting to install node.js, and gatsby cli on your local computer
+  - MacOS or Linux system (untested with Bash on Windows)
+  - [Node.js](https://nodejs.org/en/)
+  - Gatsby CLI:
 
-   ```bash
-   npm install -g gatsby-cli
-   ```
+```bash
+npm install -g gatsby-cli
+```
 
 ### Get the Code
 
@@ -39,15 +42,14 @@ git clone https://github.com/pantheon-systems/documentation.git
 Or
 
 ```bash
-git@github.com:pantheon-systems/documentation.git
+git clone git@github.com:pantheon-systems/documentation.git
+cd documentation
 ```
 
 ### Install
 
-```
-cd documentation/
-npm ci
-```
+You can install via Lando or directly on your host computer. Both ways require the docs app to use a `GITHUB_API` token to operate.
+
 #### GitHub Token
 We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet) to use files from GitHub in our docs. Before you can build a local development site, you need to provide a GitHub token to the environment:
 
@@ -57,13 +59,26 @@ We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree
 1. Copy the token to your clipboard.
 1. Create or edit `.env.development`, and add (replacing $TOKENHASH ):
 
-   ```
-   GITHUB_API=$TOKENHASH
-   ```
+```bash
+GITHUB_API=$TOKENHASH
+```
+
+#### Using Lando
+
+```bash
+lando start
+```
+
+The `lando start` command will fire up the app, install node dependencies, and start the `gatsby develop` server for you.
+
+#### Using gatsby cli Directly
+```bash
+npm ci
+```
 
 ### Run
 
-```
+```bash
 cd documentation/
 gatsby develop
 ```

--- a/README.md
+++ b/README.md
@@ -21,8 +21,6 @@ Read [our Style Guide](https://pantheon.io/docs/style-guide/) for our guidelines
 ## Local Installation
 
 ### Prerequisites
-  - Optionally, you can use [Lando](https://docs.lando.dev)
-    - By leveraging Lando, you can avoid installing Node.js, and the Gatsby CLI on your local machine.
   - MacOS or Linux system (untested with Bash on Windows)
   - [Node.js](https://nodejs.org/en/)
   - Gatsby CLI:
@@ -30,6 +28,7 @@ Read [our Style Guide](https://pantheon.io/docs/style-guide/) for our guidelines
 ```bash
 npm install -g gatsby-cli
 ```
+   - Alternatively, you can use [Lando](https://docs.lando.dev). You can use Lando instead, to avoid installing Node.js and the Gatsby CLI on your local machine.
 
 ### Get the Code
 
@@ -48,9 +47,14 @@ cd documentation
 
 ### Install
 
-You can install via Lando or directly on your host computer. Both ways require the docs app to use a `GITHUB_API` token to operate.
+#### Using the Gatsby CLI directly
+
+```bash
+npm ci
+```
 
 #### GitHub Token
+You can install directly on your host computer or via Lando. Both ways require the docs app to use a `GITHUB_API` token to operate.
 We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet) to use files from GitHub in our docs. Before you can build a local development site, you need to provide a GitHub token to the environment:
 
 1. Log in to GitHub and go to <https://github.com/settings/tokens>
@@ -63,24 +67,21 @@ We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree
 GITHUB_API=$TOKENHASH
 ```
 
-#### Using Lando
-
-```bash
-lando start
-```
-
-The `lando start` command will fire up the app, install node dependencies, and start the `gatsby develop` server for you.
-
-#### Using gatsby cli Directly
-```bash
-npm ci
-```
-
 ### Run
 
 ```bash
 cd documentation/
 gatsby develop
+```
+You can view the local environment at `localhost:8000/`. Updates to docs are automatically refreshed in the browser.
+
+
+#### Using Lando
+
+Alternatively, you can use [Lando](https://gist.github.com/tormi/a8b8fc39f9481373b24dc94cb8d2ee31). The `lando start` command intiates the the app, installs node dependencies, and starts the `gatsby develop` server for you.
+
+```bash
+lando start
 ```
 
 You can view the local environment at `localhost:8000/`. Updates to docs are automatically refreshed in the browser.

--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ Read [our Style Guide](https://pantheon.io/docs/style-guide/) for our guidelines
 ## Local Installation
 
 ### Prerequisites
-  - You can optionally use [Lando](https://docs.lando.dev)
-    - By leveraging Lando you can avoid havting to install node.js, and gatsby cli on your local computer
+  - Optionally, you can use [Lando](https://docs.lando.dev)
+    - By leveraging Lando, you can avoid installing Node.js, and the Gatsby CLI on your local machine.
   - MacOS or Linux system (untested with Bash on Windows)
   - [Node.js](https://nodejs.org/en/)
   - Gatsby CLI:


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

Adds a `.lando.yml` file and documentation in the `README.md` on how to use lando with this repo.

## Effect

- DX; allow users to contribute to this repo w/out having to install nodejs and gatsby cli on their host machine
- Users can still use nodejs and gatsby cli locally if they wish.

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
