### PR TITLE
[BUGS-4147] User in Charge is no longer required to change upstream

### DIFF
--- a/source/content/guides/composer-convert.md
+++ b/source/content/guides/composer-convert.md
@@ -32,8 +32,6 @@ Add Drupal 8 core dependency instructions to `drupal/core-recommended`, to keep 
 
 ## Before You Begin
 
-- This guide requires [User in Charge](/change-management#site-level-roles-and-permissions) permissions to set the Upstream.
-
 - This guide is written for users with access to Pantheon's [Multidev](/multidev) feature. Pantheon support is not available to users who avoid the Multidev steps.
 
 - The site owner should ensure the trusted host setting is up-to-date. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.


### PR DESCRIPTION

## Summary

This reflects changes already present in production.  This is ready for merge now.

**[Convert a Standard Drupal 8 Site to a Composer Managed Site](https://pantheon.io/docs/guides/composer-convert)** - Remove statement that "User in Charge" is required to change upstream 

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
