### PR TITLE
add terminus to session length

### DIFF
--- a/source/partials/dashboard-login-session-length.md
+++ b/source/partials/dashboard-login-session-length.md
@@ -1,1 +1,3 @@
 The Platform logs users out after 24 hours of inactivity, and forces all users to log back into the Platform every 30 days.
+
+This includes all users authenticated via [Terminus](/terminus).

--- a/source/partials/terminus/auth-login.md
+++ b/source/partials/terminus/auth-login.md
@@ -1,0 +1,4 @@
+
+## Login Duration
+
+<Partial file="dashboard-login-session-length.md" />

--- a/source/partials/terminus/auth-login.md
+++ b/source/partials/terminus/auth-login.md
@@ -1,4 +1,6 @@
 
 ## Login Duration
 
-<Partial file="dashboard-login-session-length.md" />
+The Platform logs users out after 24 hours of inactivity, and forces all users to log back into the Platform every 30 days.
+
+This includes all users authenticated via Terminus `auth:login`.


### PR DESCRIPTION
<!--
**Note:** Please fill out the PR Template to ensure proper processing. If you're not sure about a section, leave it empty, do not remove it.
-->

Closes: #

## Summary

**[Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds that Terminus users are also logged out after 24 hours of inactivity.

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

-
-

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] confirm that this is def true
- [ ] copy edit

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
