### PR TITLE
6717- Typo Fixed

### DIFF
--- a/source/content/global-cdn.md
+++ b/source/content/global-cdn.md
@@ -36,7 +36,7 @@ For more details, see [Clearing Caches for Drupal and WordPress](/clear-caches).
 
 Serve your Drupal or WordPress site even in the unlikely event that it goes down.
 
-The goal of Experience Protection is to provide a seamless, uninterrupted experience for the user. If the server is not responding and can't serve a new copy of a page, a the CDN will choose to serve a cached version instead of displaying an error, even if the cached version has expired (this is called _stale cache_).
+The goal of Experience Protection is to provide a seamless, uninterrupted experience for the user. If the server is not responding and can't serve a new copy of a page, the CDN will choose to serve a cached version instead of displaying an error, even if the cached version has expired (this is called _stale cache_).
 
 ### How long does content stay fresh? Adjust TTL
 


### PR DESCRIPTION
Closes #6717 

## Summary

**[Experience Protection](https://pantheon.io/docs/global-cdn#experience-protection)** - Typo has been corrected.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
