### PR TITLE
Clarify Autopilot access permissions

### DIFF
--- a/source/content/change-management.md
+++ b/source/content/change-management.md
@@ -25,7 +25,6 @@ If you are an administrator for a Pantheon organization, [contact support](/supp
 | Create sites within an org                       | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Work in Dev environments                         | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Access to Multidev environments                  | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
-| Access and manage [Autopilot](/guides/autopilot) | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> |
 | Access the org Dashboard                         | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  |
 | Deploy to Test and Live                          | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |
 | Invite new team members                          | <span  style="color:green">✔</span> | <span  style="color:green">✔</span> | <span  style="color:red">❌</span>  | <span  style="color:red">❌</span>  |


### PR DESCRIPTION

## Summary

**[Role-Based Permissions & Change Management](https://pantheon.io/docs/change-management)** -  Remove erroneous Autopilot permissions line. Not all users in charge are able to access the organization's Autopilot dashboard.

Autopilot team has confirmed that simply changing user role to UIC does not guarantee access. More info here:
https://pantheon.slack.com/archives/C01MZT20TDM/p1625864439306000

## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
