### PR TITLE
Update plugins-known-issues.md

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -340,7 +340,7 @@ ___
 
 **Solution 2:**
 
-1. Disable Static CSS file generation in the divi theme.
+1. Disable Static CSS file generation in the Divi theme.
 
 1. Disable Dynamic CSS at **Divi** > **Theme Options** > **General** > **Performance** and click to disable Dynamic CSS.
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -340,10 +340,15 @@ ___
 
 **Solution 2:**
 
-1. Create a [symlink](#assumed-write-access).
+1. Disable Static CSS file generation in the divi theme.
+
+1. Disable Dynamic CSS at **Divi** > **Theme Options** > **General** > **Performance** and click to disable Dynamic CSS.
+
+1. Create a [symlink](/plugins-known-issues#assumed-write-access) in `wp-content/et-cache`.
 
 1. Define the [FS_METHOD in the wp-config](#define-fs_method).
-2. Disable Dynamic CSS at **Divi** > **Theme Options** > **General** > **Performance** and click to disable Dynamic CSS.
+
+1. Purge the contents of `et-cache` but not the `et-cache` file itself.
 
 **Issue 2:** The WordPress admin dashboard becomes slow when editing posts using Divi.
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -343,6 +343,7 @@ ___
 1. Create a [symlink](#assumed-write-access).
 
 1. Define the [FS_METHOD in the wp-config](#define-fs_method).
+2. Disable Dynamic CSS at **Divi** > **Theme Options** > **General** > **Performance** and click to disable Dynamic CSS.
 
 **Issue 2:** The WordPress admin dashboard becomes slow when editing posts using Divi.
 


### PR DESCRIPTION
## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Add new solution to disable Dynamic CSS for DIVI. This is super important to stop et-cache from filling up and causing issues with editing posts in Divi.

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
