### PR TITLE
[CMS-656] Update build tools links to 3.x branch and include github/github actions combination

### DIFF
--- a/source/content/guides/build-tools/01-introduction.md
+++ b/source/content/guides/build-tools/01-introduction.md
@@ -35,6 +35,8 @@ Build Tools currently supports the following combinations of Git and CI services
 
 1. [<em class="fa fa-github" /> GitHub](https://github.com) and [CircleCI](https://circleci.com/)
 
+1. [<em class="fa fa-github" /> GitHub](https://github.com) and [Github Actions](https://github.com/features/actions)
+
 1. [<em class="fa fa-gitlab" /> GitLab](https://about.gitlab.com) with [GitLabCI](https://about.gitlab.com/product/continuous-integration/)
 
 1. [<em class="fa fa-bitbucket" /> BitBucket](https://bitbucket.org/product/) with [BitBucket Pipelines](https://bitbucket.org/product/features/pipelines)

--- a/source/content/guides/build-tools/02-create-project.md
+++ b/source/content/guides/build-tools/02-create-project.md
@@ -55,7 +55,7 @@ Make sure you have the latest versions of Terminus and the Terminus Build Tools 
 
 ### Access Tokens (Optional)
 
-The Build Tools plugin will prompt you to create access tokens for both [GitHub](https://github.com/settings/tokens) and [CircleCI](https://circleci.com/account/api), which are stored as environment variables. The GitHub token needs the **repo** (required) and **delete-repo** (optional) scopes. Optionally, you may generate these tokens ahead of time and manually export them to the local variables `GITHUB_TOKEN` and `CIRCLE_TOKEN`, respectively:
+The Build Tools plugin will prompt you to create access tokens for both [GitHub](https://github.com/settings/tokens) and [CircleCI](https://circleci.com/account/api), which are stored as environment variables. The GitHub token needs the **repo** (required), **delete-repo** (optional) and **workflow** (required if using Github Actions) scopes. Optionally, you may generate these tokens ahead of time and manually export them to the local variables `GITHUB_TOKEN` and `CIRCLE_TOKEN`, respectively:
 
 ```bash{promptUser: user}
 export GITHUB_TOKEN=yourGitHubToken
@@ -66,7 +66,7 @@ If you need to replace a token, navigate to your [project settings page in Circl
 
 ## Create a Build Tools Project
 
-Scaffold a new project from a template repository and perform a one-time setup to connect an external Git provider and CI service with Pantheon. This setup also configures SSH keys and environment variables. To use your own template repository see [Customization](https://github.com/pantheon-systems/terminus-build-tools-plugin/blob/master/README.md#customization) in the Build Tools Plugin documentation.
+Scaffold a new project from a template repository and perform a one-time setup to connect an external Git provider and CI service with Pantheon. This setup also configures SSH keys and environment variables. To use your own template repository see [Customization](https://github.com/pantheon-systems/terminus-build-tools-plugin/blob/3.x/README.md#customization) in the Build Tools Plugin documentation.
 
 Modify the commands in the following examples to match your project's needs.
 
@@ -90,7 +90,7 @@ Modify the commands in the following examples to match your project's needs.
 
 The script will ask for additional information such as tokens/credentials for GitHub and the associated CI.
 
-For a list of all available command options, see the [Build Tools Project README](https://github.com/pantheon-systems/terminus-build-tools-plugin/blob/master/README.md#buildprojectcreate)
+For a list of all available command options, see the [Build Tools Project README](https://github.com/pantheon-systems/terminus-build-tools-plugin/blob/3.x/README.md#buildprojectcreate)
 
 ### Troubleshooting
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Create a new project](https://pantheon.io/docs/guides/build-tools/create-project/)** - Add references to Github actions and update README links to 3.x branch.

### Dependencies and Timing

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
