### PR TITLE
[CMS-584] OSS Support Levels

### DIFF
--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -7,15 +7,17 @@ contributors: [greg-1-anderson, kporras07]
 reviewed: "2022-03-02"
 ---
 
-At Pantheon, we appreciate open source contributions. In an effort to effectively maintain our various public repositories in [GitHub](https://github.com/orgs/pantheon-systems/repositories), we tag Pantheon repositories with support level badges. This page describes each support level and details the support expectations for repositories.
+At Pantheon, we appreciate open source contributions. In an effort to effectively maintain our various public repositories in [GitHub](https://github.com/orgs/pantheon-systems/repositories), we tag Pantheon repositories with support level badges. The badge is typically displayed in the repository's `README.md`. 
 
-## Early Access Support
+This page describes each support level and the support expectations for our public repositories.
 
-A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available, but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program. For more information on 
+## Limited Availability
 
-## Limited Availability Support
+Support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
 
-A project in this support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
+## Early Access
+
+An projec in Early access denotes a new product or feature set that is in deve. The code is publicly available, but if there are any accompaning platform components you will need an invitation through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program. For more information on 
 
 ## Actively Maintained Support
 
@@ -23,20 +25,19 @@ A project in this support level has been publicly launched and has several eyes 
 
 ## Minimal Support
 
-A project in this support level rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
+A minimal project with minimal rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
 
 ## Unofficial Support
 
-A project that has unofficial support level is usually a Pantheon employee initiative. It typically does not have resources allocated for maintenance. Support is not guaranteed for the project because it depends on the availability and afffiliation of the project maintainer.
+A project that has unofficial support level is usually a Pantheon employee initiative. It typically does not have resources allocated for maintenance. Support is not guaranteed for the project because it depends on the availability of the project maintainer.
 
 ## Unsupported 
 
-An unsupported project is typically only for internal use at Pantheon. Although the source code is available, use these projects at your own risk, as support is not available.
+An unsupported repository is typically only for internal use at Pantheon. Although the source code is available, use these projects at your own risk, as support is not available.
 
 ## Deprecated 
 
-A deprecated project is a project that has been retired or replaced by a code base that is no longer supported by Pantheon. Details about the project can be found in the `README.md` or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. Using a project that has been deprecated is not encouraged. 
-
+A deprecated repository is a project that has been retired or replaced, and is no longer supported by Pantheon. Details about the repository can be found in the `README.md`. Additional information, such as suitable alternative projects or guidance on finding solutions, may be available in the [Community Slack](https://slackin.pantheon.io/). Using a project that has been deprecated is not encouraged.
 
 ## See Also
 - [Get Support](https://pantheon.io/docs/guides/support/)

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -27,14 +27,14 @@ A project in this support level has been publicly launched and has several eyes 
 
 A project in this support level rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
 
-## Unsupported
-
-A project in this support level rarely receives updates and people should not expect replies to issues or pull requests. You are encouraged to NOT use a project in this support level.
-
 ## Unofficial
 
 A project in this support level is usually a Pantheon employee initiative. It probably does not have any resource allocated for maintenance and support is not guaranteed for this project because it depends on the project maintainer available time if they are still in the company.
 
+## Unsupported
+
+A project in this support level may be in active use internally by Pantheon; although the source code is provided, use is at your own risk, and support is not available.
+
 ## Deprecated
 
-A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go.
+A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. You are encouraged to NOT use a project in this support level.

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -37,4 +37,4 @@ A project in this support level is usually a Pantheon employee initiative. It pr
 
 ## Deprecated
 
-A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in Slack if you are in a need for the replacement or guidance about where to go.
+A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go.

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -7,13 +7,9 @@ tags: [collaborate]
 
 At Pantheon we love Open Source, we have created lots of public repositories in our [Github account](https://github.com/orgs/pantheon-systems/repositories) and we have started tagging them with support level badges. This page describes each of those levels and what should you expect when using those repositories.
 
-## Pilot
-
-A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program.
-
 ## Early Acess
 
-Early Access projects are similar to Pilot projects, but are a little more mature, and have been opened up for use by a larger number of users. An invitation is still necessary to join an Early Access program.
+A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program.
 
 ## Limited Availability
 

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -1,21 +1,23 @@
 ---
 title: Pantheon Open Source Software Support Levels
-description: Learn about Pantheon Support Levels for Open Source Sofware
+description: Learn about Pantheon support levels for open source software
 categories: [get-started, oss]
 tags: [collaborate]
+contributors: [greg-1-anderson, kporras07]
+reviewed: "2022-03-02"
 ---
 
-At Pantheon we love Open Source, we have created lots of public repositories in our [Github account](https://github.com/orgs/pantheon-systems/repositories) and we have started tagging them with support level badges. This page describes each of those levels and what should you expect when using those repositories.
+At Pantheon, we appreciate open source contributions. In an effort to effectively maintain our various public repositories in [GitHub](https://github.com/orgs/pantheon-systems/repositories), we tag Pantheon repositories with support level badges. This page describes each support level and details the support expectations for repositories.
 
-## Early Acess
+## Early Access Support
 
-A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program.
+A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available, but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program. For more information on 
 
-## Limited Availability
+## Limited Availability Support
 
 A project in this support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
 
-## Actively Maintained
+## Actively Maintained Support
 
 A project in this support level has been publicly launched and has several eyes over it ensuring that everything works as expected. Anyone could use this project and create issues and Pull Requests in the repository as needed and we will respond to them in a timely manner. Support in this stage is available through regular Pantheon channels.
 
@@ -23,14 +25,14 @@ A project in this support level has been publicly launched and has several eyes 
 
 A project in this support level rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
 
-## Unofficial
+## Unofficial Support
 
 A project in this support level is usually a Pantheon employee initiative. It probably does not have any resource allocated for maintenance and support is not guaranteed for this project because it depends on the project maintainer available time if they are still in the company.
 
-## Unsupported
+## Unsupported 
 
-A project in this support level may be in active use internally by Pantheon; although the source code is provided, use is at your own risk, and support is not available.
+An unsupported project may be in active use internally at Pantheon. Although the source code is provided, use unsupported projects at your own risk, as support is not available.
 
-## Deprecated
+## Deprecated 
 
-A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. You are encouraged to NOT use a project in this support level.
+A deprecated project is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project `README.md` or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. You are encouraged to NOT use a project in this support level.

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -1,0 +1,40 @@
+---
+title: Pantheon Open Source Software Support Levels
+description: Learn about Pantheon Support Levels for Open Source Sofware
+categories: [get-started, oss]
+tags: [collaborate]
+---
+
+At Pantheon we love Open Source, we have created lots of public repositories in our [Github account](https://github.com/orgs/pantheon-systems/repositories) and we have started tagging them with support level badges. This page describes each of those levels and what should you expect when using those repositories.
+
+## Pilot
+
+A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team.
+
+## Early Acess
+
+A project in Early Access has the key use cases ready and we are ready to get some (more) customers in to continue the testing. In this stage, the code is publicly available but if there is any accompaning platform components you will need an invite through the project Early Access program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The full product or feature set may not be feature complete. Support in this stage is provided by the Engineering team.
+
+## Limited Availability
+
+A project in this support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is provided by the Customer Success Engineering team.
+
+## Actively Maintained
+
+A project in this support level has been publicly launched and has several eyes over it ensuring that everything works as expected. Anyone could use this project and create issues and Pull Requests in the repository as needed and we will respond to them in a timely manner. Support in this stage is provided by the Customer Success Engineering team.
+
+## Minimal Support
+
+A project in this support level rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
+
+## Unsupported
+
+A project in this support level rarely receives updates and people should not expect replies to issues or pull requests. You are encouraged to NOT use a project in this support level.
+
+## Unofficial
+
+A project in this support level is usually a Pantheon employee initiative. It probably does not have any resource allocated for maintenance and support is not guaranteed for this project because it depends on the project maintainer available time if they are still in the company.
+
+## Deprecated
+
+A project in this support level is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project README.md or you could try asking us in Slack if you are in a need for the replacement or guidance about where to go.

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -9,15 +9,15 @@ At Pantheon we love Open Source, we have created lots of public repositories in 
 
 ## Pilot
 
-A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team.
+A project in Pilot support level is a new product or feature set that we are working on. The code is publicly available but if there are any accompaning platform components you will need an invite through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program.
 
 ## Early Acess
 
-A project in Early Access has the key use cases ready and we are ready to get some (more) customers in to continue the testing. In this stage, the code is publicly available but if there is any accompaning platform components you will need an invite through the project Early Access program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The full product or feature set may not be feature complete. Support in this stage is provided by the Engineering team.
+Early Access projects are similar to Pilot projects, but are a little more mature, and have been opened up for use by a larger number of users. An invitation is still necessary to join an Early Access program.
 
 ## Limited Availability
 
-A project in this support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is provided by the Customer Success Engineering team.
+A project in this support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
 
 ## Actively Maintained
 

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -11,29 +11,31 @@ At Pantheon, we appreciate open source contributions. In an effort to effectivel
 
 This page describes each support level and the support expectations for our public repositories.
 
+## Actively Maintained Support
+
+A project with actively maintained support has been publicly launched and [support]() is available. Pantheon has dedicated resources to ensuring the source code is current and reliable. Additionally, you can create issues and pull requests in the repository as needed and the project maintainer will respond in a timely manner.
+
+
 ## Limited Availability
 
-Support level is a product or feature set that is complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
+A project in Limited Availabililty includes a features that are complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
 
 ## Early Access
 
 An projec in Early access denotes a new product or feature set that is in deve. The code is publicly available, but if there are any accompaning platform components you will need an invitation through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program. For more information on 
 
-## Actively Maintained Support
-
-A project in this support level has been publicly launched and has several eyes over it ensuring that everything works as expected. Anyone could use this project and create issues and Pull Requests in the repository as needed and we will respond to them in a timely manner. Support in this stage is available through regular Pantheon channels.
 
 ## Minimal Support
 
-A minimal project with minimal rarely receives updates but if there is an important bug or security update we will make our best effort to address it in a timely manner.
+A project with minimal support receives only important bug or security updates. The repository is supported with major fixes. If there is an issue with the source code, we will make an effort to address it in a timely manner.
 
 ## Unofficial Support
 
-A project that has unofficial support level is usually a Pantheon employee initiative. It typically does not have resources allocated for maintenance. Support is not guaranteed for the project because it depends on the availability of the project maintainer.
+A project that has unofficial support is often a Pantheon employee initiative. It typically does not have resources allocated for maintenance. Support is not guaranteed for the project because it depends on the availability of the project maintainer.
 
 ## Unsupported 
 
-An unsupported repository is typically only for internal use at Pantheon. Although the source code is available, use these projects at your own risk, as support is not available.
+An unsupported repository is typically a project created only for internal use at Pantheon. Although the source code is accessible, support is not available and there are risks associated with using the repository's code.
 
 ## Deprecated 
 

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -27,12 +27,16 @@ A project in this support level rarely receives updates but if there is an impor
 
 ## Unofficial Support
 
-A project in this support level is usually a Pantheon employee initiative. It probably does not have any resource allocated for maintenance and support is not guaranteed for this project because it depends on the project maintainer available time if they are still in the company.
+A project that has unofficial support level is usually a Pantheon employee initiative. It typically does not have resources allocated for maintenance. Support is not guaranteed for the project because it depends on the availability and afffiliation of the project maintainer.
 
 ## Unsupported 
 
-An unsupported project may be in active use internally at Pantheon. Although the source code is provided, use unsupported projects at your own risk, as support is not available.
+An unsupported project is typically only for internal use at Pantheon. Although the source code is available, use these projects at your own risk, as support is not available.
 
 ## Deprecated 
 
 A deprecated project is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project `README.md` or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. You are encouraged to NOT use a project in this support level.
+
+
+## See Also
+- [Get Support](https://pantheon.io/docs/guides/support/)

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -35,7 +35,7 @@ An unsupported project is typically only for internal use at Pantheon. Although 
 
 ## Deprecated 
 
-A deprecated project is no longer supported by Pantheon. This means it was either retired or replaced by another project. There may be details about this in the project `README.md` or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. You are encouraged to NOT use a project in this support level.
+A deprecated project is a project that has been retired or replaced by a code base that is no longer supported by Pantheon. Details about the project can be found in the `README.md` or you could try asking us in the [Community Slack](https://slackin.pantheon.io/) if you are in a need for the replacement or guidance about where to go. Using a project that has been deprecated is not encouraged. 
 
 
 ## See Also

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -17,7 +17,7 @@ A project in this support level is a product or feature set that is complete and
 
 ## Actively Maintained
 
-A project in this support level has been publicly launched and has several eyes over it ensuring that everything works as expected. Anyone could use this project and create issues and Pull Requests in the repository as needed and we will respond to them in a timely manner. Support in this stage is provided by the Customer Success Engineering team.
+A project in this support level has been publicly launched and has several eyes over it ensuring that everything works as expected. Anyone could use this project and create issues and Pull Requests in the repository as needed and we will respond to them in a timely manner. Support in this stage is available through regular Pantheon channels.
 
 ## Minimal Support
 

--- a/source/content/oss-support-levels.md
+++ b/source/content/oss-support-levels.md
@@ -7,22 +7,21 @@ contributors: [greg-1-anderson, kporras07]
 reviewed: "2022-03-02"
 ---
 
-At Pantheon, we appreciate open source contributions. In an effort to effectively maintain our various public repositories in [GitHub](https://github.com/orgs/pantheon-systems/repositories), we tag Pantheon repositories with support level badges. The badge is typically displayed in the repository's `README.md`. 
+At Pantheon, we appreciate open source contributions. In an effort to effectively maintain our public repositories in [GitHub](https://github.com/orgs/pantheon-systems/repositories), we tag each Pantheon repository with a support level badge. The badge is typically displayed in the repository's `README.md`. 
 
 This page describes each support level and the support expectations for our public repositories.
 
 ## Actively Maintained Support
 
-A project with actively maintained support has been publicly launched and [support]() is available. Pantheon has dedicated resources to ensuring the source code is current and reliable. Additionally, you can create issues and pull requests in the repository as needed and the project maintainer will respond in a timely manner.
-
+A project with actively maintained support has been publicly launched and [support](/guides/support/contact-support/) is available. Pantheon has dedicated resources to ensuring the source code for the project is current and reliable. Additionally, you can create issues and pull requests in the repository as needed, and the project maintainer will respond in a timely manner.
 
 ## Limited Availability
 
-A project in Limited Availabililty includes a features that are complete and can be used in all environments including production. Clients can use the new functionality without requiring an invite but it is an opt-in process. You are highly encouraged to report any bug you may find so that we can make a better product for everyone. Support in this stage is available through regular Pantheon channels.
+A Limited Availability project allows Pantheon to closely monitor feature developments and make any necessary adjustments before releasing a product for General Availability. A project in Limited Availabilty includes features that are complete and can be used in all environments including production. Customers can opt-in to use the product, and are highly encouraged to report any bugs so that we can release an improved product for General Availability. Pantheon [support](/guides/support/contact-support/) is available, but can vary depending on the project specifications. 
 
 ## Early Access
 
-An projec in Early access denotes a new product or feature set that is in deve. The code is publicly available, but if there are any accompaning platform components you will need an invitation through the project pilot program. Even though we make our best effort, there may be bugs and we need your help to identify them so that we can fix them. The product or feature set may not be feature complete and development is still going on. Support in this stage is provided by the Engineering team, and is only available to members of the program. For more information on 
+A product in Early Access denotes a new project or feature set that is in development and available for a limited audience. Some features are stable, but the product is only partially complete and development is still in progress. The source code is publicly available, but you will need an invitation to participate in the Early Access program and learn about any platform component changes. Support is provided and only available to customers officially enrolled in the Early Access program. For more information on support for Early Access projects, refer to our [documentation](/guides/support/early-access/)
 
 
 ## Minimal Support
@@ -39,7 +38,7 @@ An unsupported repository is typically a project created only for internal use a
 
 ## Deprecated 
 
-A deprecated repository is a project that has been retired or replaced, and is no longer supported by Pantheon. Details about the repository can be found in the `README.md`. Additional information, such as suitable alternative projects or guidance on finding solutions, may be available in the [Community Slack](https://slackin.pantheon.io/). Using a project that has been deprecated is not encouraged.
+A deprecated repository is a project that has been retired or replaced, and is no longer supported by Pantheon. Details about the repository can be found in the `README.md`. Additional information, such as suitable alternative projects or guidance on finding solutions, might be available in the [Community Slack](https://slackin.pantheon.io/). Using a project that has been deprecated is not encouraged.
 
 ## See Also
-- [Get Support](https://pantheon.io/docs/guides/support/)
+- [Get Support](/guides/support/)


### PR DESCRIPTION
This PR is part of the work we are doing to clearly identify support levels in our Open source Projects.

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Pantheon Open Source Software Support Levels](https://pantheon.io/docs/oss-support-levels)** - Create OSS Support Levels page

### Dependencies and Timing

This PR is pre-requisite for some other work we're doing in the CMS Ecosystem team but it has no pre-requisites to merge it other than getting the docs team approval.

**Release**:
- [x] Engineering review
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
