### PR TITLE
Tweak Change Upstream Permissions Note

### DIFF
--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -68,7 +68,7 @@ Enter `yes` when prompted:
 Are you sure you want change the upstream for anita-drupal to Drupal 9? (yes/no) [no]:
 ```
 
-Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the Upstream.
+Note that only the [User in Charge](/change-management#site-level-roles-and-permissions), Site Owner, or Organization Administrator can change the Upstream.
 ## Ongoing Core Updates
 
 One-click core updates can be made through the Dashboard.


### PR DESCRIPTION
## Summary
<!--
Please complete the Summary section
-->

**[Upgrade from Drupal 8](https://pantheon.io/docs/guides/drupal-9-migration/upgrade-to-d9)** -  Actually, a few more users than the User In Charge can change the upstream.


## Effect
The following changes are already committed:

* This is Documented elsewhere correctly in the Docs:
https://pantheon.io/docs/create-custom-upstream#switch-an-existing-site-to-a-custom-upstream


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
