### PR TITLE
Add info about Drush and Integrated Composer

### DIFF
--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -49,7 +49,7 @@ Autopilot is enabled for Pantheon sites at the organization level.
 
 ## Will Autopilot Work for Your Site?
 
-While Pantheon develops more features for Autopilot, some features aren't available yet. See the FAQ below for some examples.
+Pantheon is working on developing more features for Autopilot, yet some features are currently not available. Refer to the following FAQ section for more information.
 
 ## FAQ
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -63,7 +63,7 @@ Not yet. Pantheon's devs are working on Autopilot email notifications.
 
 ### Does Autopilot work with Integrated Composer?
 
-Yes. If your site is using [Integrated Composer](/integrated-composer) (`build_step` is `true` in pantheon.yml), Autopilot will be able to update it.
+Yes. If your site is using [Integrated Composer](/integrated-composer) (`build_step` is `true` in the `pantheon.yml` file), Autopilot will be able to update it.
 
 ### Does Autopilot work with build tools?
 
@@ -71,7 +71,7 @@ Not yet. Autopilot is not compatible with Build Tools or other workflows that us
 
 ### What versions of Drush are supported by Autopilot?
 
-Currently, Autopilot only supports Drush 8. See [drush versions](/drush-versions) for information on setting your Drush version.
+Currently, Autopilot only supports Drush 8. Refer to the documentation on [Drush versions](/drush-versions) for more information.
 
 ### Does Autopilot support Terminus actions?
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -49,9 +49,7 @@ Autopilot is enabled for Pantheon sites at the organization level.
 
 ## Will Autopilot Work for Your Site?
 
-While Pantheon develops more features for Autopilot, some features aren't available yet.
-
-Right now, Autopilot doesn't work with sites that use [Integrated Composer](/integrated-composer).
+While Pantheon develops more features for Autopilot, some features aren't available yet. See the FAQ below for some examples.
 
 ## FAQ
 
@@ -63,9 +61,17 @@ Yes. Access to Autopilot is account-based and individual sites in that account c
 
 Not yet. Pantheon's devs are working on Autopilot email notifications.
 
+### Does Autopilot work with Integrated Composer?
+
+Yes. If your site is using [Integrated Composer](/integrated-composer) (`build_step` is `true` in pantheon.yml), Autopilot will be able to update it.
+
 ### Does Autopilot work with build tools?
 
 Not yet. Autopilot is not compatible with Build Tools or other workflows that use external Git repositories.
+
+### What versions of Drush are supported by Autopilot?
+
+Currently, Autopilot only supports Drush 8. See [drush versions](/drush-versions) for information on setting your Drush version.
 
 ### Does Autopilot support Terminus actions?
 


### PR DESCRIPTION
Closes n/a, but related to https://getpantheon.atlassian.net/browse/OTTO-994

## Summary

Update Autopilot FAQ to include information about Drush versions and Integrated Composer.


## Effect

The FAQ was missing info about supported Drush versions, and the information it had on Integrated Composer was out of date.

## Remaining Work

- [ ] Review and publish


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
