### PR TITLE
Grammar update for Localdev info

### DIFF
--- a/source/content/guides/localdev/01-introduction.md
+++ b/source/content/guides/localdev/01-introduction.md
@@ -14,6 +14,6 @@ editpath: localdev/01-introduction.md
 
 Pantheon offers a number of [ways to connect to your site](/guides/quickstart/connection-modes). In addition to Git and SFTP modes, [Pantheon Localdev](https://pantheon.io/localdev) gives macOS users a graphical interface to your Pantheon sites, complete with a containerized local environment that makes it easy to develop and preview your site locally while still maintaining the [Pantheon Workflow](/pantheon-workflow).
 
-Localdev lets you [use an integrated development environment (**IDE**)](/guides/localdev/using-localdev#use-a-local-ide-to-develop-your-pantheon-site) to edit files, code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview.
+Localdev allows you [use an integrated development environment (**IDE**)](/guides/localdev/using-localdev#use-a-local-ide-to-develop-your-pantheon-site) to edit files, code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview.
 
 For users looking to be more hands on and willing to use the terminal, try [Terminus](/terminus) and [Lando](https://docs.devwithlando.io/started.html). The [Local Development](/local-development) doc can help you get started.

--- a/source/content/guides/localdev/01-introduction.md
+++ b/source/content/guides/localdev/01-introduction.md
@@ -14,6 +14,6 @@ editpath: localdev/01-introduction.md
 
 Pantheon offers a number of [ways to connect to your site](/guides/quickstart/connection-modes). In addition to Git and SFTP modes, [Pantheon Localdev](https://pantheon.io/localdev) gives macOS users a graphical interface to your Pantheon sites, complete with a containerized local environment that makes it easy to develop and preview your site locally while still maintaining the [Pantheon Workflow](/pantheon-workflow).
 
-Localdev lets you [use an integrated development environment (**IDE**)](/guides/localdev/using-localdev#use-a-local-ide-to-develop-your-pantheon-site) to edit files and code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview.
+Localdev lets you [use an integrated development environment (**IDE**)](/guides/localdev/using-localdev#use-a-local-ide-to-develop-your-pantheon-site) to edit files, code, and push changes to Pantheon right from your desktop. Use it if you want to avoid the command line, or to develop sites with a fully functional local preview.
 
 For users looking to be more hands on and willing to use the terminal, try [Terminus](/terminus) and [Lando](https://docs.devwithlando.io/started.html). The [Local Development](/local-development) doc can help you get started.


### PR DESCRIPTION
**[Pantheon Localdev](https://pantheon.io/docs/guides/localdev)** -  Updated grammar in the sentence explaining LocalDev function.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
