### PR TITLE
fix code sample

### DIFF
--- a/source/content/advanced-redirects.md
+++ b/source/content/advanced-redirects.md
@@ -128,7 +128,6 @@ $redirect_targets = array(
 );
 
 if ( (isset($redirect_targets[ $_SERVER['REQUEST_URI'] ] ) ) && (php_sapi_name() != "cli") ) {
-  echo 'https://'. $_SERVER['HTTP_HOST'] . $redirect_targets[ $_SERVER['REQUEST_URI'] ];
   header('HTTP/1.0 301 Moved Permanently');
   header('Location: https://'. $_SERVER['HTTP_HOST'] . $redirect_targets[ $_SERVER['REQUEST_URI'] ]);
 


### PR DESCRIPTION

## Summary
**[Advanced Redirects and Restrictions - Multiple URLs](https://pantheon.io/docs/advanced-redirects#redirect-multiple-urls) ** corrected the sample code

## Effect

The bad sample code would not work since there is output before a header, it will throw an error not completing the redirection.  Customers would be misguided.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
