### PR TITLE
No need for Fast 404 note anymore

### DIFF
--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -130,18 +130,6 @@ Dynamic Entity Reference provides a field combination for Drupal 8 that allows f
 
 ___
 
-## [Fast 404](https://www.drupal.org/project/fast_404)
-
-<ReviewDate date="2018-06-22" />
-
-**Issue**: Database connection credentials are needed before Drupal bootstrap is invoked and standard MySQL is port hard-coded.
-
-**Solution**: Pressflow settings can be [decoded in settings.php](/read-environment-config) to provide database credentials, but the module needs to be modified manually to use `$_ENV(["DB_PORT"])`.
-
-Alternatively, [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/7.59/sites/default/default.settings.php#L518) and [Drupal 8](https://github.com/pantheon-systems/drops-8/blob/8.5.4/sites/default/default.settings.php#L640) cores provide a basic version of this same feature via configuration in `settings.php`.
-
-___
-
 ## [Front](https://www.drupal.org/project/front)
 
 <ReviewDate date="2018-01-03" />


### PR DESCRIPTION
Since this commit:

https://git.drupalcode.org/project/fast_404/-/commit/1df70876b82e3eaa8c56608ea9ebb6b7d8c7cacb

The Fast 404 module will automatically pick up a custom DB port.

## Summary

This came up as a point of confusion in the community slack recently: https://drupal.slack.com/archives/C2HRLNPG8/p1628686895031000

## Effect

We no longer need to provide a specific workaround notice for Fast 404 module so we can shorten this doc page! 🎉 


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
