### PR TITLE
Missed bash prompt for two sections

### DIFF
--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -34,11 +34,11 @@ Because of that, the steps below make these codebase changes in a new branch.
 
 Set the Drupal core version, to ensure the site remains on Drupal 8 for now:
 
-  ```
-  $ composer require --no-update drupal/core-recommended:^8.9
-  $ composer update drupal/core* -W
-  $ git add composer.*
-  $ git commit -m "Remain on Drupal 8"
+  ```bash{promptUser:user}
+  composer require --no-update drupal/core-recommended:^8.9
+  composer update drupal/core* -W
+  git add composer.*
+  git commit -m "Remain on Drupal 8"
   ```
 
 ### Add Upgrade Status Module
@@ -49,11 +49,11 @@ The Upgrade Status module will help to determine whether or not your site is rea
 
 Add the Upgrade Status module to your site with Composer:
 
-```
-$ composer require drupal/upgrade-status
-$ git add composer.*
-$ git commit -m "Add Upgrade Status module"
-```
+  ```bash{promptUser:user}
+  composer require drupal/upgrade-status
+  git add composer.*
+  git commit -m "Add Upgrade Status module"
+  ```
 
 When you are ready to begin upgrading your site to Drupal 9, you may enable this module and view the status report it provides to find things that need to be done before upgrading. 
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

**[Convert a Standard Drupal 8 Site to a Composer Managed Site](https://pantheon.io/docs/guides/composer-convert)** - Add missing bash prompt and remove $ signs

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
