### PR TITLE
remove db upgrade blue banner notices

### DIFF
--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -36,16 +36,6 @@ Pantheon support is not available to users who avoid the Multidev steps.
 
 ## Will This Guide Work for Your Site?
 
-<Alert type="info" title="Do not upgrade unless the site is eligible.">
-
-In your site Dashboard, look for the blue banner across the top that says that your site is compatible with a [database upgrade](/pantheon-yml#specify-a-version-of-mariadb):
-
-> Good news, your site's database version is now configurable! Learn how.
-
-[Contact Support](/support) if you're ready to use Drupal 9, but you don't see the banner on the Dashboard.
-
-</Alert>
-
 <Partial file="drupal-9/upgrade-site-requirements.md" />
 
 ## Prepare the Local Environment

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -122,10 +122,6 @@ php_version: 7.0
 
 Specify the site's version of MariaDB to keep the software your site uses current and up to date, or set a specific version to avoid incompatibilities.
 
-The site is eligible to upgrade when the site's Dashboard displays a blue banner across the top that reads:
-
-> Good news, your site's database version is now configurable! Learn how.
-
 Enable [automated backups](/backups) and [confirm that a backup has been created](/backups#via-the-dashboard) before you configure the database version. Push the changes to a [Multidev](/multidev) and ensure that the site performs as expected.
 
 Apply this change to an existing environment. If you try to create a new environment with the `database` key specified in `pantheon.yml`, the commit will be rejected with an error.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Specify a Version of MariaDB](https://pantheon.io/docs/pantheon-yml#specify-a-version-of-mariadb)** - Remove warning about waiting to see the blue banner about site DB upgrade eligibility. All sites are now eligible for a DB upgrade.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
