### PR TITLE
Integrated Composer with private GitHub package

### DIFF
--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -54,6 +54,73 @@ Integrated Composer is a Pantheon platform feature that extends Composer <Popove
 
    - Pantheon will run Composer, generate build artifacts, and deploy it to your Dev or Multidev environment.
 
+
+### Add a Package from a Private Repository
+
+These steps outline a working method with a private GitHub repository. For more information, see [Handling private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in Composer's documentation.
+
+1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
+
+1. Use your newly generated token to create or add to `auth.json` at the root of your project.
+   ```php:title=auth.json
+   {
+      "github-oauth": {
+         "github.com": "your-token"
+      }
+   }
+   ```
+
+1. Add the repository to `composer.json`
+   ```json:title=composer.json
+   "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/mycompany/my-private-repo"
+        }
+    ],
+    ```
+
+1. Require the package and specify the branch, prefixed with `dev-`
+   ```json:title=composer.json
+    "require": {
+        "mycompany/my-private-repo": "dev-branch-name"
+    },
+   ```
+
+1. Run `composer update` to install the new package.
+
+At this stage if the package installed successfully you may commit these changes to Git and push them. If you would prefer not to have your token stored in your Git repository, you may opt to create a symlink from `auth.json` to a [Private Path](https://pantheon.io/docs/private-paths) and maintain the file via SFTP. To create this symlink, you can use these commands from the project root in terminal:
+
+1. Move the existing `auth.json` file
+   ```bash{promptUser: user
+   mv auth.json ./web/sites/default/files/private/auth.json
+   ```
+
+1. Create a symlink
+   ```bash{promptUser: user
+   ln -s ./web/sites/default/files/private/auth.json ./auth.json
+   ```
+
+1. Create the same file on *every target environment* [via SFTP](/sftp#sftp-connection-information)
+  ```bash{promptUser: user}
+  sftp -o Port=2222 env.UUID@appserver.env.UUID.drush.in
+  ```
+
+  ```bash{promptUser: sftp}{outputLines: 3-4}
+  mkdir files/private
+  put ./web/sites/default/files/private/auth.json /files/private
+  Uploading ./web/sites/default/files/private/auth.json to /files/private/auth.json
+  ./web/sites/default/files/private/auth.json        100%   97     2.0KB/s   00:00
+  exit
+  ```
+
+1. Commit the newly created symlink and updated composer files
+   ```bash{promptUser: user
+   git add auth.json composer.json composer.lock
+   git commit -m "Adding private package <your-package>"
+   git push
+   ```
+
 ### Remove Individual Site Dependencies
 
 You can remove site dependencies if they are no longer needed.

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -63,19 +63,12 @@ This GitHub token will be added to your code repository, and allows those in pos
 
 1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
 
-1. Create a new `auth.json` file by opening a terminal at the root of your project and issuing the following command
-   ```bash{promptUser: user}
-   composer config github-oauth.github.com token
-   ```
-
-1. Edit `auth.json` and add your newly generated token.
-
-1. Add the private GitHub repository to `composer.json`
+1. Add the private GitHub repository to `composer.json`, replacing `<token>` with your newly generated token.
    ```json:title=composer.json
    "repositories": [
         {
             "type": "vcs",
-            "url": "https://github.com/mycompany/my-private-repo"
+            "url": "https://<token>@github.com/mycompany/my-private-repo"
         }
     ],
     ```
@@ -89,9 +82,9 @@ This GitHub token will be added to your code repository, and allows those in pos
 
 1. Run `composer update` to install the new package.
 
-1. If the above update works locally, commit the newly created symlink and updated composer files and add them to your environment
+1. If the above update works locally, commit the updated composer files and add them to your environment
    ```bash{promptUser: user
-   git add auth.json composer.json composer.lock
+   git add composer.json composer.lock
    git commit -m "Adding private package <your-package>"
    git push
    ```

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -56,11 +56,11 @@ Integrated Composer is a Pantheon platform feature that extends Composer <Popove
 
 ### Add a Package from a Private Repository
 
-These steps outline a method for adding a package from a private GitHub repository. For additional information on handling private packages, refer to the official [Composer documentation](https://getcomposer.org/doc/articles/handling-private-packages.md).
+The following steps outline a method for adding a package from a private GitHub repository. For additional information on handling private packages, refer to the official [Composer documentation](https://getcomposer.org/doc/articles/handling-private-packages.md).
 
-This GitHub token will be added to your code repository. It allows anyone with the token to read and write to any private repositories associated with the issuing account. This is a current limitation of GitHub tokens. To limit that scope, you can create a new GitHub user and give that user permission to only the private repositories needed for your Composer packages, as well as ensuring your site repository code is not published publicly. 
+For this procedure a GitHub token will be added to your code repository. It allows anyone with the token to read and write to any private repositories associated with the issuing account. To limit that scope of the GitHub token access, you can create a new GitHub user and give that user permission to only the private repositories needed for your Composer packages and ensure your site repository code is not published publicly. 
 
-1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
+1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) page and generate a new token. Ensure the `repo` scope is selected.
 
 1. Add the private GitHub repository to `composer.json`, replacing `<token>` with your newly generated token.
    ```json:title=composer.json

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -56,9 +56,9 @@ Integrated Composer is a Pantheon platform feature that extends Composer <Popove
 
 ### Add a Package from a Private Repository
 
-These steps outline a working method for adding a package with a private GitHub repository. For more information, refer to [Handling private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in Composer's documentation.
+These steps outline a method for adding a package from a private GitHub repository. For additional information on handling private packages, refer to the official [Composer documentation](https://getcomposer.org/doc/articles/handling-private-packages.md).
 
-This GitHub token will be added to your code repository, and allows those in possession of it to read and write to any private repositories associated with the issuing account. This is a current limitation of GitHub tokens. In order to limit that scope, you may wish to create a new GitHub user and give that user permission to only the private repositories needed for your composer packages, as well as ensuring your site repository code is not published publicly. 
+This GitHub token will be added to your code repository. It allows anyone with the token to read and write to any private repositories associated with the issuing account. This is a current limitation of GitHub tokens. To limit that scope, you can create a new GitHub user and give that user permission to only the private repositories needed for your Composer packages, as well as ensuring your site repository code is not published publicly. 
 
 1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
 

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -59,6 +59,8 @@ Integrated Composer is a Pantheon platform feature that extends Composer <Popove
 
 These steps outline a working method with a private GitHub repository. For more information, see [Handling private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in Composer's documentation.
 
+This GitHub token will be added to your code repository, and allows those in possession of it to read and write to any private repositories associated with the issuing account. This is a current limitation of GitHub tokens. In order to limit that scope, you may wish to create a new GitHub user and give that user permission to only the private repositories needed for your composer packages, as well as ensuring your site repository code is not published publicly. 
+
 1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
 
 1. Use your newly generated token to create or add to `auth.json` at the root of your project.
@@ -89,32 +91,7 @@ These steps outline a working method with a private GitHub repository. For more 
 
 1. Run `composer update` to install the new package.
 
-At this stage if the package installed successfully you may commit these changes to Git and push them. If you would prefer not to have your token stored in your Git repository, you may opt to create a symlink from `auth.json` to a [Private Path](https://pantheon.io/docs/private-paths) and maintain the file via SFTP. To create this symlink, you can use these commands from the project root in terminal:
-
-1. Move the existing `auth.json` file
-   ```bash{promptUser: user
-   mv auth.json ./web/sites/default/files/private/auth.json
-   ```
-
-1. Create a symlink
-   ```bash{promptUser: user
-   ln -s ./web/sites/default/files/private/auth.json ./auth.json
-   ```
-
-1. Create the same file on *every target environment* [via SFTP](/sftp#sftp-connection-information)
-  ```bash{promptUser: user}
-  sftp -o Port=2222 env.UUID@appserver.env.UUID.drush.in
-  ```
-
-  ```bash{promptUser: sftp}{outputLines: 3-4}
-  mkdir files/private
-  put ./web/sites/default/files/private/auth.json /files/private
-  Uploading ./web/sites/default/files/private/auth.json to /files/private/auth.json
-  ./web/sites/default/files/private/auth.json        100%   97     2.0KB/s   00:00
-  exit
-  ```
-
-1. Commit the newly created symlink and updated composer files
+1. If the above update works locally, commit the newly created symlink and updated composer files and add them to your environment
    ```bash{promptUser: user
    git add auth.json composer.json composer.lock
    git commit -m "Adding private package <your-package>"

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -56,7 +56,7 @@ Integrated Composer is a Pantheon platform feature that extends Composer <Popove
 
 ### Add a Package from a Private Repository
 
-These steps outline a working method with a private GitHub repository. For more information, see [Handling private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in Composer's documentation.
+These steps outline a working method for adding a package with a private GitHub repository. For more information, refer to [Handling private packages](https://getcomposer.org/doc/articles/handling-private-packages.md) in Composer's documentation.
 
 This GitHub token will be added to your code repository, and allows those in possession of it to read and write to any private repositories associated with the issuing account. This is a current limitation of GitHub tokens. In order to limit that scope, you may wish to create a new GitHub user and give that user permission to only the private repositories needed for your composer packages, as well as ensuring your site repository code is not published publicly. 
 
@@ -81,7 +81,7 @@ This GitHub token will be added to your code repository, and allows those in pos
 
 1. Run `composer update` to install the new package.
 
-1. If the above update works locally, commit the updated composer files and add them to your environment
+1. If the above command update works locally, commit the updated composer files and add them to your environment
    ```bash{promptUser: user
    git add composer.json composer.lock
    git commit -m "Adding private package <your-package>"

--- a/source/content/guides/integrated-composer.md
+++ b/source/content/guides/integrated-composer.md
@@ -63,16 +63,14 @@ This GitHub token will be added to your code repository, and allows those in pos
 
 1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) and generate a new token with `repo` scope.
 
-1. Use your newly generated token to create or add to `auth.json` at the root of your project.
-   ```php:title=auth.json
-   {
-      "github-oauth": {
-         "github.com": "your-token"
-      }
-   }
+1. Create a new `auth.json` file by opening a terminal at the root of your project and issuing the following command
+   ```bash{promptUser: user}
+   composer config github-oauth.github.com token
    ```
 
-1. Add the repository to `composer.json`
+1. Edit `auth.json` and add your newly generated token.
+
+1. Add the private GitHub repository to `composer.json`
    ```json:title=composer.json
    "repositories": [
         {


### PR DESCRIPTION
## Summary

**[Integrated Composer](https://pantheon.io/docs/integrated-composer)** - Provide a simple path and links to relevant Composer documentation for using private repositories for packages with Integrated Composer

### Dependencies and Timing

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
