### PR TITLE
Align 'skip without https' lang with dash button

### DIFF
--- a/source/content/custom-certificates.md
+++ b/source/content/custom-certificates.md
@@ -27,7 +27,7 @@ If you require a custom, dedicated certificate, you can now bring it to the Glob
 
   <Alert type="info" title="Note">
 
-  When adding the domain to your environment, you may be presented with the option to **Verify your domain to provision HTTPS**. You can skip this step by clicking **Skip to updating DNS**.
+  When adding the domain to your environment, you may be presented with the option to **Verify your domain to provision HTTPS**. You can skip this step by clicking **Skip without HTTPS**.
 
   </Alert>
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

**[Custom Certificate on the Pantheon Global CDN](https://pantheon.io/docs/custom-certificates)** -  Changed the text referencing a dashboard button from 'skip to DNS' to 'skip without HTTPS' so the docs language is aligned with the platform. 

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
