### PR TITLE
Details about Redis for Drupal 7 and PHP 7.4

### DIFF
--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -210,7 +210,7 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 <Alert title="Note" type="info">
 
-The current version of the Redis module for Drupal 7 does not work with PHP 7.4 which uses the `php-redis 5.x` library. <a href="#drupal-7-and-php-7-4">More about this issue</a>.
+The current version of the Redis module for Drupal 7 does not work with PHP 7.4 which uses the `php-redis 5.x` library. <a href="#drupal-7-and-php-74">More about this issue</a>.
 
 </Alert>
 
@@ -382,7 +382,7 @@ The current version of the <a href="https://www.drupal.org/project/redis">Drupal
 Deprecated function: Function Redis::delete() is deprecated in Redis_Lock_PhpRedis->lockRelease() (line 111 of /web/sites/all/modules/contrib/redis/lib/Redis/Lock/PhpRedis.php).
 ```
 
-To patch the Redis module, please <a href="https://www.drupal.org/project/redis/issues/3074189">visit this page on Drupal.org</a>, download the latest patch and add it to your site's code.
+To patch the Redis module, please <a href="https://www.drupal.org/project/redis/issues/3074189">visit this page on Drupal.org</a>, download the latest patch and patch the module in the site's code with these changes.
 
 ### RedisException: Redis server went away
 

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -208,6 +208,12 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 </Alert>
 
+<Alert title="Note" type="info">
+
+The current version of the Redis module for Drupal 7 does not work with PHP 7.4 which uses the `php-redis 5.x` library. <a href="#drupal-7-and-php-7-4">More about this issue</a>.
+
+</Alert>
+
 1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
 
 1. Add the [Redis](https://www.drupal.org/project/redis) module from Drupal.org. You can install and enable the module from the command line using [Terminus](/terminus):
@@ -367,6 +373,16 @@ maxmemory
 ### Cannot Activate the Redis Plugin for WordPress
 
 WP Redis is a drop-in plugin that should only be loaded using the installation methods above. No activation is required.
+
+### Drupal 7 and PHP 7.4
+
+The current version of the <a href="https://www.drupal.org/project/redis">Drupal 7 Redis module</a> is not compatible with PHP 7.4, which uses the `php-redis 5.x` library. You may get errors like this:
+
+```php
+Deprecated function: Function Redis::delete() is deprecated in Redis_Lock_PhpRedis->lockRelease() (line 111 of /web/sites/all/modules/contrib/redis/lib/Redis/Lock/PhpRedis.php).
+```
+
+To patch the Redis module, please <a href="https://www.drupal.org/project/redis/issues/3074189">visit this page on Drupal.org</a>, download the latest patch and add it to your site's code.
 
 ### RedisException: Redis server went away
 

--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -210,7 +210,7 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 <Alert title="Note" type="info">
 
-The current version of the Redis module for Drupal 7 does not work with PHP 7.4 which uses the `php-redis 5.x` library. <a href="#drupal-7-and-php-74">More about this issue</a>.
+The current version of the Redis module for Drupal 7 does not work with PHP 7.4, which uses the `php-redis 5.x` library. Refer to [Drupal 7 and PHP 7.4](/object-cache#drupal-7-and-php-74) for more information.
 
 </Alert>
 
@@ -376,13 +376,13 @@ WP Redis is a drop-in plugin that should only be loaded using the installation m
 
 ### Drupal 7 and PHP 7.4
 
-The current version of the <a href="https://www.drupal.org/project/redis">Drupal 7 Redis module</a> is not compatible with PHP 7.4, which uses the `php-redis 5.x` library. You may get errors like this:
+The current version of the [Drupal 7 Redis module](https://www.drupal.org/project/redis) is not compatible with PHP 7.4, which uses the `php-redis 5.x` library. You may get errors like this:
 
 ```php
 Deprecated function: Function Redis::delete() is deprecated in Redis_Lock_PhpRedis->lockRelease() (line 111 of /web/sites/all/modules/contrib/redis/lib/Redis/Lock/PhpRedis.php).
 ```
 
-To patch the Redis module, please <a href="https://www.drupal.org/project/redis/issues/3074189">visit this page on Drupal.org</a>, download the latest patch and patch the module in the site's code with these changes.
+To patch the Redis module, visit [Drupal.org](https://www.drupal.org/project/redis/issues/3074189), download the latest patch, and patch the module in the site's code with these changes.
 
 ### RedisException: Redis server went away
 


### PR DESCRIPTION
Closes #6966

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Object Cache (Formerly Redis)](https://pantheon.io/docs/object-cache)** - Add notes of errors if using Redis module on PHP 7.4.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
