### PR TITLE
Fix some occurrences of drupal-recommended in docs.

### DIFF
--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -18,13 +18,13 @@ Drupal 9 sites on Pantheon have [Integrated Composer](/guides/integrated-compose
 
 By converting an empty upstream Drupal 8 site to a Composer-managed site you will do the following:
 
-1. Remove dependencies that Composer manages from the existing Drupal 8 site's Git repository, and have Composer manage those dependencies instead.
+* Remove dependencies that Composer manages from the existing Drupal 8 site's Git repository, and have Composer manage those dependencies instead.
 
-1. Switch to the `drupal-composer-managed` Integrated Composer upstream.
+* Switch to the `drupal-composer-managed` Integrated Composer upstream.
 
-The `drupal-composer-managed` Integrated Composer upstream works with Drupal 8, and following the `drupal-composer-managed` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
+The `drupal-composer-managed` Integrated Composer upstream works with Drupal 8, and following the `drupal-composer-managed` upstream will help keep your site current with any general configuration changes recommended by Pantheon.
 
-Add Drupal 8 core dependency instructions to `drupal/core-recommended`, to keep the site on Drupal 8 until you are ready to upgrade to Drupal 9.
+Add Drupal 8 core dependency instructions to `drupal/core-recommended` to keep the site on Drupal 8 until you are ready to upgrade to Drupal 9.
 
 ## Will This Guide Work for Your Site?
 
@@ -38,7 +38,7 @@ Add Drupal 8 core dependency instructions to `drupal/core-recommended`, to keep 
 
 - The site owner should ensure the trusted host setting is up-to-date. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
 
-- Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, **you should prepend the paths in this document with "web" as needed**.
+- Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, _you should prepend the paths in this document with "web" as needed_.
 
 <Alert title="Note" type="info">
 
@@ -62,7 +62,7 @@ If you receive the error message "The provided host name is not valid for this s
 
 ## Change Upstreams
 
-Your Pantheon site is now set up to use the Drupal 9 Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
+Your Pantheon site is now configured to use the Drupal 9 Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
 
 ```bash{promptUser:user}
 terminus site:upstream:set $SITE drupal-composer-managed

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -38,7 +38,7 @@ Add Drupal 8 core dependency instructions to `drupal/core-recommended` to keep t
 
 - The site owner should ensure the trusted host setting is up-to-date. Refer to the [Trusted Host Setting](/settings-php#trusted-host-setting) documentation for more information.
 
-- Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, _you should prepend the paths in this document with "web" as needed_.
+- Source site may or may not be using a [nested docroot](https://pantheon.io/docs/nested-docroot). If using it, you should prepend the paths in this document with "web" as needed.
 
 <Alert title="Note" type="info">
 

--- a/source/content/guides/composer-convert-from-empty.md
+++ b/source/content/guides/composer-convert-from-empty.md
@@ -1,6 +1,6 @@
 ---
 title: Convert an Empty Upstream Drupal Site to a Composer Managed Site
-description: Upgrade a Drupal 7 site using an empty upstream by converting it to a Composer-managed Drupal 7 site on the new Integrated Composer framework. 
+description: Upgrade a Drupal 8 site using an empty upstream by converting it to a Composer-managed Drupal 8 site on the new Integrated Composer framework. 
 type: guide
 permalink: docs/guides/:basename
 cms: "Drupal"
@@ -10,21 +10,21 @@ contributors: [dustinleblanc, greg-1-anderson, stovak, kporras07]
 reviewed: "2022-02-21"
 ---
 
-Use this guide to convert an empty upstream Drupal 7 site to use Composer to manage deployments and dependencies, then switch from `empty` to the new Integrated Composer `drupal-recommended` upstream while remaining on Drupal 7.
+Use this guide to convert an empty upstream Drupal 8 site to use Composer to manage deployments and dependencies, then switch from `empty` to the new Integrated Composer `drupal-composer-managed` upstream while remaining on Drupal 8.
 
 ## Overview
 
 Drupal 9 sites on Pantheon have [Integrated Composer](/guides/integrated-composer) built-in to manage site dependencies.
 
-By converting an empty upstream Drupal 7 site to a Composer-managed site you will do the following:
+By converting an empty upstream Drupal 8 site to a Composer-managed site you will do the following:
 
-1. Remove dependencies that Composer manages from the existing Drupal 7 site's Git repository, and have Composer manage those dependencies instead.
+1. Remove dependencies that Composer manages from the existing Drupal 8 site's Git repository, and have Composer manage those dependencies instead.
 
-1. Switch to the `drupal-recommended` Integrated Composer upstream.
+1. Switch to the `drupal-composer-managed` Integrated Composer upstream.
 
-The `drupal-recommended` Integrated Composer upstream works with Drupal 7, and following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
+The `drupal-composer-managed` Integrated Composer upstream works with Drupal 8, and following the `drupal-composer-managed` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon.
 
-Add Drupal 7 core dependency instructions to `drupal/core-recommended`, to keep the site on Drupal 7 until you are ready to upgrade to Drupal 9.
+Add Drupal 8 core dependency instructions to `drupal/core-recommended`, to keep the site on Drupal 8 until you are ready to upgrade to Drupal 9.
 
 ## Will This Guide Work for Your Site?
 
@@ -65,10 +65,10 @@ If you receive the error message "The provided host name is not valid for this s
 Your Pantheon site is now set up to use the Drupal 9 Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
 
 ```bash{promptUser:user}
-terminus site:upstream:set $SITE drupal-recommended
+terminus site:upstream:set $SITE drupal-composer-managed
 ```
 
-Following the `drupal-recommended` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon. The dependency you added above on `drupal/core-recommended` will keep you on Drupal 7 until you are ready to upgrade to Drupal 9.
+Following the `drupal-composer-managed` upstream will help keep your site up to date with any general configuration changes recommended by Pantheon. The dependency you added above on `drupal/core-recommended` will keep you on Drupal 8 until you are ready to upgrade to Drupal 9.
 
 ## Working With Dependency Versions
 

--- a/source/content/guides/drupal-9/drupal-9-hosted-createempty-md/17-troubleshooting.md
+++ b/source/content/guides/drupal-9/drupal-9-hosted-createempty-md/17-troubleshooting.md
@@ -21,7 +21,7 @@ If you encounter a `Permission denied (publickey)` error, check that your [SSH k
 If you continue to encounter the error, use HTTPS to add the remote:
 
 ```bash{outputLines:2}
-git remote add ic https://github.com/pantheon-upstreams/drupal-recommended.git && git fetch ic && git checkout --no-track -b composerify ic/master
+git remote add ic https://github.com/pantheon-upstreams/drupal-composer-managed.git && git fetch ic && git checkout --no-track -b composerify ic/master
 Switched to a new branch 'composerify'
 ```
 

--- a/source/content/guides/drupal-9/drupal-9-hosted-deprecated-upstream/03-prepare.md
+++ b/source/content/guides/drupal-9/drupal-9-hosted-deprecated-upstream/03-prepare.md
@@ -41,7 +41,7 @@ Use these values to determine which upstream a site is using:
 
 | Framework | Upstream | Site upstream is...
 |---|---|---
-|drupal8|https://github.com/pantheon-upstreams/drupal-project.git|drupal-recommended
+|drupal8|https://github.com/pantheon-upstreams/drupal-recommended.git|drupal-recommended
 |drupal8|https://github.com/pantheon-upstreams/drupal-project.git|drupal-project
 
 

--- a/source/content/guides/drupal-9/drupal-9-hosted-deprecated-upstream/11-troubleshooting.md
+++ b/source/content/guides/drupal-9/drupal-9-hosted-deprecated-upstream/11-troubleshooting.md
@@ -29,7 +29,7 @@ If you receive an error that you have conflicts while updating, resolve using th
 This is safe to run if you don't have your own changes in any of the conflicting files, such as problems with `.gitignore`.
 
 ```bash{promptUser: user}
-git pull -Xtheirs https://github.compantheon-upstreams/drupal-recommended.git master
+git pull -Xtheirs https://github.com/pantheon-upstreams/drupal-composer-managed.git master
 # resolve conflicts
 git push origin master
 ```

--- a/source/content/guides/drupal-9/drupal-9-unhosted-composer/05-contrib-custom.md
+++ b/source/content/guides/drupal-9/drupal-9-unhosted-composer/05-contrib-custom.md
@@ -91,7 +91,7 @@ Your existing site may have customizations to `settings.php` or other configurat
 
 1. Copy the existing `settings.php` to the Pantheon site and remove the `$databases` array if it exists.
 
-1. Ensure that everything in the [Pantheon settings.php](https://github.com/pantheon-upstreams/drupal-recommended/blob/master/web/sites/default/settings.php) is included.
+1. Ensure that everything in the [Pantheon settings.php](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/master/web/sites/default/settings.php) is included.
 
 1. Confirm that the `settings.php` file on the Pantheon D9 site:
 

--- a/source/content/guides/drupal-commandline.md
+++ b/source/content/guides/drupal-commandline.md
@@ -55,7 +55,7 @@ The next few sections of this guide use the example variables `my-d9-site` and `
 1. Create a new Drupal site on Pantheon:
 
   ```bash{promptUser: user}
-  terminus site:create my-d9-site "My D9 Site" "drupal-recommended"
+  terminus site:create my-d9-site "My D9 Site" "drupal-composer-managed"
   ```
 
   If you would like to associate this site with an Organization, you can add the `--org` option to the command above and pass the Organization name, label, or ID. To associate an existing site with an Organization, use the `site:org:add` command.

--- a/source/partials/drupal-apply-upstream-updates-drupal-recommended.md
+++ b/source/partials/drupal-apply-upstream-updates-drupal-recommended.md
@@ -1,4 +1,4 @@
-[Update the site](/core-updates) to the latest [Pantheon Drupal Recommended](https://github.com/pantheon-upstreams/drupal-recommended) Upstream and apply all available updates.
+[Update the site](/core-updates) to the latest [Pantheon Drupal Composer Managed](https://github.com/pantheon-upstreams/drupal-composer-managed) Upstream and apply all available updates.
 
 1. Use Terminus to list all available updates:
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Replaces several occurrences of drupal-recommended with drupal-composer-managed to reference new upstream.

I'm also updating a doc that was wrongly mentioning Drupal 7 several times

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
