### PR TITLE
Updates info on YITH WooCommerce plugins with MPDF

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1361,26 +1361,44 @@ ___
 1. Define the [FS_METHOD in the wp-config](#define-fs_method).
 ___
 
-## YITH WooCommerce Request a Quote
+## YITH WooCommerce Extensions with MPDF library
 
-<ReviewDate date="2022-04-8" />
+<ReviewDate date="2022-05-04" />
 
-**Issue:** [YITH WooCommerce Request a Quote](https://yithemes.com/themes/plugins/yith-woocommerce-request-a-quote/) uses the MPFD library which assumes write access to the site's codebase within the `wp-content/plugins` directory. This is applicable to the caching of PDFs, which is not granted on Test and Live environments on Pantheon. For additional details, refer to [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
+### Affected Plugins
+- [YITH WooCommerce Request a Quote](https://yithemes.com/themes/plugins/yith-woocommerce-request-a-quote/)
+- [YITH WooCommerce PDF Invoice and Shipping List](https://yithemes.com/themes/plugins/yith-woocommerce-pdf-invoice/)
+- [YITH WooCommerce Gift Cards](https://yithemes.com/themes/plugins/yith-woocommerce-gift-cards/)
 
-**Solution:**  Change the location where the plugin stores the PDF cache. Configure YITH WooCommerce Request a Quote to write files within the `wp-content/uploads` path for WordPress (`wp-content/uploads/ywraq_mpdf_tmp`) by adding the following code sample to `functions.php`:
+**Issue:** Various YITH WooCommerce extensions use the MPFD library which assumes write access to the site's codebase within the `wp-content/plugins` directory. This is applicable to the caching of PDFs, which is not granted on Test and Live environments on Pantheon. For additional details, refer to [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
 
-```php:title=wp-config.php
-/** Changes location where YITH WooCommerce Request a Quote stores PDF cache */
-add_filter( 'ywraq_mpdf_args', 'ywraq_mpdf_change_tmp_dir', 20, 1 );
-if ( ! function_exists( 'ywraq_mpdf_change_tmp_dir' ) ) {
-   function ywraq_mpdf_change_tmp_dir( $args ) {
+**Solution:**  Change the location where the plugin stores the PDF cache. Configure YITH WooCommerce Request a Quote to write files within the `wp-content/uploads` path for WordPress (`wp-content/uploads/yith-mpdf-tmp`) by adding the following code sample to `functions.php`:
+
+```php:title=functions.php
+/** 
+ * Changes PDF cache location for YITH WooCommerce extensions.
+ *
+ * @param array $args The configuration for MPDF initialization.
+ * @return array The updated config with writable path.
+ */
+if ( ! function_exists( 'yith_mpdf_change_tmp_dir' ) ) {
+   function yith_mpdf_change_tmp_dir( array $args ): array {
       $upload_dir      = wp_upload_dir();
       $upload_dir      = $upload_dir['basedir'];
-      $args['tempDir'] = $upload_dir . '/ywraq_mpdf_tmp/';
+      $args['tempDir'] = $upload_dir . '/yith-mpdf-tmp/';
 
       return $args;
    }
 }
+
+// Request a Quote
+add_filter( 'ywraq_mpdf_args', 'yith_mpdf_change_tmp_dir', 20, 1 );
+
+// PDF Invoice
+add_filter( 'yith_ywpdi_mpdf_args', 'yith_mpdf_change_tmp_dir', 10, 1 );
+
+// Gift Cards
+add_filter( 'yith_ywgc_mpdf_args', 'yith_mpdf_change_tmp_dir', 10, 1 );
 ```
 ___
 ## Yoast SEO

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1363,14 +1363,14 @@ ___
 
 ## YITH WooCommerce Extensions with MPDF library
 
-<ReviewDate date="2022-05-04" />
+<ReviewDate date="2023-03-09" />
 
 ### Affected Plugins
 - [YITH WooCommerce Request a Quote](https://yithemes.com/themes/plugins/yith-woocommerce-request-a-quote/)
 - [YITH WooCommerce PDF Invoice and Shipping List](https://yithemes.com/themes/plugins/yith-woocommerce-pdf-invoice/)
 - [YITH WooCommerce Gift Cards](https://yithemes.com/themes/plugins/yith-woocommerce-gift-cards/)
 
-**Issue:** Various YITH WooCommerce extensions use the MPFD library which assumes write access to the site's codebase within the `wp-content/plugins` directory. This is applicable to the caching of PDFs, which is not granted on Test and Live environments on Pantheon. For additional details, refer to [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
+**Issue:** Various YITH WooCommerce extensions use the MPFD library. This practice assumes write access to the site's codebase within the `wp-content/plugins` directory. This is applicable to the caching of PDFs, which is not granted on Test and Live environments on Pantheon. For additional details, refer to [Using Extensions That Assume Write Access](/symlinks-assumed-write-access).
 
 **Solution:**  Change the location where the plugin stores the PDF cache. Configure YITH WooCommerce Request a Quote to write files within the `wp-content/uploads` path for WordPress (`wp-content/uploads/yith-mpdf-tmp`) by adding the following code sample to `functions.php`:
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[WordPress Plugins and Themes with Known Issues](https://pantheon.io/docs/plugins-known-issues)** - Updates the YITH filters for MPDF file storage.

Since the same issue affects multiple YITH plugins that use the MPDF library, this makes the filter function reusable so it can be used as a callback for multiple filters.

Instead of adding two separate sections for each plugin, I combined them into a single section that can be easily updated as new plugins and filter names are needed.

Also updated the code sample to say the file is `functions.php` instead of `wp-config.php` since you can't use the `wp_upload_dir` function then.

## Effect

Changes the specific plugin section to a more general one, which is a new change for the page.

Code sample assumes the user's PHP version supports argument and return types. If that's not the case then the code will fail unless those are removed when pasting.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
