### PR TITLE
close 6134 - rework intro to local-development doc with reusable $site partial

### DIFF
--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -52,11 +52,11 @@ The first step is to get a `git clone` of your code from Pantheon to your local 
 
 1. Go to Your Site Dashboard, and log in to Pantheon and load the Dashboard for the site you want to work on.
 
-2. At the top of the development panel, look for the `git clone` command and copy and paste it in your terminal. It will look something like this:
+1. At the top of the development panel, look for the `git clone` command and copy and paste it in your terminal. It will look something like this:
 
-    ![Copy and Paste Git Clone](../images/dashboard/git-string.png)<br />
+    ![Copy and Paste Git Clone](../images/dashboard/git-string.png)
 
-3. On your local environment, go to where you want the code to reside. Git will create a directory as part of the clone, so you don't need to create one. Run the command you copied in step 2:
+1. On your local environment, go to where you want the code to reside. Git will create a directory as part of the clone, so you don't need to create one. Run the command you copied in step 2:
 
     ```bash{promptUser: user}
     git clone ssh://codeserver.dev.xxx@codeserver.dev.xxx.drush.in:2222/~/repository.git my-site

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -30,10 +30,12 @@ Be sure you have:
 - [Terminus](/terminus)
 - [Drush](/drush) (optional)
 
+<Partial file="export-alias.md" />
+
 To save time, clear the target site environment's cache. This can be done from the Pantheon Dashboard, from the application itself, or by running the following Terminus command:
 
 ```bash{promptUser: user}
-terminus env:clear-cache <site>.<env>
+terminus env:clear-cache $SITE.<env>
 ```
 
 There are three parts to any dynamic website:
@@ -106,8 +108,8 @@ From within the Site Dashboard:
 1. Create and get the database with Terminus commands:
 
     ```bash{promptUser: user}
-    terminus backup:create <site>.<env> --element=db
-    terminus backup:get <site>.<env> --element=db
+    terminus backup:create $SITE.<env> --element=db
+    terminus backup:get $SITE.<env> --element=db
     ```
 
 1. Import the archive into your local MySQL database using the following command:
@@ -125,8 +127,8 @@ For an overview of ways to transfer files, see [SFTP and rsync on Pantheon](/rsy
 Run the following Terminus commands:
 
 ```bash{promptUser: user}
-terminus backup:create <site>.<env> --element=files
-terminus backup:get <site>.<env> --element=files
+terminus backup:create $SITE.<env> --element=files
+terminus backup:get $SITE.<env> --element=files
 ```
 
 This will create and get a backup of the site's files.

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -20,6 +20,16 @@ If you encounter any issues, visit the [Lando GitHub repository](https://github.
 
 ## Before You Begin
 
+There are three parts to any dynamic website:
+
+1. **Code**: The application, modules or plugins, and themes.
+
+1. **Database**: The content.
+
+1. **Files**: User uploaded or application generated.
+
+You will need to transfer each one from Pantheon to your local environment.
+
 Be sure you have:
 
 - A local stack capable of running Drupal or WordPress. [Lando](https://github.com/lando/lando) integrates with the Pantheon platform. Tools such as [MAMP](https://www.mamp.info/en/), [WAMP](http://www.wampserver.com/), and [XAMPP](https://www.apachefriends.org/index.html) all work.
@@ -47,16 +57,6 @@ To save time, clear the target site environment's cache. This can be done from t
 ```bash{promptUser: user}
 terminus env:clear-cache $SITE.$ENV
 ```
-
-There are three parts to any dynamic website:
-
-1. Code (The application, modules or plugins, and themes)
-
-1. Database (content)
-
-1. Files (user uploaded or application generated)
-
-You will need to transfer each one from Pantheon to your local environment.
 
 ## Get the Code
 

--- a/source/content/local-development.md
+++ b/source/content/local-development.md
@@ -30,12 +30,22 @@ Be sure you have:
 - [Terminus](/terminus)
 - [Drush](/drush) (optional)
 
+### Export Variables
+
 <Partial file="export-alias.md" />
+
+Export the environment as a variable as well:
+
+```bash{promptUser:user}
+export ENV=dev
+```
+
+### Clear Site Environment Cache
 
 To save time, clear the target site environment's cache. This can be done from the Pantheon Dashboard, from the application itself, or by running the following Terminus command:
 
 ```bash{promptUser: user}
-terminus env:clear-cache $SITE.<env>
+terminus env:clear-cache $SITE.$ENV
 ```
 
 There are three parts to any dynamic website:
@@ -108,8 +118,8 @@ From within the Site Dashboard:
 1. Create and get the database with Terminus commands:
 
     ```bash{promptUser: user}
-    terminus backup:create $SITE.<env> --element=db
-    terminus backup:get $SITE.<env> --element=db
+    terminus backup:create $SITE.$ENV --element=db
+    terminus backup:get $SITE.$ENV --element=db
     ```
 
 1. Import the archive into your local MySQL database using the following command:
@@ -127,8 +137,8 @@ For an overview of ways to transfer files, see [SFTP and rsync on Pantheon](/rsy
 Run the following Terminus commands:
 
 ```bash{promptUser: user}
-terminus backup:create $SITE.<env> --element=files
-terminus backup:get $SITE.<env> --element=files
+terminus backup:create $SITE.$ENV --element=files
+terminus backup:get $SITE.$ENV --element=files
 ```
 
 This will create and get a backup of the site's files.

--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -100,7 +100,7 @@ The content type for this content. Defaults to `doc`, overwritten for other cont
 
 <dd>
 
-If a page is specificially written for a single CMS or CMS version, it's tagged as `"WordPress"`, `"Drupal"`, `"Drupal 7"`, `"Drupal 8"`, or `"Drupal 9"`.
+If a page is specifically written for a single CMS or CMS version, it's tagged as `"WordPress"`, `"Drupal"`, `"Drupal 7"`, `"Drupal 8"`, or `"Drupal 9"`.
 
 </dd>
 

--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -10,27 +10,4 @@
 
 1. Install the [Terminus Site Clone](https://github.com/pantheon-systems/terminus-site-clone-plugin) plugin.
 
-1. This guide uses several commands that depend on the site name in the local command line environment.
-
-  To make this easier, set the temporary variable `$SITE` in your terminal session to match the site name. Read the steps further in this doc to see which sites should be aliased (it may be more than one), then replace `anita-drupal` in this example:
-
-   ```bash{promptUser:user}
-   export SITE=anita-drupal && echo "New alias set as $SITE"
-   ```
-
-   <Accordion title="How to Use Terminus to Find the Site Name" id="site-name" icon="info-sign">
-
-   Use `terminus site:list` for a list of sites you have access to:
-
-    ```bash{outputLines:2-6}
-    terminus site:list
-    --------------------------- --------------------- ------------- ------------------- ---------------- -------------------- --------------------- ------------- ------------
-    Name                        ID                    Plan          Framework           Region           Owner                Created               Memberships   Is Frozen?
-    --------------------------- --------------------- ------------- ------------------- ---------------- -------------------- --------------------- ------------- ------------
-    anita-drupal                abdc80ce-286c-1234-   Sandbox       drupal8             Canada           3374708c-987e-1234   2020-12-15 19:40:42   d3ecc20c-395a false
-    anita-wordpres              abdc9954-fab2-1234-   Sandbox       wordpress           United States    c96ddb25-336a-1234   2020-09-02 07:18:51   d3ecc20c-395a false
-    ```
-
-    The site name is listed under `Name`. In this example, `anita-drupal`.
-
-   </Accordion>
+1. <Partial file="export-alias.md" />

--- a/source/partials/export-alias.md
+++ b/source/partials/export-alias.md
@@ -1,0 +1,24 @@
+This doc uses several commands that depend on the site name in the local command line environment.
+
+To make this easier, set the temporary variable `$SITE` in your terminal session to match the site name. Read the steps further in this doc to see which sites should be aliased (it may be more than one), then replace `anita-drupal` in this example:
+
+```bash{promptUser:user}
+export SITE=anita-drupal && echo "New alias set as $SITE"
+```
+
+<Accordion title="How to Use Terminus to Find the Site Name" id="site-name" icon="info-sign">
+
+Use `terminus site:list` for a list of sites you have access to:
+
+```bash{outputLines:2-6}
+terminus site:list
+--------------------------- --------------------- ------------- ----------------------------------- -------------------- --------------------- ------------- ------------
+Name                        ID                    Plan          Framework          Region           Owner                Created               Memberships   Is Frozen?
+--------------------------- --------------------- ------------- ------------------- ---------------- -------------------- --------------------- ------------- ------------
+anita-drupal                abdc80ce-286c-1234-   Sandbox       drupal8             Canada           3374708c-987e-1234   2020-12-15 19:40:42   d3ecc20c-395a false
+anita-wordpres              abdc9954-fab2-1234-   Sandbox       wordpress           United States    c96ddb25-336a-1234   2020-09-02 07:18:51   d3ecc20c-395a false
+```
+
+The site name is listed under `Name`. In this example, `anita-drupal`.
+
+</Accordion>


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6134 

## Summary
<!--
Please complete the Summary section
-->

**[Local Development](https://pantheon.io/docs/local-development)** - Reshape some of the introduction to the doc and create a partial for creating a `$SITE` alias.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
