### PR TITLE
Change php version to 7.3

### DIFF
--- a/source/content/drupal-phpstorm.md
+++ b/source/content/drupal-phpstorm.md
@@ -45,7 +45,7 @@ Make sure your Dev environment is in Git mode, then [clone your Git repository](
 
 1. Choose the Drupal major version.
 
-1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level 5.3.
+1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level 7.3.
 
 ### Drush Support
 

--- a/source/content/drupal-phpstorm.md
+++ b/source/content/drupal-phpstorm.md
@@ -45,7 +45,7 @@ Make sure your Dev environment is in Git mode, then [clone your Git repository](
 
 1. Choose the Drupal major version.
 
-1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level with the desired/appropriate version of PHP (e.g. 8.0).
+1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level with the appropriate version of PHP (e.g. 8.0).
 
 ### Drush Support
 

--- a/source/content/drupal-phpstorm.md
+++ b/source/content/drupal-phpstorm.md
@@ -45,7 +45,7 @@ Make sure your Dev environment is in Git mode, then [clone your Git repository](
 
 1. Choose the Drupal major version.
 
-1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level 7.3.
+1. Configure the correct version of PHP by going to **Preferences**  > **Languages & Frameworks** > [**PHP**](https://www.jetbrains.com/help/phpstorm/php.html), and choose PHP Language Level with the desired/appropriate version of PHP (e.g. 8.0).
 
 ### Drush Support
 


### PR DESCRIPTION
Closes #

## Summary

**[Configuring JetBrains PhpStorm IDE with Drupal on Pantheon](https://pantheon.io/docs/drupal-phpstorm)** - Change php version to 7.3

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
