### PR TITLE
Run builds with Terminus 2

### DIFF
--- a/.circleci/scripts/terminus-installer.php
+++ b/.circleci/scripts/terminus-installer.php
@@ -30,10 +30,10 @@ function downloadTerminus($installdir, $package)
             ]
     ];
     $context  = stream_context_create($opts);
-    $releases = file_get_contents("https://api.github.com/repos/pantheon-systems/" . $package . "/releases", false, $context);
-    $releases = json_decode($releases);
-    $version  = $releases[0]->tag_name;
-    $url      = $releases[0]->assets[0]->browser_download_url;
+    $release = file_get_contents("https://api.github.com/repos/pantheon-systems/" . $package . "/releases/tags/2.6.4", false, $context);
+    $release = json_decode($release);
+    $version  = $release->tag_name;
+    $url      = $release->assets[0]->browser_download_url;
     // Do the needful
     echo("\nDownloading Terminus " . $version . " from " . $url . " to /tmp \n");
     $couldDownload = file_put_contents("/tmp/" . $package . ".phar", file_get_contents($url));


### PR DESCRIPTION
Now that Terminus 3 is the "latest" release, we need to grab an explicit release of Terminus 2 if we want to continue using an older version.

Terminus 2 will not change often, so we might as well just hardcode the specific version we want.