### PR TITLE
Reduce confusing context

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -971,7 +971,7 @@ export ENV=dev
   git clone ssh://codeserver.dev.xxx@codeserver.dev.xxx.drush.in:2222/~/repository.git my-site
   ```
 
-1. Navigate to the codebase directory and create the symlinks listed below:
+1. Navigate to the `code/` directory and create the symlinks listed below:
 
   <Alert title="Note"  type="info" >
 
@@ -980,6 +980,7 @@ export ENV=dev
   </Alert>
 
   ```bash{promptUser: user}
+  cd code/
   ln -s ../../files/private/wflogs ./wp-content/wflogs
   ln -s ../files/private/wordfence-waf.php ./wordfence-waf.php
   ln -s ../files/private/.user.ini ./.user.ini

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -971,16 +971,22 @@ export ENV=dev
   git clone ssh://codeserver.dev.xxx@codeserver.dev.xxx.drush.in:2222/~/repository.git my-site
   ```
 
-1. Navigate to the `code/` directory and create the symlinks listed below:
+1. Change to the `code` directory:
+
+   ```bash{promptUser: user}
+   cd code/
+   ```
+   
+1. Create the following symlinks:
 
   <Alert title="Note"  type="info" >
 
-  You must remove the `/wp-content/wflogs` file if it already exists before you create the symlinks listed below.
+  You must remove the `/wp-content/wflogs` file, if it already exists, before you create the symlinks listed below.
 
   </Alert>
 
   ```bash{promptUser: user}
-  cd code/
+  
   ln -s ../../files/private/wflogs ./wp-content/wflogs
   ln -s ../files/private/wordfence-waf.php ./wordfence-waf.php
   ln -s ../files/private/.user.ini ./.user.ini


### PR DESCRIPTION
This might be not very clear for some of the users. Instead, we should add more straightforward directions like go to code/ (use `cd code`).