### PR TITLE
[BUGS-3512] Don't upload commit/upload modules/plugins or themes to IC sites

### DIFF
--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -233,6 +233,22 @@ Merge the changes manually:
 
 1. Push the changes to Pantheon. Integrated Composer will run again with the updated `composer.json`.
 
+### Changes Lost When Uploading or Committing Module/Plugin or Theme Files
+Module/Plugin and Theme files should not be committed, when using Git mode, or uploaded, when using SFTP mode, directly to your site.  The `.gitignore` file in your upstream respository has several paths defined causing files in those directories to be ignored.  These directories are:
+```none:title=code/web/
+code/web
+└─ sites/ for Drupal
+   └─ core/
+   └─ libraries/
+   └─ modules/
+└─ wp-content/ for WordPress
+   └─ mu-plugins/
+   └─ plugins/
+   └─ themes/
+```
+
+See the section [Add a Dependency to an Individual Site](#add-a-dependency-to-an-individual-site) above to add module/plugin or theme as a dependency to your site.  
+
 ### Changes Lost During Upstream Updates
 
 When **Auto-Resolve Updates** is selected and the `composer.json` contents are changed in the upstream, all changes the site's developers made to `composer.json` will be removed if Git cannot automatically merge the changes.

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -240,7 +240,9 @@ code/web
 └─ sites/ for Drupal
    └─ core/
    └─ libraries/
-   └─ modules/
+   └─ modules/custom/
+   └─ sites/*/files/
+   └─ sites/*/private/
 └─ wp-content/ for WordPress
    └─ mu-plugins/
    └─ plugins/

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -247,6 +247,8 @@ code/web
    └─ themes/
 ```
 
+See the `.gitignore` file for Drupal [here](https://github.com/pantheon-upstreams/drupal-project/blob/master/.gitignore) and for WordPress [here](https://github.com/pantheon-upstreams/wordpress-project/blob/master/.gitignore). 
+
 See the section [Add a Dependency to an Individual Site](#add-a-dependency-to-an-individual-site) above to add module/plugin or theme as a dependency to your site.  
 
 ### Changes Lost During Upstream Updates

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -233,8 +233,9 @@ Merge the changes manually:
 
 1. Push the changes to Pantheon. Integrated Composer will run again with the updated `composer.json`.
 
-### Changes Lost When Uploading or Committing Module/Plugin or Theme Files
-Module/Plugin and Theme files should not be committed, when using Git mode, or uploaded, when using SFTP mode, directly to your site.  The `.gitignore` file in your upstream respository has several paths defined causing files in those directories to be ignored.  These directories are:
+### Changes Lost During Upload or Commit of Module/Plugin or Theme Files
+
+Do not commit module/plugin or theme files directly to your site when in Git mode. You also should not upload module/plugin or theme files directly to your site when in SFTP mode. Direct commits and uploads will be lost because the `.gitignore` file in your upstream respository has several defined paths, which causes files in those directories to be ignored.  These directories are:
 <TabList>
 
 <Tab title="Drupal" id="drupal-gitignore" active={true}>

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -235,21 +235,38 @@ Merge the changes manually:
 
 ### Changes Lost When Uploading or Committing Module/Plugin or Theme Files
 Module/Plugin and Theme files should not be committed, when using Git mode, or uploaded, when using SFTP mode, directly to your site.  The `.gitignore` file in your upstream respository has several paths defined causing files in those directories to be ignored.  These directories are:
-```none:title=code/web/
-code/web
-└─ sites/ for Drupal
-   └─ core/
-   └─ libraries/
-   └─ modules/custom/
-   └─ sites/*/files/
-   └─ sites/*/private/
-└─ wp-content/ for WordPress
-   └─ mu-plugins/
-   └─ plugins/
-   └─ themes/
-```
+<TabList>
 
-See the `.gitignore` file for Drupal [here](https://github.com/pantheon-upstreams/drupal-project/blob/master/.gitignore) and for WordPress [here](https://github.com/pantheon-upstreams/wordpress-project/blob/master/.gitignore). 
+<Tab title="Drupal" id="drupal-gitignore" active={true}>
+```none:title=code/web/sites
+code/web/
+└─ core/
+└─ drush/Commands/contrib/
+└─ libraries/
+└─ modules/contrib/
+└─ private/scripts/quicksilver
+└─ profiles/contrib/
+└─ sites/*/files/
+└─ sites/*/private/
+└─ themes/contrib/
+```
+See the `.gitignore` file for Drupal [here](https://github.com/pantheon-upstreams/drupal-recommended/blob/master/.gitignore).
+
+The `contrib` folders are where community contributed modules, profiles, and themes would reside.
+The `custom` folders, which are not ignored, are where modules, profiles, and themes created by you would reside.
+</Tab>
+
+<Tab title="WordPress" id="wp-gitignore">
+```none:title=code/web/
+code/web/wp-content/
+└─ mu-plugins/
+└─ plugins/
+└─ themes/
+```
+See the `.gitignore` file for WordPress [here](https://github.com/pantheon-upstreams/wordpress-project/blob/master/.gitignore). 
+</Tab>
+
+</TabList>
 
 See the section [Add a Dependency to an Individual Site](#add-a-dependency-to-an-individual-site) above to add module/plugin or theme as a dependency to your site.  
 

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -233,7 +233,7 @@ Merge the changes manually:
 
 1. Push the changes to Pantheon. Integrated Composer will run again with the updated `composer.json`.
 
-### Changes Lost During Upload or Commit of Module/Plugin or Theme Files
+### Changes Lost During Direct Upload or Commit 
 
 Do not commit module/plugin or theme files directly to your site when in Git mode. You also should not upload module/plugin or theme files directly to your site when in SFTP mode. Direct commits and uploads will be lost because the `.gitignore` file in your upstream respository has several defined paths, which causes files in those directories to be ignored.  These directories are:
 <TabList>

--- a/source/content/integrated-composer.md
+++ b/source/content/integrated-composer.md
@@ -238,6 +238,7 @@ Module/Plugin and Theme files should not be committed, when using Git mode, or u
 <TabList>
 
 <Tab title="Drupal" id="drupal-gitignore" active={true}>
+
 ```none:title=code/web/sites
 code/web/
 └─ core/
@@ -257,6 +258,7 @@ The `custom` folders, which are not ignored, are where modules, profiles, and th
 </Tab>
 
 <Tab title="WordPress" id="wp-gitignore">
+
 ```none:title=code/web/
 code/web/wp-content/
 └─ mu-plugins/


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Adds an entry to the troubleshooting section letting users know to not upload commit/upload modules/plugins or themes to IC sites.

## Remaining Work and Prerequisites

### Dependencies and Timing

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
