### PR TITLE
Clarify D9 Composer-based docs

### DIFF
--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -14,12 +14,6 @@ At its primary level, Composer needs:
 
 Understanding how Composer can be used independent of Drupal or WordPress is a good place to learn more about the general concepts. For a summary of basic usage, see [Composer's own documentation](https://getcomposer.org/doc/01-basic-usage.md).
 
-<Enablement title="Automation Training" link="https://pantheon.io/learn-pantheon?docs" campaign="docs-webops">
-
-Learn Composer concepts with help from our experts. Pantheon delivers on-demand training to help development teams navigate the platform and improve internal WebOps.
-
-</Enablement>
-
 ## Dependencies
 
 Composer encourages a mental model where code not written specifically for a given project is a dependency. Only files unique to the project are tracked as part of the project's main source repository, also referred to as the canonical site repository. Dependencies for WordPress and Drupal include core, plugins, contrib modules, themes, and libraries. A single dependency, such as a theme, is referred to as a package.

--- a/source/content/composer.md
+++ b/source/content/composer.md
@@ -21,12 +21,13 @@ Composer encourages a mental model where code not written specifically for a giv
 Composer looks within [The PHP Package Repository](https://packagist.org/) for dependencies to install, which does not include Drupal or WordPress packages by default. Additional repositories must be configured for Composer to use packages not found in the default repository. Each framework provides it's own respective package repository so dependencies can be managed with Composer:
 
 - WordPress: <https://wpackagist.org>
+- Drupal 9: <https://packages.drupal.org/9>
 - Drupal 8: <https://packages.drupal.org/8>
 - Drupal 7: <https://packages.drupal.org/7>
 
 ## Managing Core as a Project Dependency
 
-Sites managed with Composer should use the nested docroot feature, which allows core to be installed within the `web` subdirectory instead of the default root directory of the site's codebase. A nested docroot is the simplest path towards reliable core updates in a Composer workflow.
+Sites managed with Composer should use the [nested docroot](/nested-docroot) feature, which allows core to be installed within the `web` subdirectory instead of the default root directory of the site's codebase. A nested docroot is the simplest path towards reliable core updates in a Composer workflow.
 
 This is possible on Pantheon by specifying `web_docroot: true` in `pantheon.yml` file. For details, see [Serving Sites from the Web Subdirectory](/nested-docroot).
 
@@ -54,9 +55,14 @@ You can also prevent upstream updates by [setting an empty upstream](/guides/com
 
 ## Next Steps
 
-Follow the [Build Tools Guide](/guides/build-tools) to learn best practices for Composer on Pantheon, or [upgrade to Drupal 9](/guides/drupal-9-migration).
+Here are some ways to get started using Composer for your Pantheon sites:
 
-If you already have a Drupal 8 site that you need to convert to a Composer-managed workflow, check out [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+- Create a new [Drupal 9 with Integrated Composer](/drupal-9) site. 
+- [Migrate or upgrade](/guides/drupal-9-migration) an existing Drupal 8 or 9 site to Drupal 9 with Integrated Composer.
+- [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+- Follow the [Build Tools Guide](/guides/build-tools) to learn best practices for Composer-managed sites with continuous integration (CI) workflows.
+- Create a new [WordPress with Integrated Composer](/integrated-composer) site.
+
 
 ### Partial Adoption
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -14,7 +14,10 @@ Since Drupal 9 on Pantheon is in active development and includes a number of sig
 
 ## About Drupal 9
 
-Drupal 9 includes many of the features and layout that Drupal 8 users are familiar with, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond, using Composer to easily manage site dependencies. 
+Drupal 9 includes many of the features and layout that Drupal 8 users are familiar with, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond. 
+
+
+Pantheon recommends using Composer to manage Drupal 8 and 9 site dependencies.
 
 If you're new to Composer, review our [Composer Fundamentals](/composer) workflow guide.
 
@@ -22,7 +25,7 @@ If you're new to Composer, review our [Composer Fundamentals](/composer) workflo
 
 On the Pantheon Platform, Drupal 9 sites use [Integrated Composer](/integrated-composer), letting you deploy your site on Pantheon with one-click updates for both upstream commits and Composer dependencies, while still receiving upstream updates.
 
-Pantheon recommends using Composer to manage Drupal 8 and 9 sites. Pantheon's [Drupal 9 upstream](https://github.com/pantheon-systems/drupal-project) uses Composer, and this upstream is also the recommended starting point for forking new Drupal upstreams that work with the Platform's Integrated Composer build process.
+Pantheon's [Drupal 9 upstream](https://github.com/pantheon-systems/drupal-project) is the base template for Drupal 9 Composer-managed sites. This upstream is also the recommended starting point for forking new Drupal upstreams that work with the Platform's Integrated Composer build process.
 
 If you are not able to use Composer to manage your Drupal 9 site dependencies, contact your [Pantheon Account Team](pantheon.io/contact-us?docs).
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -2,25 +2,29 @@
 title: Drupal 9
 description: Get started with Drupal 9 on the Pantheon WebOps Platform.
 categories: [get-started]
-tags: [site]
+tags: [site, composer]
 cms: drupal-9
 contributors: [populist, edwardangert]
 reviewed: "2021-06-18"
 ---
 
-Drupal 9 is available on Pantheon to all new sites, and is available as an [upgrade path for Drupal 8 sites](/guides/drupal-9-migration).
+[Drupal 9](/create-sites) is available on Pantheon to all customers, and as an [upgrade path for Drupal 8 sites](/guides/drupal-9-migration).
 
 Since Drupal 9 on Pantheon is in active development and includes a number of significant changes from previous versions of Drupal, this doc outlines the biggest changes and answers frequently asked questions.
 
 ## About Drupal 9
 
-Drupal 9 includes many of the features and layout that Drupal 8 users are familiar with, and it removes deprecated code to help improve future Drupal development.
+Drupal 9 includes many of the features and layout that Drupal 8 users are familiar with, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond, using Composer to easily manage site dependencies. 
 
-Drupal 9 updates Drupal’s underlying dependencies like [Symfony 4.4](https://symfony.com/releases/4.4) and [Twig 2](https://twig.symfony.com/doc/2.x/index.html), removes several deprecated API functions in favor of better options, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond.
+If you're new to Composer, review our [Composer Fundamentals](/composer) workflow guide.
 
 ## Drupal 9 With Integrated Composer
 
 On the Pantheon Platform, Drupal 9 sites use [Integrated Composer](/integrated-composer), letting you deploy your site on Pantheon with one-click updates for both upstream commits and Composer dependencies, while still receiving upstream updates.
+
+Pantheon recommends using Composer to manage Drupal 8 and 9 sites. Pantheon's [Drupal 9 upstream](https://github.com/pantheon-systems/drupal-project) uses Composer, and this upstream is also the recommended starting point for forking new Drupal upstreams that work with the Platform's Integrated Composer build process.
+
+If you are not able to use Composer to manage your Drupal 9 site dependencies, contact your [Pantheon Account Team](pantheon.io/contact-us?docs).
 
 <Alert title="A note about Limited Availability" type="info" icon="leaf">
 

--- a/source/content/drupal-9.md
+++ b/source/content/drupal-9.md
@@ -27,7 +27,7 @@ On the Pantheon Platform, Drupal 9 sites use [Integrated Composer](/integrated-c
 
 Pantheon's [Drupal 9 upstream](https://github.com/pantheon-systems/drupal-project) is the base template for Drupal 9 Composer-managed sites. This upstream is also the recommended starting point for forking new Drupal upstreams that work with the Platform's Integrated Composer build process.
 
-If you are not able to use Composer to manage your Drupal 9 site dependencies, contact your [Pantheon Account Team](pantheon.io/contact-us?docs).
+If you are not able to use Composer to manage your Drupal 9 site dependencies, contact your [Pantheon Account Team](https://pantheon.io/contact-us?docs).
 
 <Alert title="A note about Limited Availability" type="info" icon="leaf">
 

--- a/source/content/guides/drupal-9-migration/01-introduction.md
+++ b/source/content/guides/drupal-9-migration/01-introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate to Drupal 9 on Pantheon
 subtitle: Introduction
-description: Steps to upgrade, perform a guided migration, or migrate manually to Drupal 9 on Pantheon.
+description: Steps to upgrade or migrate to Drupal 9 on Pantheon.
 categories: [get-started]
 cms: drupal-9
 tags: [code, launch, migrate, site, updates]

--- a/source/content/guides/drupal-9-migration/01-introduction.md
+++ b/source/content/guides/drupal-9-migration/01-introduction.md
@@ -14,27 +14,28 @@ editpath: drupal-9-migration/01-introduction.md
 
 This guide provides steps to upgrade or migrate an existing Drupal 8 or 9 site to [Drupal 9 with Integrated Composer](/drupal-9) on the Pantheon Platform.
 
-To create a new Drupal 9 site, see our [Drupal 9](/drupal-9) and [Integrated Composer](/integrated-composer) docs.
+To create a new Drupal 9 site, follow our [Drupal 9](/drupal-9) doc and learn more about [Integrated Composer](/integrated-composer).
 
 ## Before You Begin
 
-Pantheon recommends using [Composer](/composer) to manage Drupal 8 and 9 site dependencies. This guide assumes you will use a Composer-based workflow with your Drupal 9 site. 
+Pantheon recommends using [Composer](/composer) to manage Drupal 8 and 9 site dependencies. This guide assumes you will use a Composer-based workflow with your Drupal 9 site.
 
 Your upgrade path to Drupal 9 on Pantheon depends on:
-- the site's start state and 
-- the target Drupal 9 workflow. 
+
+- the site's start state and
+- the target Drupal 9 workflow.
 
 ## Choose Your Adventure: Start State
 
-To choose the best migration path, begin with the start state that best matches your current site. 
+To choose the best migration path, begin with the start state that best matches your current site.
 
 ### Drupal 8 Sites on Other Hosting
 
-Starting with a Drupal 8 site not hosted on the Pantheon Platform, [instructions for manually migrate]
+Starting with a Drupal 8 site that is not hosted on the Pantheon Platform, [instructions for manually migrate]
 
 ### Pantheon Drupal 8 Sites
 
-For Pantheon-hosted Drupal 8 sites, determine which upstream  your Drupal 8 site is using.  
+For Pantheon-hosted Drupal 8 sites, determine which upstream your Drupal 8 site is using.
 
 <Partial file="drupal-9/verify-upstream.md" />
 
@@ -47,19 +48,19 @@ If you're starting with a Drupal 8 site that currently uses the `drops-8` upstre
 
 #### drupal-project (Drupal 9 Integrated Composer) Upstream
 
-Starting with a Drupal 8 site that uses the Drupal 9 Integrated Composer `drupal-project` upstream, 
+Starting with a Drupal 8 site that uses the Drupal 9 Integrated Composer `drupal-project` upstream,
 
 ...instructions...
 
 #### Drupal 8 Empty Upstream
 
-Starting with a Drupal 8 site that currently uses the `drupal8` Framework empty upstream, 
+Starting with a Drupal 8 site that currently uses the `drupal8` Framework empty upstream,
 
 ...instructions...
 
 #### Custom Upstream
 
-Starting with a Drupal 8 site that currently uses a custom upstream, 
+Starting with a Drupal 8 site that currently uses a custom upstream,
 
 ...instructions...
 

--- a/source/content/guides/drupal-9-migration/01-introduction.md
+++ b/source/content/guides/drupal-9-migration/01-introduction.md
@@ -12,19 +12,57 @@ anchorid: drupal-9-migration
 editpath: drupal-9-migration/01-introduction.md
 ---
 
-This guide provides steps to upgrade or migrate a Drupal 8 or 9 site to Drupal 9 on the Pantheon Platform.
+This guide provides steps to upgrade or migrate an existing Drupal 8 or 9 site to [Drupal 9 with Integrated Composer](/drupal-9) on the Pantheon Platform.
 
-There are a number of ways to upgrade to Drupal 9 on Pantheon, depending on the site's start state and target site workflow. This guide will help you through your adventure.
+To create a new Drupal 9 site, see our [Drupal 9](/drupal-9) and [Integrated Composer](/integrated-composer) docs.
 
 ## Before You Begin
 
-Pantheon recommends using Composer to manage Drupal 8 and 9 site dependencies. This guide assumes you are using [Composer](/composer) with your Drupal site. 
+Pantheon recommends using [Composer](/composer) to manage Drupal 8 and 9 site dependencies. This guide assumes you will use a Composer-based workflow with your Drupal 9 site. 
 
-### Create a New Drupal 9 Site
+Your upgrade path to Drupal 9 on Pantheon depends on:
+- the site's start state and 
+- the target Drupal 9 workflow. 
 
-To get started with a new site, see our [Drupal 9](/drupal-9) and [Integrated Composer](/integrated-composer) doc.
+## Choose Your Adventure: Start State
 
-### Convert Drupal 8 Site to Composer
+To choose the best migration path, begin with the start state that best matches your current site. 
 
-If you are migrating or upgrading a Drupal 8 site without Composer, begin by [Converting a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+### Drupal 8 Sites on Other Hosting
 
+Starting with a Drupal 8 site not hosted on the Pantheon Platform, [instructions for manually migrate]
+
+### Pantheon Drupal 8 Sites
+
+For Pantheon-hosted Drupal 8 sites, determine which upstream  your Drupal 8 site is using.  
+
+<Partial file="drupal-9/verify-upstream.md" />
+
+#### drops-8 Upstream
+
+If you're starting with a Drupal 8 site that currently uses the `drops-8` upstream, and
+
+- the site uses Composer to manage dependencies, xyz
+- the site **does not** use Composer, begin with [Converting a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+
+#### drupal-project (Drupal 9 Integrated Composer) Upstream
+
+Starting with a Drupal 8 site that uses the Drupal 9 Integrated Composer `drupal-project` upstream, 
+
+...instructions...
+
+#### Drupal 8 Empty Upstream
+
+Starting with a Drupal 8 site that currently uses the `drupal8` Framework empty upstream, 
+
+...instructions...
+
+#### Custom Upstream
+
+Starting with a Drupal 8 site that currently uses a custom upstream, 
+
+...instructions...
+
+### Drupal 9 Sites on Other Hosting
+
+Starting with a Drupal 9 site not hosted on the Pantheon Platform, [instructions for manually migrating]

--- a/source/content/guides/drupal-9-migration/01-introduction.md
+++ b/source/content/guides/drupal-9-migration/01-introduction.md
@@ -16,6 +16,17 @@ Drupal 9 includes many of the features and layout that Drupal 8 users are famili
 
 Drupal 9 updates Drupal’s underlying dependencies like [Symfony 4.4](https://symfony.com/releases/4.4) and [Twig 2](https://twig.symfony.com/doc/2.x/index.html), removes several deprecated API functions in favor of better options, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond.
 
-There are a number of ways to upgrade to Drupal 9 on Pantheon, and we're building out the documentation within this guide to try to help you through your adventure.
+There are a number of ways to upgrade to Drupal 9 on Pantheon, and we're building out the documentation within this guide to help you through your adventure.
 
-See our [Drupal 9](/drupal-9) and [Integrated Composer](/integrated-composer) docs to learn more about Drupal 9 on Pantheon, and to get started with a fresh new site.
+## Before You Begin
+
+Pantheon recommends using Composer to manage Drupal 8 and 9 site dependencies. This guide assumes you are using [Composer](/composer) with your Drupal site. 
+
+### Create a New Drupal 9 Site
+
+To get started with a new site, see our [Drupal 9](/drupal-9) and [Integrated Composer](/integrated-composer) doc.
+
+### Convert Drupal 8 Site to Composer
+
+If you are migrating or upgrading a Drupal 8 site without Composer, begin by [Converting a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+

--- a/source/content/guides/drupal-9-migration/01-introduction.md
+++ b/source/content/guides/drupal-9-migration/01-introduction.md
@@ -12,11 +12,9 @@ anchorid: drupal-9-migration
 editpath: drupal-9-migration/01-introduction.md
 ---
 
-Drupal 9 includes many of the features and layout that Drupal 8 users are familiar with, and it removes deprecated code to help improve future Drupal development.
+This guide provides steps to upgrade or migrate a Drupal 8 or 9 site to Drupal 9 on the Pantheon Platform.
 
-Drupal 9 updates Drupal’s underlying dependencies like [Symfony 4.4](https://symfony.com/releases/4.4) and [Twig 2](https://twig.symfony.com/doc/2.x/index.html), removes several deprecated API functions in favor of better options, and allows everyone running Drupal 8.8+ an easy upgrade path to Drupal 9 and beyond.
-
-There are a number of ways to upgrade to Drupal 9 on Pantheon, and we're building out the documentation within this guide to help you through your adventure.
+There are a number of ways to upgrade to Drupal 9 on Pantheon, depending on the site's start state and target site workflow. This guide will help you through your adventure.
 
 ## Before You Begin
 

--- a/source/content/guides/drupal-9-migration/02-migrate-prepare.md
+++ b/source/content/guides/drupal-9-migration/02-migrate-prepare.md
@@ -23,7 +23,7 @@ This overview outlines the steps to prepare an existing Drupal site for upgrade 
 
 1. Upgrade to the latest Drupal 8.9 release.
 
-   - Although Drupal supports upgrading to Drupal 9 from Drupal 8.8, ensure that your site is on the latest Drupal 8.9 release before trying Drupal 9 on Pantheon.
+   - Minimize issues by ensuring your site is on the latest Drupal 8.9 release before proceeding.
 
 1. Review the [How to Prepare Your Drupal 7 or Drupal 8 Site for Drupal 9](https://www.drupal.org/docs/9/how-to-prepare-your-drupal-7-or-8-site-for-drupal-9) guide on Drupal.org.
 

--- a/source/content/guides/drupal-9-migration/02-migrate-prepare.md
+++ b/source/content/guides/drupal-9-migration/02-migrate-prepare.md
@@ -17,9 +17,9 @@ This overview outlines the steps to prepare an existing Drupal site for upgrade 
 
 ## Test an Existing Drupal Site for Drupal 9 Upgrade Compatibility
 
-1. Convert Drupal 8 Site to Composer
+1. Drupal 8 Only: Convert Drupal 8 Site to Composer
 
-If you are starting with a Drupal 8 site without Composer, follow the steps to [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
+   - If you are starting with a Drupal 8 site without Composer, follow the steps to [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
 
 1. Upgrade to the latest Drupal 8.9 release.
 

--- a/source/content/guides/drupal-9-migration/02-migrate-prepare.md
+++ b/source/content/guides/drupal-9-migration/02-migrate-prepare.md
@@ -13,9 +13,13 @@ anchorid: drupal-9-migration/prepare
 editpath: drupal-9-migration/02-migrate-prepare.md
 ---
 
-This overview outlines the steps to prepare an existing Drupal site for upgrade or migration to Drupal 9 with Integrated Composer.
+This overview outlines the steps to prepare an existing Drupal site for upgrade or migration to Drupal 9 with Integrated Composer or Composer with Build Tools.
 
 ## Test an Existing Drupal Site for Drupal 9 Upgrade Compatibility
+
+1. Convert Drupal 8 Site to Composer
+
+If you are starting with a Drupal 8 site without Composer, follow the steps to [Convert a Standard Drupal 8 Site to a Composer Managed Site](/guides/composer-convert).
 
 1. Upgrade to the latest Drupal 8.9 release.
 

--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -16,11 +16,26 @@ reviewed: "2021-04-22"
 
 This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 **Composer-managed** site to a Drupal 9 site with Integrated Composer.
 
-Drupal 9 sites on Pantheon have Composer built-in to manage site dependencies.
+## Differences in the Drupal 9 Upstream
+
+Drupal 9 sites on Pantheon use the [drupal-project](https://github.com/pantheon-systems/drupal-project) upstream. 
+
+Unlike earlier Pantheon upstreams, the main branch of the `drupal-project` repository does not contain files that you are unlikely to adjust while building sites (including Drupal Core). Instead, these are managed by Composer as dependencies.
+
+## Upgrade Overview 
 
 The goals of this upgrade are to:
 
-[new page content here]
+- remove any dependencies that will be managed as Composer dependencies by the `drupal-project` upstream from the existing site's Git repository, and
+
+- have Composer manage those dependencies in the new site instead
+
+### Drupal 8 Sites Using the drops-8 Upstream
+
+In addition, for Drupal 8 sites using the Pantheon `drops-8` upstream, switch the upstream from [drops-8](https://github.com/pantheon-systems/drops-8) to [drupal-project](https://github.com/pantheon-systems/drupal-project). 
+
+
+[additional page content here]
 
 
 ## Ongoing Core Updates

--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -14,13 +14,16 @@ editpath: drupal-9-migration/03-upgrade-to-d9.md
 reviewed: "2021-04-22"
 ---
 
-This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 **Composer-managed** site to a Drupal 9 site with Integrated Composer.
+This doc provides an overview of upgrading an existing Pantheon-hosted Drupal 8 **Composer-managed** site to a Drupal 9 site with Integrated Composer.
 
-## Differences in the Drupal 9 Upstream
+The process of upgrading a Pantheon Drupal 8 Composer-managed site to a Drupal 9 Integrated Composer site follows the steps in the [Manually Migrate](/guides/drupal-9-migration/migrate-manual-d9#prepare-the-local-environment) guide page. This doc provides additonal reference details, including:
+- an overview of the upgrade process
+- notes on differences between the Drupal 9 and Drupal 8 (`drops-8`) upstreams, and
+- information about ongoing site maintenance.
 
-Drupal 9 sites on Pantheon use the [drupal-project](https://github.com/pantheon-systems/drupal-project) upstream. 
+## Drupal 9 Upstream Note
 
-Unlike earlier Pantheon upstreams, the main branch of the `drupal-project` repository does not contain files that you are unlikely to adjust while building sites (including Drupal Core). Instead, these are managed by Composer as dependencies.
+<Partial file="drupal-9/drupal-9-upstream-note.md" />
 
 ## Upgrade Overview 
 
@@ -35,8 +38,7 @@ The goals of this upgrade are to:
 In addition, for Drupal 8 sites using the Pantheon `drops-8` upstream, switch the upstream from [drops-8](https://github.com/pantheon-systems/drops-8) to [drupal-project](https://github.com/pantheon-systems/drupal-project). 
 
 
-[additional page content here]
-
+To complete the site migration, follow the steps in the [Manually Migrate](/guides/drupal-9-migration/migrate-manual-d9#prepare-the-local-environment) guide page.
 
 ## Ongoing Core Updates
 

--- a/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
+++ b/source/content/guides/drupal-9-migration/03-upgrade-to-d9.md
@@ -1,7 +1,7 @@
 ---
 title: Migrate to Drupal 9
-subtitle: Upgrade from Drupal 8
-description: Upgrade Pantheon Drupal 8 Sites to Drupal 9 With Integrated Composer
+subtitle: Upgrade from Drupal 8 Composer
+description: Upgrade Pantheon Drupal 8 Composer Site to Drupal 9 With Integrated Composer
 categories: [get-started]
 cms: drupal-9
 tags: [code, launch, migrate, site, updates]
@@ -14,59 +14,14 @@ editpath: drupal-9-migration/03-upgrade-to-d9.md
 reviewed: "2021-04-22"
 ---
 
-This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 site without Composer to a Drupal 9 site with Integrated Composer.
+This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 **Composer-managed** site to a Drupal 9 site with Integrated Composer.
 
 Drupal 9 sites on Pantheon have Composer built-in to manage site dependencies.
 
 The goals of this upgrade are to:
 
-- remove dependencies that Composer will manage from the existing site's Git repository, and
+[new page content here]
 
-- have Composer manage those dependencies in the new site instead.
-
-Note that since you are effectively migrating your site using these upgrade steps, the new site will not maintain your site's existing commit history.
-
-<Alert title="Multidev Required" type="danger">
-
-To maintain best practice and to avoid difficult, time-consuming repairs to the site, this doc is written for users with access to Pantheon's [Multidev](/multidev) feature.
-
-Pantheon support is not available to users who avoid the Multidev steps.
-
-</Alert>
-
-## Will This Guide Work for Your Site?
-
-<Partial file="drupal-9/upgrade-site-requirements.md" />
-
-## Prepare the Local Environment
-
-<Partial file="drupal-9/prepare-local-environment.md" />
-
-### Apply All Available Upstream Updates
-
-<Partial file="drupal-apply-upstream-updates.md" />
-
-### (Optional) Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
-
-<Partial file="drupal-9/drupal-upgrade-status.md" />
-
-<Partial file="drupal-8-convert-to-composer.md" />
-
-## Change Upstreams
-
-Set the site to use the Drupal 9 Upstream:
-
-```bash{promptUser:user}
-terminus site:upstream:set $site drupal9
-```
-
-Enter `yes` when prompted:
-
-```bash
-Are you sure you want change the upstream for anita-drupal to Drupal 9? (yes/no) [no]:
-```
-
-Note that the [User in Charge](/change-management#site-level-roles-and-permissions), Site Owner, or Organization Administrator can change the Upstream.
 
 ## Ongoing Core Updates
 

--- a/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
+++ b/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
@@ -24,7 +24,7 @@ The goals of this upgrade are to:
 
 - have Composer manage those dependencies in the new site instead, then
 
-- move the site upstream from Pantheon's [drops-8](https://github.com/pantheon-systems/drops-8) upstream to [drupal-project](https://github.com/pantheon-systems/drupal-project), Pantheon's Composer-enabled Drupal template. 
+- move the site upstream from Pantheon's [drops-8](https://github.com/pantheon-systems/drops-8) upstream to [drupal-project](https://github.com/pantheon-systems/drupal-project), Pantheon's Composer-enabled Drupal 9 template. 
 
 Note that since you are effectively migrating your site using these upgrade steps, the new site will not maintain your site's existing commit history.
 

--- a/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
+++ b/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
@@ -1,6 +1,6 @@
 ---
 title: Migrate to Drupal 9
-subtitle: Upgrade from Drupal 8 non-Composer
+subtitle: Upgrade from Drupal 8 no-Composer
 description: Upgrade Pantheon Drupal 8 Non-Composer Site to Drupal 9 With Integrated Composer
 categories: [get-started]
 cms: drupal-9
@@ -8,19 +8,19 @@ tags: [code, launch, migrate, site, updates]
 contributors: [dustinleblanc, greg-1-anderson, stovak]
 layout: guide
 showtoc: true
-permalink: docs/guides/drupal-9-migration/upgrade-to-d9
-anchorid: drupal-9-migration/upgrade-to-d9
+permalink: docs/guides/drupal-9-migration/upgrade-to-d9-nocomp
+anchorid: drupal-9-migration/upgrade-to-d9-nocomp
 editpath: drupal-9-migration/04-upgrade-to-d9-nocomp.md
 reviewed: "2021-04-22"
 ---
 
-This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 site **without Composer** to a Drupal 9 site with Integrated Composer.
+This doc shows how to upgrade a Pantheon-hosted, **non-Composer-managed** Drupal 8 site to a Drupal 9 site with Integrated Composer.
 
 Drupal 9 sites on Pantheon have Composer built-in to manage site dependencies.
 
 The goals of this upgrade are to:
 
-- remove dependencies that Composer will manage from the existing site's Git repository, and
+- remove dependencies that Composer will manage from the existing site's Git repository, 
 
 - have Composer manage those dependencies in the new site instead, then
 

--- a/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
+++ b/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
@@ -24,7 +24,11 @@ The goals of this upgrade are to:
 
 - have Composer manage those dependencies in the new site instead, then
 
-- move the site upstream from Pantheon's [drops-8](https://github.com/pantheon-systems/drops-8) upstream to [drupal-project](https://github.com/pantheon-systems/drupal-project), Pantheon's Composer-enabled Drupal 9 template. 
+- switch the upstream from [drops-8](https://github.com/pantheon-systems/drops-8) to [drupal-project](https://github.com/pantheon-systems/drupal-project).
+
+## Drupal 9 Upstream Note
+
+<Partial file="drupal-9/drupal-9-upstream-note.md" />
 
 Note that since you are effectively migrating your site using these upgrade steps, the new site will not maintain your site's existing commit history.
 

--- a/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
+++ b/source/content/guides/drupal-9-migration/04-upgrade-to-d9-nocomp.md
@@ -1,0 +1,85 @@
+---
+title: Migrate to Drupal 9
+subtitle: Upgrade from Drupal 8 non-Composer
+description: Upgrade Pantheon Drupal 8 Non-Composer Site to Drupal 9 With Integrated Composer
+categories: [get-started]
+cms: drupal-9
+tags: [code, launch, migrate, site, updates]
+contributors: [dustinleblanc, greg-1-anderson, stovak]
+layout: guide
+showtoc: true
+permalink: docs/guides/drupal-9-migration/upgrade-to-d9
+anchorid: drupal-9-migration/upgrade-to-d9
+editpath: drupal-9-migration/04-upgrade-to-d9-nocomp.md
+reviewed: "2021-04-22"
+---
+
+This doc shows how to upgrade an existing Pantheon-hosted Drupal 8 site **without Composer** to a Drupal 9 site with Integrated Composer.
+
+Drupal 9 sites on Pantheon have Composer built-in to manage site dependencies.
+
+The goals of this upgrade are to:
+
+- remove dependencies that Composer will manage from the existing site's Git repository, and
+
+- have Composer manage those dependencies in the new site instead, then
+
+- move the site upstream from Pantheon's [drops-8](https://github.com/pantheon-systems/drops-8) upstream to [drupal-project](https://github.com/pantheon-systems/drupal-project), Pantheon's Composer-enabled Drupal template. 
+
+Note that since you are effectively migrating your site using these upgrade steps, the new site will not maintain your site's existing commit history.
+
+<Alert title="Multidev Required" type="danger">
+
+To maintain best practice and to avoid difficult, time-consuming repairs to the site, this doc is written for users with access to Pantheon's [Multidev](/multidev) feature.
+
+Pantheon support is not available to users who avoid the Multidev steps.
+
+</Alert>
+
+## Will This Guide Work for Your Site?
+
+<Partial file="drupal-9/upgrade-site-requirements.md" />
+
+## Prepare the Local Environment
+
+<Partial file="drupal-9/prepare-local-environment.md" />
+
+### Apply All Available Upstream Updates
+
+<Partial file="drupal-apply-upstream-updates.md" />
+
+### (Optional) Run upgrade_status to Confirm That the Site Is Ready to Be Upgraded
+
+<Partial file="drupal-9/drupal-upgrade-status.md" />
+
+<Partial file="drupal-8-convert-to-composer.md" />
+
+## Change Upstreams
+
+Set the site to use the Drupal 9 Upstream:
+
+```bash{promptUser:user}
+terminus site:upstream:set $site drupal9
+```
+
+Enter `yes` when prompted:
+
+```bash
+Are you sure you want change the upstream for anita-drupal to Drupal 9? (yes/no) [no]:
+```
+
+Note that the [User in Charge](/change-management#site-level-roles-and-permissions), Site Owner, or Organization Administrator can change the Upstream.
+
+## Ongoing Core Updates
+
+One-click core updates can be made through the Dashboard.
+
+Navigate to **Code** in the Dev tab of the site's Dashboard. Click **Check Now**. If updates are available, click **Apply Updates**.
+
+## Troubleshooting
+
+<Partial file="composer-updating.md" />
+
+## See Also
+
+- [Composer Fundamentals and Workflows](/composer)

--- a/source/content/guides/drupal-9-migration/05-migrate-manual-d9.md
+++ b/source/content/guides/drupal-9-migration/05-migrate-manual-d9.md
@@ -11,7 +11,7 @@ layout: guide
 showtoc: true
 permalink: docs/guides/drupal-9-migration/migrate-manual-d9
 anchorid: drupal-9-migration/migrate-manual-d9
-editpath: drupal-9-migration/04-migrate-manual-d9.md
+editpath: drupal-9-migration/05-migrate-manual-d9.md
 ---
 
 In this doc, you'll create a new Drupal 9 site and migrate the code from an existing Drupal 8 site to it.

--- a/source/partials/drupal-9/drupal-9-upstream-note.md
+++ b/source/partials/drupal-9/drupal-9-upstream-note.md
@@ -1,0 +1,3 @@
+Drupal 9 sites on Pantheon use the [drupal-project](https://github.com/pantheon-systems/drupal-project) upstream. 
+
+Unlike earlier Pantheon upstreams, the main branch of the `drupal-project` repository does not contain files that you are unlikely to adjust while building sites (including Drupal Core). Instead, these are managed by Composer as dependencies.

--- a/source/partials/drupal-9/verify-upstream.md
+++ b/source/partials/drupal-9/verify-upstream.md
@@ -1,0 +1,29 @@
+To verify the site's upstream, use the Terminus command `terminus site:info $SITE`. 
+
+<Accordion title="Use Terminus to Confirm the Site Upstream" id="framework" icon="info-sign">
+
+  This example shows a shortened version of the output:
+
+  ```bash{outputLines:2-18}
+  terminus site:info $SITE
+  ------------------ -------------------------------------------------------------------------------------
+  ID                 abdc3ea1-fe0b-1234-9c9f-3cxeAA123f88
+  Name               anita-drupal
+  Label              AnitaDrupal
+  Created            2019-12-02 18:28:14
+  Framework          drupal8
+  ...
+  Upstream           8a129104-9d37-4082-aaf8-e6f31154644e: git://github.com/pantheon-systems/drops-8.git
+  ...
+  ------------------ -------------------------------------------------------------------------------------
+  ```
+  #### Common Pantheon Upstreams
+| Name              | Framework            | Upstream                      | 
+|:------------------ |:-------------------- |:-------------------------------- |
+| `drops-8` | drupal8 | `git://github.com/pantheon-systems/drops-8.git` |
+| `drupal9` Integrated Composer | drupal8 | `git://github.com/pantheon-systems/drupal-project.git` |
+| `empty` | drupal8 | `` |
+
+Use the Terminus [upstream:list](/terminus/commands/upstream-list) command to retrieve a list of upstreams accessible to you.  
+  </Accordion>
+  


### PR DESCRIPTION
## Summary

**[Drupal 9](https://pantheon.io/docs/drupal-9)** -  Update to note Composer is Pantheon's recommended way to manage Drupal 9 sites. Clarify that Drupal 9 docs assume you're using Composer.


## Effect
<!-- Use this section to detail the changes summarized above, or remove if not needed -->
The following changes are already committed:

* new partial to "verify" the current site's upstream, to separate that Terminus bit out from the other partial.
* Provides a "start here" series of prompts
* Key bit: adds clarification/context about the structural difference between drops-8 and drupal-project (D9 IC) upstream, which adds some important context

## Remaining Work
<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] write out the instructions for each step to determine state state
   - [ ] should each be a separate part of the guide?

### Consider

- [ ] convert guide introduction to landing page and turn each doc into its own guide
- [ ] including info re Build Tools target workflow
- [ ] including details on what to do if you have a custom upstream, or an empty upstream

--------------------------------------------------
## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
