### PR TITLE
Clarify how to clear Divi cache

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -352,10 +352,7 @@ ___
 
 **Issue 2:** The WordPress admin dashboard becomes slow when editing posts using Divi.
 
-**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. Clear the cache from **Theme Options** > **Builder** > **Advanced** > **Static CSS File Generation**:
-
-  ![A screenshot highlighting the option to clear the Divi cache](../images/plugins-known-issues/divi-clear-cache.png)
-
+**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. This happens regardless of Static CSS file generationg being enabled, previous large lists of files will slow down the admin area. Clear the cache by accessing the site's files [via SFTP](/sftp#sftp-connection-information) and removing everything inside of files/et-cache. You should keep the folder et-cache, just empty the contents. Some files will be regenerated here and that is okay, but over time it can grow too large especially if Static CSS generation is still enabled.
 ___
 
 ## Elementor

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -352,7 +352,7 @@ ___
 
 **Issue 2:** The WordPress admin dashboard becomes slow when editing posts using Divi.
 
-**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. This happens regardless of Static CSS file generationg being enabled, previous large lists of files will slow down the admin area. Clear the cache by accessing the site's files [via SFTP](/sftp#sftp-connection-information) and removing everything inside of files/et-cache. You should keep the folder et-cache, just empty the contents. Some files will be regenerated here and that is okay, but over time it can grow too large especially if Static CSS generation is still enabled.
+**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. Large lists of files will slow down the admin area even when Static CSS file generation is enabled. Clear the cache by accessing the site's files [via SFTP](/sftp#sftp-connection-information). Empty the contents inside the  `files/et-cache` folder, but do not remove the folder. Some files will be regenerated within the `files/et-cache` folder; this is expected behavior. Over time the files can grow too large, especially if Static CSS generation is still enabled, and you may need to repeat the steps to empty the folder.
 ___
 
 ## Elementor

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -352,7 +352,7 @@ ___
 
 **Issue 2:** The WordPress admin dashboard becomes slow when editing posts using Divi.
 
-**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. Large lists of files will slow down the admin area even when Static CSS file generation is enabled. Clear the cache by accessing the site's files [via SFTP](/sftp#sftp-connection-information). Empty the contents inside the  `files/et-cache` folder, but do not remove the folder. Some files will be regenerated within the `files/et-cache` folder; this is expected behavior. Over time the files can grow too large, especially if Static CSS generation is still enabled, and you may need to repeat the steps to empty the folder.
+**Solution:**  When the `wp-content/uploads/et-cache` directory gets too full, it tends to slow down. Large lists of files will slow down the admin area even when Static CSS file generation is disabled. Clear the cache by accessing the site's files [via SFTP](/sftp#sftp-connection-information). Empty the contents inside the  `files/et-cache` folder, but do not remove the folder. Some files will be regenerated within the `files/et-cache` folder; this is expected behavior. Over time the files can grow too large, especially if Static CSS generation is still enabled, and you may need to repeat the steps to empty the folder.
 ___
 
 ## Elementor


### PR DESCRIPTION
## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues#divi-wordpress-theme--visual-page-builder)** - Divi cache size can cause admin area to be unusable, need to clear via SFTP

## Remaining Work and Prerequisites

- [ ] Please check that my doc link to SFTP is correct

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
