### PR TITLE
Adding information about letsdebugtool.net

### DIFF
--- a/source/content/guides/launch/04-configure-dns.md
+++ b/source/content/guides/launch/04-configure-dns.md
@@ -29,6 +29,8 @@ For more detailed instructions pertaining to your specific DNS host, click below
 
 <DNSProviderDocs />
 
+If you are having difficulties issuing a [Let's Encrypt](https://letsencrypt.org) certificate you can run diagnostics at [Let's Debug](https://letsdebug.net/). This tool can identify an array of issues specifically for [Let's Encrypt](https://letsencrypt.org) certificates including problems with DNS, nameservers, networking issues, common website misconfigurations, and CA policy issues. 
+  
 </Accordion>
 
 Click [here](/dns/#frequently-asked-questions) to learn more about DNS settings.


### PR DESCRIPTION
**[Launch Essentials](https://pantheon.io/docs/guides/launch/configure-dns/)** -  Adding information for the https://letsdebug.net/ tool, this tool can assist with help figuring out why someone might not be able to issue a certificate for Let's Encrypt.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
