### PR TITLE
Wordfence advice missed a closing brace

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1035,7 +1035,7 @@ if (file_exists('/includes/prepend.php')) {
 if (file_exists('../../code/wp-content/plugins/wordfence/waf/bootstrap.php')) {
 	define("WFWAF_LOG_PATH", '../../code/wp-content/wflogs/');
 	include_once '../../code/wp-content/plugins/wordfence/waf/bootstrap.php';
-
+}
 ```
 
 #### Further Considerations with Wordfence: Utilizing data storage over files


### PR DESCRIPTION
## Summary

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Added closing brace

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
