### PR TITLE
[CMS-583] Add PHP version compatibility matrix to Terminus docs

### DIFF
--- a/source/content/terminus/updates.md
+++ b/source/content/terminus/updates.md
@@ -55,6 +55,22 @@ releases.
 
 </Alert>
 
+### PHP Version Compatibility Matrix
+
+| PHP Version | Terminus 3.x | Terminus 2.x |
+| -----------:|:-----------:| :--------: |
+| 8.2 | ❌          | ❌          |
+| 8.1 | ✅          | ❌          |
+| 8.0 | ✅          | ❌          |
+| 7.4 | ✅          | ❌          |
+| 7.3 | ❌          | ✅          |
+| 7.2 | ❌          | ✅          |
+| 7.1 | ❌          | ✅          |
+| 7.0 | ❌          | ✅          |
+| 5.6 | ❌          | ✅          |
+| 5.5 | ❌          | ✅          |
+| 5.3 | ❌          | ❌          |
+
 ## Troubleshooting
 
 ### Nothing to install or update


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes [CMS-583](https://getpantheon.atlassian.net/browse/CMS-583)

## Summary

Adds PHP version compatibility matrix to Terminus version page.

### Dependencies and Timing

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
