### PR TITLE
Autopilot guide -update email notifications instructions

### DIFF
--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -59,7 +59,11 @@ Yes. Access to Autopilot is account-based and individual sites in that account c
 
 ### Will Autopilot email VRT results?
 
+<<<<<<< HEAD
 Yes. Configure [Autopilot activity digests and alerts](/guides/autopilot/enable-autopilot/#enable-autopilot-email-notifications) in your Personal Workspace settings **Notifications** tab. 
+=======
+Yes. Configure [Autopilot activity digests and alerts](/guides/autopilot/enable-autopilot/#enable-autopilot-email-notifications) in your Personal Workspace settings Notifications tab. 
+>>>>>>> f7b870151 (update email notifications image and configuration instructions)
 
 ### Does Autopilot work with Integrated Composer?
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -11,7 +11,7 @@ showtoc: true
 anchorid: autopilot
 permalink: docs/guides/autopilot
 editpath: autopilot/01-introduction.md
-reviewed: "2021-03-26"
+reviewed: "2021-08-02"
 ---
 
 [Autopilot](https://pantheon.io/autopilot?docs) is a new feature that's part of Pantheon's [New Dashboard](/guides/new-dashboard) experience. Pantheon Autopilot automatically detects, performs, and deploys updates for WordPress and Drupal.
@@ -59,11 +59,7 @@ Yes. Access to Autopilot is account-based and individual sites in that account c
 
 ### Will Autopilot email VRT results?
 
-<<<<<<< HEAD
-Yes. Configure [Autopilot activity digests and alerts](/guides/autopilot/enable-autopilot/#enable-autopilot-email-notifications) in your Personal Workspace settings **Notifications** tab. 
-=======
-Yes. Configure [Autopilot activity digests and alerts](/guides/autopilot/enable-autopilot/#enable-autopilot-email-notifications) in your Personal Workspace settings Notifications tab. 
->>>>>>> f7b870151 (update email notifications image and configuration instructions)
+Yes. Configure [Autopilot activity digests and notifications](/guides/autopilot/enable-autopilot/#enable-autopilot-email-notifications) in your Personal Workspace settings **Notifications** tab.
 
 ### Does Autopilot work with Integrated Composer?
 
@@ -75,7 +71,7 @@ Not yet. Autopilot is not compatible with Build Tools or other workflows that us
 
 ### What versions of Drush are supported by Autopilot?
 
-Currently, Autopilot only supports Drush 8. However, Autopilot does not use Drush when updating an Integrated Composer site; you can use any Drush version when using Integrated Composer. Refer to the documentation on [Drush versions](/drush-versions) for more information. 
+Currently, Autopilot only supports Drush 8. However, Autopilot does not use Drush when updating an Integrated Composer site; you can use any Drush version when using Integrated Composer. Refer to the documentation on [Drush versions](/drush-versions) for more information.
 
 ### Does Autopilot support Terminus actions?
 

--- a/source/partials/autopilot/autopilot-email-notifications.md
+++ b/source/partials/autopilot/autopilot-email-notifications.md
@@ -1,4 +1,4 @@
-Configure email notifications for Autopilot alerts and activity digests in  your Personal Workspace settings:
+Configure email notifications for Autopilot alerts and activity digests in your Personal Workspace settings:
 
 ![Personal Workspace Settings include options for Autopilot email notifications](../../images/autopilot/new-dashboard-personal-workspace-personal-settings-autopilot-notifications.jpg)
 


### PR DESCRIPTION
## Summary

**[Autopilot Guide](https://pantheon.io/docs/guides/autopilot)** -  Updated instructions and screenshot for enabling Autopilot email notifications, to reflect new home in the Notifications tab.


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
