### PR TITLE
Capture Drush 10's warning for keywords - exit due to redirect

### DIFF
--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -235,6 +235,14 @@ The following silent failure occurs when executing `terminus drush` commands on 
 [error]
 ```
 
+Newer versions of Drush fail with a message `[warning] Drush command terminated abnormally.`, for example: 
+
+```bash
+[warning] Drush command terminated abnormally.
+[notice] Command: <site>.<env> -- 'drush <command>' [Exit: 1]
+[error]
+```
+
 Redirects kill the PHP process before Drush execution is complete. You can resolve this error by adding `php_sapi_name() != "cli"` as a conditional statement to all redirect logic within `settings.php`:
 
 ```php:title=settings.php

--- a/source/content/drush.md
+++ b/source/content/drush.md
@@ -235,7 +235,7 @@ The following silent failure occurs when executing `terminus drush` commands on 
 [error]
 ```
 
-Newer versions of Drush fail with a message `[warning] Drush command terminated abnormally.`, for example: 
+Newer versions of Drush fail with a message `[warning] Drush command terminated abnormally.`. For example: 
 
 ```bash
 [warning] Drush command terminated abnormally.


### PR DESCRIPTION
Observed this on a D9 site using Drush 10 and had trouble connecting it to this problem since keywords for the warning were not represented in this relevant section

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

For an SME maybe @dficker can review and +1 ? 

**[Drupal Drush Command-Line Utility](https://pantheon.io/docs/drush#terminus-drush-silent-failure)** - Capture how this issue manifests in newer Drush version, add keywords for search

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
