### PR TITLE
Remove HTML syntax for registered trademark symbol in title

### DIFF
--- a/source/content/guides/new-relic-deploys.md
+++ b/source/content/guides/new-relic-deploys.md
@@ -1,6 +1,6 @@
 ---
-title: Automatically Label Code Changes in New Relic&reg; Performance Monitoring using Quicksilver Hooks
-description: A guide to integrating Pantheon and New Relic&reg; Performance Monitoring for deployment labeling.
+title: Automatically Label Code Changes in New Relic®; Performance Monitoring using Quicksilver Hooks
+description: A guide to integrating Pantheon and New Relic®; Performance Monitoring for deployment labeling.
 categories: [automate]
 tags: [code, newrelic, quicksilver, workflow]
 type: guide


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Update Relic Title](https://pantheon.io/docs/guides/new-relic-deploys)** - The HTML syntax for registered trademark does not work for the title. ® needs to be coded differently.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

- Correct the formatting for "Automatically Label Code Changes in New Relic&reg; Performance Monitoring using Quicksilver Hooks"

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
