### PR TITLE
removing "geolocation" in a section that isn't about geolocation

### DIFF
--- a/source/content/guides/edge-integrations/03-drupal-sdk.md
+++ b/source/content/guides/edge-integrations/03-drupal-sdk.md
@@ -124,7 +124,7 @@ In this section, we identify the content type where you want to use personalizat
 
 1. Review your content and tag it using the Tags vocabulary (e.g. "Biking").
 
-1. Navigate to `/admin/structure/smart_content_segment_set` to configure geolocation segments. 
+1. Navigate to `/admin/structure/smart_content_segment_set` to configure interest/taxonomy segments. 
 
 1. Click **+Add Global Segment Set**.
     ![Add Global Segment Set](../../../images/guides/edge-integrations/segementsetentities.png)


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary


[Configure Interest via Taxonomy](https://pantheon.io/docs/guides/edge-integrations/drupal-sdk/#configure-interest-via-taxonomy): This section of the Edge Integrations SDK has a minor (copy/paste?) error where the word "geolocation" is used outside of the geolocation section.



## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
