### PR TITLE
Persistent Cache Public Docs

### DIFF
--- a/source/content/drupal-cache.md
+++ b/source/content/drupal-cache.md
@@ -18,6 +18,7 @@ Learn industry best practices for Drupal caching, how to take advantage of them 
 Visit `/admin/config/development/performance` for Drupal's performance settings.
 
 ### Caching
+
 ![Drupal 8 Caching options](../images/d8-cache-config.png)
 **This is a key setting**. It determines what value Drupal delivers in its `max-age` header, which is how long the reverse-proxy layer will retain a cache.
 
@@ -28,13 +29,23 @@ On Pantheon, this value defaults to 15 minutes. This is done on the first cache-
 Note that Drupal 8 has no setting to configure the minimum cache lifetime.
 
 ### Bandwidth Optimization
- ![Drupal 8 aggregate CSS and JS files](../images/d8-aggregate-css-js.png)<br />
+
+![Drupal 8 aggregate CSS and JS files](../images/d8-aggregate-css-js.png)
+
 On the Live environment, make sure to enable "Aggregate and compress CSS files" and "Aggregate and compress JavaScript files". This is critical for page render times by reducing the number of HTTP requests and reducing the amount of data transferred.
 
 ### Cache Tags
+
 Drupal 8 introduced a [cache metadata](https://www.drupal.org/docs/8/api/cache-api/cache-api) system that allows internal and external caches to be cleared in very granular fashion as data is changed. For instance, if `node 123` were resaved, caches that depends upon that node, like the full page cache of the page `mysite.com/node/123`, should be cleared.
 
 This functionality can be added via the [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache) module, which uses Drupal 8's cache metadata to communicate with the [Pantheon Global CDN](/global-cdn). The Drupal 7 version of the module depends upon the [Drupal 8 Cache Backport module](https://www.drupal.org/project/d8cache).
+
+For Drupal 9, install the Pantheon Advanced Page Cache module via [Composer](/integrated-composer#add-a-dependency-to-an-individual-site), then enable it via the Drupal Admin:
+
+```bash{promptUser: user}
+composer require drupal/pantheon_advanced_page_cache
+git commit -am "add pantheon advanced page cache module" && git push origin master
+```
 
 ## Drupal 7 Performance Configuration
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -32,16 +32,22 @@ We recommend installing the Pantheon Advanced Page Cache [plugin](https://wordpr
 
 For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
-### Persistent Cache
+## Persistent Cache
 
-Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instread of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instead of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
 
-#### How Do I Do the Thing?
+### How Do I Configure This Setting?
+
+On [Drupal](/drupal-cache#drupal-8-performance-configuration) and [WordPress](//wordpress-cache-plugin#pantheon-page-cache-plugin-configuration), you can adjust your CDN edge configuration to serve stale content for a specific amount of time.
 
 
-### Troubleshooting
+### Caching Exceptions
 
-#### How I Know If It's Working?
+Your site’s CMS page-level caching must be correctly configured in order to take advantage of Persistent Cache. 
+
+Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](caching-advanced-topics#allow-a-user-to-bypass-the-cache). 
+
+### How I Know If It's Working?
 
 
 ## Frequently Asked Questions

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -32,6 +32,18 @@ We recommend installing the Pantheon Advanced Page Cache [plugin](https://wordpr
 
 For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
+### Persistent Cache
+
+Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instread of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+
+#### How Do I Do the Thing?
+
+
+### Troubleshooting
+
+#### How I Know If It's Working?
+
+
 ## Frequently Asked Questions
 
 ### I already have a CDN. Can I use it with the Pantheon Global CDN?

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -92,9 +92,9 @@ To test how stale cache is served, compare the header results of a page refresh:
 1. In a terminal, cURL the site headers filtered for stale cache:
 
   ```bash{promptUser: user}
-  curl --head https://pantheon.io/docs | grep PContext-Resp-Is-StaleHTTP/2 301
+  curl --head https://pantheon.io/docs | grep PContext-Resp-Is-Stale
   ```  
-  If the result includes `PContext-Resp-Is-StaleHTTP/2 301`, the page has been successfully served from stale cache. 
+  If the response headers include `PContext-Resp-Is-Stale`, the page has been successfully served from stale cache. 
   
 </Tab>
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -52,35 +52,19 @@ Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the
 
 ### Confirm That Persistent Cache Works
 
-To test how stale cache is served, compare the header results of a page refresh of the site's Dev environment to the same page in Maintenance Mode.
+To test how stale cache is served, compare the header results of a page refresh:
 
-Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset. Refresh the page in the browser for the newest information.
+1. Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset
+1. Go to your site's Dev environment in Maintenance Mode
+1. Clear the cache from either the Advanced Page Cache or from the dashboard
+1. Refresh the page in the browser for the newest information
 
 Examine the results for the `age` and `max-age`.
 
-To examine the headers through the command line, use a `curl` command to examine the headers before and after you set the site to Maintenance Mode:
+To examine the headers through the command line, use a `curl` command. 
 
 ```bash{outputLines: 2-20}
-curl --head https://pantheon.io/docs
-HTTP/2 301
-content-type: text/html
-location: https://pantheon.io/docs/
-server: nginx
-strict-transport-security: max-age=31622400
-x-pantheon-styx-hostname: styx-fe2-a-5d96768699-vcdvh
-x-styx-req-id: b7b8d4d2-04d9-11ec-a467-9a05fab906d1
-cache-control: public, max-age=86400
-date: Tue, 24 Aug 2021 15:30:21 GMT
-x-served-by: cache-mdw17379-MDW, cache-ewr18124-EWR
-x-cache: HIT, HIT
-x-cache-hits: 1, 1
-x-timer: S1629819022.932985,VS0,VE1
-pantheon-trace-id: be58e6a03a904fbfa64515ee136ffd34
-vary: Cookie, Cookie
-age: 9654
-accept-ranges: bytes
-via: 1.1 varnish, 1.1 varnish
-content-length: 162
+curl --head https://pantheon.io/docs | grep PContext-Resp-Is-StaleHTTP/2 301
 ```
 
 ## Frequently Asked Questions

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -36,9 +36,9 @@ For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
 Serve your Drupal or WordPress site even in the unlikely event that it goes down.
 
-If the server is not responding and can't serve a new copy of a page, a cached version will be favored over displaying an error, even if the cached version has expired (this is called _stale cache_). With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+The goal of Persistent Cache is to provide a seamless, uninterrupted experience for the user. If the server is not responding and can't serve a new copy of a page, a the CDN will choose to serve a cached version instead of displaying an error, even if the cached version has expired (this is called _stale cache_).
 
-### Caching Exceptions - How long does content stay fresh?
+### How long does content stay fresh? Adjust TTL
 
 Adjust the length of time before the site's cached content is considered stale by adjusting the time-to-live (TTL).
 
@@ -48,11 +48,11 @@ On [Drupal](/drupal-cache#drupal-8-performance-configuration) and [WordPress](/w
 
 For best results, set the cache TTL to a value equal to or over 3700 seconds.
 
-Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](/caching-advanced-topics#allow-a-user-to-bypass-the-cache).
+Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). Learn more about the exceptions to page caching rules in [Caching: Advanced Topics](/caching-advanced-topics#allow-a-user-to-bypass-the-cache).
 
 ### Confirm That Persistent Cache Works
 
-To test how stale cache is served, compare the header results of a page refresh:
+To test how stale cache is served, compare the header results of a page refresh when the site's Dev environment is live to the header results when Dev is in Maintenance Mode:
 
 <TabList>
 
@@ -82,36 +82,39 @@ To test how stale cache is served, compare the header results of a page refresh:
   via: 1.1 varnish, 1.1 varnish
   content-length: 162
   ```
-  
+
   Note the result for `age` or `max-age`.
-  
-1. Navigate to your site's Dev environment and set the site to Maintenance Mode.
-  
+
+1. Navigate to the site's Dev environment and set the site to Maintenance Mode.
+
 1. Clear the cache from either the Advanced Page Cache module or from the Dashboard.
 
 1. In a terminal, cURL the site headers filtered for stale cache:
 
   ```bash{promptUser: user}
   curl --head https://pantheon.io/docs | grep PContext-Resp-Is-Stale
-  ```  
-  If the response headers include `PContext-Resp-Is-Stale`, the page has been successfully served from stale cache. 
-  
+  ```
+
+  If the response headers include `PContext-Resp-Is-Stale`, the page has been successfully served from stale cache.
+
 </Tab>
 
 <Tab title="Via Web Browser" id="web-browser">
 
-1. Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset.
+1. Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab.
 
-1. Go to your site's Dev environment and set the site to Maintenance Mode.
-  
+  Find the response headers for the page or asset.
+
+1. Go to the site's Dev environment and set the site to Maintenance Mode.
+
 1. Clear the cache from either the Advanced Page Cache module or [from the Dashboard](/clear-caches#pantheon-dashboard).
 
-1. Go back to your page and view the Developer Tools, and Refresh for the newest header responses.
-  
-    If the result includes `PContext-Resp-Is-StaleHTTP/2 301`, the page has been successfully served from stale cache. 
+1. Go back to the page and Developer Tools, then refresh the page for the newest header responses.
+
+  If the result includes `PContext-Resp-Is-Stale`, the page has been successfully served from stale cache.
 
 </Tab>
-  
+
 </TabList>
 
 ## Frequently Asked Questions

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -56,7 +56,32 @@ To test how stale cache is served, compare the header results of a page refresh 
 
 Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset. Refresh the page in the browser for the newest information.
 
-Examine the results for the `age`, `max-age`
+Examine the results for the `age` and `max-age`.
+
+To examine the headers through the command line, use a `curl` command to examine the headers before and after you set the site to Maintenance Mode:
+
+```bash{outputLines: 2-20}
+curl --head https://pantheon.io/docs
+HTTP/2 301
+content-type: text/html
+location: https://pantheon.io/docs/
+server: nginx
+strict-transport-security: max-age=31622400
+x-pantheon-styx-hostname: styx-fe2-a-5d96768699-vcdvh
+x-styx-req-id: b7b8d4d2-04d9-11ec-a467-9a05fab906d1
+cache-control: public, max-age=86400
+date: Tue, 24 Aug 2021 15:30:21 GMT
+x-served-by: cache-mdw17379-MDW, cache-ewr18124-EWR
+x-cache: HIT, HIT
+x-cache-hits: 1, 1
+x-timer: S1629819022.932985,VS0,VE1
+pantheon-trace-id: be58e6a03a904fbfa64515ee136ffd34
+vary: Cookie, Cookie
+age: 9654
+accept-ranges: bytes
+via: 1.1 varnish, 1.1 varnish
+content-length: 162
+```
 
 ## Frequently Asked Questions
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -34,7 +34,7 @@ For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
 ## Persistent Cache
 
-Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instead of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, stale cached versions will be favored over displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
 
 ### How Do I Configure This Setting?
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -54,18 +54,65 @@ Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the
 
 To test how stale cache is served, compare the header results of a page refresh:
 
-1. Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset
-1. Go to your site's Dev environment in Maintenance Mode
-1. Clear the cache from either the Advanced Page Cache or from the dashboard
-1. Refresh the page in the browser for the newest information
+<TabList>
 
-Examine the results for the `age` and `max-age`.
+<Tab title="Via Command Line" id="cli" active={true}>
 
-To examine the headers through the command line, use a `curl` command. 
+1. Examine the headers through the command line:
 
-```bash{outputLines: 2-20}
-curl --head https://pantheon.io/docs | grep PContext-Resp-Is-StaleHTTP/2 301
-```
+  ```bash{outputLines: 2-20}
+  curl --head https://pantheon.io/docs
+  HTTP/2 301
+  content-type: text/html
+  location: https://pantheon.io/docs/
+  server: nginx
+  strict-transport-security: max-age=31622400
+  x-pantheon-styx-hostname: styx-fe2-a-5d96768699-vcdvh
+  x-styx-req-id: b7b8d4d2-04d9-11ec-a467-9a05fab906d1
+  cache-control: public, max-age=86400
+  date: Tue, 24 Aug 2021 15:30:21 GMT
+  x-served-by: cache-mdw17379-MDW, cache-ewr18124-EWR
+  x-cache: HIT, HIT
+  x-cache-hits: 1, 1
+  x-timer: S1629819022.932985,VS0,VE1
+  pantheon-trace-id: be58e6a03a904fbfa64515ee136ffd34
+  vary: Cookie, Cookie
+  age: 9654
+  accept-ranges: bytes
+  via: 1.1 varnish, 1.1 varnish
+  content-length: 162
+  ```
+  
+  Note the result for `age` or `max-age`.
+  
+1. Navigate to your site's Dev environment and set the site to Maintenance Mode.
+  
+1. Clear the cache from either the Advanced Page Cache module or from the Dashboard.
+
+1. In a terminal, cURL the site headers filtered for stale cache:
+
+  ```bash{promptUser: user}
+  curl --head https://pantheon.io/docs | grep PContext-Resp-Is-StaleHTTP/2 301
+  ```  
+  If the result includes `PContext-Resp-Is-StaleHTTP/2 301`, the page has been successfully served from stale cache. 
+  
+</Tab>
+
+<Tab title="Via Web Browser" id="web-browser">
+
+1. Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset.
+
+1. Go to your site's Dev environment and set the site to Maintenance Mode.
+  
+1. Clear the cache from either the Advanced Page Cache module or [from the Dashboard](/clear-caches#pantheon-dashboard).
+
+1. Go back to your page and view the Developer Tools, and Refresh for the newest header responses.
+  
+    If the result includes `PContext-Resp-Is-StaleHTTP/2 301`, the page has been successfully served from stale cache. 
+
+</Tab>
+  
+</TabList>
 
 ## Frequently Asked Questions
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -50,8 +50,13 @@ For best results, set the cache TTL to a value equal to or over 3700 seconds.
 
 Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](/caching-advanced-topics#allow-a-user-to-bypass-the-cache).
 
-### How I Know If It's Working?
+### Confirm That Persistent Cache Works
 
+To test how stale cache is served, compare the header results of a page refresh of the site's Dev environment to the same page in Maintenance Mode.
+
+Navigate to the page using [Firefox](https://developer.mozilla.org/en-US/docs/Tools) or [Chrome](https://developer.chrome.com/docs/devtools/), and in the browser's developer tools open the **Network** tab and view the response headers for the page or asset. Refresh the page in the browser for the newest information.
+
+Examine the results for the `age`, `max-age`
 
 ## Frequently Asked Questions
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -34,18 +34,19 @@ For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
 ## Persistent Cache
 
-Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, stale cached versions will be favored over displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+Serve your Drupal or WordPress site even in the unlikely event that it goes down.
 
-### How Do I Configure This Setting?
+If the server is not responding and can't serve a new copy of a page, a cached version will be favored over displaying an error, even if the cached version has expired (this is called _stale cache_). With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
 
-On [Drupal](/drupal-cache#drupal-8-performance-configuration) and [WordPress](//wordpress-cache-plugin#pantheon-page-cache-plugin-configuration), you can adjust your CDN edge configuration to serve stale content for a specific amount of time.
+### Caching Exceptions - How long does content stay fresh?
 
+Adjust the length of time before the site's cached content is considered stale by adjusting the time-to-live (TTL).
 
-### Caching Exceptions
+Your site’s CMS page-level caching must be correctly configured in order to take advantage of Persistent Cache.
 
-Your site’s CMS page-level caching must be correctly configured in order to take advantage of Persistent Cache. 
+On [Drupal](/drupal-cache#drupal-8-performance-configuration) and [WordPress](/wordpress-cache-plugin#pantheon-page-cache-plugin-configuration), you can adjust your CDN edge configuration to serve stale content for a specific amount of time.
 
-Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](caching-advanced-topics#allow-a-user-to-bypass-the-cache). 
+Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](/caching-advanced-topics#allow-a-user-to-bypass-the-cache).
 
 ### How I Know If It's Working?
 

--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -46,6 +46,8 @@ Your site’s CMS page-level caching must be correctly configured in order to ta
 
 On [Drupal](/drupal-cache#drupal-8-performance-configuration) and [WordPress](/wordpress-cache-plugin#pantheon-page-cache-plugin-configuration), you can adjust your CDN edge configuration to serve stale content for a specific amount of time.
 
+For best results, set the cache TTL to a value equal to or over 3700 seconds.
+
 Users with session-style cookies set, or a `NO_CACHE` cookie set will bypass the cache, and will not see cached content. For best results, set the `NO_CACHE` cookie to persist longer than the site’s page cache (this includes logged in users and authenticated traffic). You can learn more about the exceptions to page caching rules in [Caching: Advanced Topics](/caching-advanced-topics#allow-a-user-to-bypass-the-cache).
 
 ### How I Know If It's Working?

--- a/source/content/guides/professional-services/04-advanced-global-cdn.md
+++ b/source/content/guides/professional-services/04-advanced-global-cdn.md
@@ -60,10 +60,6 @@ See every request to your website, whether or not the content was cached. Server
 
 Change or filter request and response headers before your application starts up to create, add, delete, or update parts of your request and apply custom rules.
 
-### Persistent Cache
-
-Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instread of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
-
 ### Edge Redirects
 
 Reduce requests to your CMS by moving page redirects to the edge.

--- a/source/content/guides/professional-services/04-advanced-global-cdn.md
+++ b/source/content/guides/professional-services/04-advanced-global-cdn.md
@@ -60,6 +60,10 @@ See every request to your website, whether or not the content was cached. Server
 
 Change or filter request and response headers before your application starts up to create, add, delete, or update parts of your request and apply custom rules.
 
+### Persistent Cache
+
+Serve your Drupal or WordPress site, even when it's down. If the server is not responding and can't serve a new copy of a page, it will use a cached version instread of displaying an error. With Persistent Cache, the goal is to provide a seamless, uninterrupted experience for the user.
+
 ### Edge Redirects
 
 Reduce requests to your CMS by moving page redirects to the edge.


### PR DESCRIPTION
Closes #6601 

**[Pantheon Global CDN](https://pantheon.io/docs/global-cdn)** -  Add Persistent Cache section to AGCDN page.

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Create a Persistent Cache Doc- will be done in a separate PR


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
