### PR TITLE
DOC-537: Object Cache for Composer-managed Drupal

### DIFF
--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -209,6 +209,7 @@ TRUNCATE TABLE `<tablename>`;
    terminus redis:enable $SITE
    composer require drupal/redis
    git commit --am "Add drupal/redis dependency"
+   git push origin master
    ```
 
 1. Enable the new module and export configuration:  

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -202,7 +202,7 @@ TRUNCATE TABLE `<tablename>`;
 
 <Tab title="Drupal 9 / Composer-managed" id="d9-install">
 
-1. Clone the code repository and from the project root, run the following:
+1. Clone the code repository and, from the project root, run the following:
 
    ```shell{promptUser: user}
    terminus connection:set $SITE.dev git
@@ -220,7 +220,7 @@ TRUNCATE TABLE `<tablename>`;
    terminus env:commit $SITE.dev --message="Enable Redis, export configuration"
    ```
 
-1. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site:
+1. Edit `sites/default/settings.php` to add the Redis cache configuration. These are **mandatory**, required Redis configurations for every site:
 
    ```php:title=sites/default/settings.php
    // Configure Redis
@@ -248,7 +248,7 @@ TRUNCATE TABLE `<tablename>`;
 
    <Alert title="Note" type="info">
 
-   The above Redis cache configuration should be placed in `sites/default/settings.php` rather than `settings.pantheon.php` to avoid conflicts with future upstream updates.
+   The above Redis cache configuration should be placed in `sites/default/settings.php`, rather than `settings.pantheon.php`, to avoid conflicts with future upstream updates.
 
    </Alert>
 

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -217,7 +217,6 @@ TRUNCATE TABLE `<tablename>`;
    terminus drush $SITE.dev -- en redis -y
    terminus drush $SITE.dev -- config:export -y
    terminus env:commit $SITE.dev --message="Enable Redis, export configuration"
-   git push origin master
    ```
 
 1. Edit `sites/default/settings.php` to add the Redis cache configuration. These are the **mandatory**, required Redis configurations for every site:

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -213,7 +213,7 @@ TRUNCATE TABLE `<tablename>`;
 
 1. Enable the new module and export configuration:  
    ```shell{promptUser: user}
-   terminus connection:set $SITE.dev git
+   terminus connection:set $SITE.dev sftp
    terminus drush $SITE.dev -- en redis -y
    terminus drush $SITE.dev -- config:export -y
    terminus env:commit $SITE.dev --message="Enable Redis, export configuration"

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -202,15 +202,18 @@ TRUNCATE TABLE `<tablename>`;
 
 <Tab title="Drupal 9 / Composer-managed" id="d9-install">
 
-1. This:
+1. Clone the code repository and from the project root, run the following:
 
    ```shell{promptUser: user}
-   terminus build:project:create d9 $SITE
-   terminus connection:set $SITE.dev sftp
+   terminus connection:set $SITE.dev git
    terminus redis:enable $SITE
-   git clone https://github.com/user/site
-   cd $SITE
    composer require drupal/redis
+   git commit --am "Add drupal/redis dependency"
+   ```
+
+1. Enable the new module and export configuration:  
+   ```shell{promptUser: user}
+   terminus connection:set $SITE.dev git
    terminus drush $SITE.dev -- en redis -y
    terminus drush $SITE.dev -- config:export -y
    terminus env:commit $SITE.dev --message="Enable Redis, export configuration"


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Object Cache](https://pantheon.io/docs/object-cache#enable-object-cache)** - Adds Composer-specific Object Cache steps for Drupal.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] confirm, then adjust placeholder steps

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
