### PR TITLE
GoAccess updates

### DIFF
--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -31,7 +31,7 @@ This guide is written for the latest stable release of GoAccess as of this writi
 
 To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats.
 
-1. Check where your configuration file is located with this command: `goaccess --dcf`
+1. Use the command `goaccess --dcf` to check where your configuration file is located.
 2. Copy this configuration file to your home directory. For example, if you installed GoAccess with Homebrew, your command might look like this: `cp /opt/homebrew/Cellar/goaccess/1.5.4/etc/goaccess/goaccess.conf ~/.goaccessrc`
 3. Add the following lines to the configuration file:
 

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -25,21 +25,24 @@ Be sure that you have:
   * **Mac OS X**: Install via [Homebrew](https://brew.sh/) (`brew install goaccess`)
   * **Windows**: Use [Windows Subsystem for Linux](https://docs.microsoft.com/en-us/windows/wsl/install-win10)
 
-This guide is written for the latest stable release of GoAccess as of this writing, which is version 1.4 ([release notes](https://goaccess.io/release-notes)).
+This guide is written for the latest stable release of GoAccess as of this writing, which is version 1.5 ([release notes](https://goaccess.io/release-notes)).
 
 ## Edit GoAccess Configuration
 
-To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats.
+To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats. 
 
-The configuration file is located under `~/.goaccessrc` or `%sysconfdir%/goaccess.conf` where `%sysconfdir%` is either `/etc/`, `/usr/etc/` or `/usr/local/etc/` ([read more](https://goaccess.io/faq#configuration)).
+1. Check where your configuration file is located with this command: `goaccess --dcf`
+2. Copy this configuration file to your home directory. For example, if you installed GoAccess with Homebrew, your command might look like this: 
+3. `cp /opt/homebrew/Cellar/goaccess/1.5.4/etc/goaccess/goaccess.conf ~/.goaccessrc`
+4. Add the following lines to the configuration file:
 
-Add the following lines to the `goaccess.conf` file:
-
-```none:title=goaccess.conf
+```none:title=.goaccessrc
 time-format %H:%M:%S
 date-format %d/%b/%Y
 log-format %^ - %^ [%d:%t %^]  "%r" %s %b "%R" "%u" %T "%h,%^"
 ```
+
+Note that when providing configuration from your home directory, the file needs to be named `.goaccessrc`. If you're storing this file elsewhere, it should be named `goaccess.conf`. [Read more about the configuration file](https://goaccess.io/faq#configuration).
 
 ## Create a report
 
@@ -105,7 +108,6 @@ You can navigate the `nginx-access.log` file using the CLI, without GoAccess. Th
 * Locate the most frequent URLs
 
   ```cat nginx-access.log | awk -F '\"' '{print $2}' | sort | uniq -c | sort -nr | head```
-
 
 * Identify the most frequent User Agents
 

--- a/source/content/nginx-access-log.md
+++ b/source/content/nginx-access-log.md
@@ -4,7 +4,7 @@ description: Learn how to parse the nginx-access.log file with GoAccess to gathe
 categories: [performance]
 tags: [logs, measure]
 contributors: [albertcausing, sarahg]
-reviewed: "2020-08-29"
+reviewed: "2022-01-02"
 ---
 Pantheon runs nginx web servers for optimal performance. Your site's nginx access logs record web server events and activities that can help you identify potential issues and gather information about users.
 
@@ -29,12 +29,11 @@ This guide is written for the latest stable release of GoAccess as of this writi
 
 ## Edit GoAccess Configuration
 
-To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats. 
+To parse your `nginx-access.log` files with GoAccess, you'll need to configure GoAccess to read Pantheon's log formats.
 
 1. Check where your configuration file is located with this command: `goaccess --dcf`
-2. Copy this configuration file to your home directory. For example, if you installed GoAccess with Homebrew, your command might look like this: 
-3. `cp /opt/homebrew/Cellar/goaccess/1.5.4/etc/goaccess/goaccess.conf ~/.goaccessrc`
-4. Add the following lines to the configuration file:
+2. Copy this configuration file to your home directory. For example, if you installed GoAccess with Homebrew, your command might look like this: `cp /opt/homebrew/Cellar/goaccess/1.5.4/etc/goaccess/goaccess.conf ~/.goaccessrc`
+3. Add the following lines to the configuration file:
 
 ```none:title=.goaccessrc
 time-format %H:%M:%S


### PR DESCRIPTION
## Summary

**[Parsing Nginx Access Logs with GoAccesse](https://pantheon.io/docs/nginx-access-log)** - Clarifies configuration steps and bumps GoAccess version number.

## Effect
- Clarifies where GoAccess configuration should come from. Our existing directions were not accurate for Homebrew installs, and this is (probably) how most of our readers will install GoAccess.
- Notes that this doc works with what is now the newest release of GoAccess, 1.5.4.

## Remaining Work and Prerequisites

The following changes still need to be completed:

- [ ] Copy review
- [ ] Tech review

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
