### PR TITLE
Specify that D9 sites must use IC for Autopilot

### DIFF
--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -33,7 +33,7 @@ terminus drush <site>.<env> -- status | grep "Drush version"
 
 Before you modify a site's Drush version, remember that not all versions of Drush are compatible with all versions of Drupal. See [Available Drush Versions](#available-drush-versions) and the [requirements below](#compatibility-and-requirements).
 
-Change a site's Drush version via the [pantheon.yml file](/pantheon-yml/):
+Change a site's Drush version via the [`pantheon.yml` file](/pantheon-yml/):
 
 ```yaml:title=pantheon.yml
 api_version: 1
@@ -53,11 +53,11 @@ If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.ym
 
 Drush 8 is compatible with Drupal 7 and 8.
 
-Always use Drush 8 with Drupal 7 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 up to Drupal 9.
+Always use Drush 8 with Drupal 7 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 to Drupal 9.
 
 [Drupal 9 requires Drush 10](https://www.drush.org/latest/install/#drupal-compatibility) or higher.
 
-Drush 10 is available with the [addition to your pantheon.yml file](#configure-drush-version) shown above, or for [site-local installation](#site-local-drush-usage). It requires Drupal 8 or higher, [Composer](/composer/), and PHP 7.1 or higher.
+Drush 10 is available with the [addition to your `pantheon.yml` file](#configure-drush-version) shown above, or for [site-local installation](#site-local-drush-usage). It requires Drupal 8 or higher, [Composer](/composer/), and PHP 7.1 or higher.
 
 <Alert title="Note" type="info">
 
@@ -125,4 +125,4 @@ Configure a newer version of Drush as [documented above](#configure-drush-versio
 - [Fix Up Drush Site Aliases with a Policy File (Blog)](https://pantheon.io/blog/fix-drush-site-aliases-policy-file)
 - [Expand Your Use of Drush on Pantheon with More Commands (Blog)](https://pantheon.io/blog/expand-use-drush-pantheon-more-commands)
 - [Drupal Drush Command-Line Utility](/drush/)
-- [The pantheon.yml Configuration File](/pantheon-yml)
+- [The `pantheon.yml` Configuration File](/pantheon-yml)

--- a/source/content/drush-versions.md
+++ b/source/content/drush-versions.md
@@ -53,9 +53,9 @@ If the `pantheon.yml` file does not exist, create it. If a `pantheon.upstream.ym
 
 Drush 8 is compatible with Drupal 7 and 8.
 
-Always use Drush 8 with Drupal 7 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 and later.
+Always use Drush 8 with Drupal 7 sites, as Drush 9 and Drush 10 only work on Drupal 8.4 up to Drupal 9.
 
-While Drush 5 and Drush 7 are available on Pantheon if needed, they are listed as [unsupported](https://docs.drush.org/en/8.x/install/#drupal-compatibility) by the Drush maintainers, and should be avoided unless absolutely necessary.
+[Drupal 9 requires Drush 10](https://www.drush.org/latest/install/#drupal-compatibility) or higher.
 
 Drush 10 is available with the [addition to your pantheon.yml file](#configure-drush-version) shown above, or for [site-local installation](#site-local-drush-usage). It requires Drupal 8 or higher, [Composer](/composer/), and PHP 7.1 or higher.
 
@@ -64,6 +64,10 @@ Drush 10 is available with the [addition to your pantheon.yml file](#configure-d
 When running Drush locally, we highly recommend running Drush version 8.3.2 or higher.
 
 </Alert>
+
+### Drush 5 and Drush 7
+
+While Drush 5 and Drush 7 are available on Pantheon if needed, they are listed as [unsupported](https://docs.drush.org/en/8.x/install/#drupal-compatibility) by the Drush maintainers, and should be avoided unless absolutely necessary.
 
 #### PHP Requirements
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -62,7 +62,15 @@ Not yet. [Autopilot](/guides/autopilot) is not compatible with [Build Tools](/gu
 
 ### What versions of Drush are supported by Autopilot?
 
-Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9. All Drupal 9 sites that use Integrated Composer are compatible with Autopilot.
+For sites:
+- **Up to (not including) Drupal 9**: Drush 8
+- **Drupal 9 with Integrated Composer**: Any. Autopilot will use Composer instead of Drush.
+- **Drupal 9 without Integrated Composer**: Drush 8*
+  - *Drupal 9 requires Drush 10 or higher, but Autopilot is not yet compatible with Drush 10. You might encounter other incompatibilities if you attempt to use Drush 8 with Drupal 9.
+
+Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9.
+
+All Drupal 9 sites that use Integrated Composer are compatible with Autopilot.
 
 Autopilot does not use Drush when updating an Integrated Composer site; you can use any Drush version when using Integrated Composer. Refer to the documentation on [Drush versions](/drush-versions) for more information.
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -62,9 +62,9 @@ Not yet. [Autopilot](/guides/autopilot) is not compatible with [Build Tools](/gu
 
 ### What versions of Drush are supported by Autopilot?
 
-Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9. Drupal 9 uses Drush 10 and is compatible with Autopilot.
+Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9. All Drupal 9 sites that use Integrated Composer are compatible with Autopilot.
 
-However, Autopilot does not use Drush when updating an Integrated Composer site; you can use any Drush version when using Integrated Composer. Refer to the documentation on [Drush versions](/drush-versions) for more information.
+Autopilot does not use Drush when updating an Integrated Composer site; you can use any Drush version when using Integrated Composer. Refer to the documentation on [Drush versions](/drush-versions) for more information.
 
 ### Does Autopilot support Terminus actions?
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -62,10 +62,10 @@ Not yet. [Autopilot](/guides/autopilot) is not compatible with [Build Tools](/gu
 
 ### What versions of Drush are supported by Autopilot?
 
-For sites:
+The version(s) of Drush that are supported by Autopilot for sites:
 - **Up to (not including) Drupal 9**: Drush 8
-- **Drupal 9 with Integrated Composer**: Any. Autopilot will use Composer instead of Drush.
-- **Drupal 9 without Integrated Composer**: Is not supported. Drupal 9 requires Drush 10 or higher, but Autopilot is not compatible with Drush 10 yet.
+- **Drupal 9 with Integrated Composer**: Any; Autopilot will use Composer instead of Drush.
+- **Drupal 9 without Integrated Composer**: Drush is not supported. Drupal 9 requires Drush 10 or higher, but Autopilot is not currently compatible with Drush 10.
 
 Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9.
 

--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -65,8 +65,7 @@ Not yet. [Autopilot](/guides/autopilot) is not compatible with [Build Tools](/gu
 For sites:
 - **Up to (not including) Drupal 9**: Drush 8
 - **Drupal 9 with Integrated Composer**: Any. Autopilot will use Composer instead of Drush.
-- **Drupal 9 without Integrated Composer**: Drush 8*
-  - *Drupal 9 requires Drush 10 or higher, but Autopilot is not yet compatible with Drush 10. You might encounter other incompatibilities if you attempt to use Drush 8 with Drupal 9.
+- **Drupal 9 without Integrated Composer**: Is not supported. Drupal 9 requires Drush 10 or higher, but Autopilot is not compatible with Drush 10 yet.
 
 Currently, Autopilot only supports Drush 8 for all sites up to Drupal 9.
 


### PR DESCRIPTION
## Summary

**[Introduction](https://pantheon.io/docs/guides/autopilot)** - Updated to explicitly state Drupal 9 works with any version of Drush so long as it is using Integrated Composer

Based on discussions in [Slack](https://pantheon.slack.com/archives/C01MZT20TDM/p1641401965191300?thread_ts=1641400160.190100&cid=C01MZT20TDM), it seems there is a need to specify that some Drupal 9 sites fall out of the common parameters if they are not using the recommended Integrated Composer workflow. This applies to sites using an empty upstream or external build tools. 

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
