### PR TITLE
add hours for sales and billing

### DIFF
--- a/source/content/support.md
+++ b/source/content/support.md
@@ -20,6 +20,8 @@ Pantheon offers a range of Account options that include the features required fo
 | [**Emergency On-Call**](#pantheon-on-call)                | ❌ | ❌ | 24x7: 1 Hour           | 24x7: 15 Minutes   |
 | [**Professional Services**](/guides/professional-services) | ❌ | Available for Purchase            | Available for Purchase | Available for Purchase    |
 
+Pantheon's [Sales](https://pantheon.io/contact-sales?docs) and Billing teams are generally available on business days, Monday through Friday, 9AM to 5PM PST.
+
 ### Scope Explanations
 
 - **Platform**: Support helps:


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6120 

## Summary
<!--
Please complete the Summary section
-->

**[Support Features and Response Times](https://pantheon.io/docs/support#support-features-and-response-times)** - Adds business hours for Sales and Billing teams.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
