### PR TITLE
Add clarity around use of composer.lock in an upstream

### DIFF
--- a/source/partials/ic-upstream-structure.md
+++ b/source/partials/ic-upstream-structure.md
@@ -20,6 +20,6 @@ code/
     - `composer.json`: Composer automatically updates `composer.json` with customizations for the upstream. Avoid manually modifying this file.
 - `pantheon.upstream.yml`: The `build_step: true` directive in `pantheon.upstream.yml` enables the build step.
 
-When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file and commits it back to the site’s code repository.
+When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file and commits it back to the site’s code repository.  To eliminate potential merge conflicts when applying an upstream update, the `composer.lock` file should not be committed to the upstream repository.
 
 Build artifacts are stored in a Git tag like `pantheon_build_artifacts_$BRANCHNAME` (where `$BRANCHNAME` is the name of the environment or Multidev feature branch).

--- a/source/partials/ic-upstream-structure.md
+++ b/source/partials/ic-upstream-structure.md
@@ -20,6 +20,6 @@ code/
     - `composer.json`: Composer automatically updates `composer.json` with customizations for the upstream. Avoid manually modifying this file.
 - `pantheon.upstream.yml`: The `build_step: true` directive in `pantheon.upstream.yml` enables the build step.
 
-When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file and commits it back to the site’s code repository.  To eliminate potential merge conflicts when applying an upstream update, the `composer.lock` file should not be committed to the upstream repository.
+When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file, and commits it back to the site’s code repository.  To avoid potential merge conflicts when applying an upstream update, do not commit the `composer.lock` file to the upstream repository.
 
 Build artifacts are stored in a Git tag like `pantheon_build_artifacts_$BRANCHNAME` (where `$BRANCHNAME` is the name of the environment or Multidev feature branch).


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Add clarity around use of composer.lock in an upstream

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
