### PR TITLE
update former pantheor bio

### DIFF
--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -11,7 +11,7 @@
   avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Alex%20Fornuto.jpg
   github: //github.com/alexfornuto
   twitter: https://twitter.com/AlexFornuto
-  bio: Senior Technical Content Editor for Pantheon
+  bio: Technical Writer. Confirmed human via Gom Jabbar.
 - id: edwardangert
   name: Edward Angert
   twitter: https://twitter.com/edwardangert


### PR DESCRIPTION


Closes: #6348 

## Summary

Update `contributor.yaml` bio information for Alex Fornuto.

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
