### PR TITLE
Add a11y statement to footer

### DIFF
--- a/src/layout/footer/index.js
+++ b/src/layout/footer/index.js
@@ -179,6 +179,10 @@ const Footer = ({ data }) => {
                         <span>|</span>{" "}
                         <a href="https://pantheon.io/pantheon-terms-service">
                           Terms of Use
+                        </a>{" "}
+                        <span>|</span>{" "}
+                        <a href="https://pantheon.io/accessibility-statement">
+                          Accessibility Statement
                         </a>
                       </div>
                     </div>


### PR DESCRIPTION


## Summary
<!--
Please complete the Summary section
-->

**Accessibility Statement** - Adds Pantheon's [Accessibility Statement](https://pantheon.io/accessibility-statement) to the Documentation Site footer.


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Copy review


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
