### PR TITLE
Drupal 9 with Integrated Composer info block clarification

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -24,7 +24,7 @@ On the Pantheon Platform, Drupal 9 sites use [Integrated Composer](/integrated-c
 
 <Alert title="A note about Limited Availability" type="info" icon="leaf">
 
-Drupal 9 is available on Pantheon as a Limited Availability feature release while additional features are in active development.
+Drupal 9 with Integrated Composer is available on Pantheon as a Limited Availability feature release while additional features are in active development.
 
 Pantheon engineers are rolling out changes often.
 


### PR DESCRIPTION
## Summary

**[Drupal 9
](https://pantheon.io/docs/drupal-9#drupal-9-with-integrated-composer)** -  Add explicit clarifying language to D9 with Integrated Composer info block that D9 w/ Integrated Composer is what has Limited Availability, not Drupal 9 availability itself. 


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:
- [ ]


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
