### PR TITLE
drush pm:list instead of pm:projectinfo for composer convert docu

### DIFF
--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -106,7 +106,7 @@ Once Composer is aware of all the contributed code, you'll be able to run `compo
 
 Begin by reviewing the existing site's code. Check for contributed modules in `/modules`, `/modules/contrib`, `/sites/all/modules`, and `/sites/all/modules/contrib`.
 
-1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:list` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
+1. Review the site and make a list of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:list` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
 
   This will list each module followed by the version of that module that is installed:
 

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -106,15 +106,13 @@ Once Composer is aware of all the contributed code, you'll be able to run `compo
 
 Begin by reviewing the existing site's code. Check for contributed modules in `/modules`, `/modules/contrib`, `/sites/all/modules`, and `/sites/all/modules/contrib`.
 
-1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:projectinfo` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
+1. When reviewing the site, take stock of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:list` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
 
   This will list each module followed by the version of that module that is installed:
 
   ```bash{promptUser:user}
-  terminus drush $SITE.dev pm:projectinfo -- --fields=name,version --format=table
+  terminus drush $SITE.dev pm:list -- --no-core --fields=name,version  --format=table
   ```
-
-  The command `pm:projectinfo` assumes Drush 8. If you encounter an issue with this command, [verify and configure the Drush version](/drush-versions) before you continue.
 
 1. You can add these modules to your new codebase using Composer by running the following for each module in the `$SITE` directory:
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

the partial `source/partials/drupal-8-convert-to-composer.md` mentions using a `drush pm:projectinfo` command for listing modules, with the caveat that it only works with drush 8 (true).  i've noticed that the command drush `pm:list` works with both drush 8 and drush 10, and produces nearly identical output, and provides some additional options like `--no-core` (and `--type=<module/theme>` and `--status=enabled`) which could be useful...

Screenshot attached with example output.
![drush-pmi-vs-pml](https://user-images.githubusercontent.com/87093053/137025536-3914abe3-b142-4deb-848e-97159f7386ce.png)


<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Used on (at least) these pages (which are incidentally almost the exact same document):
**[Upgrade from Drupal 8](https://pantheon.io/docs/guides/drupal-9-migration/upgrade-to-d9)**
**[Convert a Standard Drupal 8 Site to a Composer Managed Site](https://pantheon.io/docs/guides/composer-convert)**


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
