### PR TITLE
[CMS-707] Add notes for previous WordPress releases to start-states/wordpress.md

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -14,25 +14,29 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
-### <a name="20220426-3"></a>Re-enable WP-Cron for site networks
+### 20220426
+
+#### <a name="20220426-3"></a>Re-enable WP-Cron for site networks
 
 Pantheon Cron does not support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. This change reenabled WP-Cron for WordPress Site Networks. You can read more about WP-Cron for WordPress Site Networks [here](https://pantheon.io/docs/wordpress-cron#wordpress-site-networks).
 
-### <a name="20220426-2"></a>Add documentation to readme outlining branches
+#### <a name="20220426-2"></a>Add documentation to readme outlining branches
 
 Adds documentation to `README.md` which provides context on the repositories branches. This change made to prevent further [customer confusion](https://github.com/pantheon-systems/WordPress/issues/322) with regards to which branch to use as a starting point when creating a custom upstream.
 
-### <a name="20220426-1"></a>Define FS_METHOD
+#### <a name="20220426-1"></a>Define FS_METHOD
 
 When this constant is not set, WordPress writes and then deletes a temporary file to determine if it has direct access to the filesystem, which we already know to be the case. This multiplies filesystem operations and can degrade performance of the filesystem as a whole in the case of large sites that do a lot of filesystem operations. Setting this constant to `direct` tells WordPress to assume it has direct access and skip creating the extra temporary file. Read more about `FS_METHOD` [here](https://pantheon.io/docs/plugins-known-issues#define-fs_method).
 
 ## Previous Releases
 
-### <a name="20220405-2"></a>Allow DISABLE_WP_CRON to be overridden
+### 20220405
+
+#### <a name="20220405-2"></a>Allow DISABLE_WP_CRON to be overridden
 
 Allowed customers to override DISABLE_WP_CRON by defining this constant in their wp-config.php before wp-config-pantheon.php is required. Read more about enabling WP-Cron [here](https://pantheon.io/docs/wordpress-cron#enable-wp-cron).
 
-### <a name="20220405-1"></a>Disable WP-Cron
+#### <a name="20220405-1"></a>Disable WP-Cron
 
 Disabled `wp-cron.php` from running on every page load and rely on Pantheon to run cron via WP-CLI. Read more about WP-Cron [here](https://pantheon.io/docs/wordpress-cron).
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -16,15 +16,15 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ### 2022-04-26
 
-#### <a name="20220426-3"></a>Re-enable WP-Cron for site networks
+#### <a name="20220426-3" class="release-update"></a>Re-enable WP-Cron for site networks
 
 Pantheon Cron does not support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. This change reenabled WP-Cron for WordPress Site Networks. You can read more about WP-Cron for WordPress Site Networks [here](https://pantheon.io/docs/wordpress-cron#wordpress-site-networks).
 
-#### <a name="20220426-2"></a>Add documentation to readme outlining branches
+#### <a name="20220426-2" class="release-update"></a>Add documentation to readme outlining branches
 
 Adds documentation to `README.md` which provides context on the repositories branches. This change made to prevent further [customer confusion](https://github.com/pantheon-systems/WordPress/issues/322) with regards to which branch to use as a starting point when creating a custom upstream.
 
-#### <a name="20220426-1"></a>Define FS_METHOD
+#### <a name="20220426-1" class="release-update"></a>Define FS_METHOD
 
 When this constant is not set, WordPress writes and then deletes a temporary file to determine if it has direct access to the filesystem, which we already know to be the case. This multiplies filesystem operations and can degrade performance of the filesystem as a whole in the case of large sites that do a lot of filesystem operations. Setting this constant to `direct` tells WordPress to assume it has direct access and skip creating the extra temporary file. Read more about `FS_METHOD` [here](https://pantheon.io/docs/plugins-known-issues#define-fs_method).
 
@@ -32,11 +32,11 @@ When this constant is not set, WordPress writes and then deletes a temporary fil
 
 ### 2022-04-05
 
-#### <a name="20220405-2"></a>Allow DISABLE_WP_CRON to be overridden
+#### <a name="20220405-2" class="release-update"></a>Allow DISABLE_WP_CRON to be overridden
 
 Allowed customers to override DISABLE_WP_CRON by defining this constant in their wp-config.php before wp-config-pantheon.php is required. Read more about enabling WP-Cron [here](https://pantheon.io/docs/wordpress-cron#enable-wp-cron).
 
-#### <a name="20220405-1"></a>Disable WP-Cron
+#### <a name="20220405-1" class="release-update"></a>Disable WP-Cron
 
 Disabled `wp-cron.php` from running on every page load and rely on Pantheon to run cron via WP-CLI. Read more about WP-Cron [here](https://pantheon.io/docs/wordpress-cron).
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -7,36 +7,38 @@ tags: [code, site, upstreams]
 showtoc: true
 permalink: docs/start-states/wordpress
 editpath: start-states/wordpress.md/
-reviewed: "2022-05-09"
+reviewed: "2022-05-11"
 ---
 
-Pantheon's WordPress upstream
-
-<https://github.com/pantheon-systems/WordPress>
-
-<https://github.com/pantheon-systems/WordPress/tags>
-
-<https://wordpress.org/news/category/releases/>
-
-[WP Best Practices](/wordpress-best-practices)
-
-## Main Differences
-
-- list
-- of things
-- that won't change
-- much
+For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-systems/WordPress) follows [WordPress core](https://wordpress.org/news/category/releases/) one-to-one. This document is intended to provide further context to platform-specific changes in Pantheon's WordPress upstream.
 
 ## Latest Release
 
-goes here
+### <a name="20220426-3"></a>Re-enable WP-Cron for site networks
+
+Pantheon Cron does not support WordPress Site Network installations, also known as WordPress Multisite, due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. This change reenabled WP-Cron for WordPress Site Networks. You can read more about WP-Cron for WordPress Site Networks [here](https://pantheon.io/docs/wordpress-cron#wordpress-site-networks).
+
+### <a name="20220426-2"></a>Add documentation to readme outlining branches
+
+Adds documentation to `README.md` which provides context on the repositories branches. This change made to prevent further [customer confusion](https://github.com/pantheon-systems/WordPress/issues/322) with regards to which branch to use as a starting point when creating a custom upstream.
+
+### <a name="20220426-1"></a>Define FS_METHOD
+
+When this constant is not set, WordPress writes and then deletes a temporary file to determine if it has direct access to the filesystem, which we already know to be the case. This multiplies filesystem operations and can degrade performance of the filesystem as a whole in the case of large sites that do a lot of filesystem operations. Setting this constant to `direct` tells WordPress to assume it has direct access and skip creating the extra temporary file. Read more about `FS_METHOD` [here](https://pantheon.io/docs/plugins-known-issues#define-fs_method).
 
 ## Previous Releases
 
-go here
+### <a name="20220405-2"></a>Allow DISABLE_WP_CRON to be overridden
+
+Allowed customers to override DISABLE_WP_CRON by defining this constant in their wp-config.php before wp-config-pantheon.php is required. Read more about enabling WP-Cron [here](https://pantheon.io/docs/wordpress-cron#enable-wp-cron).
+
+### <a name="20220405-1"></a>Disable WP-Cron
+
+Disabled `wp-cron.php` from running on every page load and rely on Pantheon to run cron via WP-CLI. Read more about WP-Cron [here](https://pantheon.io/docs/wordpress-cron).
 
 ## Related Links
 
 - [Pantheon Start States](/start-states)
 - [WordPress Best Practices](/wordpress-best-practices)
+- [WordPress and Drupal Core Updates](/core-updates)
 - [WordPress Plugins and Themes with Known Issues](/plugins-known-issues)

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -14,7 +14,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
-### 20220426
+### 2022-04-26
 
 #### <a name="20220426-3"></a>Re-enable WP-Cron for site networks
 
@@ -30,7 +30,7 @@ When this constant is not set, WordPress writes and then deletes a temporary fil
 
 ## Previous Releases
 
-### 20220405
+### 2022-04-05
 
 #### <a name="20220405-2"></a>Allow DISABLE_WP_CRON to be overridden
 

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -598,3 +598,11 @@ h2 > .glyphicons {
 h3.popover-title {
 	margin-top: 0px;;
 }
+
+a.release-update::before {
+	display: block;
+	content: "";
+	height: 160px;
+	margin-top: -160px;
+	visibility: hidden;
+}


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

Backfills the new WordPress upstream release notes page with notes from non-core related commits in 2022.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
