### PR TITLE
Fix location of hide_git_mode_warning in example

### DIFF
--- a/source/content/terminus/configuration.md
+++ b/source/content/terminus/configuration.md
@@ -29,14 +29,12 @@ You can see all the available options for a given command (e.g., available `--fi
 The `$HOME/.terminus/config.yml` file uses YAML formatting, which relies on indentation in the form of two spaces per indent:
 
 ```yml:title=config.yml
+hide_git_mode_warning: 1
 command:
   auth:
     login:
       options:
         email: anita@example.com
-
-hide_git_mode_warning: 1
-
   site:
     pancakes:
       options:
@@ -45,9 +43,9 @@ hide_git_mode_warning: 1
 
 The example above does three things:
 
-- When the command `terminus auth:login` is run, it will automatically provide the correct email address. This is useful if you find yourself logging in to multiple accounts frequently, and want to use your regular account by default.
-
 - Terminus will warn you when running commands in an environment set to Git mode, unaware if the command affects the codebase or not:
+
+- When the command `terminus auth:login` is run, it will automatically provide the correct email address. This is useful if you find yourself logging in to multiple accounts frequently, and want to use your regular account by default.
 
   ```none
   [warning] This environment is in read-only Git mode. If you want to make changes to the codebase of this site (e.g. updating modules or plugins), you will need to toggle into read/write SFTP mode first.


### PR DESCRIPTION
`hide_git_mode_warning` cannot appear between the "auth" and the "site" examples, as these are both nested under "command".
