### PR TITLE
Object Cache (formerly Redis) Doc Update

### DIFF
--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -4,7 +4,7 @@ description: Understand how to use Object Cache as a drop-in caching mechanism f
 categories: [performance]
 tags: [cache, plugins, modules, database]
 contributors: [cityofoaksdesign, carolynshannon]
-reviewed: "2021-03-01"
+reviewed: "2021-11-16"
 ---
 
 Pantheon's [<dfn id="objectcache">Object Cache (formerly Redis)</dfn>](/object-cache) is an open-source, networked, in-memory, key-value data store based on Redis that can be used as a drop-in caching backend for your Drupal or WordPress website.
@@ -151,6 +151,9 @@ All plans except for the Basic plan can use Object Cache. Sandbox site plans can
 
    if (defined('PANTHEON_ENVIRONMENT')) {
      // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
+     $settings['container_yamls'][] = 'modules/redis/example.services.yml';
+
+     // If you get a Filepath Error, try the below, as you might have a nested webroot.
      $settings['container_yamls'][] = dirname(DRUPAL_ROOT).'/modules/redis/example.services.yml';
 
      //phpredis is built into the Pantheon application container.
@@ -476,10 +479,6 @@ wp_cache_add_non_persistent_groups( array( 'bad-actor' ) );
 ```
 
 This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `wp_cache_get( 'foo', 'bad-actor' );` will not use Redis, and instead fall back to WordPress' default runtime object cache.
-
-### Filepath Error
-
-
 
 ## Frequently Asked Questions
 

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -477,6 +477,10 @@ wp_cache_add_non_persistent_groups( array( 'bad-actor' ) );
 
 This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `wp_cache_get( 'foo', 'bad-actor' );` will not use Redis, and instead fall back to WordPress' default runtime object cache.
 
+### Filepath Error
+
+
+
 ## Frequently Asked Questions
 
 ### How much Object cache is available for each plan level?

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -151,7 +151,7 @@ All plans except for the Basic plan can use Object Cache. Sandbox site plans can
 
    if (defined('PANTHEON_ENVIRONMENT')) {
      // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
-     $settings['container_yamls'][] = 'modules/redis/example.services.yml';
+     $settings['container_yamls'][] = dirname(DRUPAL_ROOT).'/modules/redis/example.services.yml';
 
      //phpredis is built into the Pantheon application container.
      $settings['redis.connection']['interface'] = 'PhpRedis';


### PR DESCRIPTION
Closes #6727 

## Summary

**[Enable Object Cache](https://pantheon.io/docs/object-cache#enable-object-cache)** - Adjust the path if you installed to a contrib or other subdirectory.


**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
