### PR TITLE
Update public docs that discuss Varnish with GCDN

### DIFF
--- a/source/content/cache-control.md
+++ b/source/content/cache-control.md
@@ -143,7 +143,7 @@ As an alternative to using HTTP headers to control downstream caching, you can s
 
 <Alert title="Warning" type="danger">
 
-Pantheon does not support manually editing and updating the VCL. We use a standard VCL for all sites on the platform. Requests are accepted, but we do not guarantee change requests will be implemented.
+Pantheon does not support manually editing and updating the VCL. We use a standard VCL for all sites on the platform. Requests are accepted, but we do not guarantee change requests will be implemented. To submit a request, open a [Support Ticket](/support#ticket-support).
 
 </Alert>
 

--- a/source/content/drupal-8-cache.md
+++ b/source/content/drupal-8-cache.md
@@ -1,6 +1,6 @@
 ---
-title: Drupal 8 Performance and Varnish Caching Settings
-description: Optimize Drupal 8 and Varnish caching to maximize your Pantheon site's performance.
+title: Drupal 8 Performance and Global CDN Caching Settings
+description: Optimize Drupal 8 and Glocal CDN caching to maximize your Pantheon site's performance.
 cms: "Drupal"
 categories: [performance]
 tags: [cache]

--- a/source/content/drupal-8-cache.md
+++ b/source/content/drupal-8-cache.md
@@ -5,7 +5,7 @@ cms: "Drupal"
 categories: [performance]
 tags: [cache]
 ---
-To maximize your site's performance on Pantheon and to take advantage of our Varnish caching, you'll need to configure your site's performance settings.
+To maximize your site’s performance on Pantheon and to take advantage of our Global CDN, you'll need to configure your site's performance settings.
 
 <Enablement title="Agency WebOps Training" link="https://pantheon.io/learn-pantheon?docs" campaign="docs-webops">
 

--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -232,7 +232,7 @@ $this->provider->login( $redirect_to );
 
 ### Varnish Not Working/Cookie Being Set for Anonymous Users
 
-The current version of the SimpleSAMLphp Authentication module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. There are two patches; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.
+There is a known issue with the Drupal 7 version of the SimpleSAMLphp Authentication module. The module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. While there are two patches you can try to improve site performance; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.
 
 ### SimpleSAMLphp Error: can't find metadata
 

--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -232,7 +232,7 @@ $this->provider->login( $redirect_to );
 
 ### Varnish Not Working/Cookie Being Set for Anonymous Users
 
-There is a known issue with the Drupal 7 version of the SimpleSAMLphp Authentication module. The module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. While there are two patches you can try to improve site performance; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) looks to be the best solution until the fix is accepted into an official project release.
+There is a known issue with the Drupal 7 version of the SimpleSAMLphp Authentication module. The module attempts to load a session on every page, as reported in [https://drupal.org/node/2020009](https://drupal.org/node/2020009) in the official issue queue. Although there are two patches you can try in an effort to improve site performance; at this time, [https://drupal.org/node/2020009#comment-7845537](https://drupal.org/node/2020009#comment-7845537) is the recommended solution until the fix is accepted into an official project release.
 
 ### SimpleSAMLphp Error: can't find metadata
 


### PR DESCRIPTION
Closes #DOC-464

## Summary

**[Drupal 8 Performance and Global CDN Caching Settings](https://pantheon.io/docs/drupal-8-cache)** - Update verbiage to Global CDN
**[Bypassing Cache with HTTP Headers](https://pantheon.io/docs/cache-control)** - Add support ticket link

## Remaining Work and Prerequisites

The following changes still need to be completed:

- [ ] DOC-483, if any

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
