### PR TITLE
Updated WordFence Content - Added Alternative Plugin for WF

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -936,6 +936,8 @@ Complete this step in Dev, Test, and Live Environments.
 
 1. Navigate to the **Wordfence** plugin in the site's WordPress Admin and **Resume Installation** if prompted, or click **CLICK HERE TO CONFIGURE**. The plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete it after downloading.
 
+## Alternative Plugin
+You could try using [WP Cerber](https://wordpress.org/plugins/wp-cerber/) This does not require creating symlinks. (Pantheon has not tested this plugin)
 ___
 
 ## [WordPress Social Login](https://wordpress.org/plugins/wordpress-social-login/)


### PR DESCRIPTION
## Summary

Updated content - Added alternative plugin to WordFence

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
