### PR TITLE
Using -a would not commit newly added files

### DIFF
--- a/source/content/guides/jira.md
+++ b/source/content/guides/jira.md
@@ -132,7 +132,8 @@ In the commands below, replace `<site>` with your Pantheon site name.
 
 6. [Commit and push](/git/#push-changes-to-pantheon) changes to the Dev environment:
 
-        git commit -am "Create private/jira_integration.php and configure platform hooks"
+        git add .
+        git commit -m "Create private/jira_integration.php and configure platform hooks"
         git push origin master
 
 

--- a/source/content/guides/pivotal-tracker.md
+++ b/source/content/guides/pivotal-tracker.md
@@ -143,7 +143,8 @@ Next we'll add Pantheon's example [Quicksilver](/quicksilver) integration script
 6. [Commit and push](/git/#push-changes-to-pantheon) changes to the Dev environment:
 
   ```bash{promptUser: user}
-  git commit -am "Create private/scripts/pivotal_integration.php and configure platform hooks"
+  git add .
+  git commit -m "Create private/scripts/pivotal_integration.php and configure platform hooks"
   git push origin master
   ```
 

--- a/source/content/guides/trello.md
+++ b/source/content/guides/trello.md
@@ -128,7 +128,8 @@ Next we'll add Pantheon's example [Quicksilver](/quicksilver) integration script
 
 6. [Commit and push](/git/#push-changes-to-pantheon) changes to the Dev environment:
 
-        git commit -am "Create private/scripts/trello_integration.php and configure platform hooks"
+        git add .
+        git commit -m "Create private/scripts/trello_integration.php and configure platform hooks"
         git push origin master
 
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Guides for integrations used `git commit -am "message"` which would not commit the newly created files from the prior step in each guide. 

**[Integrate Jira on Pantheon with Quicksilver Hooks](https://pantheon.io/docs/guides/jira)** - Prepended with `git add .` to add untracked files
**[Integrate Pivotal Tracker Project Management Application with a site on Pantheon](https://pantheon.io/docs/guides/pivotal-tracker)** - Same
**[Integrate Trello on Pantheon with Quicksilver Hooks](https://pantheon.io/docs/guides/trello)** - Same


**Release**:
- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
