### PR TITLE
Explain Terminus automatic site and environment detection

### DIFF
--- a/source/content/terminus/examples.md
+++ b/source/content/terminus/examples.md
@@ -78,6 +78,18 @@ You can also find your site's machine name using the Terminus command `site:info
 
 </Accordion>
 
+### Automatic Site and Environment detection
+
+If a `<site>.<env>` parameter is not provided to a command that requests one, Terminus will automatically detect the site and environment to operate on from the local copy and current branch of the Pantheon site checked out at the current working directory.
+
+```bash
+git clone ssh://codeserver.dev.UUID@codeserver.dev.UUID.drush.in:2222/~/repository.git mysite
+cd mysite
+terminus env:info
+```
+
+The example above is equivalent to `terminus env:info mysite.dev`.
+
 ### Drush and WP-CLI
 
 Pantheon supports running [Drush (Drupal)](https://drushcommands.com/) and [WP-CLI (WordPress)](https://developer.wordpress.org/cli/commands/) commands remotely against a target site environment through Terminus. This is often faster and easier than leveraging such tools via local installations.

--- a/source/content/terminus/examples.md
+++ b/source/content/terminus/examples.md
@@ -78,9 +78,9 @@ You can also find your site's machine name using the Terminus command `site:info
 
 </Accordion>
 
-### Automatic Site and Environment detection
+### Automatic Site and Environment Detection
 
-If a `<site>.<env>` parameter is not provided to a command that requests one, Terminus will automatically detect the site and environment to operate on from the local copy and current branch of the Pantheon site checked out at the current working directory.
+Terminus automatically detects the site and environment if a `<site>.<env>` parameter is not provided to a command that requests one. Terminus detects and operates from the local copy and current branch of the Pantheon site checked out at the current working directory. 
 
 ```bash
 git clone ssh://codeserver.dev.UUID@codeserver.dev.UUID.drush.in:2222/~/repository.git mysite


### PR DESCRIPTION
Closes # n/a

## Summary

**[Terminus Example Usage](https://pantheon.io/docs/terminus/examples)** - Add an explanation of how Terminus automatic site and environment detection works.

## Effect

Adds a section to Terminus manual explaining that Terminus can automatically determine which site to work on based on the repository that has been cloned at the current working directory.

## Remaining Work and Prerequisites

Convert into English

### Dependencies and Timing

n/a

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
