### PR TITLE
Troubleshooting and composer-merge-plugin

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -4,7 +4,7 @@ description: Learn how to deploy a site with Integrated Composer
 tags: [composer, workflow]
 categories: [get-started]
 contributors: [ari, edwardangert]
-reviewed: "2021-05-28"
+reviewed: "2021-08-30"
 ---
 
 Integrated Composer lets you deploy your site on Pantheon with one-click updates for both upstream commits and [Composer](/composer) dependencies, while still receiving upstream updates.
@@ -221,9 +221,9 @@ To resolve, there are two potential solutions:
 
 ### Issues using `wikimedia/composer-merge-plugin`
 
-Use of the `wikimedia/composer-merge-plugin` is deprecated within Drupal: https://www.drupal.org/node/3069730
+Use of the `wikimedia/composer-merge-plugin` is deprecated within [Drupal](https://www.drupal.org/node/3069730).
 
-When using Pantheon's Integrated Composer, this plugin often tries to run a "composer update" during the "composer install", which is not allowed and will cause errors. We recommend removing `composer-merge-plugin` from your Composer toolchain.
+When using Pantheon's Integrated Composer, this plugin often tries to run a "composer update" during the "composer install," which is not allowed and will cause errors. We recommend removing `composer-merge-plugin` from your Composer toolchain.
 
 ## FAQ
 

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -219,6 +219,12 @@ To resolve, there are two potential solutions:
 
 - Remove the upstream updates by [undoing the commits](/undo-commits#revert-a-prior-commit-on-pantheon-that-has-been-deployed) or [restoring from a backup](/restore-environment-backup) made before the updates were merged. Then do the merge manually as described in [Upstream Updates Cannot Be Applied](#upstream-updates-cannot-be-applied).
 
+### Issues using `wikimedia/composer-merge-plugin`
+
+Use of the `wikimedia/composer-merge-plugin` is deprecated within Drupal: https://www.drupal.org/node/3069730
+
+When using Pantheon's Integrated Composer, this plugin often tries to run a "composer update" during the "composer install", which is not allowed and will cause errors. We recommend removing `composer-merge-plugin` from your Composer toolchain.
+
 ## FAQ
 
 ### What Composer commands does Pantheon run?


### PR DESCRIPTION
## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** -  Add a note to Integrated Composer Troubleshooting that `composer-merge-plugin` should not be used and will cause issues.



--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
