### PR TITLE
Grammar fix

### DIFF
--- a/source/content/redirects.md
+++ b/source/content/redirects.md
@@ -46,7 +46,7 @@ This is the preferred method of setting HTTPS & HSTS for your site. Find the `en
 
 ## Redirect with PHP
 
-If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects. Note that redirecting the platform domain will break the screenshot of your site in the User Dashboard, and may complicating troubleshooting for our [Support](/guides/support/contact-support/) team.
+If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects. Note that redirecting the platform domain will break the screenshot of your site in the User Dashboard, and may complicate troubleshooting for our [Support](/guides/support/contact-support/) team.
 
 <Partial file="_redirects.md" />
 


### PR DESCRIPTION
## Summary

**[Configure Redirects](https://pantheon.io/docs/redirects#redirect-with-php)** - Wrong tense was used

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
