### PR TITLE
Fix version of seach_api_pantheon; add command for creating multidev

### DIFF
--- a/source/content/solr-drupal-8.md
+++ b/source/content/solr-drupal-8.md
@@ -51,7 +51,7 @@ Solr on Drupal 8 requires a Composer managed workflow, as described in our [Buil
 1. Add the Search API Pantheon module as a required dependency:
 
   ```bash{promptUser: user}
-  composer require "drupal/search_api_pantheon ~1.6" --prefer-dist
+  composer require "drupal/search_api_pantheon ~1.0" --prefer-dist
   ```
 
 1. You should now have the Search API Pantheon module installed along with its dependencies. Run `git status` to make sure you see the expected result. Commit and push the changes:
@@ -72,6 +72,7 @@ Solr on Drupal 8 requires a Composer managed workflow, as described in our [Buil
   ```bash{promptUser: user}
   git commit -am "Require drupal/search_api_pantheon ~1.0"
   git push origin solr
+  terminus multidev:create <site>.dev solr
   ```
 
   </Tab>


### PR DESCRIPTION
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

---------------------------------------------------------
<!--
**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

**Closes Issue:**  n/a

## Summary
<!--
Please complete the Summary section
-->

**[Enabling Solr on Drupal 8](https://pantheon.io/docs/solr-drupal-8)** -  Fixes version of drupal/search_api_pantheon to existing version and adds command for creating multidev environment.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->



## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

* The docs specify to use drupal/search_api_pantheon 1.6, which doesn't exist. I updated it to 1.0 to match elsewhere in the code.
* The tab for committing changes in multidev doesn't have the step for creating a multidev environment. As someone new to Pantheon, I needed to look up how to do this. I figured having that line in the docs here would be useful to others. 



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
