### PR TITLE
Update wordfence

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -936,11 +936,11 @@ Complete this step in Dev, Test, and Live Environments.
 
 1. Navigate to the **Wordfence** plugin in the site's WordPress Admin and **Resume Installation** if prompted, or click **CLICK HERE TO CONFIGURE**. The plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete it after downloading.
 
-**Issue:** When enabling WAF (Web Application Firewall) it might result in an error "Error Connecting to the Database", the Wordfence plugin generated a bad `wordfence-waf.php` file.
+**Issue:** When enabling the Web Application Firewall (WAF), it can result in an "Error Connecting to the Database" message, in which the Wordfence plugin generates a bad `wordfence-waf.php` file.
 
-**Solution** Replace the following lines on `wordfence-waf.php`
-
+**Solution:** To mitigate this issue, replace `/code/wordfence-waf.php` with `/code/includes/prepend.php`. Change the following code on `wordfence-waf.php` 
 from:
+
 ```
 if (file_exists('/code/wordfence-waf.php')) {
 include_once '/code/wordfence-waf.php';

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -936,9 +936,9 @@ Complete this step in Dev, Test, and Live Environments.
 
 1. Navigate to the **Wordfence** plugin in the site's WordPress Admin and **Resume Installation** if prompted, or click **CLICK HERE TO CONFIGURE**. The plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete it after downloading.
 
-**Issue:** When enabling WAF (Web Application Firewall) it might result to an error "Error Connecting to the Database", the Wordfence plugin generated a bad wordfence-waf.php file.
+**Issue:** When enabling WAF (Web Application Firewall) it might result in an error "Error Connecting to the Database", the Wordfence plugin generated a bad `wordfence-waf.php` file.
 
-**Solution** Replace the following lines on wordfence-waf.php
+**Solution** Replace the following lines on `wordfence-waf.php`
 
 from:
 ```

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -936,6 +936,23 @@ Complete this step in Dev, Test, and Live Environments.
 
 1. Navigate to the **Wordfence** plugin in the site's WordPress Admin and **Resume Installation** if prompted, or click **CLICK HERE TO CONFIGURE**. The plugin requires that you download `.user.ini` to continue. As this file is blank at this point, you can delete it after downloading.
 
+**Issue:** When enabling WAF (Web Application Firewall) it might result to an error "Error Connecting to the Database", the Wordfence plugin generated a bad wordfence-waf.php file.
+
+**Solution** Replace the following lines on wordfence-waf.php
+
+from:
+```
+if (file_exists('/code/wordfence-waf.php')) {
+include_once '/code/wordfence-waf.php';
+}
+```
+to:
+
+```
+if (file_exists('/code/includes/prepend.php')) {
+        include_once '/code/includes/prepend.php';
+}
+```
 ___
 
 ## [WordPress Social Login](https://wordpress.org/plugins/wordpress-social-login/)


### PR DESCRIPTION
Customers are experiencing a broken site once the feature WAF on Wordfence has been enabled.  Added a workaround for the issue.

Closes # n/a

## Summary
**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues#wordfence)** -  Added a workaround for an issue for customers experiencing "Error Connecting to Database" when enabling WAF on WordFence

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
