### PR TITLE
[CMS-597] Add instructions for a composer tainted drops-8 site.

### DIFF
--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -161,7 +161,7 @@ Begin by reviewing the existing site's code. Check for contributed modules in `/
 
 #### Other Composer Packages
 
-If you have added non Drupal packages to your site via Composer, you should also bring them over by running the corresponding `composer require` commands for each of those packages. You can use the following command to get the differences between the master's and your current `composer.json`. Pay special attention to the stuff marked as delete in the diff output:
+If you have added non-Drupal packages to your site via Composer, use the command `composer require` to migrate each package. You can use the following command to display the differences between the master and your current `composer.json`:
 
 ```
 git diff master:composer.json composer.json
@@ -193,7 +193,7 @@ git mv themes/custom web/themes/
 git commit -m "Copy custom themes"
 ```
 
-Follow suit with any other custom code you need to carry over.
+Use with any other custom code you need to .
 
 #### settings.php
 

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -161,7 +161,11 @@ Begin by reviewing the existing site's code. Check for contributed modules in `/
 
 #### Other Composer Packages
 
-If you have added non Drupal packages to your site via Composer, you should also bring them over by running the corresponding `composer require` commands for each of those packages.
+If you have added non Drupal packages to your site via Composer, you should also bring them over by running the corresponding `composer require` commands for each of those packages. You can use the following command to get the differences between the master's and your current `composer.json`. Pay special attention to the stuff marked as delete in the diff output:
+
+```
+git diff master:composer.json composer.json
+```
 
 #### Libraries
 
@@ -212,7 +216,15 @@ The resulting `settings.php` should have no `$databases` array.
 Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This may include:
 
 - repositories configuration
+- minimum-stability
 - extra section
+- etc
+
+You can use the same diff command from above to find out the stuff that you need to copy:
+
+```
+git diff master:composer.json composer.json
+```
 
 ## Deploy
 

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -177,7 +177,7 @@ Manually copy custom code from the existing site repository to the Composer-mana
 
 #### Modules and Themes
 
-Modules:
+To move modules, use the following commands:
 
 ```bash{promptUser:user}
 git checkout master modules/custom
@@ -185,7 +185,7 @@ git mv modules/custom web/modules/
 git commit -m "Copy custom modules"
 ```
 
-Themes:
+To move themes, use the following commands:
 
 ```bash{promptUser:user}
 git checkout master themes/custom
@@ -193,7 +193,7 @@ git mv themes/custom web/themes/
 git commit -m "Copy custom themes"
 ```
 
-Use with any other custom code you need to .
+Use the above commands with any of the custom code.
 
 #### settings.php
 
@@ -213,14 +213,9 @@ The resulting `settings.php` should have no `$databases` array.
 
 ### Additional Composer Configuration
 
-Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This may include:
+Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This can include configurations related to repositories, minimum-stability, or extra sections.
 
-- repositories configuration
-- minimum-stability
-- extra section
-- etc
-
-You can use the same diff command from above to find out the stuff that you need to copy:
+You can use the diff command to get the information you need to copy:
 
 ```
 git diff master:composer.json composer.json

--- a/source/partials/drupal-8-convert-to-composer.md
+++ b/source/partials/drupal-8-convert-to-composer.md
@@ -159,6 +159,10 @@ Begin by reviewing the existing site's code. Check for contributed modules in `/
 
     </Accordion>
 
+#### Other Composer Packages
+
+If you have added non Drupal packages to your site via Composer, you should also bring them over by running the corresponding `composer require` commands for each of those packages.
+
 #### Libraries
 
 Libraries can be handled similarly to modules, but the specifics depend on how your library code was included in the source site. If you're using a library's API, you may have to do additional work to ensure that library functions properly.
@@ -202,6 +206,13 @@ rm web/sites/default/original-settings.php
 ```
 
 The resulting `settings.php` should have no `$databases` array.
+
+### Additional Composer Configuration
+
+Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This may include:
+
+- repositories configuration
+- extra section
 
 ## Deploy
 

--- a/source/partials/drupal-apply-upstream-updates.md
+++ b/source/partials/drupal-apply-upstream-updates.md
@@ -3,7 +3,7 @@
 1. Use Terminus to list all available updates:
 
   ```bash{outputLines:2}
-  terminus upstream:updates:list $SITE
+  terminus upstream:updates:list $SITE.dev
   [warning] There are no available updates for this site.
   ```
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes CMS-597

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Convert a Standard Drupal 8 Site to a Composer Managed Site](https://pantheon.io/docs/guides/composer-convert)** - Adds some instruction on how to work with a site with composer changes.

## Effect



### Dependencies and Timing

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
