### PR TITLE
[CMS-578] Initial migrate to build tools docs page.

### DIFF
--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -61,6 +61,7 @@ terminus build:project:create --git=github --team='My Agency Name' d9 my-site
    ```bash
    export SOURCE=/absolute/path/to/source/site/codebase
    export DESTINATION=/absolute/path/to/codebase/cloned/from/pantheon
+   export SOURCE_SITE_NAME=my-site
    ```
 
 ## Copy Existing Configuration
@@ -77,7 +78,7 @@ Copy any existing configuration from the source sitem and update the source path
 It is possible that the Drupal site might have relocated the configuration path to a different location. You can find out where your config yaml files are via:
 
 ```bash{promptUser:user}
-terminus drush SOURCE_SITE_NAME.dev -- status --fields=config-sync
+terminus drush $SOURCE_SITE_NAME.dev -- status --fields=config-sync
 ```
 
 If no files are copied through this step, that's acceptable.
@@ -198,7 +199,7 @@ You can use sftp `get` command to download the file to your local directory if u
 Here is a single command that downloads the file to the current local directory:
 
 ```bash{promptUser:user}
-echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info $SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 ## Upload Your Files
@@ -222,7 +223,7 @@ You can use sftp `put` command to upload the file from your local directory if u
 Below is a single command which does this. This needs to be run from the directory where the `tokens.json` backup was downloaded:
 
 ```bash{promptUser:user}
-echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info $SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -193,7 +193,13 @@ Connect to your site using SFTP command or credentials from your dashboard and g
 files/private/.build-tools/tokens.json
 ```
 
-(You can use sftp `get` command to download the file to your local directory if using SFTP command line)
+You can use sftp `get` command to download the file to your local directory if using SFTP command line.  
+
+Here is a single command that downloads the file to the current local directory:
+
+```bash{promptUser:user}
+echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+```
 
 ## Upload Your Files
 
@@ -211,7 +217,13 @@ Connect to your site using SFTP command or credentials from your dashboard and r
 files/private/.build-tools/tokens.json
 ```
 
-(You can use sftp `put` command to upload the file from your local directory if using SFTP command line)
+You can use sftp `put` command to upload the file from your local directory if using SFTP command line.
+
+Below is a single command which does this. This needs to be run from the directory where the `tokens.json` backup was downloaded:
+
+```bash{promptUser:user}
+echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+```
 
 
 You should now have all three of the major components of your site imported into your new site and CI should be working. Clear your caches on the the Pantheon Dashboard, and you are good to go!

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -1,6 +1,6 @@
 ---
-title: Migrating a Drupal with Composer site to a Build Tools site
-description: Migrate a Drupal 9 site created via Pantheon Dashboard (or Terminus) to a Build Tools based site
+title: Migrate a Composer-based Drupal Site to a Build Tools Site
+description: Migrate a Drupal 9 site created via Pantheon Dashboard (or Terminus) to a Build Tools-based site.
 type: guide
 permalink: docs/guides/:basename
 cms: "Drupal"
@@ -9,18 +9,18 @@ tags: [composer, site, workflow]
 reviewed: "2022-03-10"
 ---
 
-In this guide, we will migrate a Drupal with Composer site (site created via Pantheon dashboard or Terminus) to a Build Tools based site.
+This guides shows you how to migrate a Composer-based Drupal site (site created via Pantheon dashboard or Terminus) to a Build Tools-based site.
 
 
 ## Overview
 
-Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies. A Build Tools based Drupal 9 site has besides that, an external repository and a Continuous Integration workflow setup.
+Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies. A Drupal 9 site with Build Tools also provides site dependency management, as well as an external repository and a Continuous Integration workflow setup.
 
 The goals of this migration are:
 
-1. Create a new Drupal site in Pantheon using Terminus Build Tools plugin
+1. Create a new Drupal site in Pantheon using the [Terminus Build Tools plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
 
-1. Import your existing codebase, database and files into it
+1. Import your existing codebase, database, and files into your new site
 
 
 ## Will This Guide Work for Your Site?
@@ -42,13 +42,13 @@ Commit history: The steps in this process migrate a site, so the new site will n
 
 ## Create a new Terminus Build Tools Drupal 9 site
 
-1. Follow the [Terminus Build Tools Documentation](https://pantheon.io/docs/guides/build-tools/create-project/#create-a-build-tools-project) to create a new Drupal 9 site:
+1. Follow the [Terminus Build Tools Documentation](/guides/build-tools/create-project/#create-a-build-tools-project) to create a new Drupal 9 site:
 
   ```bash
   terminus build:project:create --git=github --team='My Agency Name' d9 my-buildtools-site
   ```
 
-1. Wait for the site to be created and the first build finishes.
+1. Wait for the site to be created and for the first build to complete.
 
 ## Prepare the Local Environment
 
@@ -56,7 +56,7 @@ Commit history: The steps in this process migrate a site, so the new site will n
 
 2. Get a local copy of both your new site (from the external repository) and your existing site codebase.
 
-1. This doc uses several commands that depend on the locations of both your existing and new site codebases. To simplify this, set the following temporary variables in your terminal session to match your folders location and sites names.
+1. Set the following temporary variables in your terminal session to match your folders location and sites names:
 
    ```bash
    export SOURCE=/absolute/path/to/source/site/codebase
@@ -67,7 +67,7 @@ Commit history: The steps in this process migrate a site, so the new site will n
 
 ## Copy Existing Configuration
 
-Copy any existing configuration from the source sitem and update the source path as needed to match your configuration folder:
+Copy any existing configuration from the source site and update the source path as needed to match your configuration folder:
 
   ```bash{promptUser:user}
   rsync -avz $SOURCE/config/ $DESTINATION/config/ --delete --delete-after
@@ -76,7 +76,7 @@ Copy any existing configuration from the source sitem and update the source path
   git commit -m "Pull in configuration from source site"
   ```
 
-It is possible that the Drupal site might have relocated the configuration path to a different location. You can find out where your config yaml files are via:
+It is possible that the Drupal site might have relocated the configuration path to a different location. You can find your `config.yaml` files are via:
 
 ```bash{promptUser:user}
 terminus drush $SOURCE_SITE_NAME.dev -- status --fields=config-sync
@@ -90,13 +90,15 @@ This section describes how to replicate your selection of contributed modules an
 
 ### Contributed Code
 
-The goal of this process is to have Composer manage all the site's contrib modules, contrib themes, core upgrades, and libraries (referred to as _contributed code_). The only things from the existing site that should remain in the git repository are custom code, custom themes, and custom modules that are specific to the existing site.
-
+The goal of this process is to have Composer manage all the site's contrib modules, contrib themes, core upgrades, and libraries (referred to as _contributed code_). The only items from the existing site that should remain in the Git repository are custom code, custom themes, and custom modules that are specific to the existing site.
 
 #### Modules and Themes
 
+Your site should already be managing contributed modules and themes through Composer. Follow the steps below to migrate these items to a new site.
 
-Your site should already be managing contributed modules and themes through composer. To migrate them to the new site, look at the source site `composer.json` and run a `composer require` command for each of those modules and themes in the `$DESTINATION` directory:
+1. Open the source site `composer.json`.
+
+1. Run a `composer require` command for each module and theme in the `$DESTINATION` directory:
 
 ```bash
 composer require drupal/PROJECT_NAME:^VERSION
@@ -106,7 +108,11 @@ You can require multiple packages in the same commands if you prefer so.
 
 #### Other Composer Packages
 
-If you have added non-Drupal packages to your site via Composer, use the command `composer require` to migrate each package. You can use the following command to display the differences between the master and your current `composer.json`:
+Follow the steps below, if you added non-Drupal packages to your site via Composer. 
+
+1. Run the command `composer require` to migrate each package. 
+
+1. Use the following command to display the differences between the master and current `composer.json`:
 
 ```
 diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
@@ -124,27 +130,27 @@ Manually copy custom code from the existing site repository to the Composer-mana
 
 #### Modules and Themes
 
-To move modules, use the following commands:
+1. Run the following commands to move modules:
 
-```bash{promptUser:user}
-mkdir -p $DESTINATION/web/modules/custom
-cp -r $SOURCE/web/modules/custom $DESTINATION/web/modules/custom
-# From $DESTINATION:
-git add web/modules/
-git commit -m "Copy custom modules"
-```
+  ```bash{promptUser:user}
+  mkdir -p $DESTINATION/web/modules/custom
+  cp -r $SOURCE/web/modules/custom $DESTINATION/web/modules/custom
+  # From $DESTINATION:
+  git add web/modules/
+  git commit -m "Copy custom modules"
+  ```
 
-To move themes, use the following commands:
+1. Run the following commands to move themes:
 
-```bash{promptUser:user}
-mkdir -p $DESTINATION/web/themes/custom
-cp -r $SOURCE/web/themes/custom $DESTINATION/web/themes/custom
-# From $DESTINATION:
-git add web/themes/
-git commit -m "Copy custom themes"
-```
+  ```bash{promptUser:user}
+  mkdir -p $DESTINATION/web/themes/custom
+  cp -r $SOURCE/web/themes/custom $DESTINATION/web/themes/custom
+  # From $DESTINATION:
+  git add web/themes/
+  git commit -m "Copy custom themes"
+  ```
 
-Use the above commands with any of the custom code.
+1. Use the above commands to move custom code (if any) to your new site.
 
 #### settings.php
 
@@ -161,17 +167,17 @@ The resulting `settings.php` should have no `$databases` array.
 
 Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This can include configurations related to repositories, minimum-stability, or extra sections.
 
-You can use the diff command to get the information you need to copy:
+1. Use the diff command to get the information you need to copy:
 
-```
-diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
-```
+  ```
+  diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
+  ```
 
-Commit your changes as needed.
+1. Commit your changes as needed.
 
 ### Push to the external repository master branch
 
-Now push to the master branch in the external repository:
+Push to the master branch in the external repository:
 
 ```
 git push origin master
@@ -181,60 +187,61 @@ And wait for Continuous Integration workflow to succeed so that it commits your 
 
 ## Add Your Database
 
-@TODO This could be redacted better to use the export functionality in dashboard to get the URL and put it into the new site.
-
 <Partial file="migrate-add-database.md" />
 
 ## Backup tokens.json file
 
-@TODO: REDACT THIS SECTION BETTER.
+1. Connect to your site using SFTP command or credentials from your dashboard and get a backup of the following file:
 
-Connect to your site using SFTP command or credentials from your dashboard and get a backup of the following file:
+  ```bash
+  files/private/.build-secrets/tokens.json
+  ```
 
-```
-files/private/.build-secrets/tokens.json
-```
+1. Use the SFTP `get` command to download the file to your local directory (this is only for SFTP command line use): 
 
-You can use sftp `get` command to download the file to your local directory if using SFTP command line.  
-
-Here is a single command that downloads the file to the current local directory:
-
-```bash{promptUser:user}
-echo "get files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
-```
+  ```bash{promptUser:user}
+  echo "get files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
+  ```
 
 ## Upload Your Files
-
-@TODO This could be redacted better to use the export functionality in dashboard to get the URL and put it into the new site.
 
 <Partial file="migrate-add-files-only-drupal.md" />
 
 ## Restore tokens.json file
 
-@TODO: REDACT THIS SECTION BETTER.
+1. Connect to your site using SFTP command or credentials from your dashboard to restore the backup of the `tokens.json` file:
 
-Connect to your site using SFTP command or credentials from your dashboard and restore the backup of the tokens.json file:
+  ```bash
+  files/private/.build-secrets/tokens.json
+  ```
 
-```
-files/private/.build-secrets/tokens.json
-```
+1. Use the SFTP `put` command to upload the file from your local directory (only if using the SFTP command line):
 
-You can use sftp `put` command to upload the file from your local directory if using SFTP command line.
+ <Alert title="Note"  type="info" >
 
-Below is a single command which does this. This needs to be run from the directory where the `tokens.json` backup was downloaded:
+ You must run this from the directory where the `tokens.json` backup was downloaded.
 
-```bash{promptUser:user}
-echo "put files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
-```
+ </Alert>
 
+  ```bash{promptUser:user}
+  echo "put files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
+  ```
 
-You should now have all three of the major components of your site imported into your new site and CI should be working. Clear your caches on the the Pantheon Dashboard, and you are good to go!
+ You should now have all three of the major components of your site imported into your new site and CI should be working. 
+
+1. Clear the caches on the Pantheon Dashboard, and you are good to go!
 
 ## Troubleshooting
 
-### Provided host name not valid
+### Provided Host Name Not Valid
 
-If you receive the error message "The provided host name is not valid for this server.", then update your `settings.php` file with a trusted host setting. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
+Update your `settings.php` file with a trusted host setting, if you receive the following error message:
+
+```none
+ The provided host name is not valid for this server
+ ```
+
+Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
 
 ### Working With Dependency Versions
 

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -149,7 +149,7 @@ Use the above commands with any of the custom code.
 Your existing site may have customizations to `settings.php` or other configuration files. Given that both sites (`$SOURCE` and `$DESTINATION`) have been created from the same upstream, it is ok to replace the `$DESTINATION` `settings.php` with the one coming from the `$SOURCE` site:
 
 ```bash{promptUser:user}
-cp $SOURCE/sites/default/settings.php $DESTINATION/web/sites/default/settings.php
+cp $SOURCE/web/sites/default/settings.php $DESTINATION/web/sites/default/settings.php
 # Review changes and commit as needed
 ```
 

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -128,7 +128,7 @@ To move modules, use the following commands:
 
 ```bash{promptUser:user}
 mkdir -p $DESTINATION/web/modules/custom
-cp -r $SOURCE/modules/custom $DESTINATION/web/modules/custom
+cp -r $SOURCE/web/modules/custom $DESTINATION/web/modules/custom
 # From $DESTINATION:
 git add web/modules/
 git commit -m "Copy custom modules"
@@ -138,7 +138,7 @@ To move themes, use the following commands:
 
 ```bash{promptUser:user}
 mkdir -p $DESTINATION/web/themes/custom
-cp -r $SOURCE/themes/custom $DESTINATION/web/themes/custom
+cp -r $SOURCE/web/themes/custom $DESTINATION/web/themes/custom
 # From $DESTINATION:
 git add web/themes/
 git commit -m "Copy custom themes"

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -77,7 +77,7 @@ Copy any existing configuration from the source sitem and update the source path
 It is possible that the Drupal site might have relocated the configuration path to a different location. You can find out where your config yaml files are via:
 
 ```bash{promptUser:user}
-terminus drush SOURCE-SITE-NAME.dev -- status --fields=config-sync
+terminus drush SOURCE_SITE_NAME.dev -- status --fields=config-sync
 ```
 
 If no files are copied through this step, that's acceptable.

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -16,11 +16,11 @@ This guides shows you how to migrate a Composer-based Drupal site (site created 
 
 Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies. A Drupal 9 site with Build Tools also provides site dependency management, as well as an external repository and a Continuous Integration workflow setup.
 
-The goals of this migration are:
+The goals of this migration are to:
 
-1. Create a new Drupal site in Pantheon using the [Terminus Build Tools plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
+- Create a new Drupal site in Pantheon using the [Terminus Build Tools plugin](https://github.com/pantheon-systems/terminus-build-tools-plugin)
 
-1. Import your existing codebase, database, and files into your new site
+- Import your existing codebase, database, and files into your new site
 
 
 ## Will This Guide Work for Your Site?
@@ -36,7 +36,7 @@ The goals of this migration are:
 
 <Alert title="Note"  type="info" >
 
-Commit history: The steps in this process migrate a site, so the new site will no longer maintain its existing commit history.
+The existing site's commit history will no longer exist after migrating to the new site.
 
 </Alert>
 
@@ -82,7 +82,7 @@ It is possible that the Drupal site might have relocated the configuration path 
 terminus drush $SOURCE_SITE_NAME.dev -- status --fields=config-sync
 ```
 
-If no files are copied through this step, that's acceptable.
+In some cases no files are copied through this step. This is not cause for concern.
 
 ## Add Contributed and Custom Code
 
@@ -104,7 +104,7 @@ Your site should already be managing contributed modules and themes through Comp
 composer require drupal/PROJECT_NAME:^VERSION
 ```
 
-You can require multiple packages in the same commands if you prefer so.
+You can require multiple packages in the same commands if desired.
 
 #### Other Composer Packages
 
@@ -150,7 +150,7 @@ Manually copy custom code from the existing site repository to the Composer-mana
   git commit -m "Copy custom themes"
   ```
 
-1. Use the above commands to move custom code (if any) to your new site.
+Use the above commands to move custom code (if any) to your new site.
 
 #### settings.php
 
@@ -167,7 +167,7 @@ The resulting `settings.php` should have no `$databases` array.
 
 Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This can include configurations related to repositories, minimum-stability, or extra sections.
 
-1. Use the diff command to get the information you need to copy:
+1. Use the `diff` command to get the information you need to copy:
 
   ```
   diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
@@ -177,13 +177,13 @@ Any additional Composer configuration that you have added to your site should be
 
 ### Push to the external repository master branch
 
-Push to the master branch in the external repository:
+1. Push to the master branch in the external repository:
 
-```
-git push origin master
-```
+  ```
+  git push origin master
+  ```
 
-And wait for Continuous Integration workflow to succeed so that it commits your code changes to the Pantheon site.
+1. Confirm that the Continuous Integration workflow to succeeds in committing your code changes to the Pantheon site.
 
 ## Add Your Database
 

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -1,0 +1,231 @@
+---
+title: Migrating a Drupal with Composer site to a Build Tools site
+description: Migrate a Drupal 9 site created via Pantheon Dashboard (or Terminus) to a Build Tools based site
+type: guide
+permalink: docs/guides/:basename
+cms: "Drupal"
+categories: [develop]
+tags: [composer, site, workflow]
+reviewed: "2022-03-10"
+---
+
+In this guide, we will migrate a Drupal with Composer site (site created via Pantheon dashboard or Terminus) to a Build Tools based site.
+
+
+## Overview
+
+Drupal 9 sites on Pantheon have [Integrated Composer](/integrated-composer) built-in to manage site dependencies. A Build Tools based Drupal 9 site has besides that, an external repository and a Continuous Integration workflow setup.
+
+The goals of this migration are:
+
+1. Create a new Drupal site in Pantheon using Terminus Build Tools plugin
+
+1. Import your existing codebase, database and files into it
+
+
+## Will This Guide Work for Your Site?
+
+<Partial file="drupal-9/upgrade-site-requirements-from-drupal-recommended.md" />
+
+- You are able to [create a new Drupal 9 site using Terminus Build Tools](https://pantheon.io/docs/guides/build-tools/create-project/#create-a-build-tools-project)
+
+## Before You Begin
+
+- Clone your existing site to your local environment following the `git clone` command from the dashboard.
+
+
+<Alert title="Note"  type="info" >
+
+Commit history: The steps in this process migrate a site, so the new site will no longer maintain its existing commit history.
+
+</Alert>
+
+## Create a new Terminus Build Tools Drupal 9 site
+
+1. Follow the [Terminus Build Tools Documentation](https://pantheon.io/docs/guides/build-tools/create-project/#create-a-build-tools-project) to create a new Drupal 9 site:
+
+```bash
+terminus build:project:create --git=github --team='My Agency Name' d9 my-site
+```
+
+1. Wait for the site to be created and the first build finishes.
+
+## Prepare the Local Environment
+
+<Partial file="drupal-9/prepare-local-environment-no-clone-no-alias.md" />
+
+2. Get a local copy of both your new site (from the external repository) and your existing site codebase.
+
+1. This doc uses several commands that depend on the locations of both your existing and new site codebases. To simplify this, set the temporary variables `$SOURCE` and `$DESTINATION` in your terminal session to match your folders location.
+
+   ```bash
+   export SOURCE=/absolute/path/to/source/site/codebase
+   export DESTINATION=/absolute/path/to/codebase/cloned/from/pantheon
+   ```
+
+## Copy Existing Configuration
+
+Copy any existing configuration from the source sitem and update the source path as needed to match your configuration folder:
+
+  ```bash{promptUser:user}
+  rsync -avz $SOURCE/config/ $DESTINATION/config/ --delete --delete-after
+  # From $DESTINATION:
+  git add config
+  git commit -m "Pull in configuration from source site"
+  ```
+
+It is possible that the Drupal site might have relocated the configuration path to a different location. You can find out where your config yaml files are via:
+
+```bash{promptUser:user}
+terminus drush SOURCE-SITE-NAME.dev -- status --fields=config-sync
+```
+
+If no files are copied through this step, that's acceptable.
+
+## Add Contributed and Custom Code
+
+This section describes how to replicate your selection of contributed modules and themes, and any custom modules or themes your development team has created in your new project structure.
+
+### Contributed Code
+
+The goal of this process is to have Composer manage all the site's contrib modules, contrib themes, core upgrades, and libraries (referred to as _contributed code_). The only things from the existing site that should remain in the git repository are custom code, custom themes, and custom modules that are specific to the existing site.
+
+
+#### Modules and Themes
+
+
+Your site should already be managing contributed modules and themes through composer. To migrate them to the new site, look at the source site `composer.json` and run a `composer require` command for each of those modules and themes in the `$DESTINATION` directory:
+
+```bash
+composer require drupal/PROJECT_NAME:^VERSION
+```
+
+You can require multiple packages in the same commands if you prefer so.
+
+#### Other Composer Packages
+
+If you have added non-Drupal packages to your site via Composer, use the command `composer require` to migrate each package. You can use the following command to display the differences between the master and your current `composer.json`:
+
+```
+diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
+```
+
+#### Libraries
+
+Libraries can be handled similarly to modules, but the specifics depend on how your library code was included in the source site. If you're using a library's API, you may have to do additional work to ensure that it functions properly.
+
+Do not forget to commit your changes during these steps.
+
+### Custom Code
+
+Manually copy custom code from the existing site repository to the Composer-managed directory.
+
+#### Modules and Themes
+
+To move modules, use the following commands:
+
+```bash{promptUser:user}
+mkdir -p $DESTINATION/web/modules/custom
+cp -r $SOURCE/modules/custom $DESTINATION/web/modules/custom
+# From $DESTINATION:
+git add web/modules/
+git commit -m "Copy custom modules"
+```
+
+To move themes, use the following commands:
+
+```bash{promptUser:user}
+mkdir -p $DESTINATION/web/themes/custom
+cp -r $SOURCE/themes/custom $DESTINATION/web/themes/custom
+# From $DESTINATION:
+git add web/themes/
+git commit -m "Copy custom themes"
+```
+
+Use the above commands with any of the custom code.
+
+#### settings.php
+
+Your existing site may have customizations to `settings.php` or other configuration files. Given that both sites (`$SOURCE` and `$DESTINATION`) have been created from the same upstream, it is ok to replace the `$DESTINATION` `settings.php` with the one coming from the `$SOURCE` site:
+
+```bash{promptUser:user}
+cp $SOURCE/sites/default/settings.php $DESTINATION/web/sites/default/settings.php
+# Review changes and commit as needed
+```
+
+The resulting `settings.php` should have no `$databases` array.
+
+### Additional Composer Configuration
+
+Any additional Composer configuration that you have added to your site should be ported over to the new `composer.json` file. This can include configurations related to repositories, minimum-stability, or extra sections.
+
+You can use the diff command to get the information you need to copy:
+
+```
+diff -Nup --ignore-all-space $SOURCE/composer.json $DESTINATION/composer.json
+```
+
+Commit your changes as needed.
+
+### Push to the external repository master branch
+
+Now push to the master branch in the external repository:
+
+```
+git push origin master
+```
+
+And wait for Continuous Integration workflow to succeed so that it commits your code changes to the Pantheon site.
+
+## Add Your Database
+
+@TODO This could be redacted better to use the export functionality in dashboard to get the URL and put it into the new site.
+
+<Partial file="migrate-add-database.md" />
+
+## Backup tokens.json file
+
+@TODO: REDACT THIS SECTION BETTER.
+
+Connect to your site using SFTP command or credentials from your dashboard and get a backup of the following file:
+
+```
+files/private/.build-tools/tokens.json
+```
+
+(You can use sftp `get` command to download the file to your local directory if using SFTP command line)
+
+## Upload Your Files
+
+@TODO This could be redacted better to use the export functionality in dashboard to get the URL and put it into the new site.
+
+<Partial file="migrate-add-files-only-drupal.md" />
+
+## Restore tokens.json file
+
+@TODO: REDACT THIS SECTION BETTER.
+
+Connect to your site using SFTP command or credentials from your dashboard and restore the backup of the tokens.json file:
+
+```
+files/private/.build-tools/tokens.json
+```
+
+(You can use sftp `put` command to upload the file from your local directory if using SFTP command line)
+
+
+You should now have all three of the major components of your site imported into your new site and CI should be working. Clear your caches on the the Pantheon Dashboard, and you are good to go!
+
+## Troubleshooting
+
+### Provided host name not valid
+
+If you receive the error message "The provided host name is not valid for this server.", then update your `settings.php` file with a trusted host setting. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
+
+### Working With Dependency Versions
+
+<Partial file="composer-updating.md" />
+
+## See Also
+
+- [Composer Fundamentals and Workflows](/composer)

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -44,9 +44,9 @@ Commit history: The steps in this process migrate a site, so the new site will n
 
 1. Follow the [Terminus Build Tools Documentation](https://pantheon.io/docs/guides/build-tools/create-project/#create-a-build-tools-project) to create a new Drupal 9 site:
 
-```bash
-terminus build:project:create --git=github --team='My Agency Name' d9 my-buildtools-site
-```
+  ```bash
+  terminus build:project:create --git=github --team='My Agency Name' d9 my-buildtools-site
+  ```
 
 1. Wait for the site to be created and the first build finishes.
 
@@ -56,7 +56,7 @@ terminus build:project:create --git=github --team='My Agency Name' d9 my-buildto
 
 2. Get a local copy of both your new site (from the external repository) and your existing site codebase.
 
-1. This doc uses several commands that depend on the locations of both your existing and new site codebases. To simplify this, set the temporary variables `$SOURCE` and `$DESTINATION` in your terminal session to match your folders location.
+1. This doc uses several commands that depend on the locations of both your existing and new site codebases. To simplify this, set the following temporary variables in your terminal session to match your folders location and sites names.
 
    ```bash
    export SOURCE=/absolute/path/to/source/site/codebase
@@ -72,7 +72,7 @@ Copy any existing configuration from the source sitem and update the source path
   ```bash{promptUser:user}
   rsync -avz $SOURCE/config/ $DESTINATION/config/ --delete --delete-after
   # From $DESTINATION:
-  git add config
+  git add config -A
   git commit -m "Pull in configuration from source site"
   ```
 
@@ -192,7 +192,7 @@ And wait for Continuous Integration workflow to succeed so that it commits your 
 Connect to your site using SFTP command or credentials from your dashboard and get a backup of the following file:
 
 ```
-files/private/.build-tools/tokens.json
+files/private/.build-secrets/tokens.json
 ```
 
 You can use sftp `get` command to download the file to your local directory if using SFTP command line.  
@@ -200,7 +200,7 @@ You can use sftp `get` command to download the file to your local directory if u
 Here is a single command that downloads the file to the current local directory:
 
 ```bash{promptUser:user}
-echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
+echo "get files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 ## Upload Your Files
@@ -216,7 +216,7 @@ echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info $
 Connect to your site using SFTP command or credentials from your dashboard and restore the backup of the tokens.json file:
 
 ```
-files/private/.build-tools/tokens.json
+files/private/.build-secrets/tokens.json
 ```
 
 You can use sftp `put` command to upload the file from your local directory if using SFTP command line.
@@ -224,7 +224,7 @@ You can use sftp `put` command to upload the file from your local directory if u
 Below is a single command which does this. This needs to be run from the directory where the `tokens.json` backup was downloaded:
 
 ```bash{promptUser:user}
-echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
+echo "put files/private/.build-secrets/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 

--- a/source/content/guides/drupal-9-to-build-tools.md
+++ b/source/content/guides/drupal-9-to-build-tools.md
@@ -45,7 +45,7 @@ Commit history: The steps in this process migrate a site, so the new site will n
 1. Follow the [Terminus Build Tools Documentation](https://pantheon.io/docs/guides/build-tools/create-project/#create-a-build-tools-project) to create a new Drupal 9 site:
 
 ```bash
-terminus build:project:create --git=github --team='My Agency Name' d9 my-site
+terminus build:project:create --git=github --team='My Agency Name' d9 my-buildtools-site
 ```
 
 1. Wait for the site to be created and the first build finishes.
@@ -61,7 +61,8 @@ terminus build:project:create --git=github --team='My Agency Name' d9 my-site
    ```bash
    export SOURCE=/absolute/path/to/source/site/codebase
    export DESTINATION=/absolute/path/to/codebase/cloned/from/pantheon
-   export SOURCE_SITE_NAME=my-site
+   export SOURCE_SITE_NAME=my-source-site
+   export DESTINATION_SITE_NAME=my-buildtools-site
    ```
 
 ## Copy Existing Configuration
@@ -199,7 +200,7 @@ You can use sftp `get` command to download the file to your local directory if u
 Here is a single command that downloads the file to the current local directory:
 
 ```bash{promptUser:user}
-echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info $SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+echo "get files/private/.build-tools/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 ## Upload Your Files
@@ -223,7 +224,7 @@ You can use sftp `put` command to upload the file from your local directory if u
 Below is a single command which does this. This needs to be run from the directory where the `tokens.json` backup was downloaded:
 
 ```bash{promptUser:user}
-echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info $SOURCE_SITE_NAME.dev --format=string --field=sftp_command)
+echo "put files/private/.build-tools/tokens.json" | $(terminus connection:info $DESTINATION_SITE_NAME.dev --format=string --field=sftp_command)
 ```
 
 

--- a/source/partials/drupal-9/upgrade-site-requirements-from-drupal-recommended.md
+++ b/source/partials/drupal-9/upgrade-site-requirements-from-drupal-recommended.md
@@ -7,8 +7,8 @@ You must confirm that your site meets the following requirements before you cont
   Run the command `terminus site:info $SITE` to display the site's basic information and properties.
 
  The following values indicate that a site is using an `drupal-recommended` upstream:
-  * The `Framework` is `drupal8`
-  * The `Upstream` includes `https://github.com/pantheon-upstreams/drupal-recommended.git`
+  - The `Framework` is `drupal8`
+  - The `Upstream` includes `https://github.com/pantheon-upstreams/drupal-recommended.git`
 
   The following is an abridged example of the output for the `terminus site:info $SITE` command, if the site upstream is set to `empty`:
 

--- a/source/partials/drupal-9/upgrade-site-requirements-from-drupal-recommended.md
+++ b/source/partials/drupal-9/upgrade-site-requirements-from-drupal-recommended.md
@@ -1,0 +1,27 @@
+You must confirm that your site meets the following requirements before you continue:
+
+- Ensure your site has the [Pantheon drupal-recommended repository](https://github.com/pantheon-upstreams/drupal-recommended) in its upstream.
+
+  ### Use Terminus to Confirm the Drupal Recommended Upstream
+
+  Run the command `terminus site:info $SITE` to display the site's basic information and properties.
+
+ The following values indicate that a site is using an `drupal-recommended` upstream:
+  * The `Framework` is `drupal8`
+  * The `Upstream` includes `https://github.com/pantheon-upstreams/drupal-recommended.git`
+
+  The following is an abridged example of the output for the `terminus site:info $SITE` command, if the site upstream is set to `empty`:
+
+  ```bash{outputLines:2-18}
+  terminus site:info $SITE
+  ------------------ -------------------------------------------------------------------------------------
+  ID                 abdc3ea1-fe0b-1234-9c9f-3cxeAA123f88
+  Name               anita-drupal
+  Label              AnitaDrupal
+  Created            2019-12-02 18:28:14
+  Framework          drupal8
+  ...
+  Upstream           897fdf15-992e-4fa1-beab-89e2b5027e03: https://github.com/pantheon-upstreams/drupal-recommended
+  ...
+  ------------------ -------------------------------------------------------------------------------------
+  ```

--- a/source/partials/migrate-add-database.md
+++ b/source/partials/migrate-add-database.md
@@ -1,6 +1,8 @@
 The **Database** import requires a single `.sql` dump that contains the site's content and configurations.
 
-1. Create a `.sql` dump using the [mysqldump](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html) utility. To reduce the size for a faster transfer, compress the resulting archive with gzip:
+1. Create a `.sql` dump using the [mysqldump](https://dev.mysql.com/doc/refman/5.7/en/mysqldump.html) utility. 
+
+1. Compress the resulting archive with gzip to reduce the size for a faster transfer:
 
   ```bash{promptUser: user}
   mysqldump -uUSERNAME -pPASSWORD DATABASENAME > ~/db.sql
@@ -14,7 +16,7 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   The resulting file will be named `db.sql.gz` You can use either the Pantheon Dashboard or a MySQL client to add your site's database.
 
-1. From the Site Dashboard, select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment.
+1. Select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment in the Site Dashboard.
 
 1. Select **<span class="glyphicons glyphicons-server"></span> Database / Files**.
 
@@ -26,9 +28,9 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   If your archive is under 100MB, you can upload the file directly:
 
-   1. In the **MySQL database** field, click **File**, then **Choose File**.
+   1. Navigate to the **MySQL database** field > click **File** > **Choose File**.
 
-   2. Select your local archive file, then press **Import**.
+   2. Select your local archive file > click **Import**.
 
    ![Import MySQL database from file](../images/dashboard/import-mysql-file.png)
 
@@ -40,9 +42,15 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   If your archive is less than 500MB, you can import it from URL:
 
-   1. In the **MySQL database** field, click **URL**.
+   1. Navigate to the **MySQL database** field > click **URL**.
 
-   1. Paste a publicly accessible URL for the `.sql.gz` file, and press **Import**. Change the end of Dropbox URLs from `dl=0` to `dl=1` so we can import your archive properly.
+   1. Paste a publicly accessible URL for the `.sql.gz` file > click **Import**. 
+
+   <Alert title="Note"  type="info" >
+
+   You must change the end of Dropbox URLs from `dl=0` to `dl=1` to import your archive correctly.
+
+   </Alert>
 
       ![Import MySQL Database from URL](../images/dashboard/import-mysql-url.png)
 
@@ -50,23 +58,29 @@ The **Database** import requires a single `.sql` dump that contains the site's c
 
   <Tab title="Over 500MBs" id="500mbsplus">
 
-  The following instructions will allow you to add database archives larger than 500MBs using the command line MySQL client, but you can also use a GUI client like Sequel Ace or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
+  The following instructions allow you to add database archives larger than 500MBs using the command line MySQL client. You can also use a GUI client like Sequel Ace or Navicat. For more information, see [Accessing MySQL Databases](/mysql-access).
 
-   1. From the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment on the Pantheon Site Dashboard, click **Connection Info** and copy the Database connection string. It will look similar to this:
+   1. Navigate to the Pantheon Site Dashboard > open the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment > click **Connection Info** > copy the Database connection string. 
+   
+    The Database connection string will look similar to this:
 
-    ```bash{promptUser: user}
-    mysql -u pantheon -p{random-password} -h dbserver.dev.{site-id}.drush.in -P {site-port} pantheon
-    ```
+      ```bash{promptUser: user}
+      mysql -u pantheon -p{random-password} -h dbserver.dev.{site-id}.drush.in -P {site-port} pantheon
+      ```
 
-   1. From your terminal, `cd` into the directory containing your `.sql` file. Paste the connection string and append it with: `< database.sql`. Your command will look like:
+   2. `cd` into the directory containing your `.sql` file in your terminal.
+   
+   1.  Paste the connection string and append it with: `< database.sql`. 
+   
+    Your command will look like:
 
-    ```bash{promptUser: user}
-    mysql -u pantheon -p{random-password} -h dbserver.dev.{site-id}.drush.in -P {site-port} pantheon < database.sql
-    ```
+      ```bash{promptUser: user}
+      mysql -u pantheon -p{random-password} -h dbserver.dev.{site-id}.drush.in -P {site-port} pantheon < database.sql
+      ```
 
-    If you encounter a connection-related error, the DB server could be in sleep mode. To resolve this, load the site in your browser to wake it up, and try again. For more information, see [Troubleshooting MySQL Connections](/mysql-access/#troubleshooting-mysql-connections).
+     If you encounter a connection-related error, the DB server could be in sleep mode. To resolve this, load the site in your browser to wake it up, and try again. For more information, see [Troubleshooting MySQL Connections](/mysql-access/#troubleshooting-mysql-connections).
 
-   3. After you run the command, the `.sql` file is imported to the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment.
+    The `.sql` file is imported to the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment after you run the command.
 
   </Tab>
 

--- a/source/partials/migrate-add-files-only-drupal.md
+++ b/source/partials/migrate-add-files-only-drupal.md
@@ -49,42 +49,42 @@ Follow the steps below to export a `tar.gz` or `.zip` file of the files in your 
 
   <Tab title="Over 500MBs" id="500mbsplusfiles">
 
-  We recommend using the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) to transfer a large number of files. This avoids using numerous command line arguments and specific directory structures, which make it easy to introduce mistakes.
+   We recommend using the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) to transfer a large number of files. This avoids using numerous command line arguments and specific directory structures, which make it easy to introduce mistakes.
 
-  Rsync only transfers the new changes to the directory after the initial rsync runs. This minimizes the time a site is in an unpredictable state (or offline) during the final step of migration, and allows you to bring over only new content rather than re-copying every single file.
+   Rsync only transfers the new changes to the directory after the initial rsync runs. This minimizes the time a site is in an unpredictable state (or offline) during the final step of migration, and allows you to bring over only new content rather than re-copying every single file.
 
-  1. Run the following command to sync your current directory to Pantheon:
+   1. Run the following command to sync your current directory to Pantheon:
 
-    ```bash{promptUser: user}
-    terminus rsync . my_site.dev:files
-    ```
+      ```bash{promptUser: user}
+      terminus rsync . my_site.dev:files
+      ```
 
-  1. Run the following command if you experience interrupted transfers due to connectivity issues, which can occur when using Rsync manually.
+   1. Run the following command if you experience interrupted transfers due to connectivity issues, which can occur when using Rsync manually.
 
-    ```bash
-    ENV='dev'
-    SITE='SITEID'
+      ```bash
+      ENV='dev'
+      SITE='SITEID'
 
-    read -sp "Your Pantheon Password: " PASSWORD
-    if [[ -z "$PASSWORD" ]]; then
-    echo "Whoops, need password"
-    exit
-    fi
+      read -sp "Your Pantheon Password: " PASSWORD
+      if [[ -z "$PASSWORD" ]]; then
+      echo "Whoops, need password"
+      exit
+      fi
 
-    while [ 1 ]
-    do
-    sshpass -p "$PASSWORD" rsync --partial -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
-    if [ "$?" = "0" ] ; then
-    echo "rsync completed normally"
-    exit
-    else
-    echo "Rsync failure. Backing off and retrying..."
-    sleep 180
-    fi
-    done
-    ```
+      while [ 1 ]
+      do
+      sshpass -p "$PASSWORD" rsync --partial -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
+      if [ "$?" = "0" ] ; then
+      echo "rsync completed normally"
+      exit
+      else
+      echo "Rsync failure. Backing off and retrying..."
+      sleep 180
+      fi
+      done
+      ```
 
-  Your files will be uploaded to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, the command waits 180 seconds before continuing where it left off.
+   Your files will be uploaded to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, the command waits 180 seconds before continuing where it left off.
 
   </Tab>
 

--- a/source/partials/migrate-add-files-only-drupal.md
+++ b/source/partials/migrate-add-files-only-drupal.md
@@ -1,55 +1,65 @@
-**Files** refer to anything within `sites/default/files`, which typically includes uploaded images, generated stylesheets, aggregated scripts, etc. Files are not under Git version control and are stored separately from the site's code.
+**Files** refer to everything stored inside `sites/default/files`. This usually consists of uploaded images, generated stylesheets, aggregated scripts, etc. Files are not under Git version control and are stored separately from the site's code.
 
 You can use the Pantheon Dashboard, SFTP, or Rsync to upload your site's files.
 
-1. Export a `tar.gz` or `.zip` file of your files directory:
+Follow the steps below to export a `tar.gz` or `.zip` file of the files in your directory.
 
-  Navigate to your Drupal site's root directory to run this command, which will create an archive file in your user's home directory:
+1. Navigate to your Drupal site's root directory to run this command: 
 
   ```bash{promptUser: user}
   cd sites/default/files
   tar -czf ~/files.tar.gz .
   ```
 
-1. From the Site Dashboard, select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment.
+  Now you have created an archive file in your user's home directory.
+
+1. Select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment in Site Dashboard.
+
 1. Select **<span class="glyphicons glyphicons-server"></span> Database / Files**.
-1. Click **Import** and add your archive accordingly (based on file size):
+
+1. Click **Import** and then add your archive (based on file size) by following the steps below.
 
   <TabList>
 
   <Tab title="Up to 100MBs" id="100mbsfiles-id" active={true}>
 
-  If your archive is under 100MB, you can upload the file directly:
+   You can upload the file directly, if your archive is under 100MB.
 
-   1. In the **Archive of site files** field, click **File**, then **Choose File**.
+   1. Navigate to the **Archive of site files** field > click **File** > **Choose File**.
 
-   1. Select your local archive file, then press **Import**.
+   1. Select your local archive file > click **Import**.
 
   </Tab>
 
   <Tab title="Up to 500MBs" id="500mbsfiles">
 
-  If your archive is less than 500MB, you can import it from URL:
+  You can import your archive from URL, if your archive is less than 500MB.
 
-   1. In the **Archive of site files** field, click **URL**.
+   1. Navigate to the **Archive of site files** field > click **URL**.
 
-   1. Paste a publicly accessible URL for the archive, and press **Import**. Change the end of Dropbox URLs from `dl=0` to `dl=1` so we can import your archive properly.
+   1. Paste a publicly accessible URL for the archive > click **Import**. 
+   
+   <Alert title="Note"  type="info" >
+
+    You must change the end of Dropbox URLs from `dl=0` to `dl=1` to import your archive correctly.
+
+   </Alert>
 
   </Tab>
 
   <Tab title="Over 500MBs" id="500mbsplusfiles">
 
-  Rsync is an excellent method for transferring a large number of files. After performing an initial rsync, subsequent jobs will only transfer the latest changes. This can help minimize the amount of time a site is in an unpredictable state (or offline) during the final step of migration, as it allows you to bring over only new content rather than re-copying every single file.
+  We recommend using the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) to transfer a large number of files. This avoids using numerous command line arguments and specific directory structures, which make it easy to introduce mistakes.
 
-  We recommend looking into the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) as a helper when doing these operations, as the number of command line arguments and specifics of directory structure make it easy for human error to impact your operation.
+  Rsync only transfers the new changes to the directory after the initial rsync runs. This minimizes the time a site is in an unpredictable state (or offline) during the final step of migration, and allows you to bring over only new content rather than re-copying every single file.
 
-  To sync your current directory to Pantheon:
+  1. Run the following command to sync your current directory to Pantheon:
 
-  ```bash{promptUser: user}
-  terminus rsync . my_site.dev:files
-  ```
+    ```bash{promptUser: user}
+    terminus rsync . my_site.dev:files
+    ```
 
-  When using Rsync manually, the script below is useful for dealing with transfers being interrupted due to connectivity issues. It uploads files to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, it waits 180 seconds and picks up where it left off:
+  1. Run the following command if you experience interrupted transfers due to connectivity issues, which can occur when using Rsync manually.
 
   ```bash
   ENV='dev'
@@ -73,6 +83,8 @@ You can use the Pantheon Dashboard, SFTP, or Rsync to upload your site's files.
   fi
   done
   ```
+
+ Your files will be uploaded to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, the command waits 180 seconds before continuing where it left off.
 
   </Tab>
 

--- a/source/partials/migrate-add-files-only-drupal.md
+++ b/source/partials/migrate-add-files-only-drupal.md
@@ -2,7 +2,7 @@
 
 You can use the Pantheon Dashboard, SFTP, or Rsync to upload your site's files.
 
-Follow the steps below to export a `tar.gz` or `.zip` file of the files in your directory.
+Follow the steps below to export a `tar.gz` or `.zip` file of your directory files.
 
 1. Navigate to your Drupal site's root directory to run this command: 
 
@@ -13,7 +13,7 @@ Follow the steps below to export a `tar.gz` or `.zip` file of the files in your 
 
   Now you have created an archive file in your user's home directory.
 
-1. Select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment in Site Dashboard.
+1. Select the **<span class="glyphicons glyphicons-wrench"></span> Dev** environment in the Site Dashboard.
 
 1. Select **<span class="glyphicons glyphicons-server"></span> Database / Files**.
 
@@ -49,7 +49,7 @@ Follow the steps below to export a `tar.gz` or `.zip` file of the files in your 
 
   <Tab title="Over 500MBs" id="500mbsplusfiles">
 
-   We recommend using the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) to transfer a large number of files. This avoids using numerous command line arguments and specific directory structures, which make it easy to introduce mistakes.
+   We recommend using the [Terminus Rsync Plugin](https://github.com/pantheon-systems/terminus-rsync-plugin) to transfer a large number of files. This allows you to avoid using multiple command line arguments and specific directory structures, which make it easy to introduce mistakes.
 
    Rsync only transfers the new changes to the directory after the initial rsync runs. This minimizes the time a site is in an unpredictable state (or offline) during the final step of migration, and allows you to bring over only new content rather than re-copying every single file.
 

--- a/source/partials/migrate-add-files-only-drupal.md
+++ b/source/partials/migrate-add-files-only-drupal.md
@@ -61,30 +61,30 @@ Follow the steps below to export a `tar.gz` or `.zip` file of the files in your 
 
   1. Run the following command if you experience interrupted transfers due to connectivity issues, which can occur when using Rsync manually.
 
-  ```bash
-  ENV='dev'
-  SITE='SITEID'
+    ```bash
+    ENV='dev'
+    SITE='SITEID'
 
-  read -sp "Your Pantheon Password: " PASSWORD
-  if [[ -z "$PASSWORD" ]]; then
-  echo "Whoops, need password"
-  exit
-  fi
+    read -sp "Your Pantheon Password: " PASSWORD
+    if [[ -z "$PASSWORD" ]]; then
+    echo "Whoops, need password"
+    exit
+    fi
 
-  while [ 1 ]
-  do
-  sshpass -p "$PASSWORD" rsync --partial -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
-  if [ "$?" = "0" ] ; then
-  echo "rsync completed normally"
-  exit
-  else
-  echo "Rsync failure. Backing off and retrying..."
-  sleep 180
-  fi
-  done
-  ```
+    while [ 1 ]
+    do
+    sshpass -p "$PASSWORD" rsync --partial -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV.$SITE@appserver.$ENV.$SITE.drush.in:files/
+    if [ "$?" = "0" ] ; then
+    echo "rsync completed normally"
+    exit
+    else
+    echo "Rsync failure. Backing off and retrying..."
+    sleep 180
+    fi
+    done
+    ```
 
- Your files will be uploaded to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, the command waits 180 seconds before continuing where it left off.
+  Your files will be uploaded to your Pantheon site's **<span class="glyphicons glyphicons-wrench"></span> Dev** environment. If an error occurs during transfer, the command waits 180 seconds before continuing where it left off.
 
   </Tab>
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes CMS-578

## Summary

**[Migrating a Drupal with Composer site to a Build Tools site](https://pr-7158--pantheon-docs.my.pantheonfrontend.website/docs/guides/drupal-9-to-build-tools)** - Add new migrate Drupal 9 to build tools page


## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Docs review and updates from the docs team

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
