### PR TITLE
Revert "Update optimize-site-traffic.md"

### DIFF
--- a/source/content/optimize-site-traffic.md
+++ b/source/content/optimize-site-traffic.md
@@ -93,8 +93,7 @@ To block an IP, add the following to `settings.php` or `wp-config.php`. Remember
 
 ```php:title=wp-config.php%20or%20settings.php
 if ($_SERVER['REMOTE_ADDR'] == '192.0.2.38') {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
+  header('HTTP/1.0 403 Forbidden');
   exit;
 }
 ```
@@ -130,8 +129,7 @@ if (!$request_ip_forbidden = in_array($request_remote_addr, $request_ip_blocklis
 }
 
 if ($request_ip_forbidden) {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
+  header('HTTP/1.0 403 Forbidden');
   exit;
 }
 ```
@@ -189,8 +187,7 @@ Remember to replace the example user agent (`UglyBot`):
 ```php:title=wp-config.php%20or%20settings.php
 // Block a single bot.
 if (strpos($_SERVER['HTTP_USER_AGENT'], 'Bork-bot') !== FALSE) {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
+  header('HTTP/1.0 403 Forbidden');
   exit;
 }
 
@@ -198,9 +195,8 @@ if (strpos($_SERVER['HTTP_USER_AGENT'], 'Bork-bot') !== FALSE) {
 $user_agents_deny_list = ['Go-http-client', 'gozilla', 'InstallShield.DigitalWizard', 'GT\:\:WWW'];
 foreach ($user_agents_deny_list as $agent) {
   if (strpos($_SERVER['HTTP_USER_AGENT'], $agent) !== FALSE) {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: https://'. $_SERVER['HTTP_HOST'] . '/404');
-  exit;
+    header('HTTP/1.0 403 Forbidden');
+    exit;
   }
 }
 ```


### PR DESCRIPTION
## Summary

This reverts commit 94550a8b1f8991d5168905ee73419cf9475cb5ee which caused cached 301s for all requests

**[Investigate and Remedy Traffic Events](https://pantheon.io/docs/optimize-site-traffic#dos-attack-mitigation)** - Revert back to original suggested 403 which is not cached in Fastly

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
