### PR TITLE
[CMS-590] Docs for WPScan changes

### DIFF
--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -29,13 +29,13 @@ WP Launch Check utilizes the [WPScan API](https://wpscan.com/api) to check for o
 
 ### Configuring WPScan
 
-Configuring WPScan is easy. Once you've obtain your API token, add it to your site's `wp-config.php` file using the following PHP code: 
+After you've obtained your API token, add it to your site's `wp-config.php` file using the following PHP code: 
 
 ```php:title=wp-config.php
 define( 'WPSCAN_API_TOKEN', '$your_api_token' );
 ```
 
-You'll also need to define which environment you'd like WPScan to run on using the `PANTHEON_WPSCAN_ENVIRONMENTS` constant. This constant is required to use the WPScan functionality, and allows users to decide whether or not scans are done on multiple environments, or just one.
+You'll also need to define which environment you want WPScan to run on using the `PANTHEON_WPSCAN_ENVIRONMENTS` constant. This constant is required to use the WPScan functionality, and allows users to decide whether or not scans are done on multiple environments, or just one.
 
 To scan one environment:
 
@@ -55,7 +55,11 @@ To scan all environments:
 define( 'PANTHEON_WPSCAN_ENVIRONMENTS', '*' );
 ```
 
-**Note:** Scanning multiple or all environments at will more rapidly exhaust your daily API request quota.
+<Alert title="Note"  type="info" >
+
+Scanning multiple or all environments will more rapidly exhaust your daily API request quota.
+
+</Alert>
 
 ## Run Launch Check Manually
 

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -35,6 +35,28 @@ Configuring WPScan is easy. Once you've obtain your API token, add it to your si
 define( 'WPSCAN_API_TOKEN', '$your_api_token' );
 ```
 
+You'll also need to define which environment you'd like WPScan to run on using the `PANTHEON_WPSCAN_ENVIRONMENTS` constant. This constant is required to use the WPScan functionality, and allows users to decide whether or not scans are done on multiple environments, or just one.
+
+To scan one environment:
+
+```php:title=wp-config.php
+define( 'PANTHEON_WPSCAN_ENVIRONMENTS', 'live' );
+```
+
+To scan multiple environments:
+
+```php:title=wp-config.php
+define( 'PANTHEON_WPSCAN_ENVIRONMENTS', ['dev', 'test', 'live'] );
+```
+
+To scan all environments:
+
+```php:title=wp-config.php
+define( 'PANTHEON_WPSCAN_ENVIRONMENTS', * );
+```
+
+**Note:** Scanning multiple or all environments at will more rapidly exhaust your daily API request quota.
+
 ## Run Launch Check Manually
 
 To manually perform a site audit using WP Launch Check from the command line (using [Terminus](/terminus)), run:

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -35,12 +35,6 @@ Configuring WPScan is easy. Once you've obtain your API token, add it to your si
 define( 'WPSCAN_API_TOKEN', '$your_api_token' );
 ```
 
-Alternatively, you could use the [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin) to add you API token at the platform level. The API token is [accessed from WP Launch Check](https://github.com/pantheon-systems/wp_launch_check/blob/9ddfd899b80ff42fa3ab060c2f44b930e8278069/php/pantheon/checks/plugins.php#L80) via `getenv('PANTHEON_WPVULNDB_API_TOKEN')`. To set this environment variable, follow the steps to install the Terminus Secrets Plugin, and add your token to your chosen environment:
-
-```bash
-terminus secrets:set <site>.<env> PANTHEON_WPVULNDB_API_TOKEN <value>
-```
-
 ## Run Launch Check Manually
 
 To manually perform a site audit using WP Launch Check from the command line (using [Terminus](/terminus)), run:

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -4,7 +4,7 @@ description: Learn more about the checks we automatically run on your Pantheon W
 cms: "WordPress"
 categories: [go-live]
 tags: [webops, launch]
-reviewed: "2020-05-27"
+reviewed: "2021-04-06"
 ---
 
 Pantheon provides static site analysis as a service for WordPress sites to make best practice recommendations on site configurations. These reports are found in the Site Dashboard under the **Status** tab, and are accessible by site team members.
@@ -22,6 +22,24 @@ In short, you get a fast, repeatable report that can help detect common problems
 ## How Does it Work?
 
 WP Launch Check is a site audit extension for WP-CLI designed for Pantheon customers. While designed initially for the Pantheon Dashboard it is intended to be fully usable outside of Pantheon.
+
+## WPScan Dependency
+
+WP Launch Check utilizes the [WPScan plugin](https://wordpress.org/plugins/wpscan/) to check for outdated or vulnerable plugins. If you wish to use this service to receive an alerts when your plugins need to be updated, you'll need to obtain an [API token](https://wpscan.com/pricing) from their website and configure your site to use your token.
+
+### Configuring WPScan
+
+Configuring WPScan is easy. Once you've obtain your API token, add it to your site's `wp-config.php` file using the following PHP code: 
+
+```php:title=wp-config.php
+define( 'WPSCAN_API_TOKEN', '$your_api_token' );
+```
+
+Alternatively, you could use the [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin) to add you API token at the platform level. The API token is [accessed from WP Launch Check](https://github.com/pantheon-systems/wp_launch_check/blob/9ddfd899b80ff42fa3ab060c2f44b930e8278069/php/pantheon/checks/plugins.php#L80) via `getenv('PANTHEON_WPVULNDB_API_TOKEN')`. To set this environment variable, follow the steps to install the Terminus Secrets Plugin, and add your token to your chosen environment:
+
+```bash
+terminus secrets:set <site>.<env> PANTHEON_WPVULNDB_API_TOKEN <value>
+```
 
 ## Run Launch Check Manually
 

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -25,7 +25,7 @@ WP Launch Check is a site audit extension for WP-CLI designed for Pantheon custo
 
 ## WPScan Dependency
 
-WP Launch Check utilizes the [WPScan plugin](https://wordpress.org/plugins/wpscan/) to check for outdated or vulnerable plugins. If you wish to use this service to receive an alerts when your plugins need to be updated, you'll need to obtain an [API token](https://wpscan.com/pricing) from their website and configure your site to use your token.
+WP Launch Check utilizes the [WPScan API](https://wpscan.com/api) to check for outdated or vulnerable plugins. If you wish to use this service to receive an alerts when your plugins need to be updated, you'll need to obtain an [API token](https://wpscan.com/pricing) from their website and configure your site to use your token.
 
 ### Configuring WPScan
 

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -52,7 +52,7 @@ define( 'PANTHEON_WPSCAN_ENVIRONMENTS', ['dev', 'test', 'live'] );
 To scan all environments:
 
 ```php:title=wp-config.php
-define( 'PANTHEON_WPSCAN_ENVIRONMENTS', * );
+define( 'PANTHEON_WPSCAN_ENVIRONMENTS', '*' );
 ```
 
 **Note:** Scanning multiple or all environments at will more rapidly exhaust your daily API request quota.

--- a/source/content/wordpress-launch-check.md
+++ b/source/content/wordpress-launch-check.md
@@ -23,11 +23,11 @@ In short, you get a fast, repeatable report that can help detect common problems
 
 WP Launch Check is a site audit extension for WP-CLI designed for Pantheon customers. While designed initially for the Pantheon Dashboard it is intended to be fully usable outside of Pantheon.
 
-## WPScan Dependency
+## WPScan (Recommended)
 
 WP Launch Check utilizes the [WPScan API](https://wpscan.com/api) to check for outdated or vulnerable plugins. If you wish to use this service to receive an alerts when your plugins need to be updated, you'll need to obtain an [API token](https://wpscan.com/pricing) from their website and configure your site to use your token.
 
-### Configuring WPScan
+### WPScan Site Configuration
 
 After you've obtained your API token, add it to your site's `wp-config.php` file using the following PHP code: 
 


### PR DESCRIPTION
## Summary

Add docs explaining WPScan dependency and configuration.

### Dependencies and Timing

- [x] WP Launch Check [PR #122](https://github.com/pantheon-systems/wp_launch_check/pull/122) has been merged
- [x] A new release has been created for WP Launch Check
- [x] `cos-framework-clis` has been updated to use the latest version of WP Launch Check

**Release**:
- [ ] Once the steps above have been completed

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
