### PR TITLE
[CMS-711] WordPress 6.0 release notes

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -51,6 +51,7 @@ Disabled `wp-cron.php` from running on every page load and rely on Pantheon to r
 ## Related Links
 
 - [Pantheon Start States](/start-states)
+- [WordPress on Pantheon Quick Start Guide](/guides/wordpress-pantheon)
 - [WordPress Best Practices](/wordpress-best-practices)
 - [WordPress and Drupal Core Updates](/core-updates)
 - [WordPress Plugins and Themes with Known Issues](/plugins-known-issues)

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -7,12 +7,22 @@ tags: [code, site, upstreams]
 showtoc: true
 permalink: docs/start-states/wordpress
 editpath: start-states/wordpress.md/
-reviewed: "2022-05-11"
+reviewed: "2022-06-01"
 ---
 
 For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-systems/WordPress) follows [WordPress core](https://wordpress.org/news/category/releases/) one-to-one. This document is intended to provide further context to platform-specific changes in Pantheon's WordPress upstream.
 
 ## Latest Release
+
+### 2022-05-24
+
+#### <a name="20220524-1" class="release-update"></a>WordPress 6.0
+
+If you’ve updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) outside of Pantheon's WordPress upstream, there are conflicting updates from the WordPress core repository.
+
+Pantheon will automatically resolve this conflict when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`
+
+## Previous Releases
 
 ### 2022-04-26
 
@@ -27,8 +37,6 @@ Adds documentation to `README.md` which provides context on the repositories bra
 #### <a name="20220426-1" class="release-update"></a>Define FS_METHOD
 
 When this constant is not set, WordPress writes and then deletes a temporary file to determine if it has direct access to the filesystem, which we already know to be the case. This multiplies filesystem operations and can degrade performance of the filesystem as a whole in the case of large sites that do a lot of filesystem operations. Setting this constant to `direct` tells WordPress to assume it has direct access and skip creating the extra temporary file. Read more about `FS_METHOD` [here](/plugins-known-issues#define-fs_method).
-
-## Previous Releases
 
 ### 2022-04-05
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -18,9 +18,9 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 #### <a name="20220524-1" class="release-update"></a>WordPress 6.0
 
-If you’ve updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) outside of Pantheon's WordPress upstream, there are conflicting updates from the WordPress core repository.
+If you have updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) bundled with Pantheon's WordPress upstream, for example with Autopilot or WP-CLI, then your site has conflicting commits with the latest WordPress 6.0 release.
 
-Pantheon will automatically resolve this conflict when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`
+Pantheon will automatically resolve these conflicts when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`
 
 ## Previous Releases
 

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -69,9 +69,3 @@ add_filter( 'wp_image_editors', 'force_use_gdlib' );
 ```
 
 See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress.org for more information.
-
-## Updating to WordPress 6.0
-
-If you’ve updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) outside of Pantheon's WordPress upstream, updating to 6.0 will result in an error (due to the [removal](https://core.trac.wordpress.org/changeset/53286) of `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`).
-
-To resolve this error delete this file, commit and push your change, and then reapply the update.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Adds release notes for WordPress 6.0 release, and removes 6.0 blurb from known issues page.

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Site Repository Tool [PR #9](https://github.com/pantheon-systems/site-repository-tool/pull/9)

**Release**:
- [ ] After dependencies above are complete

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
