### PR TITLE
Adding information for https://letsdebug.net/

### DIFF
--- a/source/content/https.md
+++ b/source/content/https.md
@@ -30,6 +30,8 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 <DNSProviderDocs />
 
+If you are having difficulties issuing a [Let's Encrypt](https://letsencrypt.org) certificate you can run diagnostics at [Let's Debug](https://letsdebug.net/). This tool can identify an array of issues specifically for [Let's Encrypt](https://letsencrypt.org) certificates including problems with DNS, nameservers, networking issues, common website misconfigurations, and CA policy issues.
+ 
 </Accordion>
 
 <Partial file="enable-https.md" />


### PR DESCRIPTION
**[HTTPS on Pantheon's Global CDN](https://pantheon.io/docs/https#lets-encrypt-certificates)** -  Adding information for the https://letsdebug.net/ tool, this tool can assist with help figuring out why someone might not be able to issue a certificate for Let's Encrypt.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
