### PR TITLE
Bitbucket defaults to adding readme

### DIFF
--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -79,7 +79,9 @@ Choose your preferred Git host:
 
 1. Select whether the repository will be private or if it can be publicly accessible from outside your organization.
  
-1. Change Include README and Include .gitignore to "No"
+1. Select **No** from the dropdown menu for **Include a README?** 
+ 
+1. Select **No** from the dropdown menu for **Include .gitignore?**
 
 1. Click **Create Repository**.
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes: #6699 

## Summary

Minor update to ensure a README file is not created when the intent is to create an empty repository for the custom upstream. 

![image](https://user-images.githubusercontent.com/91161717/139110358-c367390c-fbb1-4643-af16-937250adba00.png)


<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Create a Custom Upstream](https://pantheon.io/docs/create-custom-upstream)** - Update to Create in the Bitbucket section

## Effect

The following changes are already committed:

* Extra step to ensure the default README is set to "No"

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
