### PR TITLE
Add wp-login protection notes

### DIFF
--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -20,7 +20,9 @@ Consult our doc for a list of [WordPress best practices](/wordpress-best-practic
 In addition to your other WordPress security practices, take steps to block **brute force attacks** that attempt to access your `wp-admin` dashboard and hyperinflate traffic to your site:
 
 1. Create a separate administrator account with a strong password, then remove the `admin` account.
+
 1. Use a plugin to [limit login attempts](https://wordpress.org/plugins/search/limit+login+attempts/).
+
 1. Protect yourself from `wp-login.php` attacks:
 
    <Accordion title="How to Avoid WordPress Login Attacks" id="wp-login-attacks" icon="info-sign">
@@ -30,6 +32,8 @@ In addition to your other WordPress security practices, take steps to block **br
    </Accordion>
 
 1. Add a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
+
+1. [Restrict Access to Paths Based on IP](/advanced-redirects#restrict-access-to-paths-based-on-ip).
 
 ## Configure favicon.ico to Serve a Static Image
 

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -21,8 +21,15 @@ In addition to your other WordPress security practices, take steps to block **br
 
 1. Create a separate administrator account with a strong password, then remove the `admin` account.
 1. Use a plugin to [limit login attempts](https://wordpress.org/plugins/search/limit+login+attempts/).
-1. Protect yourself from [wp-login.php attacks](/wordpress-best-practices#avoid-wordpress-login-attacks).
-1. Consider adding a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
+1. Protect yourself from `wp-login.php` attacks:
+
+   <Accordion title="How to Avoid WordPress Login Attacks" id="wp-login-attacks" icon="info-sign">
+
+   <Partial file="wp-login-attacks.md" />
+
+   </Accordion>
+
+1. Add a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
 
 ## Configure favicon.ico to Serve a Static Image
 
@@ -37,16 +44,16 @@ This issue affects both WordPress and Drupal sites, but the request path will va
 
 **Cause**: Usually the issue originates when adding a custom favicon through the active theme for the site through some kind of upload form, and then the icon is deleted or unavailable, which causes the CMS to look for an alternative favicon.
 
-**Solution**: Add and commit a static `favicon.ico` into the path that is being requested. 
+**Solution**: Add and commit a static `favicon.ico` into the path that is being requested.
 
 ## WordPress: admin-ajax.php Generates Pages Served
 
 Plugins can utilize an Ajax API to make calls to custom functions and filters in the backend.
 
-There are a number of uses for `admin-ajax.php`, and each instance of high usage should be inspected to determine if it is causing an unexpected number of pages served. Some use cases include: 
+There are a number of uses for `admin-ajax.php`, and each instance of high usage should be inspected to determine if it is causing an unexpected number of pages served. Some use cases include:
 
-- fetching the stored counts for when content is shared on social networks; 
-- checking if a page or post is currently being worked on (locked); 
+- fetching the stored counts for when content is shared on social networks;
+- checking if a page or post is currently being worked on (locked);
 - adding media to a post during the editing process, such as when using Gutenberg widgets.
 
 Investigate calls to `admin-ajax.php` by looking at what script is calling the path, and what the payload is through browser developer tools. Access developer tools, filter for `admin-ajax`, then refresh the page:

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -21,7 +21,7 @@ In addition to your other WordPress security practices, take steps to block **br
 
 1. Create a separate administrator account with a strong password, then remove the `admin` account.
 1. Use a plugin to [limit login attempts](https://wordpress.org/plugins/search/limit+login+attempts/).
-1. Protect yourself from [wp-login.php attacks](/wordpress-best-practices#avoid-wordPress-login-attacks).
+1. Protect yourself from [wp-login.php attacks](/wordpress-best-practices#avoid-wordpress-login-attacks).
 1. Consider adding a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
 
 ## Configure favicon.ico to Serve a Static Image

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -21,6 +21,7 @@ In addition to your other WordPress security practices, take steps to block **br
 
 1. Create a separate administrator account with a strong password, then remove the `admin` account.
 1. Use a plugin to [limit login attempts](https://wordpress.org/plugins/search/limit+login+attempts/).
+1. Protect yourself from [wp-login.php attacks](/wordpress-best-practices#avoid-wordPress-login-attacks).
 1. Consider adding a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
 
 ## Configure favicon.ico to Serve a Static Image

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -126,23 +126,29 @@ This method has the advantage of being toggleable without deploying code, by act
 
 ## Avoid WordPress Login Attacks
 
-Similar to XML-RPC, the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC that is not used often anymore, `wp-login.php` is the primary entry point for logging into WordPress. There are a few recommended actions you can take to protect yourself against login abuse:
+Similar to [XML-RPC](#avoid-xml-rpc-attacks), the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC, which is no longer used often, `wp-login.php` is the primary WordPress login.
 
-1. Change the `wp-login.php` path.
+There are a few recommended actions you can take to protect yourself against login abuse:
 
-    Using a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/), you can change the login path from `wp-login.php` to any path to your choosing, such as `/login` or `/admin`. You can then redirect all `wp-login.php` requests to another page (such as `/404`).
+### Change the wp-login.php Path
 
-1. Enforce complex passwords.
+Use a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login path from `wp-login.php` to any path you choose such as `/login` or `/admin`. Then [redirect](/advanced-redirects#redirect-one-path-to-another) all traffic from `wp-login.php` to the homepage or to another page like a `404`.
 
-    WordPress out-of-the-box provides password complexity guidelines, but does not require you to enforce it. You can use plugins like [Better Passwords](https://wordpress.org/plugins/better-passwords/) to set a minimum password length and let you know if the password has been collected in a previous data breach.
+### Enforce Complex Passwords
 
-1. Add Multi-Factor Authentication (MFA).
+WordPress suggests password complexity guidelines when you create a user and password, but it does not enforce password rules. Use a plugin like [Better Passwords](https://wordpress.org/plugins/better-passwords/) to set a minimum password length and alert users if they try to use a password that has been collected in a known data breach.
 
-    Two Factor Authentication (2FA) is an added layer of protection to ensure the security of your accounts beyond just a username and password. Multi-Factor only refers to the capability of having more than two factors of authentication (for example: password, SMS, and email verification). There are many [Two-Factor Authentication](https://wordpress.org/plugins/tags/two-factor-authentication/) plugins that can be used to add protection when logging into your WordPress site.
+### Add Multi-factor Authentication (MFA)
 
-1. Use Single Sign-On (SSO), if available.
+Two Factor Authentication (2FA) and Multi-factor Authentication (MFA) are added layers of protection to ensure the security of your accounts beyond just a username and password. Multi-factor refers to the capability to have more than two factors of authentication (for example: password, SMS, and email verification). Use one of the many [Two-Factor Authentication](https://wordpress.org/plugins/tags/two-factor-authentication/) plugins to protect logins to your WordPress site.
 
-    If your organization makes use of an Identity Provider (IdP) such as Google Workspace, Microsoft AzureAD, or others, it is best to utilize that as the login authority for your WordPress site. Some plugins or services can simplify the SSO integration of your IdP, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress). Often times, a byproduct of implementing SSO is enabling MFA (if required by your organization's IdP policy).
+### Use Single Sign-On (SSO)
+
+If your organization makes use of an Identity Provider (IdP) such as Google Workspace, Microsoft AzureAD, or others for [Single Sign-On](/sso-organizations), utilize that as the login authority for your WordPress site.
+
+Some plugins or services can simplify the SSO integration of your IdP, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress).
+
+SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) as well.
 
 ## Security Headers
 

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -126,29 +126,7 @@ This method has the advantage of being toggleable without deploying code, by act
 
 ## Avoid WordPress Login Attacks
 
-Similar to [XML-RPC](#avoid-xml-rpc-attacks), the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC, which is no longer used often, `wp-login.php` is the primary WordPress login.
-
-There are a few recommended actions you can take to protect yourself against login abuse:
-
-### Change the wp-login.php Path
-
-Use a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login path from `wp-login.php` to any path you choose such as `/login` or `/admin`. Then [redirect](/advanced-redirects#redirect-one-path-to-another) all traffic from `wp-login.php` to the homepage or to another page like a `404`.
-
-### Enforce Complex Passwords
-
-WordPress suggests password complexity guidelines when you create a user and password, but it does not enforce password rules. Use a plugin like [Better Passwords](https://wordpress.org/plugins/better-passwords/) to set a minimum password length and alert users if they try to use a password that has been collected in a known data breach.
-
-### Add Multi-factor Authentication (MFA)
-
-Two Factor Authentication (2FA) and Multi-factor Authentication (MFA) are added layers of protection to ensure the security of your accounts beyond just a username and password. Multi-factor refers to the capability to have more than two factors of authentication (for example: password, SMS, and email verification). Use one of the many [Two-Factor Authentication](https://wordpress.org/plugins/tags/two-factor-authentication/) plugins to protect logins to your WordPress site.
-
-### Use Single Sign-On (SSO)
-
-If your organization makes use of an Identity Provider (IdP) such as Google Workspace, Microsoft AzureAD, or others for [Single Sign-On](/sso-organizations), utilize that as the login authority for your WordPress site.
-
-Some plugins or services can simplify the SSO integration of your IdP, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress).
-
-SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) as well.
+<Partial file="wp-login-attacks.md" />
 
 ## Security Headers
 

--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -124,6 +124,26 @@ This method has the advantage of being toggleable without deploying code, by act
 
 1. Commit your work, deploy code changes then activate the plugin on Test and Live environments.
 
+## Avoid WordPress Login Attacks
+
+Similar to XML-RPC, the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC that is not used often anymore, `wp-login.php` is the primary entry point for logging into WordPress. There are a few recommended actions you can take to protect yourself against login abuse:
+
+1. Change the `wp-login.php` path.
+
+    Using a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/), you can change the login path from `wp-login.php` to any path to your choosing, such as `/login` or `/admin`. You can then redirect all `wp-login.php` requests to another page (such as `/404`).
+
+1. Enforce complex passwords.
+
+    WordPress out-of-the-box provides password complexity guidelines, but does not require you to enforce it. You can use plugins like [Better Passwords](https://wordpress.org/plugins/better-passwords/) to set a minimum password length and let you know if the password has been collected in a previous data breach.
+
+1. Add Multi-Factor Authentication (MFA).
+
+    Two Factor Authentication (2FA) is an added layer of protection to ensure the security of your accounts beyond just a username and password. Multi-Factor only refers to the capability of having more than two factors of authentication (for example: password, SMS, and email verification). There are many [Two-Factor Authentication](https://wordpress.org/plugins/tags/two-factor-authentication/) plugins that can be used to add protection when logging into your WordPress site.
+
+1. Use Single Sign-On (SSO), if available.
+
+    If your organization makes use of an Identity Provider (IdP) such as Google Workspace, Microsoft AzureAD, or others, it is best to utilize that as the login authority for your WordPress site. Some plugins or services can simplify the SSO integration of your IdP, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress). Often times, a byproduct of implementing SSO is enabling MFA (if required by your organization's IdP policy).
+
 ## Security Headers
 
 Pantheon's Nginx configuration [cannot be modified](/platform-considerations#htaccess) to add security headers, and many solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.

--- a/source/partials/wp-login-attacks.md
+++ b/source/partials/wp-login-attacks.md
@@ -1,0 +1,23 @@
+Similar to [XML-RPC](#avoid-xml-rpc-attacks), the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC, which is no longer used often, `wp-login.php` is the primary WordPress login.
+
+There are a few recommended actions you can take to protect yourself against login abuse:
+
+### Change the wp-login.php Path
+
+Use a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login path from `wp-login.php` to any path you choose such as `/login` or `/admin`. Then [redirect](/advanced-redirects#redirect-one-path-to-another) all traffic from `wp-login.php` to the homepage or to another page like a `404`.
+
+### Enforce Complex Passwords
+
+WordPress suggests password complexity guidelines when you create a user and password, but it does not enforce password rules. Use a plugin like [Better Passwords](https://wordpress.org/plugins/better-passwords/) to set a minimum password length and alert users if they try to use a password that has been collected in a known data breach.
+
+### Add Multi-factor Authentication (MFA)
+
+Two Factor Authentication (2FA) and Multi-factor Authentication (MFA) are added layers of protection to ensure the security of your accounts beyond just a username and password. Multi-factor refers to the capability to have more than two factors of authentication (for example: password, SMS, and email verification). Use one of the many [Two-Factor Authentication](https://wordpress.org/plugins/tags/two-factor-authentication/) plugins to protect logins to your WordPress site.
+
+### Use Single Sign-On (SSO)
+
+If your organization makes use of an Identity Provider (IdP) such as Google Workspace, Microsoft AzureAD, or others for [Single Sign-On](/sso-organizations), utilize that as the login authority for your WordPress site.
+
+Some plugins or services can simplify the SSO integration of your IdP, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress).
+
+SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) as well.

--- a/source/partials/wp-login-attacks.md
+++ b/source/partials/wp-login-attacks.md
@@ -4,7 +4,7 @@ There are a few recommended actions you can take to protect yourself against log
 
 ### Change the wp-login.php Path
 
-Use a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login path from `wp-login.php` to any path you choose such as `/login` or `/admin`. Then [redirect](/advanced-redirects#redirect-one-path-to-another) all traffic from `wp-login.php` to the homepage or to another page like a `404`.
+Use a plugin like [WPS Hide Login](https://wordpress.org/plugins/wps-hide-login/) to change the login path from `wp-login.php` to any path you choose, such as `/login` or `/admin`. Then [redirect](/advanced-redirects#redirect-one-path-to-another) all traffic from `wp-login.php` to the homepage or to another page like a `404`.
 
 ### Enforce Complex Passwords
 

--- a/source/partials/wp-login-attacks.md
+++ b/source/partials/wp-login-attacks.md
@@ -1,6 +1,6 @@
 Similar to [XML-RPC](#avoid-xml-rpc-attacks), the `wp-login.php` path can be subject to abuse by bots or other spammers. Unlike XML-RPC, which is no longer used often, `wp-login.php` is the primary WordPress login.
 
-There are a few recommended actions you can take to protect yourself against login abuse:
+There are a few recommended actions you can take to protect yourself against login abuse.
 
 ### Change the wp-login.php Path
 


### PR DESCRIPTION
## Summary
Adds recommendations for protecting against `wp-login.php` attacks.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[WordPress Best Practices](https://pantheon.io/docs/wordpress-best-practices)** - Adds wp-login protection recommendations.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
