### PR TITLE
add AMP module to list of modules using SERVER_NAME

### DIFF
--- a/source/content/server_name-and-server_port.md
+++ b/source/content/server_name-and-server_port.md
@@ -42,11 +42,18 @@ if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
 }
 ```
 
-## Known Plugins/Modules Using SERVER_NAME
+## Known Plugins/Modules That Use SERVER_NAME
+
+- [Gravity Forms](http://www.gravityforms.com/)
+- [Simple Share Buttons](https://simplesharebuttons.com/plus/)
+
+### WordPress Plugins That Use SERVER_NAME
 
 - [Give](https://wordpress.org/plugins/give/)
-- [Gravity Forms](http://www.gravityforms.com/)
+- [WP Super Cache](https://wordpress.org/support/plugin/wp-super-cache)
+
+### Drupal Modules That Use SERVER_NAME
+
 - [OAuth](https://www.drupal.org/project/oauth)
 - [reCAPTCHA](https://www.drupal.org/project/recaptcha)
-- [Simple Share Buttons](https://simplesharebuttons.com/plus/)
-- [WP Super Cache](https://wordpress.org/support/plugin/wp-super-cache)
+- [AMP](https://www.drupal.org/project/amp)


### PR DESCRIPTION

## Summary

**[SERVER_NAME and SERVER_PORT on Pantheon](https://pantheon.io/docs/server_name-and-server_port)** -  Add AMP Drupal module to list of modules that use `$_SERVER['SERVER_NAME']`.

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Copy review
- [ ] Props to @ianlabao-pantheon for suggesting!

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
