### PR TITLE
Mar 21 changelog

### DIFF
--- a/source/changelogs/2021-03-01-March.md
+++ b/source/changelogs/2021-03-01-March.md
@@ -9,22 +9,14 @@ reviewed: "2021-03-01"
 
 ### Drupal 9 with One-click Composer Updates
 
-You can now create and launch Drupal 9 sites on Pantheon, now in Limited Availability. Composer is completely integrated so you can keep your sites up-to-date with one click. For more information, see the [Drupal 9](/drupal-9) documentation.
+Create and launch [Drupal 9](/drupal-9) sites on Pantheon with [Integrated Composer](/integrated-composer). Keep your Drupal 9 repository lean, avoid build artifacts on the main branch, and keep the 1-click updates for both upstream commits & Composer dependencies that you have come to know and love with Pantheon.
 
 <!-- excerpt -->
 
-### Localdev 1.0.1
+### WordPress 5.6.1
 
-[Localdev 1.0.1](/guides/localdev) improvements include updates to Lando, Composer, and Docker Desktop versions. Download [Localdev](https://pantheon.io/localdev?docs) today, and get the best of developing locally with the ability to perform critical development tasks, including editing files and code, and pushing changes to Pantheon right from your desktop.
-
-### Drupal 8.9.13
-
-[Drupal 8.9.13](https://www.drupal.org/project/drupal/releases/8.9.13) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [Drupal 8.9.13](https://www.drupal.org/project/drupal/releases/8.9.13) release notes.
-
-### Drupal 7.78
-
-[Drupal 7.78](https://www.drupal.org/project/drupal/releases/7.78) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [Drupal 7.78](https://www.drupal.org/project/drupal/releases/7.78) release notes.
+[WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) release notes. 
 
 ## Documentation
 
-With the release of [Terminus 2.5](/terminus), the Pantheon Documentation team has updated the Terminus manual to include a refreshed End of Life timeline, changelog, and command reference page.
+[The New Pantheon Dashboard](/guides/new-dashboard) - A guide for the New Pantheon Dashboard introduces the Workspaces experience and new features like [Autopilot](/autopilot).

--- a/source/changelogs/2021-03-01-March.md
+++ b/source/changelogs/2021-03-01-March.md
@@ -15,7 +15,7 @@ Create and launch [Drupal 9](/drupal-9) sites on Pantheon with [Integrated Compo
 
 ### WordPress 5.6.1
 
-[WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) release notes. 
+[WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [WordPress 5.6.1](https://wordpress.org/support/wordpress-version/version-5-6-1/#summary) release notes.
 
 ## Documentation
 

--- a/source/changelogs/2021-03-01-March.md
+++ b/source/changelogs/2021-03-01-March.md
@@ -9,7 +9,7 @@ reviewed: "2021-03-01"
 
 ### Drupal 9 with One-click Composer Updates
 
-Create and launch [Drupal 9](/drupal-9) sites on Pantheon with [Integrated Composer](/integrated-composer). Keep your Drupal 9 repository lean, avoid build artifacts on the main branch, and keep the 1-click updates for both upstream commits & Composer dependencies that you have come to know and love with Pantheon.
+Create and launch [Drupal 9](/drupal-9) sites on Pantheon with [Integrated Composer](/integrated-composer). Keep your Drupal 9 repository lean, avoid build artifacts on the main branch, and keep the one-click updates for both upstream commits & Composer dependencies that you have come to know and love with Pantheon.
 
 <!-- excerpt -->
 

--- a/source/changelogs/2021-03-01-March.md
+++ b/source/changelogs/2021-03-01-March.md
@@ -1,0 +1,30 @@
+---
+title: March 2021 Changelog
+changelog: true
+description: March 2021 Pantheon changelog updates.
+reviewed: "2021-03-01"
+---
+
+## Platform Improvements
+
+### Drupal 9 with One-click Composer Updates
+
+You can now create and launch Drupal 9 sites on Pantheon, now in Limited Availability. Composer is completely integrated so you can keep your sites up-to-date with one click. For more information, see the [Drupal 9](/drupal-9) documentation.
+
+<!-- excerpt -->
+
+### Localdev 1.0.1
+
+[Localdev 1.0.1](/guides/localdev) improvements include updates to Lando, Composer, and Docker Desktop versions. Download [Localdev](https://pantheon.io/localdev?docs) today, and get the best of developing locally with the ability to perform critical development tasks, including editing files and code, and pushing changes to Pantheon right from your desktop.
+
+### Drupal 8.9.13
+
+[Drupal 8.9.13](https://www.drupal.org/project/drupal/releases/8.9.13) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [Drupal 8.9.13](https://www.drupal.org/project/drupal/releases/8.9.13) release notes.
+
+### Drupal 7.78
+
+[Drupal 7.78](https://www.drupal.org/project/drupal/releases/7.78) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates). For more information, see the [Drupal 7.78](https://www.drupal.org/project/drupal/releases/7.78) release notes.
+
+## Documentation
+
+With the release of [Terminus 2.5](/terminus), the Pantheon Documentation team has updated the Terminus manual to include a refreshed End of Life timeline, changelog, and command reference page.

--- a/source/changelogs/2021-03-01-March.md
+++ b/source/changelogs/2021-03-01-March.md
@@ -1,7 +1,7 @@
 ---
 title: March 2021 Changelog
 changelog: true
-description: March 2021 Pantheon changelog updates.
+description: March 2021 Pantheon changelog
 reviewed: "2021-03-01"
 ---
 


### PR DESCRIPTION

Closes: #6263 

## Summary

**[March 2021 Changelog](https://pantheon.io/docs/changelog)** - March 2021 Changelog

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
