### PR TITLE
upgrade to D9: push to origin; def copy pantheon.yml

### DIFF
--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -59,7 +59,9 @@ This process involves significant changes to the codebase. We recommend you to d
   git commit -m 'Copy my pantheon.yml'
   ```
 
- If you prefer to keep the value for `database` from `pantheon.upstream.yml`, remove it from `pantheon.yml`.
+ Remove any values from `pantheon.yml` that you prefer to keep as listed in `pantheon.upstream.yml`.
+
+ Both `pantheon.yml` and the `api_version: 1` value in it are required.
 
 ## Add in the Custom and Contrib Code Needed to Run Your Site
 

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -43,7 +43,7 @@ This process involves significant changes to the codebase. We recommend you to d
   git commit -m "Pull in configuration from default branch"
   ```
 
-1. Check for `pantheon.yml` settings you need to preserve by comparing your old codebase's `pantheon.yml` to the new `pantheon.upstream.yml`:
+1. Compare the old codebase's `pantheon.yml` to the new `pantheon.upstream.yml`:
 
   ```bash{promptUser:user}
   git diff master:pantheon.yml pantheon.upstream.yml
@@ -51,15 +51,15 @@ This process involves significant changes to the codebase. We recommend you to d
 
   Press `q` on your keyboard to exit the diff display.
 
-   - If there are settings from `pantheon.yml` (shown with a `-` in the diff output), consider copying over your old `pantheon.yml` to preserve these settings:
+1. Copy the old `pantheon.yml` to preserve settings:
 
-     ```bash{promptUser:user}
-     git checkout master pantheon.yml
-     git add pantheon.yml
-     git commit -m 'Copy my pantheon.yml'
-     ```
+  ```bash{promptUser:user}
+  git checkout master pantheon.yml
+  git add pantheon.yml
+  git commit -m 'Copy my pantheon.yml'
+  ```
 
-   If you prefer to keep the value for `database` from `pantheon.upstream.yml`, remove it from `pantheon.yml`.
+ If you prefer to keep the value for `database` from `pantheon.upstream.yml`, remove it from `pantheon.yml`.
 
 ## Add in the Custom and Contrib Code Needed to Run Your Site
 
@@ -235,7 +235,7 @@ You've now committed the code to the local branch. Deploy that branch directly t
 Push the changes to a Multidev called `composerify` to safely test the site without affecting the Dev environment:
 
 ```bash{promptUser:user}
-git push -u ic composerify && terminus env:create $SITE.dev composerify
+git push -u origin composerify && terminus env:create $SITE.dev composerify
 ```
 
 Once you have confirmed the site is working, merge `composerify` into `master`, and follow the standard [relaunch workflow](/relaunch) to QA a code change before going live.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


**Closes Issue:** #6412 

## Summary
<!--
Please complete the Summary section
-->

**[Migrate to D9](https://pantheon.io/docs/guides/drupal-9-migration/upgrade-to-d9)** -  It's safer to always copy `pantheon.yml` so that one exists rather than make the step conditional. Also fix the `git push` step to `origin` instead of `ic`.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

* 
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] 👍 
- [ ] pre-flight ✔️ 
- [ ] 🚀 


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
