### PR TITLE
Autopilot: 25 pages per site; add note about ack'ing results before testing again

### DIFF
--- a/source/content/guides/autopilot/03-tests-results.md
+++ b/source/content/guides/autopilot/03-tests-results.md
@@ -47,4 +47,4 @@ From the **Autopilot Overview**:
 
 ### Is there a limit to the number screenshots Autopilot will take?
 
-Yes. Depending on your [Account](/support#support-features-and-response-times), Autopilot can be set for up to 5 pages on each site. It will check for updates once a week, and can also be run on demand. This number will increase for Autopilot General Availability.
+Yes. Depending on your [Account](/support#support-features-and-response-times), Autopilot can be set for up to 25 pages on each site. It will check for updates once a week, and can also be run on demand.

--- a/source/content/guides/autopilot/03-tests-results.md
+++ b/source/content/guides/autopilot/03-tests-results.md
@@ -43,6 +43,8 @@ From the **Autopilot Overview**:
 
 ![Autopilot Overview shows a site with a failed test](../../../images/autopilot/autopilot-overview-failed-vrt.png)
 
+If there's a failed test that requires review, review and acknowledge the test results before you run another test to avoid duplicate test results.
+
 ## FAQ
 
 ### Is there a limit to the number screenshots Autopilot will take?

--- a/source/content/guides/autopilot/03-tests-results.md
+++ b/source/content/guides/autopilot/03-tests-results.md
@@ -43,7 +43,9 @@ From the **Autopilot Overview**:
 
 ![Autopilot Overview shows a site with a failed test](../../../images/autopilot/autopilot-overview-failed-vrt.png)
 
-If there's a failed test that requires review, review and acknowledge the test results before you run another test to avoid duplicate test results.
+### Acknowledge All Failed Test Results Before You Run Another Test
+
+When a failed test requires review, no new tests can be run on the site until the results have been approved or discarded through Autopilot.
 
 ## FAQ
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->


Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Autopilot Tests and Results](https://pantheon.io/docs/guides/autopilot/tests-results/)** -  Autopilot now supports tracking 25 pages per site. Additionally, added a note reminding users to deal with failed test results before running another test.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
