### PR TITLE
fix: remove blue banner warning from Build Tools to D9

### DIFF
--- a/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
+++ b/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
@@ -32,12 +32,6 @@ Before you continue, confirm that your site meets the following criteria:
 
 1. Build artifacts are pushed to your Pantheon repository.
 
-1. The site's Dashboard displays a blue banner across the top that says that the site is compatible with a [database upgrade](/pantheon-yml#specify-a-version-of-mariadb):
-
-   > Good news, your site's database version is now configurable! Learn how.
-
-   [Contact Support](/support) if you're ready to use Drupal 9, but you don't see the banner on the Dashboard.
-
 ## Prepare the Local Environment
 
 <Partial file="drupal-9/prepare-local-environment.md" />


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Doc Page Title](https://pantheon.io/docs/doc-title)** -  <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
