### PR TITLE
Doc 339 db directive

### DIFF
--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -7,7 +7,7 @@ contributors:
  - ataylorme
 ---
 
-The docroot is the directory from which your site is served. On Pantheon, this defaults to the root directory of the site's codebase (`code`). Specifying `web_docroot: true` in your [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) file or in the [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) file in your upstream allows you to serve site files from the `web` subdirectory of your site's code repository on all Pantheon environments (e.g. `code/web`).
+The [<dfn id="droot">docroot</dfn>](/code#pantheon-git-repository) is the directory from which your site is served. On Pantheon, this defaults to the root directory of the site's codebase (`code`). Specifying `web_docroot: true` in your [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) file or in the [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) file in your upstream allows you to serve site files from the `web` subdirectory of your site's code repository on all Pantheon environments (e.g. `code/web`).
 
 <Alert title="Warning" type="danger">
 

--- a/source/content/nested-docroot.md
+++ b/source/content/nested-docroot.md
@@ -7,7 +7,7 @@ contributors:
  - ataylorme
 ---
 
-The [<dfn id="droot">docroot</dfn>](/code#pantheon-git-repository) is the directory from which your site is served. On Pantheon, this defaults to the root directory of the site's codebase (`code`). Specifying `web_docroot: true` in your [pantheon.yml](/pantheon-yml/#site-local-configurations-pantheonyml) file or in the [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations-pantheonupstreamyml) file in your upstream allows you to serve site files from the `web` subdirectory of your site's code repository on all Pantheon environments (e.g. `code/web`).
+The [<dfn id="droot">docroot</dfn>](/code#pantheon-git-repository) is the directory from which your site is served. On Pantheon, this defaults to the root directory of the site's codebase (`code`). Specifying `web_docroot: true` in your [pantheon.yml](/pantheon-yml/#nested-docroot) file or in the [pantheon.upstream.yml](/pantheon-yml/#custom-upstream-configurations) file in your upstream allows you to serve site files from the `web` subdirectory of your site's code repository on all Pantheon environments (e.g. `code/web`).
 
 <Alert title="Warning" type="danger">
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -110,6 +110,8 @@ php_version: 7.0
 
 ### Specify a Version of MariaDB
 
+Keep the software your site uses current and up to date, or set a specific version to avoid incompatibilities.
+
 Use the `database` directive in `pantheon.yml` to choose a specific version of MariaDB:
 
 ```yaml
@@ -117,23 +119,20 @@ database:
   version: 10.0
 ```
 
-- When to use it and when not to
-- Why it’s a good idea to do this
-
 Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
 
 This table shows the recommended MariaDB version for each CMS:
 
-| CMS            | Recommended MariaDB Version |
-|----------------|-----------------------------|
-| Drupal <6.51   | 10.0 - 10.3                 |
-| Drupal >= 6.51 | 10.0 - 10.5                 |
-| Drupal < 7.76  | 10.0 - 10.3                 |
-| Drupal >= 7.76 | 10.0 - 10.5                 |
-| Drupal < 8.5   | 10.0 - 10.3                 |
-| Drupal >= 8.6  | 10.0 - 10.5                 |
-| Drupal >= 9.0  | 10.4 - 10.5                 |
-| WordPress      | 10.0 - 10.5                 |
+| CMS            | Recommended MariaDB Version | Customizable After |
+|----------------|-----------------------------|--------------------|
+| Drupal <6.51   | Default                     | May, 2021          |
+| Drupal >= 6.51 | Default                     | May, 2021          |
+| Drupal < 7.76  | Default                     | May, 2021          |
+| Drupal >= 7.76 | Default                     | May, 2021          |
+| Drupal < 8.5   | Default                     | May, 2021          |
+| Drupal >= 8.6  | 10.0 - 10.4                 |                    |
+| Drupal >= 9.0  | 10.4 - 10.4                 |                    |
+| WordPress      | Default                     | July, 2021         |
 
 ### Drush Version
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -3,6 +3,7 @@ title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
 categories: [platform]
 tags: [https, launch, code, workflow]
+reviewed: "2021-04-08"
 ---
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -121,9 +121,11 @@ database:
 
 Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
 
-This table shows the recommended MariaDB version for each CMS:
+Not all CMS versions can be configured to use a specific database version on Pantheon yet.
 
-| CMS            | Recommended MariaDB Version | Customizable After |
+This table shows the recommended MariaDB version for each CMS, as well as an estimate of when the database can be configured:
+
+| CMS            | Recommended MariaDB Version | Configurable After |
 |----------------|-----------------------------|--------------------|
 | Drupal <6.51   | Default                     | May, 2021          |
 | Drupal >= 6.51 | Default                     | May, 2021          |

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -105,8 +105,30 @@ php_version: 7.0
 
 * [Upgrading PHP Versions](/php-versions) may require you to resolve compatibility issues with your site's codebase.
 * Drupal and PHP 7 require [Drush 7 or greater](/drush-versions/#configure-drush-version).
-* From time to time, we will roll out a new default version of PHP, which will be available to apply as One-click update in the Dashboard. If you are overriding the default, make sure to remove `php_version` from `pantheon.yml` as soon as possible to ensure you don't miss the latest recommended PHP version.
+* From time to time, we will roll out a new default version of PHP, which will be available to apply as a one-click update in the Dashboard. If you are overriding the default, make sure to remove `php_version` from `pantheon.yml` as soon as possible to ensure you don't miss the latest recommended PHP version.
 * You'll always be able to test new default PHP version in Dev and Test before deploying Live.
+
+### Specify a Version of MariaDB
+
+Use the `db_directive` in the `pantheon.yml` to choose a specific version of MariaDB.
+
+- When to use it and when not to
+- Why it’s a good idea to do this
+
+Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
+
+This table shows the recommended MariaDB version for each CMS:
+
+| CMS            | Recommended MariaDB Version |
+|----------------|-----------------------------|
+| Drupal <6.51   | 10.0 - 10.3                 |
+| Drupal >= 6.51 | 10.0 - 10.5                 |
+| Drupal < 7.76  | 10.0 - 10.3                 |
+| Drupal >= 7.76 | 10.0 - 10.5                 |
+| Drupal < 8.5   | 10.0 - 10.3                 |
+| Drupal >= 8.6  | 10.0 - 10.5                 |
+| Drupal >= 9.0  | 10.4 - 10.5                 |
+| WordPress      | 10.0 - 10.5                 |
 
 ### Drush Version
 
@@ -116,7 +138,7 @@ Add `drush_version` to the top level of the `pantheon.yml` file to configure the
 drush_version: 8
 ```
 
-For more information and compatibility requirements, see [Managing Drush Versions on Pantheon](/drush-versions/).
+For more information and compatibility requirements, see [Managing Drush Versions on Pantheon](/drush-versions).
 
 ### Filemount Path
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -110,7 +110,12 @@ php_version: 7.0
 
 ### Specify a Version of MariaDB
 
-Use the `db_directive` in the `pantheon.yml` to choose a specific version of MariaDB.
+Use the `database` directive in `pantheon.yml` to choose a specific version of MariaDB:
+
+```yaml
+database:
+  version: 10.0
+```
 
 - When to use it and when not to
 - Why it’s a good idea to do this

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -7,13 +7,21 @@ reviewed: "2021-04-08"
 ---
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
 
+## Find or Create pantheon.yml
+
+Your site's `pantheon.yml` configuration file can be found in the root of your site's code repository. If you have a local git clone of your site, this is the project root. When looking at the site over an SFTP connection, look in the `code` directory.
+
+If the `pantheon.yml` file is not present, you may create one.
+
+For reference implementations see [example.pantheon.yml](https://github.com/pantheon-systems/quicksilver-examples/blob/master/example.pantheon.yml) and [Quicksilver Example Scripts](https://github.com/pantheon-systems/quicksilver-examples).
+
 <Enablement title="Quicksilver Cloud Hooks Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 
 </Enablement>
 
-For reference implementations see [example.pantheon.yml](https://github.com/pantheon-systems/quicksilver-examples/blob/master/example.pantheon.yml) and [Quicksilver Example Scripts](https://github.com/pantheon-systems/quicksilver-examples).
+
 
 ## Advanced Site Configuration
 
@@ -187,6 +195,8 @@ When the same configuration value is defined in both files, the value from `pant
 
 ## Troubleshooting
 
+First, verify the syntax of entries in the file. Refer to the examples above for exact syntax, or try running the contents of your `pantheon.yml` file through a [YAML linter](http://www.yamllint.com/).
+
 ### "Changes to pantheon.yml detected, but there was an error while processing it"
 
 The Platform will automatically reject a commit that includes a `pantheon.yml` error. The error message will resemble:
@@ -201,7 +211,7 @@ remote: Version '2' is not a valid pantheon.yml version!
 remote: Valid versions are: 1
 ```
 
-While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Please refer to the examples above for exact syntax, or try running the contents of your `pantheon.yml` file through a [YAML linter](http://www.yamllint.com/).
+While our parser will reject a `pantheon.yml` that is invalid, it won't necessarily give you the exact reason the file is invalid. Syntax errors are the most common issue.
 
 ### Deploying Configuration Changes to Multidev
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -20,7 +20,7 @@ For reference implementations see [example.pantheon.yml](https://github.com/pant
 
 Define the `api_version` property in order for `pantheon.yml` to be valid:
 
-```yaml
+```yaml:title=pantheon.yml
 api_version: 1
 ```
 
@@ -28,7 +28,7 @@ api_version: 1
 
 Protect files and directories inside of your docroot from public web access with `protected_web_paths`. For example, the following ensures that a visitor to `https://example.com/example.txt` or `https://example.com/example_directory/any_nested_file` receives Access Denied (403):
 
-```yaml
+```yaml:title=pantheon.yml
 protected_web_paths:
   - /example.txt
   - /example_directory
@@ -49,7 +49,7 @@ The `pantheon.upstream.yml` file provided by your upstream might define protecte
 
 To disable all of the protected web paths defined by your site's upstream and all protected paths defined by the Pantheon platform, set the `protected_web_paths_override` property to `true`:
 
-```yaml
+```yaml:title=pantheon.yml
 protected_web_paths_override: true
 ```
 
@@ -83,7 +83,7 @@ Pantheon sites (using the default Pantheon upstreams) created or updated on or a
 
 Nest your docroot one level beneath your code repository in a directory named `web`:
 
-```yaml
+```yaml:title=pantheon.yml
 web_docroot: true
 ```
 
@@ -97,7 +97,7 @@ Override the upstream's default PHP version with the `php_version` property. PHP
 
 For example, to override the upstream default value at the site level to PHP 7:
 
-```yaml
+```yaml:title=pantheon.yml
 php_version: 7.0
 ```
 
@@ -114,9 +114,9 @@ Keep the software your site uses current and up to date, or set a specific versi
 
 Use the `database` directive in `pantheon.yml` to choose a specific version of MariaDB:
 
-```yaml
+```yaml:title=pantheon.yml
 database:
-  version: 10.0
+  version: 10.4
 ```
 
 Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
@@ -138,7 +138,7 @@ This table shows the recommended MariaDB version for each CMS:
 
 Add `drush_version` to the top level of the `pantheon.yml` file to configure the Drush version used when making calls remotely on Pantheon:
 
-```yaml
+```yaml:title=pantheon.yml
 drush_version: 8
 ```
 
@@ -156,7 +156,7 @@ We recommend *only* changing this setting when needed for [Custom Upstream Confi
 
 The only valid filemount path other than the default path for each CMS is `/files` relative to your docroot:
 
-```yaml
+```yaml:title=pantheon.yml
 filemount: /files
 ```
 


### PR DESCRIPTION
PRing this against the upgrade-in-place D9 doc since these seem to unblock each other when they're ready

<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Doc Title](https://pantheon.io/docs/doc-title)** - A one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
