### PR TITLE
[OTTO-1777] Adding Autopilot VRT workflow variables

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -88,9 +88,9 @@ When a workflow runs, there are variables that are made available through the `$
 |`to_environment`|Target environment where the database is being cloned to|`clone_database`| |
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
 |`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided.|
-|`vrt_status`| | | |
-|`vrt_result_url`| | | |
-|`updates_info`| | | |
+|`vrt_status`| |`autopilot_vrt`| |
+|`vrt_result_url`| |`autopilot_vrt`| |
+|`updates_info`| |`autopilot_vrt`| |
 
 For examples on how to use these variables, see the [Quicksilver Examples](https://github.com/pantheon-systems/quicksilver-examples) repository.
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -88,6 +88,9 @@ When a workflow runs, there are variables that are made available through the `$
 |`to_environment`|Target environment where the database is being cloned to|`clone_database`| |
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
 |`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided.|
+|`vrt_status`| | | |
+|`vrt_result_url`| | | |
+|`updates_info`| | | |
 
 For examples on how to use these variables, see the [Quicksilver Examples](https://github.com/pantheon-systems/quicksilver-examples) repository.
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -88,9 +88,9 @@ When a workflow runs, there are variables that are made available through the `$
 |`to_environment`|Target environment where the database is being cloned to|`clone_database`| |
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
 |`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided.|
-|`vrt_status`| |`autopilot_vrt`| |
-|`vrt_result_url`| |`autopilot_vrt`| |
-|`updates_info`| |`autopilot_vrt`| |
+|`vrt_status`|Result of the visual regression test|`autopilot_vrt`| |
+|`vrt_result_url`|URL to the VRT result page in the dashboard|`autopilot_vrt`| |
+|`updates_info`|List of the plugins/modules/themes that were updated prior to the VRT|`autopilot_vrt`|Returns JSON data structure|
 
 For examples on how to use these variables, see the [Quicksilver Examples](https://github.com/pantheon-systems/quicksilver-examples) repository.
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

This PR adds Autopilot VRT workflow variables to the variables table in the Quicksilver documentation.

**[Quicksilver](https://pantheon.io/docs/quicksilver)**

## Remaining Work and Prerequisites

No remaining work and prerequisites for this update.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
