### PR TITLE
Remove D6 content

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -106,16 +106,6 @@ git push origin master
 
 </Tab>
 
-<Tab title="Drupal 6" id="d6">
-
-```bash{promptUser: user}
-git pull -Xtheirs git://github.com/pantheon-systems/drops-6.git master
-# resolve conflicts
-git push origin master
-```
-
-</Tab>
-
 <Tab title="WordPress" id="wp">
 
 ```bash{promptUser: user}

--- a/source/content/database-connection-errors.md
+++ b/source/content/database-connection-errors.md
@@ -35,24 +35,7 @@ Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](
 
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.
 
-However, because the Pantheon environment data is not loaded at this time, any bootstrap to the database level will fail since there is no valid connection information. In this case, include a snippet in your `settings.php` _before_ the module's include call. For example:
-
-### Drupal 6 Style
-
-```php
-$settings = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
-  $info = $settings['databases']['default']['default'];
-  $db_url = sprintf("%s://%s:%s@%s:%s/%s",
-                    $info['driver'],
-                    $info['username'],
-                    $info['password'],
-                    $info['host'],
-                    $info['port'],
-                    $info['database']);
-  $conf = $settings['conf'];
-  # Include any other settings.php magic here.
-  include './sites/all/modules/domain/settings.inc';
-```
+However, because the Pantheon environment data is not loaded at this time, any bootstrap to the database level will fail since there is no valid connection information. In this case, include a snippet in your `settings.php` before the module's include call. 
 
 ### Drupal 7 Style
 

--- a/source/content/database-connection-errors.md
+++ b/source/content/database-connection-errors.md
@@ -35,7 +35,7 @@ Apply one-click updates within the Site Dashboard on Pantheon or via [Terminus](
 
 Some modules, like the **domain.module**, change Drupal's standard bootstrap process. They typically require you to add an include file to the end of your `settings.php`, which causes an escalated bootstrap earlier than normal so they can perform some higher level functions like checking to see if a user has access.
 
-However, because the Pantheon environment data is not loaded at this time, any bootstrap to the database level will fail since there is no valid connection information. In this case, include a snippet in your `settings.php` before the module's include call. 
+However, because the Pantheon environment data is not loaded at this time, any bootstrap to the database level will fail since there is no valid connection information. In this case, include a snippet in your `settings.php` before the module's include call.
 
 ### Drupal 7 Style
 
@@ -49,7 +49,7 @@ You can also use the above to develop Drupal 8 on Pantheon.
 
 <Alert title="Warning" type="danger">
 
-If you use any other advanced `settings.php` tricks (e.g. enabling Object Cache), you will need to do this <em>before</em> the snippet in D7, or <em>after</em> in D6 to insure you have a consistent `$conf` array.
+If you use any other advanced `settings.php` tricks (e.g. enabling Object Cache), you will need to do this <em>before</em> the snippet in D7 to ensure you have a consistent `$conf` array.
 
 </Alert>
 

--- a/source/content/drupal-cache.md
+++ b/source/content/drupal-cache.md
@@ -82,44 +82,5 @@ Cleanup on the `cache_form` table runs on cron. If the table continues to grow t
 mysql> TRUNCATE TABLE cache_form;
 ```
 
-## Drupal 6
-
-### Caching Mode
-
-In Drupal 6, most users should set their cache mode to "Aggressive" to take advantage of the reverse-proxy layer. This is like checking "cache pages for anonymous users": Drupal will "double cache" the pages locally. That can be an advantage as they'll be held until the next cache flush, which can last much longer in practice than the reverse-proxy layer.
-
-Checking "External" prevents this kind of "double caching" by freeing Drupal from the responsibility to store a page that is also being stored at the reverse-proxy layer. Again, this should only be used on sites that don't want the long-term protection of an internal page cache.
-
-### Compatibility Warnings
-Any module implementing Drupal's `hook_boot()` or `hook_exit()` will show up with a compatibility warning on External or Aggressive modes. This is because when Drupal uses Aggressive mode no logic is executed on a successful cache hit. As soon as the CMS detects that the URL being request has a cache, it returns that cache.
-
-Obviously, when the page is cached Externally in a reverse-proxy layer, Drupal is not consulted when cached pages are delivered.
-
-This limits some functionality in Drupal. For instance, the core `statistics.module` cannot count anonymous pageviews if it isn't being exercised every time a page is viewed. That said, `statistics.module` is not great for high performance sites.
-
-As a developer, you should understand the implications of the code in your application, and what it means to have cached pages delivered from an external source.
-
-### Minimum Cache Lifetime
-
-This is useful for high traffic sites that don't want to be flushing their caches when every comment is submitted.
-
-### Page Cache Maximum Age
-
-This determines the amount of time a cache will be honored in the reverse-proxy layer. Set it as high as you are comfortable.
-
-### Block Cache
-
-This can help with logged-in performance by preventing regeneration of block elements in sidebars every pageview.
-
-### Optimize CSS and JavaScript Files
-
-This setting controls whether or not to compile and cache your CSS and JavaScript files together, speeding up browser render times significantly. You might want to turn it off in Dev if you are building a theme (or developing JS), but this should always be enabled in production.
-
-![Drupal 6 Performance cache settings](../images/page-cache-module-config.png)
-
-### Contributed Modules
-
-Contributed modules like `views.module` and `panels.module` contain their own caching options, which are much more fine-grained than the basic Drupal cache settings. If you use these modules, you should definitely look at implementing their cache settings to provide a good logged-in user experience.
-
 ## See Also
 - [Global CDN Caching for High Performance](/global-cdn-caching)

--- a/source/content/drupal-cron.md
+++ b/source/content/drupal-cron.md
@@ -139,4 +139,3 @@ No. You can create a custom module that uses the [`hook_cron`](https://api.drupa
 
 - [Drupal.org Community Documentation - Set up Cron](https://www.drupal.org/docs/7/setting-up-cron/overview)
 - [Elysia Cron - extends Drupal standard Cron](https://www.drupal.org/project/elysia_cron)
-- [poormanscron - Triggers Drupal Cron from site traffic (Drupal 6 only, included in Drupal 7)](https://drupal.org/project/poormanscron)

--- a/source/content/drupal-launch-check.md
+++ b/source/content/drupal-launch-check.md
@@ -62,9 +62,6 @@ A warning within `/admin/reports/status` will appear when the `trusted_host_patt
 
 The Dashboard integration is intended to provide developers with the most actionable items; some reports are purely informational and have been omitted. Additionally, some reports are more system intensive, so it makes more sense to allow them to be run on-demand, rather than automatically.
 
-### Are there plans to support Drupal 6 sites?
-
-At this time, there are no plans to support Drupal 6 with this tool.
 
 ### Can I opt out of a specific recommendation?
 

--- a/source/content/drupal-updates.md
+++ b/source/content/drupal-updates.md
@@ -21,7 +21,7 @@ If you have already created a site and want to upgrade it to a new major version
 
 [Drupal 9.0.0](https://www.drupal.org/about/9) was released in June of 2020. Pantheon support for live Drupal 9 sites is currently in development. See our [Drupal 9 documentation page](/drupal-9) for more information on early access options for trying Drupal 9 on Pantheon.
 
-Since Drupal 9 currently has the same end-user features as [Drupal 8.9](https://www.drupal.org/project/drupal/releases/8.9.0), and because many contrib modules are not yet compatible with Drupal 9, we recommend that users upgrade their Drupal 6 or 7 sites to Drupal 8 first.
+Since Drupal 9 currently has the same end-user features as [Drupal 8.9](https://www.drupal.org/project/drupal/releases/8.9.0), and because many contrib modules are not yet compatible with Drupal 9, we recommend that users upgrade their Drupal 7 sites to Drupal 8 first.
 
 ## Upgrade to Drupal 8
 
@@ -29,7 +29,7 @@ The details of executing an upgrade/migration to Drupal 8 have continued to shif
 
 1. Create a new Drupal 8 site on Pantheon from your User Dashboard.
 1. Add the 8.x version of your contrib modules. Some of these modules will have built-in migrating functionality that will help move their data from Drupal 7 to Drupal 8.
-1. Use the [Migrate](https://www.drupal.org/project/migrate) module to move over data and configuration from Drupal 6 or 7.
+1. Use the [Migrate](https://www.drupal.org/project/migrate) module to move over data and configuration from Drupal 7.
 1. Depending on the complexity of your site, you will likely want to review, revise, and rerun your migration.
 
 ### Content and configuration
@@ -51,7 +51,7 @@ The critical commands are:
 terminus drush my-drupal-8-site.dev -- migrate-upgrade --legacy-db-key=drupal_7 --configure-only --legacy-root=https://drupal7.example.com
 ```
 
-This command configures (but does not run) the migrations from Drupal 6 or 7 to Drupal 8. In this example, the Drupal 8 site is named `my-drupal-8-site` and the command is running on the `dev` environment. The `--legacy-db-key` parameter indicates how to get the login credentials to the source Drupal 6 or 7 database. In our example, we use the [Terminus secrets](https://github.com/pantheon-systems/terminus-secrets-plugin) plugin to supply the connection info. [See our blog post for more information on how this flag is used](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush). The `--legacy-root` flag lets Drupal 8 know from where it can grab images and other uploaded media assets.
+This command configures (but does not run) the migrations from Drupal 7 to Drupal 8. In this example, the Drupal 8 site is named `my-drupal-8-site` and the command is running on the `dev` environment. The `--legacy-db-key` parameter indicates how to get the login credentials to the source Drupal 7 database. In our example, we use the [Terminus secrets](https://github.com/pantheon-systems/terminus-secrets-plugin) plugin to supply the connection info. [See our blog post for more information on how this flag is used](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush). The `--legacy-root` flag lets Drupal 8 know from where it can grab images and other uploaded media assets.
 
 The following command generates a report on how many items have been imported by each migration:
 
@@ -64,14 +64,6 @@ The following command runs the migration configured via `drush migrate-upgrade -
 ```bash{promptUser: user}
 terminus drush my-drupal-8-site.dev -- migrate-import --all
 ```
-
-## Upgrade from Drupal 6 to Drupal 7
-
-1. Start a new site using Drupal 7 as the start state.
-1. Add the 7.x version of your contrib modules.
-1. Import your existing database from Drupal 6 to the Drupal 7 site.
-1. Run the core upgrade process.
-1. Debug, QA, release.
 
 ### Content and Configuration
 
@@ -94,8 +86,8 @@ Migrations of particularly large sites to updated Drupal versions can sometimes 
 View the following [Drupal.org](https://drupal.org) resources for more information:
 
 - [Commonly implemented Migration methods](https://www.drupal.org/node/1132582)
-- [Executing a Drupal 6/7 to Drupal 8 upgrade](https://www.drupal.org/node/2257723)
-- [Upgrading from Drupal 6 or 7 to Drupal 8](https://www.drupal.org/upgrade/migrate)
+- [Executing a Drupal 7 to Drupal 8 upgrade](https://www.drupal.org/node/2257723)
+- [Upgrading from Drupal 7 to Drupal 8](https://www.drupal.org/upgrade/migrate)
 - [Performing Drupal Content Migrations on Pantheon](https://pantheon.io/blog/performing-drupal-content-migrations-pantheon)
 - [Running Drupal 8 Data Migrations on Pantheon Through Drush](https://pantheon.io/blog/running-drupal-8-data-migrations-pantheon-through-drush)
 - [Drupal 8 File Migrations

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -51,9 +51,9 @@ If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.ym
 
 ## Compatibility and Requirements
 
-Drush 8 is compatible with Drupal 6, 7, and 8.
+Drush 8 is compatible with Drupal 7 and 8.
 
-Always use Drush 8 with Drupal 7 and Drupal 6 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 and later.
+Always use Drush 8 with Drupal 7 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 and later.
 
 While Drush 5 and Drush 7 are available on Pantheon if needed, they are listed as [unsupported](https://docs.drush.org/en/8.x/install/#drupal-compatibility) by the Drush maintainers, and should be avoided unless absolutely necessary.
 

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -8,7 +8,7 @@ reviewed: "2020-02-06"
 ---
 [Drush](https://github.com/drush-ops/drush) is a command-line interface for Drupal that provides a wide set of utilities for administering and maintaining your site.
 
-Drush commands require a `settings.php` file, and it's a best practice to have one. Drupal 8 sites come with a bundled `settings.php` file out of the box. Drupal 6 and 7 sites do not contain a `settings.php` file; however, you can simply copy the `sites/default/default.settings.php` to `sites/default/settings.php` via [SFTP](/sftp) or [Git](/git) for Drush to work on older Drupal versions. For more details, see [Configuring Settings.php](/settings-php).
+Drush commands require a `settings.php` file, and it's a best practice to have one. Drupal 8 sites come with a bundled `settings.php` file out of the box. Drupal 7 sites do not contain a `settings.php` file; however, you can simply copy the `sites/default/default.settings.php` to `sites/default/settings.php` via [SFTP](/sftp) or [Git](/git) for Drush to work on older Drupal versions. For more details, see [Configuring Settings.php](/settings-php).
 
 ## Terminus Drush and Local Drush
 
@@ -126,7 +126,7 @@ Drupal's list of PHP classes and files can get corrupted or out-of-date, typical
 terminus drush <site>.<env> -- rr
 ```
 
-Note that the Registry Rebuild command is only ever necessary on Drupal 7 and Drupal 6 sites. The command `drush cache:rebuild` for Drupal 8 serves the same function that `registry rebuild` does for older versions of Drupal.
+Note that the Registry Rebuild command is only necessary on Drupal 7 sites. The command `drush cache:rebuild` for Drupal 8 serves the same function that `registry rebuild` does for older versions of Drupal.
 
 ## Run SQL Queries Using Drush on Pantheon
 

--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -51,7 +51,7 @@ mv sites/default/{settings.php,settings.local.php}
 chmod u-w sites/default/{settings.local.php,.}
 ```
 
-Drupal 8 sites running on Pantheon come with a bundled `settings.php` that includes the `settings.local.php` file, so no additional steps are required. However, sites running Drupal 6 or 7 must add a `settings.php` file that includes `settings.local.php`, as this file is not bundled on Pantheon.
+Drupal 8 sites running on Pantheon come with a bundled `settings.php` that includes the `settings.local.php` file, so no additional steps are required. However, sites running Drupal 7 must add a `settings.php` file that includes `settings.local.php`, as this file is not bundled on Pantheon.
 
 </Accordion>
 

--- a/source/content/migrate.md
+++ b/source/content/migrate.md
@@ -423,7 +423,3 @@ Follow the [standard procedure for migrating WordPress sites to Pantheon](#migra
 1. Move the `mysql.sql` database out of the `wp-content` directory and into the project's root directory.
 
 1. Follow the procedure to [manually migrate](/migrate-manual) your site.
-
-### How do I migrate a Drupal 6 site to Pantheon?
-
-Anyone wishing to migrate a Drupal 6 site to Pantheon can work with one of our Long Term Support (LTS) partners: [Tag1 Consulting](https://tag1consulting.com/) or [myDropWizard](https://www.mydropwizard.com/drupal-6-lts). Both of these partners are experienced in supporting sites on the Pantheon platform and specialize in maintaining security and site functionality for Drupal 6 sites. Should you need to keep your site running on D6, you will be in excellent hands working with them.

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -455,22 +455,6 @@ Fatal error: require_once(): Failed opening required
 '/srv/bindings/xxxxxxxxx/code/sites/all/modules/redis/redis.autoload.inc'
 ```
 
-### Drupal 6 Cache Backport
-
-If you have a Drupal 6 site, you will also need the [Cache Backport](https://drupal.org/project/cache_backport) module. This module is a full backport of the Drupal 7 `cache.inc` for Drupal 6. See [INSTALL.TXT](https://git.drupalcode.org/project/cache_backport/blob/master/INSTALL.txt) for how to configure Cache Backport.
-
-If you see the following message:
-
-```bash
-File not found:
-'sites/all/modules/cache_backport/system.admin.inc'
-```
-
-You skipped a step; `settings.php` must include the cache\_backport files. Add the following to `settings.php` before the Redis configuration:
-
-```php:title=settings.php
-$conf['cache_inc'] = 'sites/all/modules/cache_backport/cache.inc';
-```
 
 ### You have requested a non-existent service
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -139,8 +139,6 @@ This table shows the recommended MariaDB version for each CMS:
 
 | CMS           | Recommended MariaDB Version |
 |---------------|-----------------------------|
-| Drupal < 6.51 | 10.3                        |
-| Drupal ≥ 6.51 | 10.4                        |
 | Drupal < 7.76 | 10.3                        |
 | Drupal ≥ 7.76 | 10.4                        |
 | Drupal < 8.5  | 10.3                        |

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -66,7 +66,6 @@ Before changing your PHP version, confirm that your CMS is compatible:
 - [WordPress Requirements](https://wordpress.org/about/requirements/)
 - [Drupal 8 and 9 PHP version support](https://www.drupal.org/docs/system-requirements/php-requirements#php_required)
 - [Drupal 7 PHP version support](https://www.drupal.org/docs/7/system-requirements/php-requirements#php_required)
-- As of Drupal 6.45, Drupal 6 is [compatible with PHP 7.2](https://www.mydropwizard.com/blog/announcing-drupal-645-and-selected-contrib-php-72). Older versions of Drupal 6 require PHP 5.4 and below.
 
 
 ## Configure PHP Version

--- a/source/content/read-environment-config.md
+++ b/source/content/read-environment-config.md
@@ -42,18 +42,6 @@ Pantheon uses Pressflow to automatically read the environmental configuration. I
 extract(json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE));
 ```
 
-## Drupal 6
-
-```php
-<?php
-$settings = json_decode($_SERVER['PRESSFLOW_SETTINGS'], TRUE);
-$db = $settings['databases']['default']['default'];
-// You can do the following on one line. It's broken in two here for readability.
-$db_url = $db['driver'] . '://' . $db['username'] . ':' . $db['password'];
-$db_url .= '@' . $db['host'] . ':' . $db['port'] . '/' . $db['database'];
-$conf = $settings['conf'];
-```
-
 ## Domain Access
 
 Place [Domain Access setup routine](https://www.drupal.org/node/1096962) above any [Redis configurations](/object-cache#enable-object-cache) in `settings.php`. For example, for Drupal 7:

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -118,17 +118,6 @@ if (!defined('PANTHEON_ENVIRONMENT')) {
 }
 ```
 
-### Drupal 6
-
-```php
-// Local development configuration.
-if (!defined('PANTHEON_ENVIRONMENT')) {
-  // Database.
-  $db_url = 'mysql://username:password@localhost/databasename';
-  $db_prefix = '';
-}
-```
-
 ## Frequently Asked Questions
 
 ### Can I delete the default.settings.php file?
@@ -239,7 +228,7 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 
 - Drupal 8 - [https://github.com/pantheon-systems/drops-8/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-8/blob/master/sites/default/default.settings.php)
 - Drupal 7 -  [https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php)
-- Drupal 6 -  [https://github.com/pantheon-systems/drops-6/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-6/blob/master/sites/default/default.settings.php)
+
 
 ### Where can I find examples of Pantheon settings.php?
 

--- a/source/content/settings-php.md
+++ b/source/content/settings-php.md
@@ -229,7 +229,6 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 - Drupal 8 - [https://github.com/pantheon-systems/drops-8/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-8/blob/master/sites/default/default.settings.php)
 - Drupal 7 -  [https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php)
 
-
 ### Where can I find examples of Pantheon settings.php?
 
 You can view examples at the [pantheon-settings-examples repo](https://github.com/pantheon-systems/pantheon-settings-examples).


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #6600 

## Summary
<!--
Please complete the Summary section
-->

**[Various D6 References](https://pantheon.io/docs/migrate)** - Remove Drupal 6 documentation references, as it is no longer supported by Pantheon CSEs

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
