### PR TITLE
CMS-568: Migrate empty upstream to drupal recommended (No CI)

### DIFF
--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -1,0 +1,75 @@
+---
+title: Convert an Empty Upstream Drupal Site to a Composer Managed Site
+description: Upgrade a Drupal 8 site using empty upsteam, by converting it to a Composer-managed Drupal 8 site on the new Integrated Composer framework. 
+type: guide
+permalink: docs/guides/:basename
+cms: "Drupal"
+categories: [develop]
+tags: [composer, site, workflow]
+contributors: [dustinleblanc, greg-1-anderson, stovak, kporras07]
+reviewed: "2022-02-21"
+---
+
+In this guide, we'll convert an empty upstream Drupal 8 site to use Composer to manage deployments and dependencies, then switch from `empty` to the new Integrated Composer `drupal-recommended` upstream while remaining on Drupal 8.
+
+## Overview
+
+Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies.
+
+The goals of this conversion are: 
+
+1. Remove dependencies that Composer will manage from the existing Drupal 8 site's Git repository, and have Composer manage those dependencies instead.
+
+1. Switch to the `drupal-recommended` Integrated Composer upstream.
+
+The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
+
+1. Add Drupal 8 core dependency instructions to `drupal/core-recommended`, to keep the site on Drupal 8 until you are ready to upgrade to Drupal 9.
+
+## Will This Guide Work for Your Site?
+
+<Partial file="drupal-9/upgrade-site-requirements-from-empty.md" />
+
+## Before You Begin
+
+- This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the Upstream.
+
+- This guide is written for users with access to Pantheon's [Multidev](/multidev) feature. Pantheon support is not available to users who avoid the Multidev steps.
+
+- The site owner should ensure the trusted host setting is up-to-date. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
+
+- Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, **you should prepend the paths in this document with "web" as needed**.
+
+- **Commit history note**: The steps in this process migrate a site, so the new site will no longer maintain its existing commit history.
+
+## Prepare the Local Environment
+
+<Partial file="drupal-9/prepare-local-environment.md" />
+
+## Add the Integrated Composer Upstream in a New Local Branch
+
+<Partial file="drupal-8-convert-to-composer-from-empty.md" />
+
+### Troubleshooting: Provided host name not valid
+
+If you receive the error message "The provided host name is not valid for this server.", then update your `settings.php` file with a trusted host setting. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
+
+## Change Upstreams
+
+Your Pantheon site is now set up to use the Drupal 9 Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
+
+```bash{promptUser:user}
+terminus site:upstream:set $SITE drupal-recommended
+```
+
+Following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon. The dependency you added above on `drupal/core-recommended` will keep you on Drupal 8 until you are ready to upgrade to Drupal 9.
+
+Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the Upstream.
+
+## Working With Dependency Versions
+
+<Partial file="composer-updating.md" />
+
+## See Also
+
+- [Composer Fundamentals and Workflows](/composer)

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -16,7 +16,7 @@ In this guide, we'll convert an empty upstream Drupal 8 site to use Composer to 
 
 Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies.
 
-The goals of this conversion are: 
+The goals of this conversion include the following: 
 
 1. Remove dependencies that Composer will manage from the existing Drupal 8 site's Git repository, and have Composer manage those dependencies instead.
 
@@ -30,7 +30,7 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 <Partial file="drupal-9/upgrade-site-requirements-from-empty.md" />
 
-- You have no Continous Integration setup or you don't need it anymore.
+- You have not set up Continous Integration or you no longer need it. 
 
 ## Before You Begin
 

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -46,7 +46,7 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 ## Prepare the Local Environment
 
-<Partial file="drupal-9/prepare-local-environment.md" />
+<Partial file="drupal-9/prepare-local-environment-no-clone.md" />
 
 ## Add the Integrated Composer Upstream in a New Local Branch
 

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -42,7 +42,7 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 - Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, **you should prepend the paths in this document with "web" as needed**.
 
-- **Commit history note**: The steps in this process migrate a site, so the new site will no longer maintain its existing commit history.
+Note: The steps in this process migrate a site, so the new site will no longer maintain the site's existing commit history.
 
 ## Prepare the Local Environment
 

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -30,6 +30,8 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 <Partial file="drupal-9/upgrade-site-requirements-from-empty.md" />
 
+- You have no Continous Integration setup or you don't need it anymore.
+
 ## Before You Begin
 
 - This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the Upstream.

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -42,7 +42,12 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 - Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, **you should prepend the paths in this document with "web" as needed**.
 
-Note: The steps in this process migrate a site, so the new site will no longer maintain the site's existing commit history.
+<Alert title="Note" type="info">
+
+  The steps in this process migrate a site and it's content, but not the commit history. The new site will not maintain the site's existing commit history.
+
+</Alert>
+
 
 ## Prepare the Local Environment
 

--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -42,7 +42,7 @@ The `drupal-recommended` Integrated Composer upstream works with Drupal 8, and f
 
 ## Prepare the Local Environment
 
-<Partial file="drupal-9/prepare-local-environment.md" />
+<Partial file="drupal-9/prepare-local-environment-no-clone.md" />
 
 ## Apply All Available Upstream Updates
 

--- a/source/partials/drupal-8-convert-to-composer-from-empty.md
+++ b/source/partials/drupal-8-convert-to-composer-from-empty.md
@@ -43,7 +43,7 @@ Set the Drupal core version, to ensure the site remains on Drupal 8 for now:
 
 ### Add Upgrade Status Module
 
-This step is optional; you may wait and add the Upgrade Status module to your site later.
+This step is optional. You can wait and add the Upgrade Status module to your site later.
 
 The Upgrade Status module will help to determine whether or not your site is ready to upgrade to Drupal 9.
 
@@ -55,7 +55,7 @@ Add the Upgrade Status module to your site with Composer:
   git commit -m "Add Upgrade Status module"
   ```
 
-When you are ready to begin upgrading your site to Drupal 9, you may enable this module and view the status report it provides to find things that need to be done before upgrading.
+When you are ready to begin upgrading your site to Drupal 9, you can enable this module and view the status report it provides to find things that need to be done before upgrading.
 
 ### Copy Existing Configuration
 

--- a/source/partials/drupal-8-convert-to-composer-from-empty.md
+++ b/source/partials/drupal-8-convert-to-composer-from-empty.md
@@ -1,0 +1,278 @@
+This process involves significant changes to the codebase that may take some time to complete, and can be complicated to roll back. 
+
+To minimize issues, these steps make the codebase changes in a new branch:
+
+1. In your local terminal, change directories to the site project. For example, if you keep your projects in a folder called `projects` in the home directory:
+
+  ```bash{promptUser:user}
+  cd ~/projects/$SITE/
+  ```
+
+1. Add the Pantheon Drupal Project upstream as a new remote called `ic`, fetch the `ic` upstream, and checkout to a new local branch based on it called `composerify`:
+
+  ```bash{outputLines:2}
+  git remote add ic git@github.com:pantheon-upstreams/drupal-recommended.git && git fetch ic && git checkout --no-track -b composerify ic/master
+  Switched to a new branch 'composerify'
+  ```
+
+  If you prefer, you can replace `composerify` with another branch name. If you do, remember to adjust the other examples in this doc to match.
+
+  <Accordion title="Troubleshoot: Permission denied (publickey)" id="permission-denied-publickey" icon="question-sign">
+
+  If you encounter a `Permission denied (publickey)` error, check that your [SSH keys](/ssh-keys) are set up correctly.
+
+  If you continue to encounter the error, use HTTPS to add the remote:
+
+   ```bash{outputLines:2}
+   git remote add ic https://github.com/pantheon-upstreams/drupal-recommended.git && git fetch ic && git checkout --no-track -b composerify ic/master
+   Switched to a new branch 'composerify'
+   ```
+
+  </Accordion>
+
+### Set Drupal Core Version
+
+Set the Drupal core version, to ensure the site remains on Drupal 8 for now:
+
+  ```bash{promptUser:user}
+  composer require --no-update drupal/core-recommended:^8.9
+  composer require --dev drupal/core-dev:^8.9
+  git add composer.*
+  git commit -m "Remain on Drupal 8"
+  ```
+
+### Add Upgrade Status Module
+
+This step is optional; you may wait and add the Upgrade Status module to your site later.
+
+The Upgrade Status module will help to determine whether or not your site is ready to upgrade to Drupal 9.
+
+Add the Upgrade Status module to your site with Composer:
+
+  ```bash{promptUser:user}
+  composer require drupal/upgrade_status
+  git add composer.*
+  git commit -m "Add Upgrade Status module"
+  ```
+
+When you are ready to begin upgrading your site to Drupal 9, you may enable this module and view the status report it provides to find things that need to be done before upgrading.
+
+### Copy Existing Configuration
+
+Copy any existing configuration from the default branch. Adjust the source folder as needed depending on your folder structure. If no files are copied through this step, that's ok:
+
+  ```bash{promptUser:user}
+  git checkout master sites/default/config
+  git mv sites/default/config/* config
+  git rm -f sites/default/config/.htaccess
+  git commit -m "Pull in configuration from default branch"
+  ```
+
+### Copy pantheon.yml
+
+1. Compare the old codebase's `pantheon.yml` to the new `pantheon.upstream.yml`:
+
+  ```bash{promptUser:user}
+  git diff master:pantheon.yml pantheon.upstream.yml
+  ```
+
+  Press `q` on your keyboard to exit the diff display.
+
+1. Copy the old `pantheon.yml` to preserve settings:
+
+  ```bash{promptUser:user}
+  git checkout master pantheon.yml
+  git add pantheon.yml
+  git commit -m 'Copy my pantheon.yml'
+  ```
+
+  Remove any values from `pantheon.yml` that you prefer to keep listed in `pantheon.upstream.yml`. Then add `build_step: true` to `pantheon.yml` if it is not already included.
+
+ In the `pantheon.yml` file, the `api_version: 1` and `build_step: true` values are required.
+
+## Add in the Custom and Contrib Code Needed to Run Your Site
+
+What makes your site code unique is your selection of contributed modules and themes, and any custom modules or themes your development team has created. These customizations need to be replicated in your new project structure.
+
+### Contributed Code
+
+#### Modules and Themes
+
+The goal of this process is to have Composer manage all the site's contrib modules, contrib themes, core upgrades, and libraries (we'll call this _contributed code_). The only things that should be migrated from the existing site are custom code, custom themes, and custom modules that are specific to the existing site.
+
+The steps here ensure that any modules and themes from [drupal.org](https://drupal.org) are in the `composer.json` `require` list.
+
+Once Composer is aware of all the contributed code, you'll be able to run `composer update` from within the directory to have Composer upgrade all the contributed code automatically.
+
+Begin by reviewing the existing site's code. Check for contributed modules in `/modules`, `/modules/contrib`, `/sites/all/modules`, and `/sites/all/modules/contrib`.
+
+1. Review the site and make a list of exactly what versions of modules and themes you depend on. One way to do this is to run the `pm:list` Drush command from within a contributed modules folder (e.g. `/modules`, `/themes`, `/themes/contrib`, `/sites/all/themes`, `/sites/all/themes/contrib`, etc.).
+
+  This will list each module followed by the version of that module that is installed:
+
+  ```bash{promptUser:user}
+  terminus drush $SITE.dev pm:list -- --no-core --fields=name,version  --format=table
+  ```
+
+  If you were already using composer to manage your site dependencies, you could just look at your source site `composer.json` file and get the package names and version from there.
+
+1. You can add these modules to your new codebase using Composer by running the following for each module in the `$SITE` directory:
+
+  ```bash{promptUser:user}
+  composer require drupal/MODULE_NAME:^VERSION
+  ```
+
+  Where `MODULE_NAME` is the machine name of the module in question, and `VERSION` is the version of that module the site is currently using. Composer may pull in a newer version than what you specify, depending upon what versions are available. You can read more about the caret (`^`) in the [Composer documentation](https://getcomposer.org/doc/articles/versions.md#caret-version-range-).
+
+  Some modules use different version formats.
+
+   - For older-style Drupal version strings:
+
+   ```none
+   Chaos Tools (ctools)  8.x-3.4
+   ```
+
+    Replace the `8.x-` to convert this into `^3.4`
+
+   - Semantic Versioning version strings:
+
+   ```none
+   Devel (devel)  4.1.1
+   ```
+
+    Use the version directly, e.g. `^4.1.1`
+
+    <Accordion title="Troubleshoot: Could not find a version of MODULE_NAME" id="tr-minmodule" icon="question-sign">
+
+      If you get the following error, the module listed in the error (or its dependencies) does not meet compatibility requirements:
+
+      ```none
+      [InvalidArgumentException]
+      Could not find a version of package drupal/MODULE_NAME matching your minimum-stability (stable). Require it with an explicit version constraint allowing its desired stability.
+      ```
+
+      If there is no stable version you can switch to, you may need to adjust the `minimum-stability` setting of `composer.json` to a more relaxed value, such as `beta`, `alpha`, or `dev` (not recommended). You can read more about `minimum-stability` in the [Composer documentation](https://getcomposer.org/doc/04-schema.md#minimum-stability).
+
+        - If a dev version of a module fails because it requires a development version of a dependency, allowlist the dev dependency in the same `composer require` as the module:
+
+        ```bash{promptUser:user}
+        composer require drupal/some-module:^1@dev org/some-dependency:^2@dev
+        ```
+
+    </Accordion>
+
+#### Libraries
+
+Libraries can be handled similarly to modules, but the specifics depend on how your library code was included in the source site. If you're using a library's API, you may have to do additional work to ensure that library functions properly.
+
+### Custom Code
+
+Manually copy custom code from the existing site repository to the Composer-managed directory.
+
+#### Modules and Themes
+
+Modules:
+
+```bash{promptUser:user}
+git checkout master modules/custom
+git mv modules/custom web/modules/
+git commit -m "Copy custom modules"
+```
+
+Themes:
+
+```bash{promptUser:user}
+git checkout master themes/custom
+git mv themes/custom web/themes/
+git commit -m "Copy custom themes"
+```
+
+Follow suit with any other custom code you need to carry over.
+
+#### settings.php
+
+Your existing site may have customizations to `settings.php` or other configuration files. Review these carefully and extract relevant changes from these files to copy over. Always review any file paths referenced in the code, as these paths may change in the transition to Composer.
+
+We don't recommend that you completely overwrite the `settings.php` file with the old one, as it contains customizations for moving the configuration directory you don't want to overwrite, as well as platform-specific customizations.
+
+```bash{promptUser:user}
+git status # Ensure working tree is clean
+git show master:sites/default/settings.php > web/sites/default/original-settings.php
+diff -Nup --ignore-all-space web/sites/default/settings.php web/sites/default/original-settings.php
+# edit web/sites/default/settings.php and commit as needed
+rm web/sites/default/original-settings.php
+```
+
+The resulting `settings.php` should have no `$databases` array.
+
+## Deploy
+
+You've now committed the code to the local branch. Deploy that branch directly to a new Multidev (called `composerify` in the steps below) and test the site in the browser.
+
+### Deploy to a Multidev
+
+1. Push the changes to a Multidev called `composerify` to safely test the site without affecting the Dev environment:
+
+   ```bash{promptUser:user}
+   git push -u origin composerify && terminus env:create $SITE.dev composerify
+   ```
+
+1. Make a small change to `pantheon.yml`:
+
+   ```yaml:title=pantheon.yml
+   database:
+    version: 10.4
+
+   # add a comment to trigger a change and build
+   ```
+
+1. Commit and push the change to trigger an Integrated Composer build on the Multidev:
+
+   ```bash{promptUser: user}
+   git commit -am "trigger composer build"
+   git push origin composerify
+   ```
+
+Since the commit history of the `composerify` Multidev has no commits in common with the `master` branch, you cannot view the Multidev commit history from the Dashboard or the Integrated Composer logs.
+
+If the site is not working, try this Composer command on the local `composerify` branch:
+
+```bash{promptUser:user}
+composer --no-dev --optimize-autoloader --no-interaction --no-progress --prefer-dist --ansi install
+```
+
+If Composer runs into an error or if any files have been changed (files that are not ignored by `.gitignore`), resolve those issues before you continue. See the [Integrated Composer Troubleshooting](/integrated-composer#troubleshooting-code-syncs-and-upstream-updates) section for more information about troubleshooting Integrated Composer.
+
+### Move composerify to the Main Dev Branch
+
+Once you have confirmed that the site works in the Multidev, replace the `master` branch and its commit history with the `composerify` Multidev's commit history.
+
+1. Retrieve the most recent commit hash from the local `composerify` branch:
+
+   ```bash{promptUser:user}
+   git log --format="%H" -n 1
+   ```
+
+   This will give you a commit hash like `fd3636f58f5b275b998bb1c9267bff8808353840`.
+
+1. Reset the `master` branch to match that commit then force push that to the Dev environment:
+
+   ```bash{promptUser: user}
+   git checkout master
+   git reset --hard fd3636f58f5b275b998bb1c9267bff8808353840
+   git push --force origin master
+   ```
+
+Your site's Dev environment is now set up to use the Drupal 9 Integrated Composer upstream. 
+
+### Troubleshooting: Inspect Site Logs
+
+If the site doesn't load properly, before you do too much work to investigate issues, clear the cache and try again.
+
+Use Terminus to inspect the site's logs;
+
+```bash{promptUser: user}
+terminus drush $SITE.composerify -- wd-show
+```
+
+See our [logs collection](/logs) documentation for more information.

--- a/source/partials/drupal-9/prepare-local-environment-no-clone.md
+++ b/source/partials/drupal-9/prepare-local-environment-no-clone.md
@@ -1,9 +1,9 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP 7.4, along with their required dependencies. Note: Terminus 2 is not yet compatible with PHP 8. Restart the shell or terminal environment after entering the following command:
+   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP, along with their required dependencies. Note: Terminus 3 should be used for PHP >= 8.0. Restart the shell or terminal environment after entering the following command:
 
     ```bash{promptUser:user}
-    brew install git composer php@7.4
+    brew install git composer php
     ```
 
    - Windows users can install [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows) and [Git](https://git-scm.com/download/win), and may need to install [XAMPP](https://www.apachefriends.org/index.html) or similar to satisfy some dependencies.

--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -1,9 +1,9 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP 7.4, along with their required dependencies. Note: Terminus 2 is not yet compatible with PHP 8. Restart the shell or terminal environment after entering the following command:
+   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP, along with their required dependencies. Note: Terminus 3 should be used for PHP >= 8.0. Restart the shell or terminal environment after entering the following command:
 
     ```bash{promptUser:user}
-    brew install git composer php@7.4
+    brew install git composer php
     ```
 
    - Windows users can install [Composer](https://getcomposer.org/doc/00-intro.md#installation-windows) and [Git](https://git-scm.com/download/win), and may need to install [XAMPP](https://www.apachefriends.org/index.html) or similar to satisfy some dependencies.

--- a/source/partials/drupal-9/prepare-local-environment.md
+++ b/source/partials/drupal-9/prepare-local-environment.md
@@ -1,6 +1,6 @@
 1. Review our documentation on [Git](/git), [Composer](/composer), and [Terminus](/terminus), and have them installed and configured on your local computer. Pantheon requires Composer 2 at minimum.
 
-   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP, along with their required dependencies. Note: Terminus 3 should be used for PHP >= 8.0. Restart the shell or terminal environment after entering the following command:
+   - Mac users can use [Homebrew](https://brew.sh/) to install Git, Composer, and PHP, along with their required dependencies. Note that Terminus 3 should be used for PHP versions 8.0 and up. Restart the shell or terminal environment after entering the following command:
 
     ```bash{promptUser:user}
     brew install git composer php

--- a/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
+++ b/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
@@ -1,12 +1,12 @@
 You must confirm that your site meets the following requirements before you continue:
 
-- Ensure your site has the [Pantheon empty repo](https://github.com/pantheon-systems/empty) in its upstream.
+- Ensure your site has the [Pantheon empty repository](https://github.com/pantheon-systems/empty) in its upstream.
 
   ### Use Terminus to Confirm the empty Upstream
 
   Run the command `terminus site:info $SITE` to display the site's basic information and properties.
  
- The following values indicate that a site is using a `empty` upstream: 
+ The following values indicate that a site is using an `empty` upstream: 
   * The `Framework` is `drupal8`
   * The `Upstream` includes `https://github.com/pantheon-systems/empty.git`
   

--- a/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
+++ b/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
@@ -1,0 +1,29 @@
+You must confirm that your site meets the following requirements before you continue:
+
+- Ensure your site has the [Pantheon empty repo](https://github.com/pantheon-systems/empty) in its upstream.
+
+  ### Use Terminus to Confirm the empty Upstream
+
+  Run the command `terminus site:info $SITE` to display the site's basic information and properties.
+ 
+ The following values indicate that a site is using a `empty` upstream: 
+  * The `Framework` is `drupal8`
+  * The `Upstream` includes `https://github.com/pantheon-systems/empty.git`
+  
+  The following is an abridged example of the output for the `terminus site:info $SITE` command, if the site upstream is set to `empty`:
+
+  ```bash{outputLines:2-18}
+  terminus site:info $SITE
+  ------------------ -------------------------------------------------------------------------------------
+  ID                 abdc3ea1-fe0b-1234-9c9f-3cxeAA123f88
+  Name               anita-drupal
+  Label              AnitaDrupal
+  Created            2019-12-02 18:28:14
+  Framework          drupal8
+  ...
+  Upstream           4c7176de-e079-eed1-154d-44d5a9945b65: https://github.com/pantheon-systems/empty.git
+  ...
+  ------------------ -------------------------------------------------------------------------------------
+  ```
+
+- The site does not use another package and library manager like [Ludwig](https://www.drupal.org/project/ludwig).

--- a/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
+++ b/source/partials/drupal-9/upgrade-site-requirements-from-empty.md
@@ -2,7 +2,7 @@ You must confirm that your site meets the following requirements before you cont
 
 - Ensure your site has the [Pantheon empty repository](https://github.com/pantheon-systems/empty) in its upstream.
 
-  ### Use Terminus to Confirm the empty Upstream
+  ### Use Terminus to Confirm the Empty Upstream
 
   Run the command `terminus site:info $SITE` to display the site's basic information and properties.
  
@@ -26,4 +26,4 @@ You must confirm that your site meets the following requirements before you cont
   ------------------ -------------------------------------------------------------------------------------
   ```
 
-- The site does not use another package and library manager like [Ludwig](https://www.drupal.org/project/ludwig).
+- The site does not use another package and library manager, such as [Ludwig](https://www.drupal.org/project/ludwig).


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes CMS-568

## Summary

Add new "Convert an Empty Upstream Drupal Site to a Composer Managed Site" page.
<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Convert an Empty Upstream Drupal Site to a Composer Managed Site](https://pr-7113--pantheon-docs.my.pantheonfrontend.website/docs/guides/composer-convert-from-empty)** - Add this new doc page.

## Effect

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
