### PR TITLE
6405 drush composer

### DIFF
--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -86,3 +86,7 @@ framework: drupal9
 When you create a project with Lando from the Pantheon recipe, the `framework` will default to `drupal8` for a Drupal 8 or Drupal 9 site.
 
 If you created new project with Lando, change the value for `framework` to `drupal9`, then run `lando rebuild`.
+
+### Site-local Drush Is Required for Drupal 9 Sites
+
+Do not remove `drush/drush` from `composer.json`. If it's removed, `terminus drush` commands will fail with errors related to Twig.

--- a/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
@@ -132,4 +132,4 @@ This doc uses the following aliases:
   terminus drush $D9_SITE.dev -- updatedb
   ```
 
-1. Review the site, then proceed to launch using the [Pantheon Relauch](/relaunch) documentation.
+1. Review the site, then proceed to launch using the [Pantheon Relaunch](/relaunch) documentation.

--- a/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
+++ b/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
@@ -53,7 +53,7 @@ brew install jq rsync
    git checkout -b d9-upgrade-2021
    ```
 
-1. Use Terminus and Drush to export the latest version of the config files from the production envronment to `sites/default/files/config`:
+1. Use Terminus and Drush to export the latest version of the config files from the production environment to `sites/default/files/config`:
 
    ```bash{promptUser: user}
    terminus drush $SITE.live -- config:export --destination sites/default/files/config

--- a/source/content/guides/drupal-9-migration/troubleshoot.md
+++ b/source/content/guides/drupal-9-migration/troubleshoot.md
@@ -65,6 +65,10 @@ Given the nature of the bug, it might be easier to reinstall Drupal 9.
 | [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache) |     Yes     |     Yes     |
 | [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon)                   |     Yes     |   Not yet   |
 
+### Site-local Drush Is Required for Drupal 9 Sites
+
+Do not remove `drush/drush` from `composer.json`. If it's removed, `terminus drush` commands will fail with errors related to Twig.
+
 ### Where can I report an issue?
 
 [Contact support](/support) to report any issues that you encounter.

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -49,7 +49,7 @@ You can [upgrade from an existing Drupal 8](/guides/drupal-9-migration/upgrade-t
 
 ### Remove Individual Site Dependencies
 
-You can remove site dependencies if they are no longer needed. 
+You can remove site dependencies if they are no longer needed.
 
 1. Remove the dependency locally:
 
@@ -65,10 +65,9 @@ You can remove site dependencies if they are no longer needed.
 
 1. Navigate to **Code** in the Dev tab of the site's Dashboard.
 
-1. Click **Check Now**. 
+1. Click **Check Now**.
 
 1. If updates are available, click **Apply Updates**.
-
 
 ## Upstream
 
@@ -130,6 +129,10 @@ Some packages are not compatible with Composer 2. If you encounter a build error
 <Partial file="composer-support-scope.md"/>
 
 ## Troubleshooting Code Syncs and Upstream Updates
+
+### Site-local Drush Is Required for Drupal 9 Sites
+
+Do not remove `drush/drush` from `composer.json`. If it's removed, `terminus drush` commands will fail with errors related to Twig.
 
 ### View the Output of the Commit Log First
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6405 

## Summary
<!--
Please complete the Summary section
-->

**[Troubleshoot Drupal 9](https://pantheon.io/docs/guides/drupal-9-migration/troubleshoot)** - Explicitly tell users not to remove `drush/drush` from `composer.json` because that makes things break.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] 👍 


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
