### PR TITLE
Adding information for Mac M1 chip support

### DIFF
--- a/source/content/guides/localdev/04-troubleshoot-support.md
+++ b/source/content/guides/localdev/04-troubleshoot-support.md
@@ -99,5 +99,5 @@ No, new Multidev environments must still be created from the Site Dashboard or [
 
 ### Can I setup Localdev with a Mac that has an M1 chip?
 
-No, as of the moment Macs with M1 chip is not yet supported.
+No, Macs with the M1 chip are not currently supported.
 

--- a/source/content/guides/localdev/04-troubleshoot-support.md
+++ b/source/content/guides/localdev/04-troubleshoot-support.md
@@ -96,3 +96,8 @@ You can verify which version of PHP your site is using by clicking **Launch Term
 ### Can I create Multidev environments from Localdev?
 
 No, new Multidev environments must still be created from the Site Dashboard or [Terminus](/terminus/commands/multidev-create).
+
+### Can I setup Localdev with a Mac that has an M1 chip?
+
+No, as of the moment Macs with M1 chip is not yet supported.
+


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

Adding information for Mac M1 chip support

**[Pantheon Localdev - Support & Troubleshooting](https://pantheon.io/docs/guides/localdev/troubleshoot-support)** -Adding information fo Mac M1 chip support

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

- Can I setup Localdev with a Mac that has an M1 chip?
   No, as of the moment Macs with M1 chip is not yet supported.

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
