### PR TITLE
Clarify Cron, including for Site Networks

### DIFF
--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -10,11 +10,13 @@ reviewed: "2022-04-27"
 
 ## Cron Overview
 
-Cron is a standard utility in Unix and Linux systems that it is used to schedule commands for automatic execution at configured intervals. These scheduled commands or tasks are known as cron jobs. Cron scheduling allows for the execution of tasks at specified intervals ranging from once a minute to once a year. Cron is generally used for running scheduled backups, monitoring disk space, deleting files that are no longer required, running system maintenance tasks, and much more.
+Cron is a standard utility in Unix and Linux systems that it is used to schedule commands for automatic execution at configured intervals. These scheduled commands or tasks are known as cron jobs. Cron scheduling allows for the execution of tasks at specified intervals ranging from once a minute to once a year.
+
+Cron is generally used for running scheduled backups, monitoring disk space, deleting files that are no longer required, running system maintenance tasks, and much more.
 
 ## Pantheon Cron Overview
 
-Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. Running Cron on the platform provides a more reliable schedule and ensures visitors are not interrupted by a script triggered by WordPress cron.
+Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. Running cron on the platform provides a more reliable schedule and ensures visitors are not interrupted by a script triggered by WordPress cron.
 
 ## WP-Cron Overview
 
@@ -41,7 +43,7 @@ Pantheon Cron will not execute jobs on inactive environments, including [sleepin
 
 ### WordPress Site Networks
 
-Pantheon Cron cannot support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Site Networks will continue to use WP Cron.
+Pantheon Cron does not support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Site Networks use WP-Cron.
 
 ### Security
 
@@ -59,33 +61,34 @@ Several jobs are automatically configured during the installation of WordPress. 
 
 Use [Terminus](/terminus) to see job details in WP-Cron. Terminus, through WP-CLI, provides details, such as:
 
- - What is scheduled to run
- - What will run next
- - What event hooks are configured
+- What is scheduled to run
+- What will run next
+- What event hooks are configured
 
 You can also use Terminus and WP-CLI to:
 
- - Schedule your own jobs
- - Execute existing jobs
- - Manage WP-Cron related features
+- Schedule your own jobs
+- Execute existing jobs
+- Manage WP-Cron related features
 
-We recommend that you use the following command to test WP-Cron and ensure everything is working correctly:
+Use the following command to test WP-Cron and ensure everything is working correctly:
 
 ```bash{promptUser: user}
 terminus wp <SITE_NAME>.<ENV-NAME> -- cron test
 ```
-* Replace `<SITE_NAME>` with your site's name
-* Replace `<ENV_NAME>` with the desired environment ("dev", "test", "live", or the Multidev branch name)
 
-If this is a WordPress site on the Pantheon upstream it will now be running on Pantheon Cron, so you should expect to see the following:
+- Replace `<SITE_NAME>` with your site's name
+- Replace `<ENV_NAME>` with the desired environment ("dev", "test", "live", or the Multidev branch name)
+
+If this is a WordPress site on the Pantheon upstream it will now be running on Pantheon Cron, and you should see:
 
 ```bash
 Error: The DISABLE_WP_CRON constant is set to true. WP-Cron spawning is disabled.
 ```
 
-This is not an error, but indicates that WordPress' internal cron scheduler has been deactivated and that the site will now rely on Pantheon cron.
+This is not an error, but indicates that WordPress's internal cron scheduler has been deactivated and that the site will now rely on Pantheon Cron.
 
-If this is a WordPress Site Network or has WordPress cron overridden to be enabled, the result should be:
+If this is a WordPress Site Network or has WordPress cron overridden, the result should be:
 
 ```bash{promptUser: user}
 Success: WP-Cron spawning is working as expected.
@@ -101,13 +104,17 @@ All `terminus wp` commands require a site name and environment to operate. WordP
 
 <Alert title="Note" type="info">
 
-Terminus cannot execute Cron Jobs if you enable the Security setting on your Dashboard. You may see status report errors on the Dashboard as a result.
+Terminus cannot execute cron jobs if you enable the Security setting on your Dashboard. You may see status report errors on the Dashboard as a result.
 
 </Alert>
 
 ### Enable WP-Cron
 
-Pantheon's WordPress upstream disables WP-Cron by default in favor of Pantheon Cron. You must add the code below to your `wp-config.php` file to enable WP-Cron's internal processing if you want to instead use WP-Cron. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+Pantheon's WordPress upstream disables WP-Cron by default in favor of Pantheon Cron.
+
+If you want to use WP-Cron instead, add the following code to your `wp-config.php` file to enable WP-Cron's internal processing.
+
+This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`:
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', false);
@@ -121,11 +128,13 @@ There are several plugins you can use if you want to keep an eye on WP-Cron but 
 
 ## Manage WP-Cron Externally
 
-You can use external Crons if you want more control over your site's Cron jobs, or if you don't want WP-Cron or Pantheon Cron to handle jobs internally. This will solve the problems with high traffic and low traffic sites discussed in the Troubleshooting section.
+You can use external crons if you want more control over your site's cron jobs, or if you don't want WP-Cron or Pantheon Cron to handle jobs internally. This will solve the problems with high traffic and low traffic sites discussed in the [Troubleshooting](#troubleshooting) section.
 
 ### Disable WP-Cron
 
-Pantheon's WordPress upstream disables WP-Cron by default. If you are on a Custom Upstream that does not have this setting, or the site is a WordPress Multisite, you must add the code below to your `wp-config.php` file to ensure WP-Cron is disabled. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+Pantheon's WordPress upstream disables WP-Cron by default.
+
+If you are on a Custom Upstream that does not have this setting, or the site is a WordPress Multisite, add the following code to your `wp-config.php` file to ensure WP-Cron is disabled. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`:
 
 ```php:title=wp-config.php
 define('DISABLE_WP_CRON', true);
@@ -161,7 +170,7 @@ You can use the Cron service to make a call to the `wp-cron.php` script if you a
 
 ### Problems With Low Traffic Sites
 
-On WordPress Multisite installations that do not have Pantheon Cron, WP-Cron will skip jobs in WordPress sites with low traffic. This doesn't mean your page will be slow from previous jobs when someone eventually visits your site. Regardless of how many jobs WP-Cron has to execute, all jobs are run in the background so your site's performance is not adversely affected.
+On WordPress Multisite installations that do not have Pantheon Cron, WP-Cron will skip jobs in WordPress sites with low traffic. This doesn't mean your page will be slow from previous jobs when someone eventually visits your site. Regardless of how many jobs WP-Cron has to execute, all jobs are run in the background so that your site's performance is not adversely affected.
 
 Low traffic WordPress sites on Pantheon are put to sleep after either one or twelve hours pass without site visitors (see [idle containers](/application-containers#idle-containers) for more information). Pantheon Cron jobs do not run in sleeping environments.
 

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -5,15 +5,16 @@ cms: "WordPress"
 categories: [automate]
 tags: [cron]
 contributors: [greg-1-anderson, CdrMarks, whitneymeredith, jspellman814]
+reviewed: "2022-04-27"
 ---
 
 ## Cron Overview
 
-Cron is a standard utility in Unix and Linux systems that it is used to schedule commands for automatic execution at configured intervals. These scheduled commands or tasks are known as cron jobs. Cron scheduling allows for the execution of tasks at specified intervals ranging from once a minute to once a year. Cron is generally used for running scheduled backups, monitoring disk space, deleting files that are no longer required, running system maintenance tasks, and much more. 
+Cron is a standard utility in Unix and Linux systems that it is used to schedule commands for automatic execution at configured intervals. These scheduled commands or tasks are known as cron jobs. Cron scheduling allows for the execution of tasks at specified intervals ranging from once a minute to once a year. Cron is generally used for running scheduled backups, monitoring disk space, deleting files that are no longer required, running system maintenance tasks, and much more.
 
 ## Pantheon Cron Overview
 
-Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. Running Cron on the platform provides a more reliable schedule and ensures visitors are not interrupted by a script triggered by WordPress cron. 
+Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. Running Cron on the platform provides a more reliable schedule and ensures visitors are not interrupted by a script triggered by WordPress cron.
 
 ## WP-Cron Overview
 
@@ -40,11 +41,11 @@ Pantheon Cron will not execute jobs on inactive environments, including [sleepin
 
 ### WordPress Site Networks
 
-Pantheon Cron cannot support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Site Networks will continue to use WP Cron. 
+Pantheon Cron cannot support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Site Networks will continue to use WP Cron.
 
 ### Security
 
-WP-Cron is a PHP file that is usually located in the root directory of your WordPress installation. The `wp-cron.php` file is subject to DDoS attacks, but generally, `wp-cron.php` is secure. 
+WP-Cron is a PHP file that is usually located in the root directory of your WordPress installation. The `wp-cron.php` file is subject to DDoS attacks, but generally, `wp-cron.php` is secure.
 
 There is only one parameter you can pass that will affect the script, `doing_wp_cron`. The `$_GET` value is not filtered, and is only used as a flag (not as an input for a process or variable). All inputs are ignored outside this. Currently, `wp-cron.php` does not have any known vulnerabilities or exploits, although it should be noted that no script on a server attached to the Internet is 100% secure.
 
@@ -74,7 +75,7 @@ We recommend that you use the following command to test WP-Cron and ensure every
 terminus wp <SITE_NAME>.<ENV-NAME> -- cron test
 ```
 * Replace `<SITE_NAME>` with your site's name
-* Replace `<ENV_NAME>` with the desired environment ("dev", "test", "live", or the Multidev branch name) 
+* Replace `<ENV_NAME>` with the desired environment ("dev", "test", "live", or the Multidev branch name)
 
 If this is a WordPress site on the Pantheon upstream it will now be running on Pantheon Cron, so you should expect to see the following:
 
@@ -155,14 +156,14 @@ Do not add a value to the `doing_wp_cron` query variable. This variable must be 
 ### Using Your Own Server
 
 You can use the Cron service to make a call to the `wp-cron.php` script if you administer your own server. You will have to learn how to correctly set up a Cron job and use something like `wget` or `curl` to fetch a web page. Using your own server is not safer than using a web-based Cron service.
- 
-## Troubleshooting 
+
+## Troubleshooting
 
 ### Problems With Low Traffic Sites
 
 On WordPress Multisite installations that do not have Pantheon Cron, WP-Cron will skip jobs in WordPress sites with low traffic. This doesn't mean your page will be slow from previous jobs when someone eventually visits your site. Regardless of how many jobs WP-Cron has to execute, all jobs are run in the background so your site's performance is not adversely affected.
 
-Low traffic WordPress sites on Pantheon are put to sleep after either one or twelve hours pass without site visitors (see [idle containers](/application-containers#idle-containers) for more information). Pantheon Cron jobs do not run in sleeping environments. 
+Low traffic WordPress sites on Pantheon are put to sleep after either one or twelve hours pass without site visitors (see [idle containers](/application-containers#idle-containers) for more information). Pantheon Cron jobs do not run in sleeping environments.
 
 ### Problems With High Traffic Sites
 
@@ -171,6 +172,6 @@ You might run into problems with WP-Cron if your WordPress-powered site is high 
 - **Race condition**: When more than one user visits your site and triggers WP-Cron to execute the same job. WP-Cron works hard to eliminate race conditions, but they can still happen, especially on high traffic sites.
 - **Long running process**: Any task that takes longer than the standard 60 seconds to run. Developers can adjust how long a PHP task is allowed to run with the `set_time_limit()` function. If this is set to be longer than the window between jobs, then you can end up with more than one copy of `wp-cron.php` executing.
 
-Both of these issues are addressed within WP-Cron's internal [locking](https://core.trac.wordpress.org/browser/tags/4.1.1/src/wp-includes/cron.php#L231) doc. 
+Both of these issues are addressed within WP-Cron's internal [locking](https://core.trac.wordpress.org/browser/tags/4.1.1/src/wp-includes/cron.php#L231) doc.
 
 Pantheon Cron limits the occurrences of the above issues.

--- a/source/content/wordpress-cron.md
+++ b/source/content/wordpress-cron.md
@@ -13,7 +13,7 @@ Cron is a standard utility in Unix and Linux systems that it is used to schedule
 
 ## Pantheon Cron Overview
 
-Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. 
+Pantheon Cron runs WordPress cron jobs as an hourly task or on demand through Terminus. This is in contrast to WP-Cron which executes jobs when a site is loaded by a visitor. Running Cron on the platform provides a more reliable schedule and ensures visitors are not interrupted by a script triggered by WordPress cron. 
 
 ## WP-Cron Overview
 
@@ -38,11 +38,15 @@ Pantheon Cron will not execute jobs on inactive environments, including [sleepin
 
 </Alert>
 
+### WordPress Site Networks
+
+Pantheon Cron cannot support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Site Networks will continue to use WP Cron. 
+
 ### Security
 
 WP-Cron is a PHP file that is usually located in the root directory of your WordPress installation. The `wp-cron.php` file is subject to DDoS attacks, but generally, `wp-cron.php` is secure. 
 
-There is only one parameter you can pass that will affect the script, `doing_wp_cron`. The `$_GET` value is not filtered, and is only used as a flag (not as an input for a process or variable). All inputs are ignored outside this. Currently, `wp-cron.php` does not have any known vulnerabilities or exploits, although it shoule be noted that no script on a server attached to the Internet is 100% secure.
+There is only one parameter you can pass that will affect the script, `doing_wp_cron`. The `$_GET` value is not filtered, and is only used as a flag (not as an input for a process or variable). All inputs are ignored outside this. Currently, `wp-cron.php` does not have any known vulnerabilities or exploits, although it should be noted that no script on a server attached to the Internet is 100% secure.
 
 ## Manage WP-Cron Internally
 
@@ -72,25 +76,41 @@ terminus wp <SITE_NAME>.<ENV-NAME> -- cron test
 * Replace `<SITE_NAME>` with your site's name
 * Replace `<ENV_NAME>` with the desired environment ("dev", "test", "live", or the Multidev branch name) 
 
-The result should look like this:
+If this is a WordPress site on the Pantheon upstream it will now be running on Pantheon Cron, so you should expect to see the following:
 
 ```bash
+Error: The DISABLE_WP_CRON constant is set to true. WP-Cron spawning is disabled.
+```
+
+This is not an error, but indicates that WordPress' internal cron scheduler has been deactivated and that the site will now rely on Pantheon cron.
+
+If this is a WordPress Site Network or has WordPress cron overridden to be enabled, the result should be:
+
+```bash{promptUser: user}
 Success: WP-Cron spawning is working as expected.
 ```
 
-This lets you know that WP-Cron is working correctly on your site. You can run any cron-related command with [WP-CLI](https://developer.wordpress.org/cli/commands/cron/ "wp-cli web site"). Use [Terminus](/terminus) when using WP-CLI to manage your Pantheon hosted WordPress site. The command format is as follows:
+You can run any cron-related command with [WP-CLI](https://developer.wordpress.org/cli/commands/cron/ "wp-cli web site"). Use [Terminus](/terminus) when using WP-CLI to manage your Pantheon hosted WordPress site. The command format is as follows:
 
 ```bash{promptUser: user}
 terminus wp <SITE_NAME>.<ENV_NAME> -- cron <your wp-cron command and switches here>
 ```
 
-All `terminus wp` commands require a site name and environment to operate.
+All `terminus wp` commands require a site name and environment to operate. WordPress Site Networks will require an additional `--url=<url>` parameter to specify which subsite to run the command on.
 
 <Alert title="Note" type="info">
 
 Terminus cannot execute Cron Jobs if you enable the Security setting on your Dashboard. You may see status report errors on the Dashboard as a result.
 
 </Alert>
+
+### Enable WP-Cron
+
+Pantheon's WordPress upstream disables WP-Cron by default in favor of Pantheon Cron. You must add the code below to your `wp-config.php` file to enable WP-Cron's internal processing if you want to instead use WP-Cron. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+
+```php:title=wp-config.php
+define('DISABLE_WP_CRON', false);
+```
 
 ### Plugins
 
@@ -104,10 +124,10 @@ You can use external Crons if you want more control over your site's Cron jobs, 
 
 ### Disable WP-Cron
 
-Pantheon's WordPress upstreams disable WP-Cron by default. You must add the code below to your `wp-config.php` file to enable WP-Cron's internal processing if you want to continue using WP-Cron. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
+Pantheon's WordPress upstream disables WP-Cron by default. If you are on a Custom Upstream that does not have this setting, or the site is a WordPress Multisite, you must add the code below to your `wp-config.php` file to ensure WP-Cron is disabled. This line must be above the `require_once` expression that pulls in `wp-config-pantheon.php`.
 
 ```php:title=wp-config.php
-define('DISABLE_WP_CRON', false);
+define('DISABLE_WP_CRON', true);
 ```
 
 ### Free Services
@@ -134,23 +154,23 @@ Do not add a value to the `doing_wp_cron` query variable. This variable must be 
 
 ### Using Your Own Server
 
- You can use the Cron service to make a call to the `wp-cron.php` script if you administer your own server. You will have to learn how to correctly set up a Cron job and use something like `wget` or `curl` to fetch a web page. Using your own server is not safer than using a web-based Cron service.
+You can use the Cron service to make a call to the `wp-cron.php` script if you administer your own server. You will have to learn how to correctly set up a Cron job and use something like `wget` or `curl` to fetch a web page. Using your own server is not safer than using a web-based Cron service.
  
 ## Troubleshooting 
 
 ### Problems With Low Traffic Sites
 
-WP-Cron will skip jobs in WordPress sites with low traffic. This doesn't mean your page will be slow from previous jobs when someone eventually visits your site. Regardless of how many jobs WP-Cron has to execute, all jobs are run in the background so your site's performance is not adversely affected.
+On WordPress Multisite installations that do not have Pantheon Cron, WP-Cron will skip jobs in WordPress sites with low traffic. This doesn't mean your page will be slow from previous jobs when someone eventually visits your site. Regardless of how many jobs WP-Cron has to execute, all jobs are run in the background so your site's performance is not adversely affected.
 
 Low traffic WordPress sites on Pantheon are put to sleep after either one or twelve hours pass without site visitors (see [idle containers](/application-containers#idle-containers) for more information). Pantheon Cron jobs do not run in sleeping environments. 
 
 ### Problems With High Traffic Sites
 
- You might run into problems with WP-Cron if your WordPress-powered site is high traffic. The main issues that come up are **race conditions** and **long running processes**.
+You might run into problems with WP-Cron if your WordPress-powered site is high traffic. The main issues that come up are **race conditions** and **long running processes**.
 
 - **Race condition**: When more than one user visits your site and triggers WP-Cron to execute the same job. WP-Cron works hard to eliminate race conditions, but they can still happen, especially on high traffic sites.
 - **Long running process**: Any task that takes longer than the standard 60 seconds to run. Developers can adjust how long a PHP task is allowed to run with the `set_time_limit()` function. If this is set to be longer than the window between jobs, then you can end up with more than one copy of `wp-cron.php` executing.
 
 Both of these issues are addressed within WP-Cron's internal [locking](https://core.trac.wordpress.org/browser/tags/4.1.1/src/wp-includes/cron.php#L231) doc. 
 
-You can also review the [Disable WP-Cron](#disable-wp-cron) section of this doc to limit the occurrences of the above issues.
+Pantheon Cron limits the occurrences of the above issues.


### PR DESCRIPTION
## Summary

With the launch of Pantheon Cron, the document needed a few re-organizations and clarifying points. We have also recently discovered that this change does not work with WordPress Multisites

**[Cron for WordPress](https://pantheon.io/docs/wordpress-cron)** - Clarify overall document, add exceptions for WPMS

### Dependencies and Timing

- [ ] Waiting on engineering to revert change to WPMS https://getpantheon.atlassian.net/browse/BUGS-4805

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
