### PR TITLE
Update to D7 tab re: Redis and PHP versions

### DIFF
--- a/source/content/object-cache.md
+++ b/source/content/object-cache.md
@@ -202,11 +202,13 @@ TRUNCATE TABLE `<tablename>`;
 
 <Tab title="Drupal 7" id={"d7-install"}>
 
-<Alert title="Note" type="info">
+#### Before You Begin
 
-This configuration uses the `Redis_CacheCompressed` class for better performance. This requires the Redis module version 3.13 or later. For versions before 3.13, use `Redis_Cache` in step 4 instead.
+Please note:
 
-</Alert>
+* This configuration uses the `Redis_CacheCompressed` class for better performance. This requires the Redis module version 3.13 or later. For versions before 3.13, use `Redis_Cache` in step 4 instead.
+
+* The version of Redis for Drupal 7 isn’t compatible with PHP 7.4, as PHP 7.4 uses php-redis 5. We recommend that you upgrade your version of PHP to avoid any errors, or you may consider using [this patch](https://www.drupal.org/project/redis/issues/3074189) as a workaround.
 
 1. Enable the Redis cache server from your Pantheon Site Dashboard by going to **Settings** > **Add Ons** > **Add**. It may take a couple minutes for the Redis server to come online.
 


### PR DESCRIPTION
Closes #6966 

## Summary

**[Object Cache (formerly Redis)](https://pantheon.io/docs/object-cache#d7-install)** - Updated D7 tab to reflect current recommendations to avoid errors with PHP version.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
