### PR TITLE
[CMS-549] Add new switch to drupal-recommended upstream doc page.

### DIFF
--- a/source/content/guides/switch-drupal-recommended-upstream.md
+++ b/source/content/guides/switch-drupal-recommended-upstream.md
@@ -7,7 +7,7 @@ cms: "Drupal"
 categories: [develop]
 tags: [composer, site, workflow]
 contributors: [kporras07]
-reviewed: "2022-02-22"
+reviewed: "2022-04-03"
 ---
 
 In this guide, we will convert an existing site from the Drupal 9 (`drupal9`) upstream to the new Drupal with Composer (`drupal-recommended`) upstream.
@@ -82,13 +82,13 @@ After you complete the upstream change, you need to apply the available upstream
 
 ### Solving Merge Conflicts When Applying Upstream Updates
 
-Conflicts can occur when modified file(s) within your site's codebase do not align with changes made to the same file(s) in the site's upstream.
+Conflicts can occur when a modified file within your site's codebase does not align with changes made to the same file in the site's upstream.
 
-> When a merge isn’t resolved automatically, Git leaves the index and the working tree in a special state that gives you all the information you need to help resolve the merge.
+> When a merge isn’t resolved automatically, Git leaves the index and the working tree in a special state that gives you all the information you need to resolve the merge.
 >
 > \- [Git Manual](https://www.kernel.org/pub/software/scm/git/docs/)
 
-If you receive the error that you have conflicts while updating core, the fastest resolution is often the `-Xtheirs` flag. This will attempt to automatically resolve the conflicts with a preference for upstream changes.
+If you receive the error that you have conflicts while updating core, the fastest resolution is often the `-Xtheirs` flag. This will attempt to automatically resolve the conflict with a preference for upstream changes.
 
 This is safe to run if you don't have your own changes in any of the conflicting files (e.g. problems with `.gitignore`).
 
@@ -100,10 +100,10 @@ git push origin master
 
 Double-check the files before going forward to make sure no bugs were introduced.
 
-If you modified upstream files, the `-Xtheirs` flag will drop your changes. In that case you should [manually resolve conflicts](/git-resolve-merge-conflicts#manually-resolve-conflicts). 
+If you modified upstream files, the `-Xtheirs` flag will drop your changes. You should [manually resolve conflicts](/git-resolve-merge-conflicts#manually-resolve-conflicts) to fix this issue.
 
 
-Once you applied the upstream updates (either via the dashboard or after solving merge conflicts) you are now in the Drupal with Composer upstream.
+After you apply the upstream updates, either using the Dashboard or after solving merge conflicts, you are will be in the Drupal with Composer upstream.
 
 ## See Also
 

--- a/source/content/guides/switch-drupal-recommended-upstream.md
+++ b/source/content/guides/switch-drupal-recommended-upstream.md
@@ -1,5 +1,5 @@
 ---
-title: Switch from Drupal 9 to Drupal with Composer upstream
+title: Switch from Drupal 9 to Drupal with Composer Upstream
 description: Switch to the new Pantheon upstream to take advantage of the new structure and future updates.
 type: guide
 permalink: docs/guides/:basename
@@ -10,7 +10,7 @@ contributors: [kporras07]
 reviewed: "2022-02-22"
 ---
 
-In this guide, we will convert an existing site from the Drupal 9 (drupal9) upstream to the new Drupal with Composer (drupal-recommended) upstream.
+In this guide, we will convert an existing site from the Drupal 9 (`drupal9`) upstream to the new Drupal with Composer (`drupal-recommended`) upstream.
 
 ## Overview
 
@@ -26,11 +26,11 @@ The goals of this conversion are:
 
 You must confirm that your site meets the following requirements before you continue:
 
-- Ensure your site has the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream.
+- Ensure your site uses the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream.
 
-  ### Use Terminus to Confirm the drupal9 Upstream
+### Use Terminus to Confirm the drupal9 Upstream
 
-  Run the command `terminus site:info $SITE` to display the site's basic information and properties.
+Run the command `terminus site:info $SITE` to display the site's basic information and properties.
 
  The following values indicate that a site is using a `drupal9` upstream:
   * The `Framework` is `drupal8`
@@ -54,7 +54,7 @@ You must confirm that your site meets the following requirements before you cont
 
 ## Before You Begin
 
-- This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the Upstream.
+- This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the upstream.
 
 ## Prepare the Local Environment
 
@@ -72,13 +72,13 @@ Change the upstream your site is tracking with the following command:
 terminus site:upstream:set $SITE drupal-recommended
 ```
 
-Following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
+Following the `drupal-recommended` upstream will help keep your site current with any general configuration changes recommended by Pantheon.
 
-Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the Upstream.
+Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the upstream.
 
 ## Apply New Upstream Updates
 
-Once you did the upstream change, you need to apply the available upstream updates. You could first try to do this from the Pantheon Dashboard in the dev environment. If it works then you are ready; otherwise, continue to the next section about merge conflicts.
+After you complete the upstream change, you need to apply the available upstream updates. Try to do this from the Pantheon Dashboard in the Dev environment. If this is not successful, continue to the next section about merge conflicts.
 
 ### Solving Merge Conflicts When Applying Upstream Updates
 

--- a/source/content/guides/switch-drupal-recommended-upstream.md
+++ b/source/content/guides/switch-drupal-recommended-upstream.md
@@ -14,21 +14,21 @@ In this guide, we will convert an existing site from the Drupal 9 (`drupal9`) up
 
 ## Overview
 
-Drupal 9 sites created in the platform prior to November 30, 2021 use the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream. Based on some needs we detected from the community, we released a new upstream with a slightly different structure. The [Drupal with Composer](https://github.com/pantheon-upstreams/drupal-recommended) is now the default Drupal 9 upstream in the platform and users are encouraged to switch to it to take advantage of the improved structure and future updates.
+Drupal 9 sites created on the platform prior to November 30, 2021 use the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream. Based on community needs, we have released a new upstream. [Drupal with Composer](https://github.com/pantheon-upstreams/drupal-recommended) is now the default Drupal 9 upstream on the platform and users are encouraged to switch to it to take advantage of the improved structure and updates.
 
-The goals of this conversion are:
+The goals of this conversion doc include the following:
 
-1. Set the site to use the new upstream
-1. Apply the upstream changes
-1. Resolve any merge conflicts that may appear during this process.
+* Configure the site to use the new upstream.
+* Apply the upstream changes.
+* Resolve any merge conflicts that might arise during the conversion process.
 
 ## Will This Guide Work for Your Site?
 
-You must confirm that your site meets the following requirements before you continue:
+You must confirm that your site meets the following requirement before you continue:
 
 - Ensure your site uses the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream.
 
-### Use Terminus to Confirm the drupal9 Upstream
+### Use Terminus to Confirm the Drupal 9 Upstream
 
 Run the command `terminus site:info $SITE` to display the site's basic information and properties.
 
@@ -66,44 +66,42 @@ Run the command `terminus site:info $SITE` to display the site's basic informati
 
 ## Switch to Drupal with Composer Upstream
 
-Change the upstream your site is tracking with the following command:
+Change the upstream that your site is tracking with the following command:
 
 ```bash{promptUser:user}
 terminus site:upstream:set $SITE drupal-recommended
 ```
 
-Following the `drupal-recommended` upstream will help keep your site current with any general configuration changes recommended by Pantheon.
+Follow the `drupal-recommended` upstream to keep your site current with any general configuration changes recommended by Pantheon.
 
 Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the upstream.
 
 ## Apply New Upstream Updates
 
-After you complete the upstream change, you need to apply the available upstream updates. Try to do this from the Pantheon Dashboard in the Dev environment. If this is not successful, continue to the next section about merge conflicts.
+After you complete the upstream change, you need to apply the available upstream updates. Use the Pantheon Dashboard in the Dev environment to apply updates. If this is not successful, continue to the next section for help resolving with merge conflicts.
 
 ### Solving Merge Conflicts When Applying Upstream Updates
 
-Conflicts can occur when a modified file within your site's codebase does not align with changes made to the same file in the site's upstream.
+Conflicts can occur when a modified file in your site's codebase does not align with changes made to the same file in the site's upstream.
 
-> When a merge isn’t resolved automatically, Git leaves the index and the working tree in a special state that gives you all the information you need to resolve the merge.
+> When a merge isn’t resolved automatically, Git leaves the index and the working tree in a state that provides the information you need to resolve the merge.
 >
 > \- [Git Manual](https://www.kernel.org/pub/software/scm/git/docs/)
 
-If you receive the error that you have conflicts while updating core, the fastest resolution is often the `-Xtheirs` flag. This will attempt to automatically resolve the conflict with a preference for upstream changes.
+If you receive an error that you have conflicts while updating, resolve using the `-Xtheirs` flag. This will automatically resolve the conflict with a preference for upstream changes.
 
-This is safe to run if you don't have your own changes in any of the conflicting files (e.g. problems with `.gitignore`).
+This is safe to run if you don't have your own changes in any of the conflicting files, such as problems with `.gitignore`.
 
 ```bash{promptUser: user}
 git pull -Xtheirs https://github.compantheon-upstreams/drupal-recommended.git master
 # resolve conflicts
 git push origin master
 ```
+Check that the files are correct before going forward to ensure no bugs are introduced.
 
-Double-check the files before going forward to make sure no bugs were introduced.
+If you modified upstream files, the `-Xtheirs` flag will drop your changes. You can [manually resolve conflicts](/git-resolve-merge-conflicts#manually-resolve-conflicts) to fix this issue.
 
-If you modified upstream files, the `-Xtheirs` flag will drop your changes. You should [manually resolve conflicts](/git-resolve-merge-conflicts#manually-resolve-conflicts) to fix this issue.
-
-
-After you apply the upstream updates, either using the Dashboard or after solving merge conflicts, you are will be in the Drupal with Composer upstream.
+You will be in the Drupal with Composer upstream after you apply the upstream updates.
 
 ## See Also
 

--- a/source/content/guides/switch-drupal-recommended-upstream.md
+++ b/source/content/guides/switch-drupal-recommended-upstream.md
@@ -1,0 +1,111 @@
+---
+title: Switch from Drupal 9 to Drupal with Composer upstream
+description: Switch to the new Pantheon upstream to take advantage of the new structure and future updates.
+type: guide
+permalink: docs/guides/:basename
+cms: "Drupal"
+categories: [develop]
+tags: [composer, site, workflow]
+contributors: [kporras07]
+reviewed: "2022-02-22"
+---
+
+In this guide, we will convert an existing site from the Drupal 9 (drupal9) upstream to the new Drupal with Composer (drupal-recommended) upstream.
+
+## Overview
+
+Drupal 9 sites created in the platform prior to November 30, 2021 use the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream. Based on some needs we detected from the community, we released a new upstream with a slightly different structure. The [Drupal with Composer](https://github.com/pantheon-upstreams/drupal-recommended) is now the default Drupal 9 upstream in the platform and users are encouraged to switch to it to take advantage of the improved structure and future updates.
+
+The goals of this conversion are:
+
+1. Set the site to use the new upstream
+1. Apply the upstream changes
+1. Resolve any merge conflicts that may appear during this process.
+
+## Will This Guide Work for Your Site?
+
+You must confirm that your site meets the following requirements before you continue:
+
+- Ensure your site has the [Drupal 9](https://github.com/pantheon-upstreams/drupal-project) upstream.
+
+  ### Use Terminus to Confirm the drupal9 Upstream
+
+  Run the command `terminus site:info $SITE` to display the site's basic information and properties.
+
+ The following values indicate that a site is using a `drupal9` upstream:
+  * The `Framework` is `drupal8`
+  * The `Upstream` includes `https://github.com/pantheon-upstreams/drupal-project`
+
+  The following is an abridged example of the output for the `terminus site:info $SITE` command, if the site upstream is set to `drupal9`:
+
+  ```bash{outputLines:2-18}
+  terminus site:info $SITE
+  ------------------ -------------------------------------------------------------------------------------
+  ID                 abdc3ea1-fe0b-1234-9c9f-3cxeAA123f88
+  Name               anita-drupal
+  Label              AnitaDrupal
+  Created            2019-12-02 18:28:14
+  Framework          drupal8
+  ...
+  Upstream           e96c6794-77fe-4931-9a20-48a2fe1a3789: https://github.com/pantheon-upstreams/drupal-project
+  ...
+  ------------------ -------------------------------------------------------------------------------------
+  ```
+
+## Before You Begin
+
+- This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the Upstream.
+
+## Prepare the Local Environment
+
+<Partial file="drupal-9/prepare-local-environment-no-clone.md" />
+
+## Apply All Available Upstream Updates
+
+<Partial file="drupal-apply-upstream-updates.md" />
+
+## Switch to Drupal with Composer Upstream
+
+Change the upstream your site is tracking with the following command:
+
+```bash{promptUser:user}
+terminus site:upstream:set $SITE drupal-recommended
+```
+
+Following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
+
+Note that only the [User in Charge](/change-management#site-level-roles-and-permissions) can set the Upstream.
+
+## Apply New Upstream Updates
+
+Once you did the upstream change, you need to apply the available upstream updates. You could first try to do this from the Pantheon Dashboard in the dev environment. If it works then you are ready; otherwise, continue to the next section about merge conflicts.
+
+### Solving Merge Conflicts When Applying Upstream Updates
+
+Conflicts can occur when modified file(s) within your site's codebase do not align with changes made to the same file(s) in the site's upstream.
+
+> When a merge isn’t resolved automatically, Git leaves the index and the working tree in a special state that gives you all the information you need to help resolve the merge.
+>
+> \- [Git Manual](https://www.kernel.org/pub/software/scm/git/docs/)
+
+If you receive the error that you have conflicts while updating core, the fastest resolution is often the `-Xtheirs` flag. This will attempt to automatically resolve the conflicts with a preference for upstream changes.
+
+This is safe to run if you don't have your own changes in any of the conflicting files (e.g. problems with `.gitignore`).
+
+```bash{promptUser: user}
+git pull -Xtheirs https://github.compantheon-upstreams/drupal-recommended.git master
+# resolve conflicts
+git push origin master
+```
+
+Double-check the files before going forward to make sure no bugs were introduced.
+
+If you modified upstream files, the `-Xtheirs` flag will drop your changes. In that case you should [manually resolve conflicts](/git-resolve-merge-conflicts#manually-resolve-conflicts). 
+
+
+Once you applied the upstream updates (either via the dashboard or after solving merge conflicts) you are now in the Drupal with Composer upstream.
+
+## See Also
+
+- [Composer Fundamentals and Workflows](/composer)
+- [Resolve Git Merge Conflicts](/git-resolve-merge-conflicts)


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes CMS-549

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Switch from Drupal 9 to Drupal with Composer upstream](https://pr-7114--pantheon-docs.my.pantheonfrontend.website/docs/guides/switch-drupal-recommended-upstream)** - Add new docs page.

## Effect

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
