### PR TITLE
Remove EWWW Image Optimizer issues from docs

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -376,20 +376,6 @@ PHP Fatal error: Uncaught EE_Error: An attempt to access and/or write to a file 
 
 ___
 
-## [EWWW Image Optimizer](https://wordpress.org/plugins/ewww-image-optimizer/)
-
-<ReviewDate date="2018-10-16" />
-
-**Issue:** EWWW Image Optimizer attempts to install and execute third party binary tools to perform image optimization, which is restricted on our platform. The error message is:
-
-> EWWW Image Optimizer uses jpegtran, optipng, pngout, pngquant, gifsicle, and cwebp. You are missing: jpegtran, optipng, gifsicle. Please install via the Settings Page or the Installation Instructions.
-
-The solutions [outlined in the EWWW documentation](https://docs.ewww.io/article/6-the-plugin-says-i-m-missing-something) do not apply to Pantheon.
-
-**Solution:** Use an alternative plugin like [EWWW Image Optimizer Cloud](https://wordpress.org/plugins/ewww-image-optimizer-cloud/), which is a cloud version of the plugin that executes the compression from an external service instead of the server. Another alternative that works well with the default configuration is [Smush Image Compression and Optimization](https://wordpress.org/plugins/wp-smushit/).
-
-___
-
 ## [FacetWP](https://facetwp.com)
 
 <ReviewDate date="2019-10-15" />


### PR DESCRIPTION
## Summary
EWWW IO no longer attempts to install any binary tools on Pantheon sites, and now allows free (unlimited) JPG optimization on Pantheon (and other "exec-deprived") sites via our API. Additionally, the solution listed is no longer relevant, nor is it supported by us, so the entire EWWW IO section ought to be removed.

**[Doc Page Title](https://pantheon.io/docs/doc-title)** -  Removes outdated information regarding usage of EWWW Image Optimizer on Pantheon sites.

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
