### PR TITLE
[Integrated Composer] Fix for confusing step under adding dependencies to individual sites

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -53,6 +53,8 @@ Please note the Limited Availability program does not include a path to upgrade 
 
 ### Remove Individual Site Dependencies
 
+You can remove site dependencies if they are no longer needed. 
+
 1. Remove the dependency locally:
 
    ```bash{promptUser: user}

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -51,9 +51,7 @@ Please note the Limited Availability program does not include a path to upgrade 
 
    - Pantheon will run Composer, generate build artifacts, and deploy it to your Dev or Multidev environment.
 
-### Remove Individual Site dependencies
-
-If/when you decide to remove the dependency:
+### Remove Individual Site Dependencies
 
 1. Remove the dependency locally:
 

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -51,11 +51,19 @@ Please note the Limited Availability program does not include a path to upgrade 
 
    - Pantheon will run Composer, generate build artifacts, and deploy it to your Dev or Multidev environment.
 
-1. Remove dependencies:
+### Remove Individual Site dependencies
+
+If/when you decide to remove the dependency:
+
+1. Remove the dependency locally:
 
    ```bash{promptUser: user}
     composer remove drupal/pkg-name
    ```
+
+1. Commit `composer.json` and `composer.lock` and push.
+
+   - Pantheon will run Composer, generate build artifacts, etc.
 
 ## Apply One-click Updates
 


### PR DESCRIPTION
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

<!--
**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** -  This patch breaks the add/remove processes into separate steps to clarify that you do **not** have to remove the dependency locally to complete the adding process.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
