### PR TITLE
Add Rate Limiting Section to AGCDN Page

### DIFF
--- a/source/content/guides/professional-services/04-advanced-global-cdn.md
+++ b/source/content/guides/professional-services/04-advanced-global-cdn.md
@@ -105,6 +105,18 @@ Support for blue/green deployment<Popover title="Blue/Green Deployment" content=
 
 [See a comparison of the features](https://pantheon.io/product/advanced-global-cdn#pricing-matrix-wrapper) offered by our CDN services.
 
+### Rate Limiting
+
+Rate Limiting with Advanced Global CDN lets you place limits on request volume at the network perimeter. Organizations of all sizes can adopt this edge configuration to block malicious traffic. With Rate Limiting, guard critical assets including login, form, and promotional pages, with an added layer of security.
+
+The benefits of this feature include:
+
+- Volumetric Attack Mitigation - Reduce the effectiveness of malicious traffic, including brute-force login and denial-of-service attacks.
+
+- Granular Control - Rate Limiting supports adjustable configurations that can be adjusted on a per policy basis, including requests per second, and detection window.
+
+- Custom Responses - Select from actions that allow you to block requests or log them, and configure custom responses for each policy.
+
 ## Frequently Asked Questions
 
 ### Is Global CDN still included?


### PR DESCRIPTION
Closes # N/A

## Summary

**[Rate Limiting](https://pantheon.io/docs//guides/professional-services/advanced-global-cdn)** - Add rate limiting section to AGCDN page in PS guide.

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
