### PR TITLE
Add known issue regarding merge conflict with WP 6.0 twentytwentytwo theme

### DIFF
--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -74,4 +74,4 @@ See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress
 
 If you’ve updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) outside of Pantheon's WordPress upstream, updating to 6.0 will result in an error (due to the [removal](https://core.trac.wordpress.org/changeset/53286) of `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`).
 
-To resolve this error delete this file, commit and push your change, and reapply the update.
+To resolve this error delete this file, commit and push your change, and then reapply the update.

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -69,3 +69,9 @@ add_filter( 'wp_image_editors', 'force_use_gdlib' );
 ```
 
 See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress.org for more information.
+
+## Updating to WordPress 6.0
+
+If you’ve updated the `twentytwentytwo` theme outside of Pantheon's WordPress upstream, updating to 6.0 will result in an error (due to the [removal](https://core.trac.wordpress.org/changeset/53286) of `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`).
+
+To resolve this error delete this file, commit and push your change, and reapply the update.

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -72,6 +72,6 @@ See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress
 
 ## Updating to WordPress 6.0
 
-If you’ve updated the `twentytwentytwo` theme outside of Pantheon's WordPress upstream, updating to 6.0 will result in an error (due to the [removal](https://core.trac.wordpress.org/changeset/53286) of `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`).
+If you’ve updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) outside of Pantheon's WordPress upstream, updating to 6.0 will result in an error (due to the [removal](https://core.trac.wordpress.org/changeset/53286) of `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`).
 
 To resolve this error delete this file, commit and push your change, and reapply the update.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

Add known issue regarding merge conflict with WP 6.0 and twentytwentytwo theme. See [Slack discussion](https://pantheon.slack.com/archives/C024NA0Q1TJ/p1653509236092539) for additional context.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
