### PR TITLE
Add "exit" command to User-Agent Block

### DIFF
--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -177,6 +177,7 @@ Remember to replace the example user agent (`UglyBot`):
 // Either check a single bot.
 if (stripos($_SERVER['HTTP_USER_AGENT'], 'UglyBot') !== FALSE) {
   header('HTTP/1.0 403 Forbidden');
+  exit;
 }
 
 // Or check against a list of bots.


### PR DESCRIPTION
## Summary
<!--
Please complete the Summary section
-->

**[Investigate and Remedy Traffic Events](https://pantheon.io/docs/optimize-site-traffic)** -  The header set does not work without the "exit;" command ran right afterwards. This one example does not have "exit;" included.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
