### PR TITLE
cross-linking changes on Pantheon Filesystem page here

### DIFF
--- a/source/content/private-paths.md
+++ b/source/content/private-paths.md
@@ -60,6 +60,10 @@ WordPress does not have a core feature to configure a private path folder for fi
 
 Site developers could author their own custom solution to provide authentication, access checks, and ultimately use PHP's [readfile()](http://php.net/readfile/) or [fpassthru()](http://php.net/fpassthru/) functions to read files from the `wp-content/uploads/private` (WordPress) or `sites/default/files/private` (Drupal) areas, respectively, and then output them to the authenticated web user's browser.
 
+### Known Limitations of File Names and Permissions
+
+Please see [Pantheon Filesystem](/files#known-limitations-of-file-names-and-permissions) for more information.
+
 ### Additional Drupal Configuration
 
 These files will be web-accessible based on the access control rules that you set for your site and will use the following directory: `sites/default/files/private`


### PR DESCRIPTION
***Please merge #6535 before this one, as the link here is a dependency***

Closes #6198 and #6535 

## Summary

**[Private Path for Files](https://pantheon.io/docs/private-paths#private-path-for-files)** -  Pantheon Filesystem page updated, added a link to that doc on this page.

## Effect
The following changes are already committed:

* Updated Pantheon Filesystem page with a section on this known limitation

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
