### PR TITLE
add Drupal Steward to platform-considerations

### DIFF
--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -138,7 +138,7 @@ Be sure to encode URLs that use ampersands with `%26` in place of `&`.
 
 ## Drupal Steward
 
-The Pantheon platform includes [Drupal Steward](https://www.drupal.org/drupal-security-team/steward), a platform-level mitigation of certain highly-critical vulnerabilities that are identified in Drupal core, as a feature for all Drupal sites on Pantheon.
+The Pantheon platform includes [Drupal Steward](https://www.drupal.org/drupal-security-team/steward), a platform-level mitigation of certain highly-critical vulnerabilities that are identified in Drupal core, as a feature for all Drupal sites on Pantheon. All Pantheon sites are protected by Drupal Steward.
 
 For more information about Drupal Steward, visit the [Drupal Steward FAQ](https://www.drupal.org/drupal-security-team/steward/faq).
 

--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -132,9 +132,15 @@ MySQL stored procedures are not supported. Due to the nature of the platform, th
 
 ## Drupal 7 and Ampersands
 
-A Drupal 7 site given a URL with an ampersand (&) in it, excluding query parameter separation, will return a 404, regardless of the presence of a matching path.
+A Drupal 7 site given a URL with an ampersand (`&`) in it, excluding query parameter separation, will return a 404, regardless of the presence of a matching path.
 
 Be sure to encode URLs that use ampersands with `%26` in place of `&`.
+
+## Drupal Steward
+
+The Pantheon platform includes [Drupal Steward](https://www.drupal.org/drupal-security-team/steward), a platform-level mitigation of certain highly-critical vulnerabilities that are identified in Drupal core, as a feature for all Drupal sites on Pantheon.
+
+For more information about Drupal Steward, visit the [Drupal Steward FAQ](https://www.drupal.org/drupal-security-team/steward/faq).
 
 ## Email and Deliverability
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Platform Considerations](https://pantheon.io/docs/platform-considerations#drupal-steward)** - Adds information about Drupal Steward and how it's included as part of Pantheon's platform features.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
