### PR TITLE
Replacement of Sequel Pro with Sequel Ace throughout the Documentation

### DIFF
--- a/source/content/database-workflow.md
+++ b/source/content/database-workflow.md
@@ -16,7 +16,7 @@ Pushing content up to Live should almost never be done to a launched site, as it
 </Alert>
 
 ## MySQL Clients
-You can use any number of MySQL clients such as [MySQL Workbench](https://dev.mysql.com/downloads/workbench/), [Sequel Pro](https://www.sequelpro.com/download), [Navicat](https://www.navicat.com/download), [PHPMyAdmin](https://www.phpmyadmin.net/), and others to  administer your site's database
+You can use any number of MySQL clients such as [MySQL Workbench](https://dev.mysql.com/downloads/workbench/), [Sequel Ace (formerly Sequel Pro)](https://sequel-ace.com/), [Navicat](https://www.navicat.com/download), [PHPMyAdmin](https://www.phpmyadmin.net/), and others to  administer your site's database
 and [manage configurations](/pantheon-workflow/#configuration-management) as needed.
 
 ## Cloning the Database

--- a/source/content/guides/drupal-9-migration/05-drupal-9-to-pantheon.md
+++ b/source/content/guides/drupal-9-migration/05-drupal-9-to-pantheon.md
@@ -236,7 +236,7 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   <Tab title="Over 500MBs" id="500mbsplus">
 
-  The following instructions will allow you to add database archives larger than 500MBs using the command line MySQL client, but you can also use a GUI client like Sequel Pro or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
+  The following instructions will allow you to add database archives larger than 500MBs using the command line MySQL client, but you can also use a GUI client like Sequel Ace or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
 
    1. From the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment on the Pantheon Site Dashboard, click **Connection Info** and copy the Database connection string. It will look similar to this:
 

--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -325,7 +325,7 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   <Tab title="Over 500MBs" id="500mbsplus">
 
-  The following instructions will allow you to add database archives larger than 500MBs using the command line MySQL client, but you can also use a GUI client like Sequel Pro or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
+  The following instructions will allow you to add database archives larger than 500MBs using the command line MySQL client, but you can also use a GUI client like Sequel Ace or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
 
    1. From the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment on the Pantheon Site Dashboard, click **Connection Info** and copy the Database connection string. It will look similar to this:
 

--- a/source/content/mysql-access.md
+++ b/source/content/mysql-access.md
@@ -32,15 +32,15 @@ As each database server is in the cloud, the credentials will occasionally be up
 
 There's a wide array of MySQL clients that can be used, including:
 - [MySQL Workbench](https://dev.mysql.com/downloads/workbench/),
-- [Sequel Pro](https://www.sequelpro.com/download),
+- [Sequel Ace (formerly Sequel Pro)](https://sequel-ace.com/),
 - [Navicat](https://www.navicat.com/download),
 - [PHPMyAdmin](https://www.phpmyadmin.net/),
 
 and others. See the documentation or issue queue of your software to learn more about how to configure a connection.
 
-### Open Sequel Pro Database Connection
+### Open Sequel Ace Database Connection
 
-Drupal users can create [`spf-template.spf`](https://gist.github.com/aaronbauman/f50cc691eb3ed60a358c#file-spf-template-spf) and use the following script to establish a database connection in Sequel Pro via [Terminus](/terminus) and [Drush](/drush):
+Drupal users can create [`spf-template.spf`](https://gist.github.com/aaronbauman/f50cc691eb3ed60a358c#file-spf-template-spf) and use the following script to establish a database connection in Sequel Ace via [Terminus](/terminus) and [Drush](/drush):
 
 ```bash:title=establish-db-connection.sh
 #!/bin/bash
@@ -79,9 +79,9 @@ PORT=`echo $CONNECTION_STRING | sed -e 's/.*--port=\([^\\ ]*\).*/\1/g'`
 PASSWORD=`echo $CONNECTION_STRING | sed -e 's/.*--password=\([^\\ ]*\).*/\1/g'`
 USER=`echo $CONNECTION_STRING | sed -e 's/.*--user=\([^\\ ]*\).*/\1/g'`
 
-# This is for Sequel Pro:
+# This is for Sequel Ace:
 eval "echo \"$(< $TEMPLATE)\""
-# For some reason, Sequel Pro or Open do not behave the same way given the -f
+# For some reason, Sequel Ace or Open do not behave the same way given the -f
 # flag compared to opening a file from file system. So, we write to a tmp file.
 eval "echo \"$(< $TEMPLATE)\"" > $TMP_SPF
 

--- a/source/content/ssh-tunnels.md
+++ b/source/content/ssh-tunnels.md
@@ -112,9 +112,9 @@ You can destroy the tunnel by using the port value found within the **Connection
 ps -fU USERNAME | grep "ssh -f" | grep "PORT:" | awk '{print $2}' | xargs kill
 ```
 
-## Use Sequel Pro to SSH Tunnel to a MySQL Database
+## Use Sequel Ace to SSH Tunnel to a MySQL Database
 
-[Sequel Pro](https://www.sequelpro.com/) is an open-source MySQL database client that supports SSH tunneling on Mac. You can configure other MySQL clients in a similar manner.
+[Sequel Ace (formerly Sequel Pro)](https://sequel-ace.com/) is an open-source MySQL database client that supports SSH tunneling on Mac. You can configure other MySQL clients in a similar manner.
 
 ## Manually Create an SSH Tunnel to a Redis Cache Server
 

--- a/source/content/terminus/configuration.md
+++ b/source/content/terminus/configuration.md
@@ -40,7 +40,7 @@ hide_git_mode_warning: 1
   site:
     pancakes:
       options:
-        app: sequelpro
+        app: sequelace
 ```
 
 The example above does three things:
@@ -55,4 +55,4 @@ The example above does three things:
 
   Defining `TERMINUS_HIDE_GIT_MODE_WARNING` disables that message, which is useful for those using Terminus for frequent changes to files, not code. <Popover content="See <a href='/pantheon-workflow'>Use the Pantheon WebOps Workflow</a> for more information on Code versus Content."/>
 
-- The Terminus Plugin [Pancakes](https://github.com/terminus-plugin-project/terminus-pancakes-plugin) lets you open your Pantheon site database with a SQL GUI client. Rather than define the app every time, this configuration will always use Sequel Pro, unless otherwise specified.
+- The Terminus Plugin [Pancakes](https://github.com/terminus-plugin-project/terminus-pancakes-plugin) lets you open your Pantheon site database with a SQL GUI client. Rather than define the app every time, this configuration will always use Sequel Ace, unless otherwise specified.


### PR DESCRIPTION
Closes #7062 

## Summary

**[Accessing MySQL Databases](https://pantheon.io/docs/mysql-access)** - Replaced all mentions of Sequel Pro with its successor, Sequel Ace, per the developer's [announcement](https://github.com/sequelpro/sequelpro/issues/3705).

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
