### PR TITLE
Changelog - July 2021 - fixed links

### DIFF
--- a/source/changelogs/2021-07-01-July.md
+++ b/source/changelogs/2021-07-01-July.md
@@ -31,4 +31,4 @@ reviewed: "2021-07-01"
 
 ## Documentation
 
-[Upgrade from Drupal 8 to Drupal 9 with Build Tools](https://pr-6414--pantheon-docs.my.pantheonfrontend.website/docs/guides/drupal-9-migration/build-tools-to-d9-build-tools) - Build Tools connects Pantheon with your CI service and external Git provider. Users can now migrate from Drupal 8 to Drupal 9 with Build Tools. More information can be found in our [documentation](https://pr-6414--pantheon-docs.my.pantheonfrontend.website/docs/guides/drupal-9-migration).
+[Upgrade from Drupal 8 to Drupal 9 with Build Tools](/guides/drupal-9-migration/build-tools-to-d9-build-tools) - Build Tools connects Pantheon with your CI service and external Git provider. Users can now migrate from Drupal 8 to Drupal 9 with Build Tools. More information can be found in our [documentation](/guides/drupal-9-migration).


### PR DESCRIPTION
## Summary


**[Pantheon Changelog](https://pantheon.io/docs/changelog/)** - Documentation section. Fixed links.

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
