### PR TITLE
add lando d9 workaround

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -69,3 +69,16 @@ See the [Drupal 9 Migration Guide](/guides/drupal-9-migration/troubleshoot) for 
 ### Where can I report an issue?
 
 [Contact support](/support) to report any issues that you encounter.
+
+### Can I Use Lando or Localdev for Drupal 9
+
+Local development options for Drupal 9 are currently being implemented into [Localdev](/guides/localdev).
+
+Some users have reported success using [Lando](https://docs.lando.dev/basics/) with Drupal 9, but it relies on a workaround and requires extra configuration. Check the status of the [Lando repo's issue](https://github.com/lando/lando/issues/2831#issuecomment-771833900) before you continue.
+
+Manually update the [Lando config file](https://docs.lando.dev/config/global.html#config-yml) to set `drupal9` as the framework:
+
+```yml:title=~/.lando/config.yml
+# Lando issue 2831 workaround for D9
+framework: drupal9
+```

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -76,9 +76,13 @@ Local development options for Drupal 9 are currently being implemented into [Loc
 
 Some users have reported success using [Lando](https://docs.lando.dev/basics/) with Drupal 9, but it relies on a workaround and requires extra configuration. Check the status of the [Lando repo's issue](https://github.com/lando/lando/issues/2831#issuecomment-771833900) before you continue.
 
-Manually update the [Lando config file](https://docs.lando.dev/config/global.html#config-yml) to set `drupal9` as the framework:
+Manually update the [landofile](https://docs.lando.dev/config/lando.html#base-file) in the project folder, and set `drupal9` as the framework:
 
-```yml:title=~/.lando/config.yml
+```yml:title=lando.yml
 # Lando issue 2831 workaround for D9
 framework: drupal9
 ```
+
+When you create a project with Lando from the Pantheon recipe, the `framework` will default to `drupal8` for a Drupal 8 or Drupal 9 site.
+
+If you created new project with Lando, change the value for `framework` to `drupal9`, then run `lando rebuild`.

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -70,7 +70,7 @@ See the [Drupal 9 Migration Guide](/guides/drupal-9-migration/troubleshoot) for 
 
 [Contact support](/support) to report any issues that you encounter.
 
-### Can I Use Lando or Localdev for Drupal 9
+### Can I Use Lando or Localdev for Drupal 9?
 
 Local development options for Drupal 9 are currently being implemented into [Localdev](/guides/localdev).
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Drupal 9 on Pantheon](https://pantheon.io/docs/drupal-9)** -  Add Lando consideration for Drupal 9 (currently a workaround).

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] +1 from Slack
- [ ] 👍 from @pirog ? (👋 )


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
