### PR TITLE
[CMS-711] Modify 6.0 release notes

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -18,9 +18,9 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 #### <a name="20220524-1" class="release-update"></a>WordPress 6.0
 
-If you have updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) bundled with Pantheon's WordPress upstream, for example with Autopilot or WP-CLI, then your site has conflicting commits with the latest WordPress 6.0 release.
+If you have updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) bundled with Pantheon's WordPress upstream, for example with Autopilot or WP-CLI, your site has conflicting commits with the latest WordPress 6.0 release.
 
-Pantheon will automatically resolve these conflicts when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) conflicting `LICENSE.md` files within the `wp-content/themes` directory.
+Pantheon will automatically resolve these conflicts when you click the `Apply Updates` button on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) conflicting `LICENSE.md` files within the `wp-content/themes` directory.
 
 ## Previous Releases
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -20,7 +20,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 If you have updated the [Twenty Twenty-Two theme](https://wordpress.org/themes/twentytwentytwo/) bundled with Pantheon's WordPress upstream, for example with Autopilot or WP-CLI, then your site has conflicting commits with the latest WordPress 6.0 release.
 
-Pantheon will automatically resolve these conflicts when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) `wp-content/themes/twentytwentytwo/assets/fonts/LICENSE.md`
+Pantheon will automatically resolve these conflicts when the `Apply Updates` button is clicked on your dashboard by [removing](https://core.trac.wordpress.org/changeset/53286) conflicting `LICENSE.md` files within the `wp-content/themes` directory.
 
 ## Previous Releases
 


### PR DESCRIPTION
## Summary

With the roll out of https://github.com/pantheon-systems/site-repository-tool/pull/12, more than one LICENSE.md file could be effected when applying upstream updates. This PR changes the 6.0 release notes to cover that.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
