### PR TITLE
close 6189: clarify the steps to access slow and bin logs

### DIFF
--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -3,18 +3,23 @@ title: Accessing MySQL Databases
 description: Configure and troubleshoot your Pantheon website's MySQL database connections.
 categories: [develop]
 tags: [database, local, ssh]
-reviewed: "2020-07-30"
+reviewed: "2021-07-16"
 ---
+
 Pantheon provides direct access for your MySQL databases, both for debugging and for importing large databases. Each site environment (Dev, Test and Live) has a separate database, so credentials for one cannot be used on another. The credentials are automatically included in your site configuration.
 
 <Alert title="Note" type="info">
+
 Due to the nature of our platform, the connection information will change from time to time due to server upgrades, endpoint migrations, etc. You will need to check the Dashboard periodically or when you can’t connect.
+
 </Alert>
 
 ## Database Connection Information
 
-MySQL credentials for each site environment are located in the Dashboard:<br />
-![MySQL Credentials](../images/dashboard/mysql-info.png)<br />
+MySQL credentials for each site environment are located in the Dashboard:
+
+![MySQL Credentials](../images/dashboard/mysql-info.png)
+
 The following required fields are provided:
 
 - **Server**: The hostname of the MySQL server.
@@ -25,7 +30,13 @@ The following required fields are provided:
 
 As each database server is in the cloud, the credentials will occasionally be updated and may change without notice. Normally, this is transparent to a site as the credentials are automatically included by the server. However, if you've saved the credentials in a local client and a month later you can't connect, check your Dashboard for the current credentials.
 
-There's a wide array of MySQL clients that can be used, including [MySQL Workbench](https://dev.mysql.com/downloads/workbench/), [Sequel Pro](https://www.sequelpro.com/download), [Navicat](https://www.navicat.com/download), [PHPMyAdmin](https://www.phpmyadmin.net/), and others. See the instruction manual or issue queue of your software to learn more about how to configure a connection.
+There's a wide array of MySQL clients that can be used, including:
+- [MySQL Workbench](https://dev.mysql.com/downloads/workbench/),
+- [Sequel Pro](https://www.sequelpro.com/download),
+- [Navicat](https://www.navicat.com/download),
+- [PHPMyAdmin](https://www.phpmyadmin.net/),
+
+and others. See the documentation or issue queue of your software to learn more about how to configure a connection.
 
 ### Open Sequel Pro Database Connection
 

--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -137,13 +137,25 @@ Can’t connect to local MySQL server through socket '/var/lib/mysql/mysql.sock'
 
 ## Frequently Asked Questions
 
-### How can I access my MySQL slow query logs?
+### How can I access my MySQL Slow Query logs?
 
-Pantheon logs underperforming database queries using the [MySQL Slow Query Log](https://dev.mysql.com/doc/refman/5.5/en/slow-query-log.html). To access the log for your database, get the SFTP connection info for the environment in question. Then, replace the word "appserver" with "dbserver" in the connection string. The MySQL slow query logs are in the `logs` subdirectory.
+Pantheon logs underperforming database queries using the [MySQL Slow Query Log](https://dev.mysql.com/doc/refman/5.5/en/slow-query-log.html).
+
+To access the log for your database:
+
+1. Get the SFTP connection info for the environment in question.
+1. Replace the word `appserver` with `dbserver` in the connection string.
+1. The MySQL slow query logs are in the `logs` subdirectory.
 
 ### How can I access MySQL binary logs?
 
-To access [MySQL binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html) ("binlogs"), connect to the database server as described above for the slow query logs. Binlogs are stored in the `data` subdirectory. These logs are generally not used for development but may be useful to troubleshoot disk quota issues.
+These logs are generally not used for development but may be useful to troubleshoot disk quota issues.
+
+To access [MySQL binary logs](https://dev.mysql.com/doc/internals/en/binary-log-overview.html) ("binlogs"):
+
+1. Get the SFTP connection info for the environment in question.
+1. Replace the word `appserver` with `dbserver` in the connection string.
+1. The MySQL slow query logs are in the `data` subdirectory.
 
 ### Are table prefixes supported?
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6189 

## Summary
<!--
Please complete the Summary section
-->

**[Accessing MySQL DBs](https://pantheon.io/docs/mysql-access#frequently-asked-questions)** - Clarifies the steps to take in order to access slow logs and bin logs.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
