### PR TITLE
Add HM Require Login to WP Known Plugin Issues

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -449,6 +449,14 @@ ___
 
 ___
 
+## [HM Require Login](https://github.com/humanmade/hm-require-login)
+
+**Issue:** WordPress' cookies disappear shortly after successfully logging in.  When attempting to access a second page in the admin, the user is shown the login screen.
+
+**Solution:** Use another plugin such as [Force Login](https://wordpress.org/plugins/wp-force-login/) or [Restricted Site Access](https://wordpress.org/plugins/restricted-site-access/).
+
+___
+
 ## [InfiniteWP](https://infinitewp.com)
 
 <ReviewDate date="2019-10-01" />

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -451,7 +451,9 @@ ___
 
 ## [HM Require Login](https://github.com/humanmade/hm-require-login)
 
-**Issue:** WordPress' cookies disappear shortly after a user successfully logs in.  When attempting to access a second page in the admin, the user is shown the login screen.
+<ReviewDate date="2021-11-04" />
+
+**Issue:** WordPress's cookies disappear shortly after a user successfully logs in. When the user attempts to access a second page in the WordPress Admin, the user is shown the login screen.
 
 **Solution:** Use an alternative plugin such as [Force Login](https://wordpress.org/plugins/wp-force-login/) or [Restricted Site Access](https://wordpress.org/plugins/restricted-site-access/).
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -451,9 +451,9 @@ ___
 
 ## [HM Require Login](https://github.com/humanmade/hm-require-login)
 
-**Issue:** WordPress' cookies disappear shortly after successfully logging in.  When attempting to access a second page in the admin, the user is shown the login screen.
+**Issue:** WordPress' cookies disappear shortly after a user successfully logs in.  When attempting to access a second page in the admin, the user is shown the login screen.
 
-**Solution:** Use another plugin such as [Force Login](https://wordpress.org/plugins/wp-force-login/) or [Restricted Site Access](https://wordpress.org/plugins/restricted-site-access/).
+**Solution:** Use an alternative plugin such as [Force Login](https://wordpress.org/plugins/wp-force-login/) or [Restricted Site Access](https://wordpress.org/plugins/restricted-site-access/).
 
 ___
 


### PR DESCRIPTION
## Summary

While working on a Hackweek project, it was determined that HM Require Login doesn't work as intended on the platform.

**[WordPress Plugin and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Add HM Require Login to WP Known Plugin Issues

**Release**:
- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
