### PR TITLE
Updated WebP Express Review date, Issue 1 solution, and added Issue 2 and Solution

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -809,9 +809,22 @@ ___
 
 ## WebP Express
 
-<ReviewDate date="2019-08-25" />
+<ReviewDate date="2022-01-21" />
 
-**Issue:** [WebP Express](https://wordpress.org/plugins/webp-express/) assumes write access to paths in the codebase that are write-only in non-dev environments. Because the plugin uses `is_dir` to check for the path, a symlink to `files/` does not resolve the issue.
+**Issue 1:** [WebP Express](https://wordpress.org/plugins/webp-express/) assumes write access to paths in the codebase that are write-only in non-dev environments. Because the plugin uses `is_dir` to check for the path, a symlink to `files/` does not resolve the issue.
+
+**Solution:** Create Symlink for `wp-content/webp-express` in the wp-content directory and run the following line of code:
+
+```bash{promptUser: user}
+  ln -s ./uploads/webp-express ./webp-express
+  ```
+
+  See [Using Extensions That Assume Write Access](https://pantheon.io/docs/symlinks-assumed-write-access)for more information.
+
+  **Issue 2:** Broken WebP images due to files being served from the wrong directory.
+
+  **Solution** Set the WebP Express settings for `Destination Structure` to `Image Roots` in `/wp-admin/options-general.php?page=webp_express_settings_page` and then clear the cache.
+
 ___
 
 ## Weather Station


### PR DESCRIPTION
Updated WebP Express Review date, Issue 1 solution, and added Issue 2 and Solution

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #6305 

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues#webp-express)** - I updated the WebP Express entry review date, the solution for Issue 1, and added Issue 2 and its solution.
## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
