### PR TITLE
add D9 to Redis docs

### DIFF
--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -126,7 +126,7 @@ All plans except for the Basic plan can use Object Cache. Sandbox site plans can
 
 </Tab>
 
-<Tab title="Drupal 8" id="d8-install">
+<Tab title="Drupal 8/9" id="d8-install">
 
 1. Enable Object Cache from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for Object Cache to come online.
 
@@ -165,7 +165,7 @@ All plans except for the Basic plan can use Object Cache. Sandbox site plans can
 
      $settings['cache']['default'] = 'cache.backend.redis'; // Use Redis as the default cache.
      $settings['cache_prefix']['default'] = 'pantheon-redis';
-     
+
      $settings['cache']['bins']['form'] = 'cache.backend.database'; // Use the database for forms
    }
    ```


### PR DESCRIPTION
## Summary
Adds Drupal 9 to Object Cache documentation

The following changes are already committed:

* Made explicit Drupal 8 documentation also works for Drupal 9

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
