### PR TITLE
Update optimize-site-traffic.md

### DIFF
--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -17,7 +17,7 @@ To get the most information about your site's traffic, review the `nginx-access.
 
 Consult our doc for a list of [WordPress best practices](/wordpress-best-practices), and how to [avoid XML-RPC attacks](/wordpress-best-practices#avoid-xml-rpc-attacks) in particular.
 
-In addition to your other WordPress security practices, take steps to block **brute force attacks** that attempt to access your `wp-admin` dashboard and hyperinflate traffic to your site:
+In addition to your other WordPress security practices, take steps to block brute force attacks that attempt to access your `wp-admin` dashboard and hyperinflate traffic to your site:
 
 1. Create a separate administrator account with a strong password, then remove the `admin` account.
 
@@ -31,7 +31,7 @@ In addition to your other WordPress security practices, take steps to block **br
 
    </Accordion>
 
-1. Add a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to lure and ban bad bots.
+1. Add a [honeypot](https://wordpress.org/plugins/search/honeypot/) plugin to attract and ban bad bots.
 
 1. [Restrict Access to Paths Based on IP](/advanced-redirects#restrict-access-to-paths-based-on-ip).
 

--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -93,7 +93,8 @@ To block an IP, add the following to `settings.php` or `wp-config.php`. Remember
 
 ```php:title=wp-config.php%20or%20settings.php
 if ($_SERVER['REMOTE_ADDR'] == '192.0.2.38') {
-  header('HTTP/1.0 403 Forbidden');
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
   exit;
 }
 ```
@@ -129,7 +130,8 @@ if (!$request_ip_forbidden = in_array($request_remote_addr, $request_ip_blocklis
 }
 
 if ($request_ip_forbidden) {
-  header('HTTP/1.0 403 Forbidden');
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
   exit;
 }
 ```
@@ -187,7 +189,8 @@ Remember to replace the example user agent (`UglyBot`):
 ```php:title=wp-config.php%20or%20settings.php
 // Block a single bot.
 if (strpos($_SERVER['HTTP_USER_AGENT'], 'Bork-bot') !== FALSE) {
-  header('HTTP/1.0 403 Forbidden');
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
   exit;
 }
 
@@ -195,8 +198,9 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Bork-bot') !== FALSE) {
 $user_agents_deny_list = ['Go-http-client', 'gozilla', 'InstallShield.DigitalWizard', 'GT\:\:WWW'];
 foreach ($user_agents_deny_list as $agent) {
   if (strpos($_SERVER['HTTP_USER_AGENT'], $agent) !== FALSE) {
-    header('HTTP/1.0 403 Forbidden');
-    exit;
+  header('HTTP/1.0 301 Moved Permanently');
+  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
+  exit;
   }
 }
 ```


### PR DESCRIPTION
Swapped, in four places (two under IP blocking, two under user agent blocking):
```
  header('HTTP/1.0 403 Forbidden');
```
for
```
  header('HTTP/1.0 301 Moved Permanently');
  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
```

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Investigate and Remedy Traffic Events](https://pantheon.io/docs/optimize-site-traffic)** - Changed a section of scripting that was not preventing IP/user agent access to pages served via Fastly/Varnish.
Pre-change:
```
  header('HTTP/1.0 403 Forbidden');
```
Post-change:
```
  header('HTTP/1.0 301 Moved Permanently');
  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
```

## Effect

This change will allow the block to be cached on Fastly/Varnish, as it does seem to cache 3##-level responses

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Additional alerts to users already using the old, ineffective method?

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
