### PR TITLE
Update drupal-cron.md

### DIFF
--- a/source/content/drupal-cron.md
+++ b/source/content/drupal-cron.md
@@ -138,4 +138,5 @@ No. You can create a custom module that uses the [`hook_cron`](https://api.drupa
 ## Resources
 
 - [Drupal.org Community Documentation - Set up Cron](https://www.drupal.org/docs/7/setting-up-cron/overview)
-- [Elysia Cron - extends Drupal standard Cron](https://www.drupal.org/project/elysia_cron)
+- [Elysia Cron - extends Drupal standard Cron for D7](https://www.drupal.org/project/elysia_cron)
+- [Ultimate Cron - extends Drupal standard Cron for D7, D8 and D9](https://www.drupal.org/project/ultimate_cron)

--- a/source/content/drupal-cron.md
+++ b/source/content/drupal-cron.md
@@ -138,5 +138,5 @@ No. You can create a custom module that uses the [`hook_cron`](https://api.drupa
 ## Resources
 
 - [Drupal.org Community Documentation - Set up Cron](https://www.drupal.org/docs/7/setting-up-cron/overview)
-- [Elysia Cron - extends Drupal standard Cron for D7](https://www.drupal.org/project/elysia_cron)
-- [Ultimate Cron - extends Drupal standard Cron for D7, D8 and D9](https://www.drupal.org/project/ultimate_cron)
+- [Elysia Cron - extends Drupal standard Cron for Drupal 7](https://www.drupal.org/project/elysia_cron)
+- [Ultimate Cron - extends Drupal standard Cron for Drupal 7, Drupal 8, and Drupal 9](https://www.drupal.org/project/ultimate_cron)


### PR DESCRIPTION
Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Cron for Drupal](https://pantheon.io/docs/drupal-cron)** - Link to Ultimate Cron. Added link to Ultimate Cron, as the only Drupal cron extender listed only goes up to Drupal 7.


**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
