### PR TITLE
add delete site roles/perms

### DIFF
--- a/source/content/delete-site.md
+++ b/source/content/delete-site.md
@@ -3,10 +3,12 @@ title: Deleting a Site on Pantheon
 description: Information on removing a Drupal or WordPress site from Pantheon.
 categories: [manage]
 tags: [billing, site, sandbox]
-reviewed: "2020-07-24"
+reviewed: "2021-05-11"
 ---
 
 At some point, you may need or want to delete one of your sites on Pantheon. The number of free sites you can create is increased after a free site is deleted, or after it has converted to a paid plan.
+
+Only the site's User in Charge or Owner can delete a site. See [Roles and Permissions](/change-management#roles-and-permissions) for more information.
 
 <Alert title="Warning" type="danger">
 

--- a/source/content/delete-site.md
+++ b/source/content/delete-site.md
@@ -8,7 +8,7 @@ reviewed: "2021-05-11"
 
 At some point, you may need or want to delete one of your sites on Pantheon. The number of free sites you can create is increased after a free site is deleted, or after it has converted to a paid plan.
 
-Only the site's User in Charge or Owner can delete a site. See [Roles and Permissions](/change-management#roles-and-permissions) for more information.
+Only the site's "User in Charge" or "Owner" can delete a site. See [Roles and Permissions](/change-management#roles-and-permissions) for more information.
 
 <Alert title="Warning" type="danger">
 


### PR DESCRIPTION
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

<!--
**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


**Closes:** #6337 

## Summary
<!--
Please complete the Summary section
-->

**[Delete a Site](https://pantheon.io/docs/delete-site)** -  Specify which user permissions can delete a site.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

* add a line about roles and permissions to the Deleting a Site doc


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] copy review


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
