### PR TITLE
6607: adjust pm:projectinfo and add pm:list as alternative

### DIFF
--- a/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
@@ -82,8 +82,9 @@ This doc uses the following aliases:
 
   ```bash{promptUser: user}
   terminus drush $D8_SITE.dev pm:projectinfo -- --fields=name,version --format=table
-
   ```
+
+  The command `pm:projectinfo` assumes Drush 8. If you encounter an issue with this command, [verify and configure the Drush version](/drush-versions) before you continue.
 
 1. Then use Composer on your D9 site to add these there:
 

--- a/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
@@ -81,7 +81,8 @@ This doc uses the following aliases:
 1. List contrib modules and themes on your D8 site:
 
   ```bash{promptUser: user}
-  terminus drush $D8_SITE.dev pm:projectinfo -- --status=enabled --fields=name,version --format=table
+  terminus drush $D8_SITE.dev pm:projectinfo -- --fields=name,version --format=table
+
   ```
 
 1. Then use Composer on your D9 site to add these there:

--- a/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
@@ -81,7 +81,7 @@ This doc uses the following aliases:
 1. List contrib modules and themes on your D8 site:
 
   ```bash{promptUser: user}
-  terminus drush $D8_SITE.dev -- pm:projectinfo --status=enabled --fields=name,version --format=table
+  terminus drush $D8_SITE.dev pm:projectinfo -- --fields=name,version --format=table
   ```
 
 1. Then use Composer on your D9 site to add these there:

--- a/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/04-migrate-manual-d9.md
@@ -81,7 +81,7 @@ This doc uses the following aliases:
 1. List contrib modules and themes on your D8 site:
 
   ```bash{promptUser: user}
-  terminus drush $D8_SITE.dev pm:projectinfo -- --fields=name,version --format=table
+  terminus drush $D8_SITE.dev pm:projectinfo -- --status=enabled --fields=name,version --format=table
   ```
 
 1. Then use Composer on your D9 site to add these there:

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -62,13 +62,15 @@ Once Composer is aware of all the contributed code, you'll be able to run `compo
 
 Begin by reviewing the existing site's code. Check for contributed modules in `/modules`, `/modules/contrib`, `/sites/all/modules`, and `/sites/all/modules/contrib`.
 
-1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:projectinfo` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.):
+1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:projectinfo` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
+
+  This will list each module followed by the version of that module that is installed:
 
   ```bash{promptUser:user}
   terminus drush $SITE.dev pm:projectinfo -- --fields=name,version --format=table
   ```
 
-  This will list each module followed by the version of that module that is installed.
+  The command `pm:projectinfo` assumes Drush 8. If you encounter an issue with this command, [verify and configure the Drush version](/drush-versions) before you continue.
 
 1. You can add these modules to your new codebase using Composer by running the following for each module in the `$SITE` directory:
 

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -62,10 +62,10 @@ Once Composer is aware of all the contributed code, you'll be able to run `compo
 
 Begin by reviewing the existing site's code. Check for contributed modules in `/modules`, `/modules/contrib`, `/sites/all/modules`, and `/sites/all/modules/contrib`.
 
-1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to change to run the `pm:projectinfo` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
+1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:projectinfo` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.):
 
   ```bash{promptUser:user}
-  terminus drush $SITE.dev -- pm:projectinfo --fields=name,version --format=table
+  terminus drush $SITE.dev pm:projectinfo -- --fields=name,version --format=table
   ```
 
   This will list each module followed by the version of that module that is installed.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6607 

## Summary
<!--
Please complete the Summary section
-->

**[Upgrade from Drupal 8](https://pantheon.io/docs/guides/drupal-9-migration/upgrade-to-d9#modules-and-themes)** -   Adjust `drush pm:projectinfo` command to work for users where the `--` seemed misunderstood by Terminus before.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
