### PR TITLE
brew install php7.4 before starting D9 steps

### DIFF
--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -1,6 +1,6 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP 7.4, along with their required dependencies. Restart the shell or terminal environment after this command:
+   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP 7.4, along with their required dependencies. Restart the shell or terminal environment after entering the following command:
 
     ```bash{promptUser:user}
     brew install git composer php@7.4

--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -1,9 +1,9 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install both Git and Composer, along with their required dependencies:
+   - Mac users can use [Homebrew](https://brew.sh/) to install both Git, Composer, and PHP 7.4, along with their required dependencies. Restart the shell or terminal environment after this command:
 
     ```bash{promptUser:user}
-    brew install git composer
+    brew install git composer php@7.4
     ```
 
    - Windows users can install [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows) and [Git](https://git-scm.com/download/win), and may need to install [XAMPP](https://www.apachefriends.org/index.html) or similar to satisfy some dependencies.

--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -1,6 +1,6 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install both Git, Composer, and PHP 7.4, along with their required dependencies. Restart the shell or terminal environment after this command:
+   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP 7.4, along with their required dependencies. Restart the shell or terminal environment after this command:
 
     ```bash{promptUser:user}
     brew install git composer php@7.4


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #6359 

## Summary

**[Migrate to Drupal 9 on Pantheon](https://pantheon.io/docs/guides/drupal-9-migration/prepare)** - Added PHP 7.4 as a required component to prepare the local environment (added to reusable partial).

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Copy edit

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
