### PR TITLE
run s3fs.make in current dir

### DIFF
--- a/source/content/drupal-s3.md
+++ b/source/content/drupal-s3.md
@@ -134,9 +134,9 @@ terminus drush <site>.<env> -- en libraries s3fs -y
 Get the [AWS SDK Library 2.x](https://github.com/aws/aws-sdk-php/releases):
 
 ```bash{outputLines: 2-3}
-terminus drush <site>.<env> -- make --no-core sites/all/modules/s3fs/s3fs.make code/
+terminus drush <site>.<env> -- make --no-core sites/all/modules/s3fs/s3fs.make -y
   //or if you have a contrib subfolder for modules use:
-  //terminus drush <site>.<env> -- make --no-core sites/all/modules/contrib/s3fs/s3fs.make code/
+  //terminus drush <site>.<env> -- make --no-core sites/all/modules/contrib/s3fs/s3fs.make -y
 ```
 
 The above command will add the AWS SDK version 2.x library into the `sites/all/libraries/awssdk2` directory.


### PR DESCRIPTION


## Summary

**[AWS S3 Setup for Drupal](https://pantheon.io/docs/drupal-s3)** - Fix d7 step for installing the awssdk2 library, run s3fs.make in current dir

## Effect
existing command installs the library at /code/code/sites/all/libraries/awssdk2 
resulting in an exception "Unable to load the AWS SDK. Please ensure that the awssdk2 library is installed correctly." 

suggested command installs the library here: /code/sites/all/libraries/awssdk2


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
