### PR TITLE
Load static assets uncached and purge automation

### DIFF
--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -52,6 +52,21 @@ For CSS or JavaScript changes, Drupal and WordPress each offer methods to ensure
 
 Dev and Multidev environments do not cache static assets.
 
+Another solution to consider when debugging issues related to stale static assets is to load the file via a custom PHP script that sets a `no-cache` header value, for example: 
+
+```php
+<?php
+
+// Punch through the Pantheon edge cache.
+header("Cache-Control: no-cache, must-revalidate");
+
+// Set JSON header
+header('Content-Type: application/json');
+
+// Echo file content
+echo file_get_contents("/path/to/file.json");
+```
+
 ## Using Your Own Session-Style Cookies
 
 Pantheon passes all cookies beginning with SESS that are followed by numbers and lowercase characters back to the application. When at least one of these cookies is present, the Global CDN will not try to respond to the request from its cache or store the response.

--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -67,6 +67,32 @@ header('Content-Type: application/json');
 echo file_get_contents("/path/to/file.json");
 ```
 
+`pantheon_clear_edge_paths` is a platform function that can be implemented in a [Quicksilver hook (like `deploy`)](https://pantheon.io/docs/quicksilver#hooks) to automatically purge a given static asset from cache, for example: 
+```
+<?php
+
+// Punch through the Pantheon edge cache.
+setcookie('NO_CACHE', '1');
+
+// Test clearing files-only path
+if (function_exists('pantheon_clear_edge_paths')) {
+    $paths = [
+      'sites/default/files/file.json'
+    ];
+
+    // Test path types.
+    foreach ($paths as $path) {
+        try {
+            pantheon_clear_edge_paths([$path]);
+        } catch (Exception $e) {
+            echo "<pre>";
+            print_r($e);
+            echo "</pre>";
+        }
+    }
+}
+```
+
 ## Using Your Own Session-Style Cookies
 
 Pantheon passes all cookies beginning with SESS that are followed by numbers and lowercase characters back to the application. When at least one of these cookies is present, the Global CDN will not try to respond to the request from its cache or store the response.


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Caching: Advanced Topics](https://pantheon.io/docs/caching-advanced-topics#manually-expiring-cache-for-static-assets)**  Address a common pain point that frequently adds tension and confusion in early stages of the customer journey 

* provide example custom script for loading uncached static assets 
* provide example quicksilver script to auto purge after a given workflow such as `deploy`
* [ ] Todo: consider inclusion of additional QS example script that uses pantheon_clear_edge_all(); combined with passthru('drush cc all'); to achieve purging all caches automatically after deploying to live env (vs purging 1 file alone via pantheon_clear_edge_paths)



Attribution for the example scripts should go to @kyletaylored (thank you so much Kyle!)

cc @joebortelpantheon 

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
