### PR TITLE
WP CLI was linking to incorrect external docs

### DIFF
--- a/source/content/wp-cli.md
+++ b/source/content/wp-cli.md
@@ -74,7 +74,7 @@ echo "SELECT * FROM wp_users WHERE ID=1;" | terminus wp $site.$env -- db query
 
 ## Execute PHP Code Using WP-CLI on Pantheon
 
-The [`wp eval`](https://developer.wordpress.org/cli/commands/eval/) command is not supported on Pantheon, but you can still run the interactive shell [`wp shell`](https://developer.wordpress.org/cli/commands/eval/) to execute PHP commands:
+The [`wp eval`](https://developer.wordpress.org/cli/commands/eval/) command is not supported on Pantheon, but you can still run the interactive shell [`wp shell`](https://developer.wordpress.org/cli/commands/shell/) to execute PHP commands:
 
 ```bash
 terminus wp $site.$env -- shell


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

**[Using WP-CLI On The Pantheon Platform](https://pantheon.io/docs/wp-cli#execute-php-code-using-wp-cli-on-pantheon)** - Fix link

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
