### PR TITLE
fix broken anchor and text

### DIFF
--- a/source/content/support.md
+++ b/source/content/support.md
@@ -26,7 +26,7 @@ Keep these tips in mind when opening a new support ticket or chat, to help us mo
 
 ### Open the Ticket in the Right Place
 
-If you are a member of an [Organization](/organizations), use the Organization's Dashboard to visit the support tab. Contacting Support from your User Dashboard will not provide the same support level as a Site Dashboard owned by an Organization with a higher Account package. For a visual, check out the [Support Tab from the Organization Dashboard](#the-support-tab-from-the-organization-dashboard).
+If you are a member of an [Organization](/organizations), use the Organization's Dashboard to visit the support tab. Contacting Support from your User Dashboard will not provide the same support level as a Site Dashboard owned by an Organization with a higher Account package. For a visual, check out the [Support Tab on the Organization Dashboard](#organization-dashboard-support-tab).
 
 ### One ticket per issue
 
@@ -48,7 +48,7 @@ If your site uses nonstandard admin URLs, custom logins, etc., please let us kno
 
 We're all only human. We always try our best to understand the situation, but we may not always get it right the first time. At the same time, our explanations or solutions might not always make sense to you. Don't be afraid to correct us, or to ask for clarification if we don't seem to understand the issue.
 
-### The Support Tab from the Organization Dashboard
+### Organization Dashboard Support Tab
 
 If you are part of an Organization with an enhanced Account package, navigate to the Support tab from the Organization's Dashboard to make use of the Organization's Support level:
 

--- a/source/content/support.md
+++ b/source/content/support.md
@@ -3,7 +3,7 @@ title: Get Support
 description: Learn how to access Pantheon's expert team and what your Account tier includes.
 categories: [platform]
 tags: [dashboard, support]
-reviewed: "2020-02-11"
+reviewed: "2021-05-27"
 ---
 
 ![Screenshot of the Support Tab](../images/dashboard/support-tab.png)
@@ -144,15 +144,15 @@ If your site is slow or modules aren't working, please see our [performance arti
 
 Pantheon can only assist if we can replicate the problem. Intermittent issues and server errors are rarely random, rather, they are issues with a yet undefined trigger. Please try to replicate and debug [site errors](/errors-and-server-responses) in your Development environment. If you [contact support](/support), include your findings and attach screenshots whenever possible.
 
-### Local Development
-
-We recommend development on the platform, rather than on a local environment. Unexpected behavior, not apparent on local instances such as MAMP or shared hosting, can be due to different versions of PHP, different levels of error reporting, Apache vs NGINX, or server configuration. Pantheon is not responsible for resolving such issues.
-
 ### Isolated Issues
 
 Pantheon Support can quickly determine if an issue is platform related. We take full responsibility for our services and performance, but if something is affecting your site only, or a single environment only, we will most likely refer you to our debugging tutorials or offer to connect you with an agency partner to help you with the resolution.
 
 If problems with your site become severe and overload resources, we will contact you and ask you to take immediate action. If unresponsive, we may need to put the site into maintenance mode.
+
+### Local Development
+
+We recommend development on the platform, rather than on a local environment. Unexpected behavior, not apparent on local instances such as MAMP or shared hosting, can be due to different versions of PHP, different levels of error reporting, Apache vs NGINX, or server configuration. Pantheon is not responsible for resolving such issues.
 
 ### Platform Support
 

--- a/src/layout/footer/index.js
+++ b/src/layout/footer/index.js
@@ -112,7 +112,7 @@ const Footer = ({ data }) => {
                           <a href="https://status.pantheon.io/">Status</a>
                         </li>
                         <li className="last leaf menu-mlid-1154">
-                          <Link to="/support/">
+                          <Link to="/support">
                             Support
                           </Link>
                         </li>

--- a/src/layout/footer/index.js
+++ b/src/layout/footer/index.js
@@ -112,7 +112,7 @@ const Footer = ({ data }) => {
                           <a href="https://status.pantheon.io/">Status</a>
                         </li>
                         <li className="last leaf menu-mlid-1154">
-                          <Link to="/support">
+                          <Link to="/support/">
                             Support
                           </Link>
                         </li>


### PR DESCRIPTION

**[Get Support](https://pantheon.io/docs/support)** -  Minor fix to broken anchor and label.



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
