### PR TITLE
Add references to Drupal 9

### DIFF
--- a/source/content/guides/build-tools/02-create-project.md
+++ b/source/content/guides/build-tools/02-create-project.md
@@ -10,7 +10,7 @@ type: guide
 permalink: docs/guides/build-tools/create-project/
 editpath: build-tools/02-create-project.md
 image: buildToolsGuide-thumb
-reviewed: "2021-09-16"
+reviewed: "2020-05-08"
 ---
 
 In this section, we will use the Terminus Build Tools Plugin to create a new project consisting of a Git repository, a Continuous Integration service, and a Pantheon site.

--- a/source/content/guides/build-tools/02-create-project.md
+++ b/source/content/guides/build-tools/02-create-project.md
@@ -10,7 +10,7 @@ type: guide
 permalink: docs/guides/build-tools/create-project/
 editpath: build-tools/02-create-project.md
 image: buildToolsGuide-thumb
-reviewed: "2020-05-08"
+reviewed: "2021-09-16"
 ---
 
 In this section, we will use the Terminus Build Tools Plugin to create a new project consisting of a Git repository, a Continuous Integration service, and a Pantheon site.
@@ -82,6 +82,12 @@ Modify the commands in the following examples to match your project's needs.
   terminus build:project:create --git=github --team='My Agency Name' wp my-site
   ```
 
+- Start a GitHub project with Drupal 9:
+
+  ```bash{promptUser: user}
+  terminus build:project:create --git=github --team='My Agency Name' d9 my-site
+  ```
+
 - Start a GitHub project with Drupal 8:
 
   ```bash{promptUser: user}
@@ -147,6 +153,7 @@ terminus auth:login --machine-token=<machine-token>
 
 Pantheon's Composer-based example repositories are maintained and supported on GitHub. After browsing existing issues, report errors in the appropriate repository's issue queue:
 
+- [Drupal 9](https://github.com/pantheon-upstreams/drupal-project/issues)
 - [Drupal 8](https://github.com/pantheon-systems/example-drops-8-composer/issues)
 - [WordPress](https://github.com/pantheon-systems/example-wordpress-composer/issues)
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch. For more information on contributing to Pantheon documentation, see the [Contributor Guidelines](https://pantheon.io/docs/contribute). Please refer to our [Style Guide](https://pantheon.io/docs/style-guide) and [this reference](https://developers.google.com/style) for formatting recommendations when contributing to the docs. 

**Note:** Please fill out the PR template to ensure proper processing. If you're not sure about a section, leave it empty.
-->

## Summary
<!--
Please complete the Summary section
-->

**[Create a New Project (Build Tools)](https://pantheon.io/docs/guides/build-tools/create-project/)** -  Adds references to D9 alias when generating a project. Depends on https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/396

## Effect
The following changes are already committed:

* D9 support added to Build Tools

## Remaining Work
The following changes still need to be completed:

- [x] Merge aliases + README.md changes in build tools: https://github.com/pantheon-systems/terminus-build-tools-plugin/pull/396


--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
