### PR TITLE
mark upgrade_status section as optional

### DIFF
--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -40,7 +40,7 @@ The site owner should ensure the trusted host setting is up-to-date. Refer to th
 
 <Partial file="drupal-apply-upstream-updates.md" />
 
-### Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
+### (Optional) Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
 
 <Partial file="drupal-9/drupal-upgrade-status.md" />
 

--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -46,7 +46,7 @@ Pantheon support is not available to users who avoid the Multidev steps.
 
 <Partial file="drupal-apply-upstream-updates.md" />
 
-### Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
+### (Optional) Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
 
 <Partial file="drupal-9/drupal-upgrade-status.md" />
 

--- a/source/partials/drupal-9/drupal-upgrade-status.md
+++ b/source/partials/drupal-9/drupal-upgrade-status.md
@@ -1,4 +1,4 @@
-This section is optional but recommended.
+This section is optional, but recommended.
 
 Before you attempt to upgrade to Drupal 9, confirm that the site is ready with the [Upgrade Status](https://www.drupal.org/project/upgrade_status) Drupal module.
 

--- a/source/partials/drupal-9/drupal-upgrade-status.md
+++ b/source/partials/drupal-9/drupal-upgrade-status.md
@@ -1,6 +1,8 @@
+This section is optional but recommended.
+
 Before you attempt to upgrade to Drupal 9, confirm that the site is ready with the [Upgrade Status](https://www.drupal.org/project/upgrade_status) Drupal module.
 
-This step is optional. Converting a Drupal 8 site that is not managed by Composer (`drops-8`) to use [Integrated Composer](/integrated-composer) is time-consuming. Upgrade Status helps find potential issues before you invest the time to convert the site.
+Converting a Drupal 8 site that is not managed by Composer (`drops-8`) to use [Integrated Composer](/integrated-composer) is time-consuming. Upgrade Status helps find potential issues before you invest the time to convert the site.
 
 <Accordion title="Test Drupal Upgrade Status in a Temporary Multidev" id="drupal-upgrade-status" icon="lightbulb">
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary
<!--
Please complete the Summary section
-->

**[Upgrade from Drupal 8](https://pantheon.io/docs/guides/drupal-9-migration/upgrade-to-d9#run-upgrade_status-to-confirm-that-the-site-is-ready-to-be-upgraded)** -  Clarify that the `upgrade_status` section itself is optional but recommended.

<!-- Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity. -->


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

*
*


## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
