### PR TITLE
Correct links in quicksilver to update 404 page

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -8,13 +8,13 @@ reviewed: "2020-03-10"
 
 Hook into platform workflows to automate your Pantheon WebOps workflow. Tell Pantheon which script you want to run, and the platform will run it automatically every time you or another team member triggers the corresponding workflow. View (and contribute) to a [growing set of example scripts](https://github.com/pantheon-systems/quicksilver-examples/). Find examples to enable functionality like chat-ops, database sanitization, deployment logging, and automated testing operations with a CI server.
 
-[Quicksilver Cloud Hooks Training](/learn-pantheon)
+[Quicksilver Cloud Hooks Training](https://pantheon.io/docs/learn-pantheon)
 
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 
 </Enablement>
 
-For example, committing a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml) file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
+For example, committing a [pantheon.yml](https://pantheon.io/docs/pantheon-yml) file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
 
 ```yaml:title=pantheon.yml
 api_version: 1
@@ -148,5 +148,5 @@ For some [Autopilot](/guides/autopilot) users, Quicksilver hooks are not detecte
 
 ## See Also
 
-- [The `pantheon.yml` Configuration File](https://pantheon.io/docs/pantheon-yml)
+- [The pantheon.yml Configuration File](https://pantheon.io/docs/pantheon-yml)
 - [Quicksilver Examples Repository](https://github.com/pantheon-systems/quicksilver-examples/)

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -8,7 +8,7 @@ reviewed: "2020-03-10"
 
 Hook into platform workflows to automate your Pantheon WebOps workflow. Tell Pantheon which script you want to run, and the platform will run it automatically every time you or another team member triggers the corresponding workflow. View (and contribute) to a [growing set of example scripts](https://github.com/pantheon-systems/quicksilver-examples/). Find examples to enable functionality like chat-ops, database sanitization, deployment logging, and automated testing operations with a CI server.
 
-[Quicksilver Cloud Hooks Training](https://pantheon.io/docs/learn-pantheon)
+<Enablement title="Quicksilver Cloud Hooks Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
 
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -8,13 +8,13 @@ reviewed: "2020-03-10"
 
 Hook into platform workflows to automate your Pantheon WebOps workflow. Tell Pantheon which script you want to run, and the platform will run it automatically every time you or another team member triggers the corresponding workflow. View (and contribute) to a [growing set of example scripts](https://github.com/pantheon-systems/quicksilver-examples/). Find examples to enable functionality like chat-ops, database sanitization, deployment logging, and automated testing operations with a CI server.
 
-[Quicksilver Cloud Hooks Training](https://pantheon.io/agencies/learn-pantheon?docs)
+[Quicksilver Cloud Hooks Training](/learn-pantheon)
 
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 
 </Enablement>
 
-For example, committing a [`pantheon.yml`](/pantheon-yml) file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
+For example, committing a [`pantheon.yml`](https://pantheon.io/docs/pantheon-yml) file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
 
 ```yaml:title=pantheon.yml
 api_version: 1
@@ -89,7 +89,7 @@ When a workflow runs, there are variables that are made available through the `$
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
 |`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided.|
 
-For examples on how to use these variables, see the [Quicksilver Examples](/quicksilver-examples) repository.
+For examples on how to use these variables, see the [Quicksilver Examples](https://pantheon.io/docs/quicksilver-examples) repository.
 
 
 ## Secrets
@@ -148,5 +148,5 @@ For some [Autopilot](/guides/autopilot) users, Quicksilver hooks are not detecte
 
 ## See Also
 
-- [The `pantheon.yml` Configuration File](/pantheon-yml)
+- [The `pantheon.yml` Configuration File](https://pantheon.io/docs/pantheon-yml)
 - [Quicksilver Examples Repository](https://github.com/pantheon-systems/quicksilver-examples/)

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -8,13 +8,13 @@ reviewed: "2020-03-10"
 
 Hook into platform workflows to automate your Pantheon WebOps workflow. Tell Pantheon which script you want to run, and the platform will run it automatically every time you or another team member triggers the corresponding workflow. View (and contribute) to a [growing set of example scripts](https://github.com/pantheon-systems/quicksilver-examples/). Find examples to enable functionality like chat-ops, database sanitization, deployment logging, and automated testing operations with a CI server.
 
-<Enablement title="Quicksilver Cloud Hooks Training" link="https://pantheon.io/agencies/learn-pantheon?docs">
+[Quicksilver Cloud Hooks Training](https://pantheon.io/agencies/learn-pantheon?docs)
 
 Set up existing scripts and write your own with help from our experts. Pantheon delivers custom workshops to help development teams master our platform and improve their internal WebOps.
 
 </Enablement>
 
-For example, committing a `pantheon.yml` file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
+For example, committing a [`pantheon.yml`](/pantheon-yml) file with the following contents to the root of your site's code repository with the script adapted from [slack_notification](https://github.com/pantheon-systems/quicksilver-examples/tree/master/slack_notification) will post to Slack every time you deploy:
 
 ```yaml:title=pantheon.yml
 api_version: 1
@@ -89,7 +89,7 @@ When a workflow runs, there are variables that are made available through the `$
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
 |`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided.|
 
-For examples on how to use these variables, see the [Quicksilver Examples](https://github.com/pantheon-systems/quicksilver-examples) repository.
+For examples on how to use these variables, see the [Quicksilver Examples](/quicksilver-examples) repository.
 
 
 ## Secrets
@@ -148,5 +148,5 @@ For some [Autopilot](/guides/autopilot) users, Quicksilver hooks are not detecte
 
 ## See Also
 
-- [The Pantheon.yml Configuration File](/pantheon-yml)
+- [The `pantheon.yml` Configuration File](/pantheon-yml)
 - [Quicksilver Examples Repository](https://github.com/pantheon-systems/quicksilver-examples/)


### PR DESCRIPTION
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

<!--
**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

**Closes Issue:** #

## Summary
<!--
Please complete the Summary section
-->

**Fix 404 page** -  Fix Quicksilver 404 page

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
