### PR TITLE
6549: Upgrade MariaDB through all envs first

### DIFF
--- a/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
+++ b/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
@@ -177,6 +177,24 @@ brew install jq rsync
 
 1. Log in to the site as admin and take a look under **Reports** at **Upgrade Status**. Any modules which **Upgrade Status** shows are incompatible will need to be updated in the next few steps. Take note of the versions **Upgrade Status** recommends. If your module is incompatible it will need to be removed from the Composer file.
 
+### Upgrade MariaDB in All Environments
+
+Once you have confirmed that the MariaDB upgrade worked in the Multidev, push the changes to the Dev environment to ensure the other components upgrade smoothly.
+
+This mitigates the possible risks associated with the time it takes for the platform to upgrade the database. The possible risks are minimal, but just in case:
+
+```bash{promptUser: user}
+git push origin master
+```
+
+From the Dashboard, merge the code from Dev, through Test, to Live.
+
+Or use Terminus, and replace the `$ENV` in this example with the target environment:
+
+```bash{promptUser: user}
+terminus env:deploy --sync-content --note "upgrade DB" --updatedb -- $SITE.$ENV
+```
+
 ## Custom Module Code
 
 Custom module code is outside the scope of this document. See [drupal.org](https://www.drupal.org/docs/creating-custom-modules) for getting your custom code updated with the new version numbers and any code deprecations.

--- a/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
+++ b/source/content/guides/drupal-9-migration/06-build-tools-to-d9-build-tools.md
@@ -6,7 +6,7 @@ categories: [develop]
 cms: drupal-9
 tags: [code, launch, migrate, site, updates]
 contributors: [stovak, edwardangert, carolynshannon]
-reviewed: "2021-06-30"
+reviewed: "2021-08-20"
 layout: guide
 showtoc: true
 permalink: docs/guides/drupal-9-migration/build-tools-to-d9-build-tools


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6549 

## Summary
<!--
Please complete the Summary section
-->

**[Upgrade-in-place: Drupal 8 with Build Tools](https://pantheon.io/docs/guides/drupal-9-migration/build-tools-to-d9-build-tools#upgrade-mariadb-in-all-environments)** - Recommends that users upgrade MariaDB in each environment before other changes in order to give the Platform a chance to complete the upgrade on its own.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] confirm terminus command


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
