### PR TITLE
Remove internal error message from public Autopilot docs

### DIFF
--- a/source/content/guides/autopilot/05-troubleshoot.md
+++ b/source/content/guides/autopilot/05-troubleshoot.md
@@ -83,35 +83,6 @@ Switch to Drush 8 in the `pantheon.yml` file.
 
 </Accordion>
 
-## Element Exclusions
-
-<Accordion title="We didn’t detect any plugins, modules or themes that were eligible for exclusion." id="no-eligible-available" icon="info-sign">
-
-### Issue
-
-The list of elements is unavailable when Autopilot is started for the first time; it is only set after Autopilot is initialized.
-
-Refresh the extensions list used for exclusions when Autopilot is started for the first time.
-
-### Solution
-
-Trigger a workflow to refresh extensions with the following code change:
-
-```graphql
-mutation {
-  refreshAvailableExtensions(
-    args: { id: "SITE_UUID"}
-  ) {
-    id
-    description
-  }
-}
-```
-
-After the workflow completes, refresh the Autopilot settings or restart the initialization wizard. The extension options should be present.
-
-</Accordion>
-
 ## Modified Plugin or Theme Name
 
 <Accordion title="Ran into an issue with a WordPress update and did not proceed with deployment." id="wp-update-issue" icon="info-sign">


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #[DOC-576](https://getpantheon.atlassian.net/browse/DOC-576)

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Troubleshoot Autopilot Error Messages](https://pantheon.io/docs/guides/autopilot/troubleshoot-autopilot/#autopilot-is-blocked)** - Remove internal error message from public documentation.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
