### PR TITLE
add note that existing env is required for db upgrade to work

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -139,6 +139,12 @@ database:
   version: 10.4
 ```
 
+<Alert title="Changing the database requires an exising env" type="warning">
+
+You must apply this change to an existing environment. If you try to create a new environment with the `database` key specified in `pantheon.yml`, the commit will be rejected with an error.
+
+</Alert>
+
 Keep in mind that some versions of Drupal and WordPress require a specific minimum or maximum version for compatibility.
 
 Currently, not all CMS versions can be configured to use a specific database version on Pantheon.


### PR DESCRIPTION
## Summary

**[Specify a Version of MariaDB](https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb)** -
Add a note that this won't work without an existing env.

## Additional Information
We were tripped up with this until contacting support. If you try to create a new env with the change to `pantheon.yml` you'll get an error along the lines of:

```
remote: PANTHEON ERROR:        
remote: 
remote: Commit 845690079b3b7597cbbaa44983e8b17ed71d8dcd rejected.        
remote: Commit: A commit between 71d15271ddc7d8d98a22c3e5e804482aaaffa415 and 845690079b3b7597cbbaa44983e8b17ed71d8dcd        
remote: contains changes to `pantheon.yml`, however there was an internal error that        
remote: prevented these changes from being applied.        
remote: 
remote: The specific error returned was: Internal exception        
remote: 
remote: There was an internal error processing the request 
```


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
