### PR TITLE
Reference correct branch in merge conflict docs

### DIFF
--- a/source/content/git-resolve-merge-conflicts.md
+++ b/source/content/git-resolve-merge-conflicts.md
@@ -4,7 +4,7 @@ description: Learn how to resolve conflicts in your site code base.
 categories: [troubleshoot]
 tags: [git, local, webops]
 contributors: [alexfornuto]
-reviewed: "2020-10-15"
+reviewed: "2022-05-26"
 ---
 
 [Git](https://git-scm.com/) is the version control tool at the heart of the Pantheon workflow. If you're a developer who likes to use [local development](/local-development), it's a good way to work with the Pantheon platform: develop locally, commit, and push to master to deploy code into your Pantheon Development environment.
@@ -26,7 +26,7 @@ This is safe to run if you don't have your own changes in any of the conflicting
 <Tab title="Drupal 8" id="d8" active={true}>
 
   ```bash{promptUser: user}
-  git pull -Xtheirs https://github.com/pantheon-systems/drops-8.git default
+  git pull -Xtheirs https://github.com/pantheon-systems/drops-8.git master
   # resolve conflicts
   git push origin master
   ```
@@ -36,7 +36,7 @@ This is safe to run if you don't have your own changes in any of the conflicting
 <Tab title="Drupal 7" id="d7">
 
   ```bash{promptUser: user}
-  git pull -Xtheirs https://github.com/pantheon-systems/drops-7.git default
+  git pull -Xtheirs https://github.com/pantheon-systems/drops-7.git master
   # resolve conflicts
   git push origin master
   ```
@@ -46,7 +46,7 @@ This is safe to run if you don't have your own changes in any of the conflicting
 <Tab title="WordPress" id="wp">
 
   ```bash{promptUser: user}
-  git pull -Xtheirs https://github.com/pantheon-systems/WordPress.git default
+  git pull -Xtheirs https://github.com/pantheon-systems/WordPress.git master
   # resolve conflicts
   git push origin master
   ```


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

The [resolving merge conflicts page](https://pantheon.io/docs/git-resolve-merge-conflicts#resolve-conflicts-when-updating-core) is referencing the wrong branch when running `git pull`. If there are other places that the branch referenced was changed from master to default, those should also be addressed.

### Dependencies and Timing

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)