### PR TITLE
Issue 6431: Upstream Updates Cannot Be Applied if user has the default upstream but site uses a custom upstream

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -119,7 +119,6 @@ Upstream refers to the source code that is hosted in the [Pantheon code reposito
 
 1. Commit and push.
 
-
 ## Support
 
 ### Pantheon Supports Composer 2
@@ -128,11 +127,9 @@ The version of Composer on the platform is Composer 2.
 
 Some packages are not compatible with Composer 2. If you encounter a build error that instructs you to contact [Support](/support), validate the package version's compatibility locally first, and check Drupal's [Preparing your site for Composer 2](https://www.drupal.org/docs/develop/using-composer/preparing-your-site-for-composer-2#s-composer-plugins) documentation for packages that have already been identified.
 
-
 ### Pantheon's Scope of Support for Composer
 
 <Partial file="composer-support-scope.md"/>
-
 
 ## Troubleshooting Code Syncs and Upstream Updates
 
@@ -160,7 +157,23 @@ We were not able to perform the merge safely. See the Applying Upstream Updates 
 ]
 ```
 
-The upstream updates and your Composer changes to the site are in a conflict that cannot be automatically merged by Git. We do not recommend using **Auto-resolve updates** in this case since it will cause your changes to the site's `composer.json` file, to be lost. To resolve, merge the changes manually:
+**Issue 1:** The site might use a [Custom Upstream](/custom-upstream).
+
+**Solution:** Copy the Upstream URL and then follow **Solution 2**:
+
+1. From the Site Dashboard, go to the Dev environment.
+
+1. Click **Settings**, then **About site**.
+
+1. Copy the **Upstream** URL and use it in place of the Pantheon Upstream URL in **Solution 2**.
+
+**Issue 2:** The upstream updates and your Composer changes to the site are in a conflict that cannot be automatically merged by Git.
+
+- We do not recommend using **Auto-resolve updates** in this case since it will cause your changes to the site's `composer.json` file to be lost.
+
+**Solution 2:**
+
+Merge the changes manually:
 
 1. Create a [local Git clone](/local-development#get-the-code) of the Pantheon site repository.
 

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -161,13 +161,13 @@ We were not able to perform the merge safely. See the Applying Upstream Updates 
 
 **Solution 1:** Copy the Upstream URL and then follow **Solution 2**:
 
-1. From the Site Dashboard, go to the Dev environment.
+1. From the Site Dashboard, navigate to the Dev environment.
 
 1. Click **Settings**, then **About site**.
 
-1. Copy the **Upstream** URL and use it in place of the Pantheon Upstream URL in **Solution 2**.
+1. Copy the **Upstream** URL and use it instead of the Pantheon Upstream URL in **Solution 2**.
 
-**Issue 2:** The upstream updates and your Composer changes to the site are in a conflict that cannot be automatically merged by Git.
+**Issue 2:** The upstream updates and your Composer changes to the site, are in a conflict that cannot be automatically merged by Git.
 
 - We do not recommend using **Auto-resolve updates** in this case since it will cause your changes to the site's `composer.json` file to be lost.
 

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -159,7 +159,7 @@ We were not able to perform the merge safely. See the Applying Upstream Updates 
 
 **Issue 1:** The site might use a [Custom Upstream](/custom-upstream).
 
-**Solution:** Copy the Upstream URL and then follow **Solution 2**:
+**Solution 1:** Copy the Upstream URL and then follow **Solution 2**:
 
 1. From the Site Dashboard, go to the Dev environment.
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6431 

## Summary
<!--
Please complete the Summary section
-->

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** -  Suggests a solution for when Upstream updates cannot be applied because the user has the default upstream in commands but the site uses a Custom Upstream

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
