### PR TITLE
remove kint from D8 w/CLI

### DIFF
--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -158,7 +158,7 @@ You may have heard that some Drupal 8 developers are [using Composer](https://pa
 1. Enable the modules:
 
   ```bash{promptUser: user}
-  terminus drush $TERMINUS_SITE.dev -- pm-enable devel devel_generate kint webprofiler -y
+  terminus drush $TERMINUS_SITE.dev -- pm-enable devel devel_generate webprofiler -y
   ```
 
   All of these modules are helpful during active development. We use Devel Generate in this walkthrough to make nodes on the Live environment.


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #6378 

## Summary

**[Create a D8 Site From CLI Using Terminus and Drush](https://pantheon.io/docs/guides/drupal8-commandline)** - Update doc to remove Kint from steps. Kint was removed in [devel 4.1.1](https://www.drupal.org/project/devel/releases/4.1.1).

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
