### PR TITLE
June 2021 Changelog

### DIFF
--- a/source/changelogs/2021-06-01-June.md
+++ b/source/changelogs/2021-06-01-June.md
@@ -19,7 +19,7 @@ reviewed: "2021-06-01"
 
 ### WordPress 5.7.2
 
-[WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation.
+[WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates](/core-updates) documentation.
 
 
 ## Sponsored Projects

--- a/source/changelogs/2021-06-01-June.md
+++ b/source/changelogs/2021-06-01-June.md
@@ -7,6 +7,10 @@ reviewed: "2021-06-01"
 
 ## Platform Improvements
 
+### Drupal 9.1.8
+
+[Drupal 9.1.8](https://www.drupal.org/project/drupal/releases/9.1.8) is now available for production sites. Read the [Drupal 9.1.8 release notes](https://www.drupal.org/project/drupal/releases/9.1.8) for details about this release. [Drupal 9](/drupal-9) sites on Pantheon use [Integrated Composer](/integrated-composer), enabling one-click core updates through the Dashboard. To check for available updates, click **Check Now** from the site Dashboard **Dev** tab.
+
 ### Drupal 8.9.15
 
 [Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation. For more information, see the [Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) release notes.

--- a/source/changelogs/2021-06-01-June.md
+++ b/source/changelogs/2021-06-01-June.md
@@ -9,22 +9,24 @@ reviewed: "2021-06-01"
 
 ### Drupal 9.1.8
 
-[Drupal 9.1.8](https://www.drupal.org/project/drupal/releases/9.1.8) is now available for production sites. Read the [Drupal 9.1.8 release notes](https://www.drupal.org/project/drupal/releases/9.1.8) for details about this release. [Drupal 9](/drupal-9) sites on Pantheon use [Integrated Composer](/integrated-composer), enabling one-click core updates through the Dashboard. To check for available updates, click **Check Now** from the site Dashboard **Dev** tab.
+[Drupal 9.1.8](https://www.drupal.org/project/drupal/releases/9.1.8) is now available for production sites. [Drupal 9](/drupal-9) sites on Pantheon use [Integrated Composer](/integrated-composer), enabling one-click core updates through the Dashboard. To check for available updates, click **Check Now** from the site Dashboard **Dev** tab.
+
+<!-- excerpt -->
 
 ### Drupal 8.9.15
 
-[Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation. For more information, see the [Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) release notes.
+[Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation.
 
 ### WordPress 5.7.2
 
-[WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation. For more information, see the [WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) release notes.
+[WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation.
 
 
 ## Sponsored Projects
 
 ### WP-CLI 2.5.0
 
-[WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) is now available. This release fixes security vulnerabilities, and users are urged to upgrade their sites. For more information, see the [WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) release notes. Detailed information on using WP-CLI on the Pantheon Platform can be found in the [WP-CLI](/wp-cli) documentation.
+[WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) is now available. This release fixes security vulnerabilities, and users are urged to upgrade. For more information, see the [WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) release notes. Detailed information on using WP-CLI on the Pantheon Platform can be found in the [WP-CLI](/wp-cli) documentation.
 
 ## Documentation
 

--- a/source/changelogs/2021-06-01-June.md
+++ b/source/changelogs/2021-06-01-June.md
@@ -7,8 +7,20 @@ reviewed: "2021-06-01"
 
 ## Platform Improvements
 
-### Drupal 9.1.7
+### Drupal 8.9.15
 
+[Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) is now available on the Pantheon platform. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation. For more information, see the [Drupal 8.9.15](https://www.drupal.org/project/drupal/releases/8.9.15) release notes.
+
+### WordPress 5.7.2
+
+[WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) is now available on the Pantheon platform. This release fixes security vulnerabilities, and users are urged to upgrade their sites immediately. Detailed information on applying and debugging core updates can be found in the [Core Updates documentation](/core-updates) documentation. For more information, see the [WordPress 5.7.2](https://wordpress.org/news/2021/05/wordpress-5-7-2-security-release/) release notes.
+
+
+## Sponsored Projects
+
+### WP-CLI 2.5.0
+
+[WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) is now available. This release fixes security vulnerabilities, and users are urged to upgrade their sites. For more information, see the [WP-CLI 2.5.0](https://make.wordpress.org/cli/2021/05/19/wp-cli-v2-5-0-release-notes/) release notes. Detailed information on using WP-CLI on the Pantheon Platform can be found in the [WP-CLI](/wp-cli) documentation.
 
 ## Documentation
 

--- a/source/changelogs/2021-06-01-June.md
+++ b/source/changelogs/2021-06-01-June.md
@@ -1,0 +1,15 @@
+---
+title: June 2021 Changelog
+changelog: true
+description: June 2021 Pantheon changelog
+reviewed: "2021-06-01"
+---
+
+## Platform Improvements
+
+### Drupal 9.1.7
+
+
+## Documentation
+
+[Upgrade from Drupal 8 to Drupal 9 with Integrated Composer](/guides/drupal-9-migration/upgrade-to-d9) - Convert a Drupal 8 site to a Drupal 9 site managed with Integrated Composer. If you have more questions about switching to Drupal 9, stop by our [Thursday office hours](https://pantheon.io/developers/office-hours).


### PR DESCRIPTION

**Closes:** #6408 

## Summary

**[June 2021 Changelog](https://pantheon.io/docs/changelog)** -  Pantheon Changelog for June 2021.


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
