### PR TITLE
Integrated Upstream structure partial - typo fix

### DIFF
--- a/source/partials/ic-upstream-structure.md
+++ b/source/partials/ic-upstream-structure.md
@@ -1,7 +1,7 @@
 The upstream has the following directory structure:
 
-```none:title=core/
-core/
+```none:title=code/
+code/
 ├─ .gitignore
 ├─ composer.json
 └─ pantheon.upstream.yml


### PR DESCRIPTION
## Summary
Typo in Integrated Upstream structure part.

**[Integrated Composer Page](https://pantheon.io/docs/integrated-composer)**
and
**[Drupal 9 Page](https://pantheon.io/docs/drupal-9)** 
has this partial describing Integrated Composer structure.

Fixed head path for it.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
