### PR TITLE
Add links to Disaster Recovery guide and Pantheon status page from /docs

### DIFF
--- a/source/content/guides/disaster-recovery/03-site-goes-down.md
+++ b/source/content/guides/disaster-recovery/03-site-goes-down.md
@@ -1,6 +1,6 @@
 ---
 title: Pantheon Disaster Recovery Playbook
-subtitle: What to Do When Your Site Goes Down
+subtitle: What to Do If Your Site Goes Down
 description: Working with Pantheon support during emergencies
 generator: pagination
 layout: guide
@@ -94,7 +94,7 @@ Incidents may involve managed services like the Advanced Global CDN, Signal Scie
 
 ### Executive Escalation
 
-In cases where regular emergency support is not resolving the issues,  and the incident is causing significant customer business impact, Pantheon executive involvement may become necessary. Note that these parties may already be notified and involved through internal escalation by the Account team.
+In cases where regular emergency support is not resolving the issues and the incident is causing significant customer business impact, Pantheon executive involvement may become necessary. Note that these parties may already be notified and involved through internal escalation by the Account team.
 
 ## Ongoing Diagnosis
 

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -45,15 +45,16 @@
       secondary: true
     - title: 'GUIDES'
       summary: 'Need some help leveling up your dev skills? Try one of our guides.'
-      icon: 'i-monitoring.svg'
       url: '/guides/'
       secondary: true
     - title: 'DISASTER RECOVERY PLAYBOOK'
       summary: 'Be ready to act if your site stops responding.'
       url: '/guides/disaster-recovery/site-goes-down/'
+      secondary: true
     - title: 'PLATFORM STATUS'
       summary: 'Check for platform incident reports.'
       url: 'https://status.pantheon.io/'
+      secondary: true
   fourohfourlinks:
     title: 'Popular Documentation'
     links:

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -48,6 +48,12 @@
       icon: 'i-monitoring.svg'
       url: '/guides/'
       secondary: true
+  disasterrecovery:
+    call-to-action:
+      title: 'Disaster Recovery Playbook'
+      sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
+      url: '/guides/disaster-recovery/site-goes-down'
+      type: 'guide'
   fourohfourlinks:
     title: 'Popular Documentation'
     links:

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -48,12 +48,13 @@
       icon: 'i-monitoring.svg'
       url: '/guides/'
       secondary: true
-  fourohfourlinks:
-    call-to-action:
-      title: 'Disaster Recovery Playbook'
-      sub-title: 'Be ready to act if your site stops responding. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
+    - title: 'DISASTER RECOVERY PLAYBOOK'
+      summary: 'Be ready to act if your site stops responding.'
       url: '/guides/disaster-recovery/site-goes-down/'
-      type: 'guide'
+    - title: 'PLATFORM STATUS'
+      summary: 'Check for platform incident reports.'
+      url: 'https://status.pantheon.io/'
+  fourohfourlinks:
     title: 'Popular Documentation'
     links:
       - text: 'Terminus Manual'
@@ -69,11 +70,6 @@
       - text: 'Generating and Adding SSH Keys'
         url: '/ssh-keys/'
   three-column-links:
-    call-to-action:
-      title: 'Disaster Recovery Playbook'
-      sub-title: 'Be ready to act if your site stops responding. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
-      url: '/guides/disaster-recovery/site-goes-down/'
-      type: 'guide'
     title: 'Popular Documentation'
     links:
       - text: 'Terminus Manual'

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -49,12 +49,12 @@
       url: '/guides/'
       secondary: true
   fourohfourlinks:
-    title: 'Popular Documentation'
     call-to-action:
       title: 'Disaster Recovery Playbook'
       sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
       url: '/guides/disaster-recovery/site-goes-down'
       type: 'guide'
+    title: 'Popular Documentation'
     links:
       - text: 'Terminus Manual'
         url: '/terminus/'
@@ -69,12 +69,12 @@
       - text: 'Generating and Adding SSH Keys'
         url: '/ssh-keys/'
   three-column-links:
-    title: 'Popular Documentation'
     call-to-action:
       title: 'Disaster Recovery Playbook'
       sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
       url: '/guides/disaster-recovery/site-goes-down'
       type: 'guide'
+    title: 'Popular Documentation'
     links:
       - text: 'Terminus Manual'
         url: '/terminus/'

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -1,11 +1,11 @@
 - id: home
   title: 'Documentation Topics'
-  call-to-action: 
+  call-to-action:
     title: 'Quick Start Guide'
     sub-title: 'New to our platform? Check out our step-by-step guide to learn all the basics.'
     url: '/guides/quickstart/'
     type: 'guide'
-  topics: 
+  topics:
     - title: 'Get Started'
       summary: 'Migrate existing sites or spin up a new site, then learn how to manage your projects on Pantheon.'
       icon: 'icon-start.svg'
@@ -48,14 +48,13 @@
       icon: 'i-monitoring.svg'
       url: '/guides/'
       secondary: true
-  disasterrecovery:
+  fourohfourlinks:
+    title: 'Popular Documentation'
     call-to-action:
       title: 'Disaster Recovery Playbook'
       sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
       url: '/guides/disaster-recovery/site-goes-down'
       type: 'guide'
-  fourohfourlinks:
-    title: 'Popular Documentation'
     links:
       - text: 'Terminus Manual'
         url: '/terminus/'
@@ -71,7 +70,12 @@
         url: '/ssh-keys/'
   three-column-links:
     title: 'Popular Documentation'
-    links: 
+    call-to-action:
+      title: 'Disaster Recovery Playbook'
+      sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
+      url: '/guides/disaster-recovery/site-goes-down'
+      type: 'guide'
+    links:
       - text: 'Terminus Manual'
         url: '/terminus/'
       - text: 'Upgrade to Drupal 9'

--- a/source/data/home.yaml
+++ b/source/data/home.yaml
@@ -2,7 +2,7 @@
   title: 'Documentation Topics'
   call-to-action:
     title: 'Quick Start Guide'
-    sub-title: 'New to our platform? Check out our step-by-step guide to learn all the basics.'
+    sub-title: 'New to the Pantheon platform? Check out our step-by-step guide to learn all the basics.'
     url: '/guides/quickstart/'
     type: 'guide'
   topics:
@@ -51,8 +51,8 @@
   fourohfourlinks:
     call-to-action:
       title: 'Disaster Recovery Playbook'
-      sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
-      url: '/guides/disaster-recovery/site-goes-down'
+      sub-title: 'Be ready to act if your site stops responding. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
+      url: '/guides/disaster-recovery/site-goes-down/'
       type: 'guide'
     title: 'Popular Documentation'
     links:
@@ -71,8 +71,8 @@
   three-column-links:
     call-to-action:
       title: 'Disaster Recovery Playbook'
-      sub-title: 'Be ready to act if your site goes. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
-      url: '/guides/disaster-recovery/site-goes-down'
+      sub-title: 'Be ready to act if your site stops responding. Check for platform incident reports at [https://status.pantheon.io/](https://status.pantheon.io/).'
+      url: '/guides/disaster-recovery/site-goes-down/'
       type: 'guide'
     title: 'Popular Documentation'
     links:


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[pantheon.io/docs](https://pantheon.io/docs)** - Add links to Disaster Recovery guide and Pantheon status page from the Docs landing page.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
