### PR TITLE
add composer merge plugin to list

### DIFF
--- a/source/content/modules-known-issues.md
+++ b/source/content/modules-known-issues.md
@@ -112,6 +112,17 @@ This disables auto-building in all Pantheon environments. This will allow Drush 
 
 ___
 
+## [Composer Merge Plugin](https://github.com/wikimedia/composer-merge-plugin)
+
+<ReviewDate date="2021-08-13" />
+
+This plugin is [deprecated](https://www.drupal.org/docs/develop/using-composer/managing-dependencies-for-a-custom-project).
+
+**Issue**: The `wikimedia/composer-merge-plugin` package plugin automatically runs `composer update` during `composer install`, causing conflicts with Pantheon's Integrated Composer framework. 
+
+**Solution**: Sites managing dependencies for a custom project should move to the recommended [path repository method](https://www.drupal.org/docs/develop/using-composer/managing-dependencies-for-a-custom-project).
+___
+
 ## [DropzoneJS](https://www.drupal.org/project/dropzonejs)
 
 <ReviewDate date="2020-06-30" />


### PR DESCRIPTION
## Summary
<!--
Please complete the Summary section
-->

**[Drupal Modules with Known Issues: Composer Merge Plugin](https://pantheon.io/docs/modules-known-issues)** -  Adds Wikimedia composer_merge_plugin to the list of modules with known issues.


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Needs technical review to confirm workaround is correct for Composer-managed sites.


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
