### PR TITLE
[EI-243] Edge Integrations WP API documentation

### DIFF
--- a/source/content/guides/edge-integrations/04-wordpress-sdk.md
+++ b/source/content/guides/edge-integrations/04-wordpress-sdk.md
@@ -97,6 +97,56 @@ A company using Edge Integrations might want to use query strings to define a vi
 
 To implement this, refer to the [example](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/blob/main/docs/interest.md#set_interest) in our WordPress SDK repository.
 
+## WP REST API
+
+The WordPress Edge Integrations plugin provides REST API endpoints for all of the major functions and output available via server-side PHP code. This allows JavaScript-based front-ends and custom Gutenberg blocks to be informed about Edge Integrations configuration, segments and user data. Edge Integrations uses the `pantheon/v1/ei` endpoint (e.g. `https://domain.com/wp-json/pantheon/v1/ei`) and exposes the following endpoints:
+
+* `/pantheon/v1/ei/segments`
+* `/pantheon/v1/ei/segments/connection`
+* `/pantheon/v1/ei/segments/geo`
+* `/pantheon/v1/ei/segments/interests`
+* `/pantheon/v1/ei/config`
+* `/pantheon/v1/ei/config/geo/allowed`
+* `/pantheon/v1/ei/config/interest/cookie-expiration`
+* `/pantheon/v1/ei/config/interest/post-types`
+* `/pantheon/v1/ei/config/interest/taxonomies`
+* `/pantheon/v1/ei/config/interest/threshold`
+* `/pantheon/v1/ei/user`
+* `/pantheon/v1/ei/user/conn-speed`
+* `/pantheon/v1/ei/user/conn-type`
+* `/pantheon/v1/ei/user/geo/city`
+* `/pantheon/v1/ei/user/geo/continent-code`
+* `/pantheon/v1/ei/user/geo/country-code`
+* `/pantheon/v1/ei/user/geo/country-name`
+* `/pantheon/v1/ei/user/geo/region`
+* `/pantheon/v1/ei/user/interest`
+
+A full list and descriptions of all endpoints exists in the [WordPress Edge Integrations SDK documentation](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk/tree/main/docs). API documentation and the ability to make test requests can also be done from the [API documentation](https://pantheon.stoplight.io/docs/edge-integrations/fed9ddb2a5046-ei)
+
+### Segments
+
+These endpoints expose the different types of segments available with Edge Integrations. It does *not* necessarily reflect the *currently active* segments (see [Config](#Config) below). _Segments_, in this context, mean the different ways by which users can be identified. For Edge Integrations, this means information gathered about a user based on their geolocation information and interest tracking. For the purposes of the API, "connection" is split away from the other "geo" segments into its own namespace. 
+
+[Read more about `segments`](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments).
+
+### Config
+
+The `config` endpoints expose information about how the Edge Integrations plugin works and what the current settings are. Most of these reflect things that are set via the filters available in the main `Pantheon\EI\WP` namespace as well as those in `Pantheon\EI\WP\Interest` and `Pantheon\EI\WP\Geo`. These allow you to have an understanding of the current working state of the plugin in the API.
+
+[Read more about `config`](https://pantheon.stoplight.io/docs/edge-integrations/edaa3dbe9bca3-ei-config).
+
+### User
+
+The `user` endpoints allow you to get information about the current user. Because it's possible a JavaScript frontend or Gutenberg block may be unaware of the current HTTP headers sent from the CDN, query parameters can be passed into any of these endpoints to forward that information from the server to the front-end, allowing you to interact with that information if it's not otherwise available.
+
+[Read more about `user`](https://pantheon.stoplight.io/docs/edge-integrations/9adbc8702b480-ei-user).
+
+## How to Integrate with Gutenberg/the WordPress Block Editor
+
+The WordPress Edge Integrations plugin doesn't have any block editor integration out of the box, but the API endpoints described above can be used as a foundation upon which to build blocks that meet the needs of your site and implementation. 
+
+[Read more about blocks](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/).
+
 ## How to Integrate with Cookie Consent Management Plugins
 
 Integrating cookie consent management plugins disallows user tracking if the user has not accepted cookies or other forms of local storage. This might be required based on the privacy laws of your region. In those cases, you cannot store any tracking information unless the user consents to it.

--- a/source/content/guides/edge-integrations/04-wordpress-sdk.md
+++ b/source/content/guides/edge-integrations/04-wordpress-sdk.md
@@ -99,7 +99,7 @@ To implement this, refer to the [example](https://github.com/pantheon-systems/ed
 
 ## WP REST API
 
-The WordPress Edge Integrations plugin provides REST API endpoints for all of the major functions and output available via server-side PHP code. This allows JavaScript-based front-ends and custom Gutenberg blocks to be informed about Edge Integrations configuration, segments and user data. Edge Integrations uses the `pantheon/v1/ei` endpoint (e.g. `https://domain.com/wp-json/pantheon/v1/ei`) and exposes the following endpoints:
+The WordPress Edge Integrations plugin provides REST API endpoints for all of the major functions and output available via server-side PHP code. This allows JavaScript-based front-ends and custom Gutenberg blocks to be informed about the Edge Integrations configuration, segments, and user data. Edge Integrations uses the `pantheon/v1/ei` endpoint (e.g. `https://domain.com/wp-json/pantheon/v1/ei`) and exposes the following endpoints:
 
 * `/pantheon/v1/ei/segments`
 * `/pantheon/v1/ei/segments/connection`
@@ -125,13 +125,13 @@ A full list and descriptions of all endpoints exists in the [WordPress Edge Inte
 
 ### Segments
 
-These endpoints expose the different types of segments available with Edge Integrations. It does *not* necessarily reflect the *currently active* segments (see [Config](#Config) below). _Segments_, in this context, mean the different ways by which users can be identified. For Edge Integrations, this means information gathered about a user based on their geolocation information and interest tracking. For the purposes of the API, "connection" is split away from the other "geo" segments into its own namespace. 
+The endpoints above expose the different types of segments available within Edge Integrations. It does not necessarily reflect the currently active segments (more information can be found in the [Config section](#Config) below). In this context, Segments indicate the different ways users can be identified. For Edge Integrations, it is information gathered about a user based on their geolocation information and interest tracking. For the purposes of the API, "connection" is split away from the other "geo" segments into its own namespace. 
 
 [Read more about `segments`](https://pantheon.stoplight.io/docs/edge-integrations/48045c3028625-ei-segments).
 
 ### Config
 
-The `config` endpoints expose information about how the Edge Integrations plugin works and what the current settings are. Most of these reflect things that are set via the filters available in the main `Pantheon\EI\WP` namespace as well as those in `Pantheon\EI\WP\Interest` and `Pantheon\EI\WP\Geo`. These allow you to have an understanding of the current working state of the plugin in the API.
+The `config` endpoints expose information about how the Edge Integrations plugin works and what the current settings are. Most of these reflect what is set via the filters available in the main `Pantheon\EI\WP` namespace, as well as those in `Pantheon\EI\WP\Interest` and `Pantheon\EI\WP\Geo`. These allow you to have an understanding of the current working state of the plugin in the API.
 
 [Read more about `config`](https://pantheon.stoplight.io/docs/edge-integrations/edaa3dbe9bca3-ei-config).
 
@@ -143,7 +143,7 @@ The `user` endpoints allow you to get information about the current user. Becaus
 
 ## How to Integrate with Gutenberg/the WordPress Block Editor
 
-The WordPress Edge Integrations plugin doesn't have any block editor integration out of the box, but the API endpoints described above can be used as a foundation upon which to build blocks that meet the needs of your site and implementation. 
+The WordPress Edge Integrations plugin does not have any block editor integration out of the box, but the API endpoints described above can be used as a foundation upon which to build blocks that meet the needs of your site and implementation. 
 
 [Read more about blocks](https://developer.wordpress.org/block-editor/how-to-guides/block-tutorial/writing-your-first-block-type/).
 


### PR DESCRIPTION
## Summary

**[Edge Integrations/WordPress SDK](https://pantheon.io/docs/guides/edge-integrations/wordpress-sdk/)** - Adds a new section about WP REST API integration.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
