### PR TITLE
add TOC for guides

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ workflows:
           deployment-path: docs
           incremental-build: true
           gcp-bucket: "static.pantheonfrontend.website"
-          gatsby-cache-version: "v1.8.10"
+          gatsby-cache-version: "v1.8.11"
           pre-steps:
             - checkout
             - run:

--- a/source/content/guides/drupal-9-migration/03-migrate-guided-d9.md
+++ b/source/content/guides/drupal-9-migration/03-migrate-guided-d9.md
@@ -7,7 +7,6 @@ cms: drupal-9
 tags: [code, launch, migrate, site, updates]
 reviewed: "2021-03-31"
 layout: guide
-showtoc: true
 permalink: docs/guides/drupal-9-migration/migrate-guided-d9
 anchorid: drupal-9-migration/migrate-guided-d9
 editpath: drupal-9-migration/03-migrate-guided-d9.md

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -125,7 +125,7 @@ class GuideTemplate extends React.Component {
               <main id="docs-main" className="col-md-9 guide-doc-body">
                 <div className="row guide-content-well">
                   <article
-                    className={`col-xs-${contentCols} col-md-${contentCols}`}
+                    className={`col-xs-${contentCols} col-md-${contentCols} doc`}
                     id="doc"
                   >
                     <HeaderBody
@@ -144,12 +144,7 @@ class GuideTemplate extends React.Component {
                     </MDXProvider>
                   </article>
                   {node.frontmatter.showtoc && (
-                    <div
-                      className="col-md-3 pio-docs-sidebar hidden-print hidden-xs hidden-sm affix-top"
-                      role="complementary"
-                    >
-                      <TOC title="Contents" />
-                    </div>
+                    <TOC title="Contents" />
                   )}
                 </div>
                 {node.frontmatter.getfeedbackform && (


### PR DESCRIPTION


## Summary

Add TOC for guide pages if showtoc:true


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
