### PR TITLE
Add clarifying note about web_docroot: true and Quicksilver script paths

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -49,7 +49,7 @@ Quicksilver scripts that trigger on the deploy hook operate on the state of the 
 
 Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will run in order, and only execute the next when the previous has finished or timed out.
 
-We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`), but the referenced path in your pantheon.yml file should _not_ include the `web/` path prefix.
+We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`), but the script paths in your pantheon.yml file should _not_ include the `web/` path prefix and should continue to look like the examples above.
 
 ## Hooks
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -49,7 +49,7 @@ Quicksilver scripts that trigger on the deploy hook operate on the state of the 
 
 Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will run in order, and only execute the next when the previous has finished or timed out.
 
-We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`), but the script paths in your pantheon.yml file should _not_ include the `web/` path prefix and should continue to look like the examples above.
+We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`), but the script paths in your `pantheon.yml` file should not include the `web/` path prefix and should resemble the examples above.
 
 ## Hooks
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -49,7 +49,7 @@ Quicksilver scripts that trigger on the deploy hook operate on the state of the 
 
 Quicksilver currently supports `webphp` scripting, which runs a PHP script via the same runtime environment as the website itself. PHP scripts are subject to the same limits as any code on the platform, like [timeouts](/timeouts), and cannot be batched. In the future we may add additional types. The commands will run in order, and only execute the next when the previous has finished or timed out.
 
-We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`).
+We recommend setting up a dedicated directory in the docroot (e.g., `private/scripts`) for tracking these files. If your site uses a [nested docroot](/nested-docroot), the scripts directory needs to be located in the `web` subdirectory of your site's code repository (e.g., `web/private/scripts`), but the referenced path in your pantheon.yml file should _not_ include the `web/` path prefix.
 
 ## Hooks
 


### PR DESCRIPTION
## Summary

**[Automate and Integrate your WebOps Workflow with Quicksilver](https://pantheon.io/docs/quicksilver#script-type-and-location)** - Clarifying Quicksilver script paths when web_docroot is true.


## Remaining Work
None


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
