### PR TITLE
Clarify Elite plan PHP memory limit

### DIFF
--- a/source/content/platform-resources.md
+++ b/source/content/platform-resources.md
@@ -41,7 +41,7 @@ The platform resources provided to your website depend on your current plan. Pan
         <td>256MB</td>
         <td>256MB</td>
         <td>512MB</td>
-        <td>up to 1024MB</td>
+        <td>512MB<Popover content="Up to 1024MB is available for certain Elite plans. <a href='https://pantheon.io/pantheon-elite-plans'>Learn more about Pantheon Elite Plans</a> and contact Sales for information about plans with custom resources." /></td>
       </tr>
       <tr>
         <th scope="row" class="thead-inverse">MySQL Buffer Pool</th>


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Platform Resources](https://pantheon.io/docs/platform-resources#platform-resources)** - Clarify that the PHP memory limit is 512MB, and that 1024MB is available as an option for custom Elite plans.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
