### PR TITLE
[DOC-637] Add end-of-sale language to php-versions

### DIFF
--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -68,7 +68,7 @@ End-of-Sale versions are no longer available to new sites on the platform.  Exis
 
 </dl>
 
-\* Sites that use this version of PHP will continue to serve pages, but new development cannot be done. The behavior of the development environment is undefined and not supported. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment.
+\* Sites that use PHP version 5.3 will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can upgrade your PHP version in the development environment to resume development on your site. 
 
 #### Compatibility Considerations
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -34,13 +34,13 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | [8.1](https://v81-php-info.pantheonsite.io/)| ➖ | Available <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.1. New Relic is not supported in PHP 8.1." /> |
 | [8.0](https://v80-php-info.pantheonsite.io/) | ✅          | Active <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.0." /> |
 | [7.4](https://v74-php-info.pantheonsite.io/) | ✅          | Active  |
-| [7.3](https://v73-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.2](https://v72-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.1](https://v71-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.0](https://v70-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [5.6](https://v56-php-info.pantheonsite.io/) | ❌          | EOL |
-| [5.5](https://v55-php-info.pantheonsite.io/) | ❌          | EOL |
-| [5.3](https://v53-php-info.pantheonsite.io/) | ❌          | EOL * |
+| [7.3](https://v73-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.2](https://v72-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.1](https://v71-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.0](https://v70-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [5.6](https://v56-php-info.pantheonsite.io/) | ⚠️          | EOL |
+| [5.5](https://v55-php-info.pantheonsite.io/) | ❌          | End-of-Sale |
+| [5.3](https://v53-php-info.pantheonsite.io/) | ❌          | End-of-Sale * |
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
@@ -50,7 +50,19 @@ Click on the links above to see the complete PHP info for each version, includin
 
 <dd>
 
-End-of-life (**EOL**) versions are available on the platform but no longer under active development, and should not be used unless absolutely necessary.
+End-of-life (**EOL**) versions are available on the platform but no longer receiving updates, and should not be used unless absolutely necessary.
+
+</dd>
+
+</dl>
+
+<dl>
+
+<dt>End-of-Sale</dt>
+
+<dd>
+
+End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future.
 
 </dd>
 


### PR DESCRIPTION
Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**Upgrade PHP Versions ([Live site](https://pantheon.io/docs/php-versions), [PR preview](https://pr-7440--pantheon-docs.my.pantheonfrontend.website/docs/php-versions))** - Add "End-of-Sale" language for PHP 5.3 and 5.5.  Changed EOL icon to a warning symbol so EOS could have the red X.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
