### PR TITLE
Improving the docs - Changed the titles on the home page to begin with an imperative verb to maintain consistency

### DIFF
--- a/source/content/guides/drupal8-commandline.md
+++ b/source/content/guides/drupal8-commandline.md
@@ -1,5 +1,5 @@
 ---
-title: Create a Drupal 8 Site From the Command Line Using Terminus and Drush
+title: Creating a Drupal 8 Site From the Command Line Using Terminus and Drush
 description: Learn how to add modules, and manage configuration between Pantheon environments.
 cms: "Drupal 8"
 categories: [get-started]

--- a/source/content/guides/wordpress-commandline.md
+++ b/source/content/guides/wordpress-commandline.md
@@ -1,5 +1,5 @@
 ---
-title: Create a WordPress Site From the Command Line Using Terminus and WP-CLI
+title: Creating a WordPress Site From the Command Line Using Terminus and WP-CLI
 description: Learn how to install and use Terminus and WP-CLI to control a WordPress site on Pantheon.
 cms: "WordPress"
 categories: [get-started]

--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -1,5 +1,5 @@
 ---
-title: Manually Migrate Sites to Pantheon
+title: Manually Migrating Sites to Pantheon
 description: Learn how to manually migrate a Drupal or WordPress site to Pantheon
 categories: [get-started]
 tags: [code, dashboard, migrate, site]

--- a/source/content/migrate-wordpress-site-networks.md
+++ b/source/content/migrate-wordpress-site-networks.md
@@ -1,5 +1,5 @@
 ---
-title: 'Migrate to Pantheon: WordPress Site Networks'
+title: 'Migrating WordPress Site Networks to Pantheon'
 description: Learn how to import a WordPress Site Network into Pantheon.
 cms: "WordPress"
 categories: [get-started]

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -22,7 +22,7 @@ To ensure a successful migration, complete the following tasks on the source sit
 - Remove unneeded code, database tables, and files
 - [Configure SSH keys](/ssh-keys)
 
-## Migrating Existing Sites
+## Migrate Existing Sites
 
 Pantheon provides a guided path for migrating existing sites to the platform, which begins by clicking the **Migrate Existing Site** button on the User Dashboard.
 
@@ -110,7 +110,7 @@ The recommended way to migrate Drupal sites from another host is to use `drush a
 
 </TabList>
 
-## Manually Migrating a Site to Pantheon
+## Manually Migrate a Site to Pantheon
 
 Manually migrate your site to Pantheon when any of the following apply:
 
@@ -140,7 +140,7 @@ If your code, database, and files have completed migrating, but your site is not
 
 Next, check [log files](/logs) to help identify and fix errors. Drupal or WordPress core is upgraded as part of migration, so you may have additional work to complete the upgrade.
 
-### Migrating from Acquia
+### Migrate from Acquia
 
 Acquia uses a nested docroot directory called `docroot`. When migrating from Acquia to Pantheon, you may choose to move the contents of `docroot` up and remove the folder, or rename it to `web` and set `web_docroot: true` in your `pantheon.yml` file. For more information on nested docroots, see [Serving Sites from the Web Subdirectory](/nested-docroot).
 

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -1,5 +1,5 @@
 ---
-title: Migrate Sites to Pantheon
+title: Migrating Sites to Pantheon
 description: General instructions for preparing and migrating remotely-hosted Drupal or WordPress sites to Pantheon.
 categories: [get-started]
 tags: [dashboard, migrate, site]
@@ -22,7 +22,7 @@ To ensure a successful migration, complete the following tasks on the source sit
 - Remove unneeded code, database tables, and files
 - [Configure SSH keys](/ssh-keys)
 
-## Migrate Existing Sites
+## Migrating Existing Sites
 
 Pantheon provides a guided path for migrating existing sites to the platform, which begins by clicking the **Migrate Existing Site** button on the User Dashboard.
 
@@ -110,7 +110,7 @@ The recommended way to migrate Drupal sites from another host is to use `drush a
 
 </TabList>
 
-## Manually Migrate a Site to Pantheon
+## Manually Migrating a Site to Pantheon
 
 Manually migrate your site to Pantheon when any of the following apply:
 
@@ -140,7 +140,7 @@ If your code, database, and files have completed migrating, but your site is not
 
 Next, check [log files](/logs) to help identify and fix errors. Drupal or WordPress core is upgraded as part of migration, so you may have additional work to complete the upgrade.
 
-### Migrate from Acquia
+### Migrating from Acquia
 
 Acquia uses a nested docroot directory called `docroot`. When migrating from Acquia to Pantheon, you may choose to move the contents of `docroot` up and remove the folder, or rename it to `web` and set `web_docroot: true` in your `pantheon.yml` file. For more information on nested docroots, see [Serving Sites from the Web Subdirectory](/nested-docroot).
 


### PR DESCRIPTION


Closes #

## Summary

Improving the docs - Changed the titles on the home page to begin with an imperative verb to maintain consistency.


https://pantheon.io/docs/get-started

For example: Changed **Migrate Sites to Pantheon** to **Migrating Sites to Pantheon**



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
