### PR TITLE
Update Autopilot Error - add Integrated Composer

### DIFF
--- a/source/content/guides/autopilot/05-troubleshoot.md
+++ b/source/content/guides/autopilot/05-troubleshoot.md
@@ -234,13 +234,21 @@ Ensure the Dev environment is live and reachable with no fatal errors and return
 
 <Accordion title="Could not create or reset the Autopilot Multidev due to an unexpected error." id="cannot-converge-multidev" icon="info-sign">
 
-### Diagnosis
+### CMS Error
 
+#### Diagnosis
 This can result from Drush or WP-CLI failing after `db pull`. This might be Autopilot specific, due to a site-level CMS issue, or could also be due to a platform-wide event.
 
-### Solution
-
+#### Solution
 Check that CLI cache clear steps work in the Dev environment. See if creating other Multidevs works correctly, delete the Autopilot environment and branch. Deleting the branch is important because the branch remains in Git if only the Multidev is deleted. If these actions works correctly, try running Autopilot again.
+
+### Composer Error
+
+#### Diagnoses
+If utilizing [Integrated Composer](https://pantheon.io/docs/guides/integrated-composer), the error could be caused by a composer build failure.
+
+#### Solution
+Check the build log in the site dashboard on the latest commit to see if an error was posted, or test locally running `composer install` or `composer update` using [Composer 2](https://pantheon.io/docs/guides/integrated-composer#pantheon-supports-composer-2) to see if any issues can be identified.
 
 </Accordion>
 

--- a/source/content/guides/autopilot/05-troubleshoot.md
+++ b/source/content/guides/autopilot/05-troubleshoot.md
@@ -244,11 +244,13 @@ Check that CLI cache clear steps work in the Dev environment. See if creating ot
 
 ### Composer Error
 
-#### Diagnoses
-If utilizing [Integrated Composer](https://pantheon.io/docs/guides/integrated-composer), the error could be caused by a composer build failure.
+#### Diagnosis
+The error could be caused by a Composer build failure if you are utilizing [Integrated Composer](https://pantheon.io/docs/guides/integrated-composer), 
 
 #### Solution
-Check the build log in the site dashboard on the latest commit to see if an error was posted, or test locally running `composer install` or `composer update` using [Composer 2](https://pantheon.io/docs/guides/integrated-composer#pantheon-supports-composer-2) to see if any issues can be identified.
+Check the build log in the Site dashboard. Review the most recent commit to see if an error was posted.
+
+You can also use [Composer 2](https://pantheon.io/docs/guides/integrated-composer#pantheon-supports-composer-2) to test locally and identify issues by running `composer install` or `composer update`
 
 </Accordion>
 


### PR DESCRIPTION
## Summary

Sometimes a failure to create a multidev is due to a Composer build error when using a site with Integrated Composer. This captures that potential scenario to provide a customer another option to investigate.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Troubleshoot Autopilot Error Messages](https://pantheon.io/docs/guides/autopilot/troubleshoot-autopilot)** - Add another issue that may cause an Autopilot multidev to fail to create.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Add new issue / solution

## Remaining Work and Prerequisites

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
