### PR TITLE
The use of upstream-configuration and upstream-config were inverted for Drupal and WordPress

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -90,13 +90,13 @@ Upstream refers to the source code that is hosted in the Pantheon code repositor
    - Drupal:
 
     ```bash{promptUser: user}
-    cd upstream-config
+    cd upstream-configuration
     ```
 
    - WordPress:
 
     ```bash{promptUser: user}
-    cd upstream-configuration
+    cd upstream-config
     ```
 
 1. Run `composer require` for each dependency:

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -96,7 +96,7 @@ Upstream refers to the source code that is hosted in the Pantheon code repositor
    - WordPress:
 
     ```bash{promptUser: user}
-    cd upstream-config
+    cd upstream-config 
     ```
 
 1. Run `composer require` for each dependency:


### PR DESCRIPTION
The use of upstream-configuration and upstream-config were inverted for Drupal and WordPress. Drupal uses upstream-configuration (https://github.com/pantheon-upstreams/drupal-project/tree/master/upstream-configuration) and WordPress uses upstream-config (https://github.com/pantheon-upstreams/wordpress-project/tree/master/upstream-config)

Closes # N/A

## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Updated [How to Add Dependencies to Your Upstream](https://pantheon.io/docs/integrated-composer#how-to-add-dependencies-to-your-upstream) section, WP and Drupal git commands in Step 2 were inverted.

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
