### PR TITLE
CMS-250: Update description of sync_code Quicksilver hook

### DIFF
--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -67,9 +67,15 @@ You can hook into the following workflows:
 | `clone_database`                       | Clone database between environments                                 | target (to_env)            |                                             |
 | `deploy`                               | Deploy code to Test or Live                                         | target                     |                                             |
 | `deploy_product`                       | Create site                                                         | Dev                        | `after` stage valid, `before` stage invalid |
-| `sync_code`                            | Push code via Git or commit OSD/SFTP changes via Pantheon Dashboard | Dev or Multidev            |                                             |
+| `sync_code`                            | Changed code due to git push, commit via Pantheon Dashboard, upstream update, or multidev merge | Dev or Multidev            |                                             |
 | `create_cloud_development_environment` | Create Multidev environment                                         | Multidev                   | `after` stage valid, `before` stage invalid |
 | `autopilot_vrt`                        | Autopilot Visual Regression test                                    | "Autopilot" Multidev       | `after` stage valid, `before` stage invalid |
+
+<Alert type="info" title="Note">
+
+On sites using [Integrated Composer](/integrated-composer), the `sync_code` hook will run after the build runs, once the artifacts have been completely deployed to the application server.
+
+</Alert>
 
 ## Variables
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -66,14 +66,14 @@ You can hook into the following workflows:
 | `clear_cache`                          | Clear CMS and Edge Cache                                            |                            |                                             |
 | `clone_database`                       | Clone database between environments                                 | target (to_env)            |                                             |
 | `deploy`                               | Deploy code to Test or Live                                         | target                     |                                             |
-| `deploy_product`                       | Create site                                                         | Dev                        | `after` stage valid, `before` stage invalid |
-| `sync_code`                            | Changed code due to git push, commit via Pantheon Dashboard, upstream update, or multidev merge | Dev or Multidev            |                                             |
+| `deploy_product`                       | Create site                                                         | Dev                        | `after` stage valid, `before` stage invalid 
+| `sync_code`                            | Change code with `git push`, commit via the Pantheon Dashboard, upstream update, or Multidev merge | Dev or Multidev            |                                             |
 | `create_cloud_development_environment` | Create Multidev environment                                         | Multidev                   | `after` stage valid, `before` stage invalid |
 | `autopilot_vrt`                        | Autopilot Visual Regression test                                    | "Autopilot" Multidev       | `after` stage valid, `before` stage invalid |
 
 <Alert type="info" title="Note">
 
-On sites using [Integrated Composer](/integrated-composer), the `sync_code` hook will run after the build runs, once the artifacts have been completely deployed to the application server.
+On sites using [Integrated Composer](/integrated-composer), the `sync_code` hook runs after the build runs, once the artifacts have been completely deployed to the application server.
 
 </Alert>
 

--- a/source/content/quicksilver.md
+++ b/source/content/quicksilver.md
@@ -67,7 +67,7 @@ You can hook into the following workflows:
 | `clone_database`                       | Clone database between environments                                 | target (to_env)            |                                             |
 | `deploy`                               | Deploy code to Test or Live                                         | target                     |                                             |
 | `deploy_product`                       | Create site                                                         | Dev                        | `after` stage valid, `before` stage invalid 
-| `sync_code`                            | Change code with `git push`, commit via the Pantheon Dashboard, upstream update, or Multidev merge | Dev or Multidev            |                                             |
+| `sync_code`                            | Use the command `git push` to change the code; commit via the Pantheon Dashboard, upstream update, or Multidev merge | Dev or Multidev            |                                             |
 | `create_cloud_development_environment` | Create Multidev environment                                         | Multidev                   | `after` stage valid, `before` stage invalid |
 | `autopilot_vrt`                        | Autopilot Visual Regression test                                    | "Autopilot" Multidev       | `after` stage valid, `before` stage invalid |
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #CMS-250

## Summary

**[Automate and Integrate your WebOps Workflow with Quicksilver](https://pantheon.io/docs/quicksilver)** - Updates description of sync_code hook after bugfix.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Describes which workflows will cause sync_code to run
* Adds a note regarding the timing of the hook execution

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

**Release**:
- [ ] Hold until https://github.com/pantheon-systems/titan-mt/pull/18720 is released
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
