### PR TITLE
Add drupal.org profile url for John Spellman

### DIFF
--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -340,14 +340,6 @@
   bio: API, Cloud & Integration Expert
   avatar: //avatars3.githubusercontent.com/u/192050
   github: //github.com/LukasRos
-- id: jspellman814
-  name: John Spellman
-  avatar: //github.com/jspellman814.png?size=460
-  github: //github.com/jspellman814
-  wordpress: //profiles.wordpress.org/jspellman
-  drupal: //www.drupal.org/u/jspellman
-  linkedin: //www.linkedin.com/in/john-spellman-86039262
-  bio: Software Engineer, Pantheon
 - id: peter-pantheon
   name: Peter Sawczynec
   avatar: //pantheon.io/sites/default/files/styles/540x540_top/public/Peter%20Sawczynec.jpg
@@ -361,6 +353,14 @@
   github: //github.com/eeeschwartz/
   linkedin: //www.linkedin.com/in/eeeschwartz
   bio: Civic developer, human centered!
+- id: jspellman814
+  name: John Spellman
+  avatar: //github.com/jspellman814.png?size=460
+  github: //github.com/jspellman814
+  wordpress: //profiles.wordpress.org/jspellman
+  drupal: //www.drupal.org/u/jspellman
+  linkedin: //www.linkedin.com/in/john-spellman-86039262
+  bio: Software Engineer, Pantheon
 - id: stovak
   name: Tom Stovall
   github: //github.com/stovak

--- a/source/data/contributor.yaml
+++ b/source/data/contributor.yaml
@@ -345,6 +345,7 @@
   avatar: //github.com/jspellman814.png?size=460
   github: //github.com/jspellman814
   wordpress: //profiles.wordpress.org/jspellman
+  drupal: //www.drupal.org/u/jspellman
   linkedin: //www.linkedin.com/in/john-spellman-86039262
   bio: Software Engineer, Pantheon
 - id: peter-pantheon


### PR DESCRIPTION
## Summary

Adds drupal.org profile url to [John Spellman's contrib bio](https://pantheon.io/docs/contributors/jspellman814).

## Effect

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
