### PR TITLE
[DOC-637] (not for merge) PHP end-of-sale alternatives

### DIFF
--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -68,7 +68,7 @@ End-of-Sale versions are no longer available to new sites on the platform.  Exis
 
 </dl>
 
-\* Sites that use this version of PHP will continue to serve pages, but new development cannot be done. The behavior of the development environment is undefined and not supported. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment.
+\* Sites that use PHP version 5.3 will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can upgrade your PHP version in the development environment to resume development on your site. 
 
 #### Compatibility Considerations
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -40,7 +40,7 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | [7.0](https://v70-php-info.pantheonsite.io/) | ❌          | EOL     |
 | [5.6](https://v56-php-info.pantheonsite.io/) | ❌          | EOL |
 | [5.5](https://v55-php-info.pantheonsite.io/) | 🚫          | End-of-Sale <Popover title="End-of-Sale" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future." /> |
-| [5.3](https://v53-php-info.pantheonsite.io/) | 🚫          | End-of-Sale <Popover title="Retired" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment." />* |
+| [5.3](https://v53-php-info.pantheonsite.io/) | 🚫          | End-of-Sale <Popover title="End-of-Sale" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment." />* |
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -34,13 +34,13 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | [8.1](https://v81-php-info.pantheonsite.io/)| ➖ | Available <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.1. New Relic is not supported in PHP 8.1." /> |
 | [8.0](https://v80-php-info.pantheonsite.io/) | ✅          | Active <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.0." /> |
 | [7.4](https://v74-php-info.pantheonsite.io/) | ✅          | Active  |
-| [7.3](https://v73-php-info.pantheonsite.io/) | ⚠️          | EOL     |
-| [7.2](https://v72-php-info.pantheonsite.io/) | ⚠️          | EOL     |
-| [7.1](https://v71-php-info.pantheonsite.io/) | ⚠️          | EOL     |
-| [7.0](https://v70-php-info.pantheonsite.io/) | ⚠️          | EOL     |
-| [5.6](https://v56-php-info.pantheonsite.io/) | ⚠️          | EOL |
-| [5.5](https://v55-php-info.pantheonsite.io/) | ❌          | End-of-Sale |
-| [5.3](https://v53-php-info.pantheonsite.io/) | ❌          | End-of-Sale * |
+| [7.3](https://v73-php-info.pantheonsite.io/) | ❌          | EOL     |
+| [7.2](https://v72-php-info.pantheonsite.io/) | ❌          | EOL     |
+| [7.1](https://v71-php-info.pantheonsite.io/) | 🛑          | EOL     |
+| [7.0](https://v70-php-info.pantheonsite.io/) | 🛑          | EOL     |
+| [5.6](https://v56-php-info.pantheonsite.io/) | ❌          | EOL |
+| [5.5](https://v55-php-info.pantheonsite.io/) | ❌❗️          | End-of-Sale <Popover title="End-of-Sale" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future." /> |
+| [5.3](https://v53-php-info.pantheonsite.io/) | 🚫          | Retired <Popover title="Retired" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment." />* |
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -34,13 +34,13 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | [8.1](https://v81-php-info.pantheonsite.io/)| ➖ | Available <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.1. New Relic is not supported in PHP 8.1." /> |
 | [8.0](https://v80-php-info.pantheonsite.io/) | ✅          | Active <Popover title="Compatibility Note" content="WordPress is not fully compatible with PHP 8.0." /> |
 | [7.4](https://v74-php-info.pantheonsite.io/) | ✅          | Active  |
-| [7.3](https://v73-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.2](https://v72-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.1](https://v71-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.0](https://v70-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [5.6](https://v56-php-info.pantheonsite.io/) | ❌          | EOL |
-| [5.5](https://v55-php-info.pantheonsite.io/) | ❌          | EOL |
-| [5.3](https://v53-php-info.pantheonsite.io/) | ❌          | EOL * |
+| [7.3](https://v73-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.2](https://v72-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.1](https://v71-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [7.0](https://v70-php-info.pantheonsite.io/) | ⚠️          | EOL     |
+| [5.6](https://v56-php-info.pantheonsite.io/) | ⚠️          | EOL |
+| [5.5](https://v55-php-info.pantheonsite.io/) | ❌          | End-of-Sale |
+| [5.3](https://v53-php-info.pantheonsite.io/) | ❌          | End-of-Sale * |
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
@@ -50,7 +50,19 @@ Click on the links above to see the complete PHP info for each version, includin
 
 <dd>
 
-End-of-life (**EOL**) versions are available on the platform but no longer under active development, and should not be used unless absolutely necessary.
+End-of-life (**EOL**) versions are available on the platform but no longer receiving updates, and should not be used unless absolutely necessary.
+
+</dd>
+
+</dl>
+
+<dl>
+
+<dt>End-of-Sale</dt>
+
+<dd>
+
+End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future.
 
 </dd>
 

--- a/source/content/php-versions.md
+++ b/source/content/php-versions.md
@@ -36,17 +36,17 @@ Changes made to the `pantheon.yml` file on a branch **are not** detected when cr
 | [7.4](https://v74-php-info.pantheonsite.io/) | ✅          | Active  |
 | [7.3](https://v73-php-info.pantheonsite.io/) | ❌          | EOL     |
 | [7.2](https://v72-php-info.pantheonsite.io/) | ❌          | EOL     |
-| [7.1](https://v71-php-info.pantheonsite.io/) | 🛑          | EOL     |
-| [7.0](https://v70-php-info.pantheonsite.io/) | 🛑          | EOL     |
+| [7.1](https://v71-php-info.pantheonsite.io/) | ❌          | EOL     |
+| [7.0](https://v70-php-info.pantheonsite.io/) | ❌          | EOL     |
 | [5.6](https://v56-php-info.pantheonsite.io/) | ❌          | EOL |
-| [5.5](https://v55-php-info.pantheonsite.io/) | ❌❗️          | End-of-Sale <Popover title="End-of-Sale" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future." /> |
-| [5.3](https://v53-php-info.pantheonsite.io/) | 🚫          | Retired <Popover title="Retired" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment." />* |
+| [5.5](https://v55-php-info.pantheonsite.io/) | 🚫          | End-of-Sale <Popover title="End-of-Sale" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future." /> |
+| [5.3](https://v53-php-info.pantheonsite.io/) | 🚫          | End-of-Sale <Popover title="Retired" content="End-of-Sale versions are no longer available to new sites on the platform.  Existing sites using these versions will be automatically upgraded in the future. To resume development on a site using a retired version of PHP, upgrade the PHP version on the development environment." />* |
 
 Click on the links above to see the complete PHP info for each version, including the list of supported PHP extensions.
 
 <dl>
 
-<dt>EOL</dt>
+<dt>❌ EOL</dt>
 
 <dd>
 
@@ -58,7 +58,7 @@ End-of-life (**EOL**) versions are available on the platform but no longer recei
 
 <dl>
 
-<dt>End-of-Sale</dt>
+<dt>🚫 End-of-Sale</dt>
 
 <dd>
 


### PR DESCRIPTION
Some alternative example formatting ideas for [PR 7740](https://github.com/pantheon-systems/documentation/pull/7440)

## Summary

**PHP Versions ( [Live site](https://pantheon.io/docs/php-versions), [PR preview](https://pr-7441--pantheon-docs.my.pantheonfrontend.website/docs/php-versions) )** - A variety of other icon possibilities, example pop-overs for EOL and End-of-Sale
## Effect


### Dependencies and Timing


**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
