### PR TITLE
add section to set db in pantheon.yml

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -119,7 +119,7 @@ php_version: 7.0
 
 <Alert type="info" title="Do not set the database version unless the site is eligible.">
 
-The site is eligible to upgrade if the site's Dashboard shows a blue banner across the top that reads:
+The site is eligible to upgrade if the site's Dashboard displays a blue banner across the top that reads:
 
 > Good news, your site's database version is now configurable! Learn how.
 
@@ -136,19 +136,19 @@ database:
 
 Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
 
-Not all CMS versions can be configured to use a specific database version on Pantheon yet.
+Currently, not all CMS versions can be configured to use a specific database version on Pantheon.
 
-This table shows the recommended MariaDB version for each CMS, as well as an estimate of when the database can be configured:
+The following table shows the recommended MariaDB version for each CMS, as well as an estimate of when the database can be configured:
 
 | CMS            | Recommended MariaDB Version | Configurable After |
 |----------------|-----------------------------|--------------------|
-| Drupal <6.51   | Default                     | May, 2021          |
+| Drupal < 6.51  | Default                     | May, 2021          |
 | Drupal >= 6.51 | Default                     | May, 2021          |
 | Drupal < 7.76  | Default                     | May, 2021          |
 | Drupal >= 7.76 | Default                     | May, 2021          |
 | Drupal < 8.5   | Default                     | May, 2021          |
-| Drupal >= 8.6  | 10.0 - 10.4                 |                    |
-| Drupal >= 9.0  | 10.4 - 10.4                 |                    |
+| Drupal >= 8.6  | 10.0 - 10.4                 | Not specified      |
+| Drupal >= 9.0  | 10.4                        | Not specified      |
 | WordPress      | Default                     | July, 2021         |
 
 ### Drush Version

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -3,7 +3,7 @@ title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
 categories: [platform]
 tags: [https, launch, code, workflow]
-reviewed: "2021-04-08"
+reviewed: "2021-04-13"
 ---
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
 
@@ -20,8 +20,6 @@ For reference implementations see [example.pantheon.yml](https://github.com/pant
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 
 </Enablement>
-
-
 
 ## Advanced Site Configuration
 
@@ -117,6 +115,42 @@ php_version: 7.0
 * From time to time, we will roll out a new default version of PHP, which will be available to apply as a one-click update in the Dashboard. If you are overriding the default, make sure to remove `php_version` from `pantheon.yml` as soon as possible to ensure you don't miss the latest recommended PHP version.
 * You'll always be able to test new default PHP version in Dev and Test before deploying Live.
 
+### Specify a Version of MariaDB
+
+<Alert type="info" title="Do not set the database version unless the site is eligible.">
+
+The site is eligible to upgrade if the site's Dashboard shows a blue banner across the top that reads:
+
+> Good news, your site's database version is now configurable! Learn how.
+
+</Alert>
+
+Keep the software your site uses current and up to date, or set a specific version to avoid incompatibilities.
+
+Use the `database` directive in `pantheon.yml` to choose a specific version of MariaDB:
+
+```yaml:title=pantheon.yml
+database:
+  version: 10.4
+```
+
+Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
+
+Not all CMS versions can be configured to use a specific database version on Pantheon yet.
+
+This table shows the recommended MariaDB version for each CMS, as well as an estimate of when the database can be configured:
+
+| CMS            | Recommended MariaDB Version | Configurable After |
+|----------------|-----------------------------|--------------------|
+| Drupal <6.51   | Default                     | May, 2021          |
+| Drupal >= 6.51 | Default                     | May, 2021          |
+| Drupal < 7.76  | Default                     | May, 2021          |
+| Drupal >= 7.76 | Default                     | May, 2021          |
+| Drupal < 8.5   | Default                     | May, 2021          |
+| Drupal >= 8.6  | 10.0 - 10.4                 |                    |
+| Drupal >= 9.0  | 10.4 - 10.4                 |                    |
+| WordPress      | Default                     | July, 2021         |
+
 ### Drush Version
 
 Add `drush_version` to the top level of the `pantheon.yml` file to configure the Drush version used when making calls remotely on Pantheon:
@@ -159,7 +193,7 @@ For more information, see [Automate your Workflow with Quicksilver Platform Inte
 
 ## Custom Upstream Configurations
 
-Add a `pantheon.upstream.yml` file to your organization's [Custom Upstream](/custom-upstream) to set default configurations for all downstream sites. The same [properties described above](#advanced-site-configuration) can be used in this file. In addition, it is also possible to define a [`deploy_product` Quicksilver hook](/quicksilver#hooks) here; however other Quicksilver workflows are not supported.
+Add a `pantheon.upstream.yml` file to your organization's [Custom Upstream](/custom-upstream) to set default configurations for all downstream sites. The same [properties described above](#advanced-site-configuration) can be used in this file. In addition, it is also possible to define a [`deploy_product` Quicksilver hook](/quicksilver/#hooks) here; however other Quicksilver workflows are not supported.
 
 This file should only be edited in the Custom Upstream repository where it is defined. Similarly, the Custom Upstream repository should not define a `pantheon.yml` file; it should place all configuration settings in the upstream file instead.
 


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Should be merged right before PLAT-1915 - sync with @gloria-panth 

## Summary

**[Pantheon](https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb)** - Users can now set the database version for some CMS versions from `pantheon.yml`.


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] copy edit
- [ ] plat-1915 timing
- [ ] make sure there's no merge conflict in #6145 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
