### PR TITLE
composer.lock should not be in the .gitignore

### DIFF
--- a/source/partials/ic-upstream-structure.md
+++ b/source/partials/ic-upstream-structure.md
@@ -20,7 +20,7 @@ code/
     - `composer.json`: Composer automatically updates `composer.json` with customizations for the upstream. Avoid manually modifying this file.
 - `pantheon.upstream.yml`: The `build_step: true` directive in `pantheon.upstream.yml` enables the build step.
 
-When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file, and commits it back to the site’s code repository. To avoid potential merge conflicts after applying an upstream update, do not commit the `composer.lock` file to the upstream repository and instead add it to the `.gitignore` file.
+When a site is created, Pantheon runs `composer install`, generates a `composer.lock` file, and commits it back to the site’s code repository. To avoid potential merge conflicts after applying an upstream update, do not commit the `composer.lock` file to the upstream repository.
 
 Build artifacts are stored in a Git tag like `pantheon_build_artifacts_$BRANCHNAME`, where `$BRANCHNAME` is the name of the environment or Multidev feature branch.
 


### PR DESCRIPTION
I added this line but later found out that it was incorrect. Sorry for the confusion

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

Removes the recomendation to add it to your .gitignore file since that cascades down and ignores the downstream .lock files that are needed.

**[Integrated Composer](https://pantheon.io/docs/guides/integrated-composer)** - composer.lock should not be in the .gitignore

## Effect

Fixes some incorrect advice I had added.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
