### PR TITLE
Added additional unsupported mysql features

### DIFF
--- a/source/content/platform-considerations.md
+++ b/source/content/platform-considerations.md
@@ -130,6 +130,8 @@ Pantheon does not currently support LESS or Sass/Compass CSS preprocessor langua
 
 MySQL stored procedures are not supported. Due to the nature of the platform, there is no guarantee that they will  persist following a database migration. You can avoid the use of stored procedures by using parameterized queries or [object-relational mapping](https://en.wikipedia.org/wiki/Object-relational_mapping).
 
+MySQL [Triggers](https://dev.mysql.com/doc/refman/8.0/en/triggers.html) and [Events](https://dev.mysql.com/doc/refman/8.0/en/events-overview.html) are also not supported. As an alternative, you may consider Cron for [WordPress](https://pantheon.io/docs/wordpress-cron) or [Drupal](https://pantheon.io/docs/drupal-cron). 
+
 ## Drupal 7 and Ampersands
 
 A Drupal 7 site given a URL with an ampersand (`&`) in it, excluding query parameter separation, will return a 404, regardless of the presence of a matching path.


### PR DESCRIPTION
Closes #6087 

## Summary

**[Database Stored Procedures](https://pantheon.io/docs/platform-considerations#database-stored-procedures)** -  Expanded section to add Triggers and Events as unsupported MySQL features.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
