### PR TITLE
Default Bitbucket settings conflict with upstreams

### DIFF
--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -85,6 +85,18 @@ Choose your preferred Git host:
 
 1. Select **No** from the dropdown menu for **Include .gitignore?**.
 
+1. Set the **Default branch name** to **master**
+
+  <Alert type="info" title="Note">
+
+  As of January 27th, 2021, all new repositories on Bitbucket are initialized with the default branch name `main`.
+
+  As a company, Pantheon is trying to use [more inclusive language in our repositories](https://pantheon.io/blog/diversity-equity-and-inclusion-pantheon?docs). While our team works to make Custom Upstreams less reliant on older naming conventions, new Custom Upstreams currently default to using the `master` branch name.
+
+  Git's default naming convention differs from GitHub's. If you don't initialize the repository on Bitbucket, Git will assign the default branch name as `master` when you clone the repository locally.
+
+  </Alert>
+
 1. Click **Create Repository**.
 
 1. Copy the repository URL (HTTPS), found on the top right of the page:

--- a/source/content/create-custom-upstream.md
+++ b/source/content/create-custom-upstream.md
@@ -89,11 +89,14 @@ Choose your preferred Git host:
 
   <Alert type="info" title="Note">
 
-  As of January 27th, 2021, all new repositories on Bitbucket are initialized with the default branch name `main`.
+  As of January 27th, 2021, all new repositories on Bitbucket are initialized with `main` as the default branch name.
+ 
+  Pantheon intends to remove harmful language from our code and documentation. Please refer to our documentation on [more inclusive language in our      
+  repositories](https://pantheon.io/blog/diversity-equity-and-inclusion-pantheon?docs) for more information. 
 
-  As a company, Pantheon is trying to use [more inclusive language in our repositories](https://pantheon.io/blog/diversity-equity-and-inclusion-pantheon?docs). While our team works to make Custom Upstreams less reliant on older naming conventions, new Custom Upstreams currently default to using the `master` branch name.
+  As we strive to make Custom Upstreams less reliant on older naming conventions, new Custom Upstreams currently default to using the `master` branch name.
 
-  Git's default naming convention differs from GitHub's. If you don't initialize the repository on Bitbucket, Git will assign the default branch name as `master` when you clone the repository locally.
+  Please note that Git's default naming convention differs from GitHub's. If you do not initialize the repository on Bitbucket, Git will assign the default branch name as `master` when you clone the repository locally.
 
   </Alert>
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Create a Custom Upstream](https://pantheon.io/docs/create-custom-upstream)** - Bitbucket defaults to `main` which causes Custom Upstreams to fail to pull. Updated docs to have similar language as GitHub's instructions.

![image](https://user-images.githubusercontent.com/91161717/147391693-80bcc8e1-ce16-4107-8278-5e2fafec2a75.png)

https://jira.atlassian.com/browse/BCLOUD-20212?error=login_required&error_description=Login+required&state=49354ef0-9f2f-4380-99d8-cfc5f8c2e29b

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
