### PR TITLE
Typo "scope support" on Get Support

### DIFF
--- a/source/content/support.md
+++ b/source/content/support.md
@@ -141,7 +141,7 @@ We love helping developers succeed!
 
 Our Account packages feature a range of support features including basic platform support to more comprehensive support and a dedicated Customer Success Manager.
 
-While we have limits to the scope support we can provide, our [Professional Services](/guides/professional-services) team can be contracted to help unblock you in areas that fall outside of support scope.
+While we have limits to the scope of support we can provide, our [Professional Services](/guides/professional-services) team can be contracted to help unblock you in areas that fall outside of support scope.
 
 [Contact Sales](https://pantheon.io/contact-us?docs) if your requirements fall outside the scope outlined below.
 


### PR DESCRIPTION
## Summary

**[Get Support](https://pantheon.io/docs/support#scope-of-support)** - Potential typo "scope support".

## Effect

There is potentially a typo in the text...

> While we have limits to the scope support we can provide, our Professional Services team can be contracted to help unblock you in areas that fall outside of support scope.

...where "scope support" is perhaps meant to be "scope of support".

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)