### PR TITLE
[CMS-799][BUGS-5125] Release notes for pantheon-cache WPCLI command deprecation, REST API responses

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -14,7 +14,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
-### 2022-08-16
+### 2022-08-30
 
 #### <a name="20220818" class="release-update"></a>Ensure REST API responses are not cached for authenticated users
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -14,6 +14,16 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
+### 2022-08-16
+
+#### <a name="20220816" class="release-update"></a>Deprecate `pantheon-cache` in favor of `pantheon cache`
+
+When the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) plugin is active, WordPress sites on Pantheon have two distinct but similarly-named WP-CLI commands: `wp pantheon cache` (which is provided by Pantheon Advanced Page Cache) and `wp pantheon-cache` (which is provided by the Pantheon mu-plugin. This creates in a confusing end result where it's unclear what Pantheon cache WP-CLI command to use or which subcommands are available for which parent commands.
+
+This change aims to help eliminate this confusion by deprecating `wp pantheon-cache` and moving the `set-maintenance-mode` subcommand under `pantheon cache`. When the `pantheon-cache` command is run, a deprecation notice will be displayed with the updated command and the function will be executed. A deprecation notice has also been added to the text that displays when a user runs `wp pantheon-cache set-maintenance-mode --help`. The `pantheon-cache` command will be removed and display an error when run in a future release, and fully removed entirely in a release following that.
+
+## Previous Releases
+
 ### 2022-07-12
 
 #### <a name="20220606-1" class="release-update"></a>Show a more meaningful notice when trying to install WP plugin in Git mode
@@ -30,8 +40,6 @@ The update notice behavior will be as follows:
 - If a WP Core update is not detected, the update notice is only shown on the update-core or update-core-network page.
 
 Notices will still only be shown on dev and multidev environments. Users can click the notice on the updates page at any time to find out if an update is available via their Pantheon dashboard.
-
-## Previous Releases
 
 ### 2022-05-24
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -16,6 +16,10 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ### 2022-08-16
 
+#### <a name="20220818" class="release-update"></a>Ensure REST API responses are not cached for authenticated users
+
+REST API responses were being cached for logged-in users, which was causing issues when updating Posts via the block editor (such as creating new taxonomy terms, for example). This commit changes the cache headers so that API responses are no longer cached for authenticated users.
+
 #### <a name="20220816" class="release-update"></a>Deprecate `pantheon-cache` in favor of `pantheon cache`
 
 When the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) plugin is active, WordPress sites on Pantheon have two distinct but similarly-named WP-CLI commands: `wp pantheon cache` (which is provided by Pantheon Advanced Page Cache) and `wp pantheon-cache` (which is provided by the Pantheon mu-plugin. This leads to confusion about which Pantheon cache WP-CLI command to use or which subcommands are available for which parent commands.

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -18,7 +18,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 #### <a name="20220816" class="release-update"></a>Deprecate `pantheon-cache` in favor of `pantheon cache`
 
-When the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) plugin is active, WordPress sites on Pantheon have two distinct but similarly-named WP-CLI commands: `wp pantheon cache` (which is provided by Pantheon Advanced Page Cache) and `wp pantheon-cache` (which is provided by the Pantheon mu-plugin. This creates in a confusing end result where it's unclear what Pantheon cache WP-CLI command to use or which subcommands are available for which parent commands.
+When the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) plugin is active, WordPress sites on Pantheon have two distinct but similarly-named WP-CLI commands: `wp pantheon cache` (which is provided by Pantheon Advanced Page Cache) and `wp pantheon-cache` (which is provided by the Pantheon mu-plugin. This leads to confusion about which Pantheon cache WP-CLI command to use or which subcommands are available for which parent commands.
 
 This change aims to help eliminate this confusion by deprecating `wp pantheon-cache` and moving the `set-maintenance-mode` subcommand under `pantheon cache`. When the `pantheon-cache` command is run, a deprecation notice will be displayed with the updated command and the function will be executed. A deprecation notice has also been added to the text that displays when a user runs `wp pantheon-cache set-maintenance-mode --help`. The `pantheon-cache` command will be removed and display an error when run in a future release, and fully removed entirely in a release following that.
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Pantheon WordPress Upstream](https://pantheon.io/docs/start-states/wordpress)** - adds release notes for change in pantheon-systems/WordPress#336

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [x] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [x] After pantheon-systems/WordPress#336 is merged

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
