### PR TITLE
Update composer convert docs

### DIFF
--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -36,6 +36,7 @@ Set the Drupal core version, to ensure the site remains on Drupal 8 for now:
 
   ```bash{promptUser:user}
   composer require --no-update drupal/core-recommended:^8.9
+  composer require --no-update --dev drupal/core-dev:^8.9
   composer require "composer/installers:^1.9"
   composer update drupal/core* -W
   git add composer.*

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -36,9 +36,7 @@ Set the Drupal core version, to ensure the site remains on Drupal 8 for now:
 
   ```bash{promptUser:user}
   composer require --no-update drupal/core-recommended:^8.9
-  composer require --no-update --dev drupal/core-dev:^8.9
-  composer require "composer/installers:^1.9"
-  composer update drupal/core* -W
+  composer require --dev drupal/core-dev:^8.9
   git add composer.*
   git commit -m "Remain on Drupal 8"
   ```


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Convert a Standard Drupal 8 Site to a Composer Managed Site](https://pantheon.io/docs/guides/composer-convert#set-drupal-core-version)** - Updates instructions to set Drupal version to 8

## Effect

The following changes are already committed:

* Simplify instructions
* Add missing core-dev composer require

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
