### PR TITLE
[CMS-391] Modify docs to reflect WP Cron changes

### DIFF
--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -104,7 +104,7 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-By default, Pantheon's WordPress upstreams have WP_CRON disabled. If you wish to continue using WP_CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+By default, Pantheon's WordPress upstreams have WP-CRON disabled. If you wish to continue using WP-CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', false);

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -104,7 +104,7 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-By default, Pantheon's WordPress upstreams have WP-CRON disabled. If you wish to continue using WP-CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+By default, Pantheon's WordPress upstreams have WP-Cron disabled. If you wish to continue using WP-Cron, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', false);

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -104,7 +104,7 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-By default, Pantheon's WordPress upstreams have WP_CRON disabled. If you wish to continue using WP_CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing:
+By default, Pantheon's WordPress upstreams have WP_CRON disabled. If you wish to continue using WP_CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', false);

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -4,7 +4,7 @@ description: Learn how to create and run jobs using Pantheon Cron or WordPress's
 cms: "WordPress"
 categories: [automate]
 tags: [cron]
-contributors: [greg-1-anderson, CdrMarks, whitneymeredith]
+contributors: [greg-1-anderson, CdrMarks, whitneymeredith, jspellman814]
 ---
 
 ## Cron Overview
@@ -104,12 +104,10 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-You will need to disable WP-Cron if your upstream does not have the definition below.
-
-Add the code below to your `wp-config.php` file to disable WP-Cron's internal processing:
+By default, Pantheon's WordPress upstreams have WP_CRON disabled. If you wish to continue using WP_CRON, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing:
 
 ```php:title=wp-config.php
-define('DISABLE_WP_CRON', true);
+define('DISABLE_WP_CRON', false);
 ```
 
 ### Free Services

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -104,7 +104,7 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-By default, Pantheon's WordPress upstreams have WP-Cron disabled. If you wish to continue using WP-Cron, you will need to add the code below to your `wp-config.php` file to enable WP-Cron's internal processing. This line needs to be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+Pantheon's WordPress upstreams disable WP-Cron by default. You must add the code below to your `wp-config.php` file to enable WP-Cron's internal processing if you want to continue using WP-Cron. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', false);


### PR DESCRIPTION
## Summary

[Cron for WordPress](https://pantheon.io/docs/wordpress-cron) - These documentation updates are based on the WP Cron changes being implemented in [#312](https://github.com/pantheon-systems/WordPress/pull/312) and [#9](https://github.com/pantheon-upstreams/wordpress-project/pull/9).

### Dependencies and Timing

- [x] PR [#312](https://github.com/pantheon-systems/WordPress/pull/312) is merged
- [x] PR [#9](https://github.com/pantheon-upstreams/wordpress-project/pull/9) is merged
- [x] After the next major/minor version of WordPress has been merged into the two repos above.

**Release**:
- [ ] After the dependencies above have been merged

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
