### PR TITLE
Remove link to http-security plugin

### DIFF
--- a/source/content/wordpress-best-practices.md
+++ b/source/content/wordpress-best-practices.md
@@ -132,7 +132,7 @@ This method has the advantage of being toggleable without deploying code, by act
 
 Pantheon's Nginx configuration [cannot be modified](/platform-considerations#htaccess) to add security headers, and many solutions (including plugins) written about security headers for WordPress involve modifying the `.htaccess` file for Apache-based platforms.
 
-There are plugins for WordPress that do not require `.htaccess` to set security headers (like [GD Security Headers](https://wordpress.org/plugins/gd-security-headers/) or [HTTP headers to improve web site security](https://wordpress.org/plugins/http-security/)), but header specifications may change more rapidly than the plugins can keep up with. In those cases, you may want to define the headers yourself.
+There are plugins for WordPress that do not require `.htaccess` to set security headers (like [GD Security Headers](https://wordpress.org/plugins/gd-security-headers/)), but header specifications may change more rapidly than the plugins can keep up with. In those cases, you may want to define the headers yourself.
 
 Adding code like the example below in a plugin (or [mu-plugin](/mu-plugin)) can help add security headers for WordPress sites on Pantheon, or any other Nginx-based platform. Do not add this to your theme's `functions.php` file, as it will not be executed for calls to the REST API.
 


### PR DESCRIPTION
## Summary

Removes a plugin link from the [WordPress Best Practices](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length) doc.

The referenced plugin is no longer available: https://wordpress.org/plugins/http-security/ 

## Effect

The following changes are already committed:

* removes the link

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
