### PR TITLE
add partials to style guide

### DIFF
--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -935,6 +935,30 @@ Standard markdown tables don't allow for cells to span multiple rows or columns,
 
 ___
 
+## Reusable Content
+
+Create reusable content in a separate Markdown file that can be included within sections of other docs. These are called **partials**.
+
+Place the Markdown file within the `source/partials/` directory, in its own directory if it is feature-specific.
+
+Partials use all of the same Markdown, style, and HTML as needed and outlined on this page, but do not require frontmatter. They can be included as their own paragraphs and sections as well as in lists as a step or bullet point.
+
+After you create the file, include it in the doc:
+
+<Example>
+
+<Partial file="partial-example.md" />
+
+<hr className="source-code" /> <br/>
+
+```markdown
+<Partial file="partial-example.md" />
+```
+
+</Example>
+
+___
+
 ## Tooltips
 
 Tooltips are a great way to add additional information without cluttering up a section. For example, you can define jargon and even link out to an external resource without being distracting to the reader:

--- a/source/partials/partial-example.md
+++ b/source/partials/partial-example.md
@@ -1,0 +1,9 @@
+This is an example of a partial.
+
+It's reusable content so that editors can maintain a single source of information that can be included in multiple docs.
+
+Keep the following in mind when using a partial:
+
+- Check for existing partials first. Don't recreate existing content. Check the [partials directory](https://github.com/pantheon-systems/documentation/tree/main/source/partials) in the GitHub repo.
+- Leave the heading out. Let the referring doc decide how to introduce the content for the context.
+- Use links to headings that will work in any doc. Use `[Frontmatter](/style-guide#frontmatter)` instead of `[Frontmatter](#frontmatter)`.

--- a/source/partials/partial-example.md
+++ b/source/partials/partial-example.md
@@ -5,7 +5,7 @@ It's reusable content so that editors can maintain a single source of informatio
 Keep the following in mind when using a partial:
 
 - Check for existing partials first. Don't recreate existing content. Check the [partials directory](https://github.com/pantheon-systems/documentation/tree/main/source/partials) in the GitHub repo.
-- Leave the heading out. Let the referring doc decide how to introduce the content for the context.
+- Exclude the heading. Use the context of the referring doc to introduce the content.
 - Use links to headings that will work in any doc. Use `[Frontmatter](/style-guide#frontmatter)` instead of `[Frontmatter](#frontmatter)`.
 - Note that if you include an image within a partial in a subdirectory, it requires another set of `../` to escape the directory.
    - So an image referenced from a partial in `source/partials/autopilot/` would be `../../images/autopilot/image.png`.

--- a/source/partials/partial-example.md
+++ b/source/partials/partial-example.md
@@ -7,3 +7,5 @@ Keep the following in mind when using a partial:
 - Check for existing partials first. Don't recreate existing content. Check the [partials directory](https://github.com/pantheon-systems/documentation/tree/main/source/partials) in the GitHub repo.
 - Leave the heading out. Let the referring doc decide how to introduce the content for the context.
 - Use links to headings that will work in any doc. Use `[Frontmatter](/style-guide#frontmatter)` instead of `[Frontmatter](#frontmatter)`.
+- Note that if you include an image within a partial in a subdirectory, it requires another set of `../` to escape the directory.
+   - So an image referenced from a partial in `source/partials/autopilot/` would be `../../images/autopilot/image.png`.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Style Guide](https://pantheon.io/docs/style-guide#reusable-content)** - Added a section to the Style Guide that shows how to include reusable content with partials.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
