### PR TITLE
Update plugins-known-issues.md

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -582,11 +582,32 @@ ___
 
 ## [Redirection](https://wordpress.org/plugins/redirection/)
 
-<ReviewDate date="2019-01-17" />
+<ReviewDate date="2021-06-08" />
 
-**Issue:** Customers have reported issues with 404 logging creating large database tables, reducing site performance.
+**Issue 1:** Customers have reported issues with 404 logging creating large database tables, reducing site performance.
 
 **Solution:** Consider using PHP code to set up your redirects. See [Configure Redirects](/redirects) for more information.
+
+**Issue 2:** [Redirection](https://redirection.me/) prefers `$_SERVER['SERVER_NAME']` over `$_SERVER['HTTP_HOST']` for [URL and server](https://redirection.me/support/matching-redirects/) redirects. By default, `$_SERVER['SERVER_NAME']` returns Pantheon's internal server name and not the current hostname, as a result, Redirection's "URL and server" based redirects never match.
+
+**Solution:** In `wp-config.php`, add the following above the line `/* That's all, stop editing! Happy Pressing. */`:
+
+  ```php:title=wp-config.php
+  // Map $_SERVER['HTTP_HOST'] to $_SERVER['SERVER_NAME'] 
+  // to allow the Redirection plugin to work when using 
+  // "URL and server" based redirects. By default, 
+  // $_SERVER['SERVER_NAME'] returns Pantheon's internal 
+  // server name and not the current hostname, as a 
+  // result, Redirection's "URL and server" based 
+  // redirects never match.
+  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+  ```
+
+<Alert title="Warning" type="danger">
+
+This workaround may potentially break other functionality that depends on the default Pantheon return value for `$_SERVER['SERVER_NAME']`.
+
+</Alert>
 
 ___
 


### PR DESCRIPTION
Closes #

## Summary
**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues/#redirection)** -  Adds a new issue and a solution for the Redirection plugin.

## Effect
Redirection prefers `$_SERVER['SERVER_NAME']` over `$_SERVER['HTTP_HOST']` for [URL and server](https://redirection.me/support/matching-redirects/) redirects. By default, `$_SERVER['SERVER_NAME']` returns Pantheon's internal server name and not the current hostname, as a result, Redirection's "URL and server" based redirects never match.

## Remaining Work

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
