### PR TITLE
Update `filemount` paths in Pantheon.yml docs

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -160,7 +160,7 @@ For more information and compatibility requirements, see [Managing Drush Version
 
 ### Filemount Path
 
-Pantheon provides a [cloud-based filesystem](/files) to store user-generated content and other website files. By default, we create a symlink to this filesystem at `sites/default/files` (Drupal) or `wp-content/uploads` (WordPress), but you can change the location with the `filemount` variable.
+Pantheon provides a [cloud-based filesystem](/files) to store user-generated content and other website files. By default, we create a symlink to this filesystem at `sites/default/files` (Drupal), `wp-content/uploads` (WordPress), or `app/uploads` (WordPress using Bedrock), but you can change the location with the `filemount` variable.
 
 <Alert title="Warning" type="danger">
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes # n/a

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Pantheon YAML Configuration Files](https://pantheon.io/docs/pantheon-yml)** - Update filemount paths to include Bedrock path.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The Bedrock path `app/uploads` is now a supported value for the `filemount` pantheon.yml setting.

## Remaining Work and Prerequisites

None, the change has already been deployed to production.

### Dependencies and Timing

**Release**:
- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
