### PR TITLE
Blank box blocked mouse interaction

### DIFF
--- a/src/components/toc/style.css
+++ b/src/components/toc/style.css
@@ -1,22 +1,3 @@
-
-/*
-  Tocbot Library hack (used inTable of Contents component)
-  this solves the scrolling overlap with the nav bar
-*/
-@media (min-width: 769px) {
-  #doc h1::before,
-  #terminus h1::before,
-  #doc h2::before,
-  #terminus h2::before,
-  #doc h3::before,
-  #terminus h3::before {
-    display: block;
-    content: "";
-    height: 160px;
-    margin-top: -160px;
-    visibility: hidden;
-  }
-}
 #doc h1,
 #terminus h1,
 #doc h2,

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -2,6 +2,7 @@
 html {
 	position: relative;
 	min-height: 100%;
+	scroll-padding-top: 160px;
 }
 
 p,


### PR DESCRIPTION
## Summary

Due to the absolute-positioned navigation bar on Desktop, regular anchor links would have the title hidden.

This was originally combatted by adding an empty `:before` element of 160px height, which did fix the problem but caused another, it overlaps the section before it and prevents mouse clicking on those elements under it. 

This PR is to use the CSS property `scroll-padding-top` on the global `html` element to put these in view of the user. This works well except that the ToC element is a little too clever and adds its own spacing on top of this. It works when refreshing a page or navigating directly to it, but using the sidebar navigation doesn't work. 

It should probably also be adjusted or removed for mobile.

You can see the current behavior when trying to scroll by clicking on the horizontal scrollbar here:
https://pantheon.io/docs/rsync-and-sftp#download-a-drupal-directory-from-pantheon

## Remaining Work and Prerequisites

- [ ] Override or remove the `winScrollTop` variable in `jquery.tocify.js` 
- [ ] Test with different browser widths
- [ ] Test any alternate views that may use anchor tags

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
