### PR TITLE
Adjust curl commands used for cache testing

### DIFF
--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -9,7 +9,7 @@ tags: [cache, cdn]
 
 1. Open a terminal.
 1. Enter the following command with your full Pantheon domain URL.
-    - The `-L` flag tells curl to resend the request to the new location in the case of a 301, 302, or 303 redirect.
+    - The `-L` flag instructs curl to resend the request to the new location in the case of a 301, 302, or 303 redirect.
     - The `-I` flag sends a HEAD request to fetch only the HTTP headers for the specified URL.
     - The `-H 'accept-encoding: gzip, deflate, br'` flag and header forces curl to more closely simulate a typical browser request, resulting in typical cache behavior.
     - The `egrep '(HTTP|cache-control|age:)'` command limits the output to include only the relevant information.

--- a/source/content/test-global-cdn-caching.md
+++ b/source/content/test-global-cdn-caching.md
@@ -9,15 +9,13 @@ tags: [cache, cdn]
 
 1. Open a terminal.
 1. Enter the following command with your full Pantheon domain URL.
+    - The `-L` flag tells curl to resend the request to the new location in the case of a 301, 302, or 303 redirect.
     - The `-I` flag sends a HEAD request to fetch only the HTTP headers for the specified URL.
     - The `-H 'accept-encoding: gzip, deflate, br'` flag and header forces curl to more closely simulate a typical browser request, resulting in typical cache behavior.
     - The `egrep '(HTTP|cache-control|age:)'` command limits the output to include only the relevant information.
 
   ```bash{outputLines: 2-7}
-  curl -I -H "accept-encoding: gzip, deflate, br" https://scalewp.io | egrep '(HTTP|cache-control|age:)'
-    % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-  0 14801    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0
+  curl -L -Is -H "accept-encoding: gzip, deflate, br" https://scalewp.io | egrep '(HTTP|cache-control|age:)'
   HTTP/2 200
   cache-control: public, max-age=86400
   age: 65772


### PR DESCRIPTION
## Summary

[Testing Global CDN Caching](https://pantheon.io/docs/test-global-cdn-caching) - Adjusts curl commands used for testing caching.

## Effect

The following changes are already committed:

* Adds the `-L` flag to the example curl command. This tells curl to follow the location header. Without this, if you curl a URL that redirects, you do not see any cache headers at all (only a `HTTP/1.1 301 Moved Permanently`).
* Adjusts the `-I` flag in the same command to `-Is`. Adding the `s` tells it to be "silent" -- so you don't see the download progress info, which is nice in this case since it's not relevant to what we're investigating. We also use `-Is` in another example further down the page, might as well be consistent.

## Remaining Work and Prerequisites

- [x] Verify commands work as expected
- [ ] One thing worth considering when adding the `-L` flag is a use-case where someone actually wants to check if a redirect response itself has cache headers. I think most readers of this doc would want to see the caching status of the final post-redirect destination, so this change is correct, but perhaps we should also add an example of how to check the cache headers for a 301/302/303 (the original command did not show these).

**Release**:
- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
