### PR TITLE
Create a Custom Upstream Doc Update

### DIFF
--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -342,7 +342,7 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
 
 <Tab title="GitLab" id="gitlab-auth">
 
-Custom Upstreams from GitLab repositories must be created for you by Pantheon Support.
+Custom Upstreams from GitLab repositories must be set up for you by Pantheon Support.
 
 1. From the repository, click on **<i class="fa fa-gear"></i> Settings**, then **Repository**.
 

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -342,7 +342,7 @@ To avoid incompatibilities, you must track Pantheon's corresponding upstream rep
 
 <Tab title="GitLab" id="gitlab-auth">
 
-Custom Upstreams from GitLab repositories must be set up for you by Pantheon Support.
+A Custom Upstream from a GitLab repository must be set up for you by Pantheon Support.
 
 1. From the repository, click on **<i class="fa fa-gear"></i> Settings**, then **Repository**.
 


### PR DESCRIPTION
Closes #6469 

## Summary

**[Connect Repository to Pantheon](https://pantheon.io/docs/create-custom-upstream#connect-repository-to-pantheon)** - Clarify that Support creates a Custom Upstream from an existing GitLab repo (and does not create the GitLab repo).

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
