### PR TITLE
[CMS-909] Add WordPress Composer Managed EA docs

### DIFF
--- a/source/content/guides/wordpress-composer/01-introduction.md
+++ b/source/content/guides/wordpress-composer/01-introduction.md
@@ -45,7 +45,7 @@ Please reach out to our [Professional Services](https://pantheon.io/professional
 
 1. Review [Custom Upstream Workflow](/guides/composer#custom-upstream-workflow).
 
-## See Also
+## More Resources
 
 - [Composer Fundamentals and WebOps Workflows](/guides/composer)
 

--- a/source/content/guides/wordpress-composer/01-introduction.md
+++ b/source/content/guides/wordpress-composer/01-introduction.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress Composer Managed on Pantheon
+title: WordPress with Composer on Pantheon
 subtitle: Introduction
 description: Learn more about using WordPress with Composer on Pantheon.
 categories: [develop]

--- a/source/content/guides/wordpress-composer/01-introduction.md
+++ b/source/content/guides/wordpress-composer/01-introduction.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress with Composer on Pantheon
+title: WordPress Composer Managed on Pantheon
 subtitle: Introduction
 description: Learn more about using WordPress with Composer on Pantheon.
 categories: [develop]
@@ -31,7 +31,7 @@ There are different cases for using Composer to manage dependencies on a WordPre
 
 Complete the steps below before using this guide to create or manage updates on your Pantheon Composer-managed WordPress site.
 
-<Alert title="Note for Existing WordPress Composer Sites"  type="info" >
+<Alert title="Existing WordPress Composer Sites" type="info" >
 
 Please reach out to our [Professional Services](https://pantheon.io/professional-services) team for information on site migration services if you have an existing Composer-managed WordPress site that you would like to migrate to the Pantheon platform.
 

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -47,7 +47,7 @@ Review the sections below for important information about your site, including a
 
 ### Environment Variables
 
-Bedrock makes use of an `.env` file to store environment variables. Pantheon takes care of many of these variabled in `.env.pantheon`. You may set your own environment variables in a new .env or environment variables that are local-only in `.env.local` using the `.env.example` as a guide. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
+Bedrock makes use of an `.env` file to store environment variables. Pantheon takes care of many of these variables in `.env.pantheon`. You may set your own environment variables in a new `.env` or environment variables that are local-only in `.env.local` using the `.env.example` as a guide. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
 
 ### WordPress Config
 

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -8,7 +8,7 @@ contributors: [whitneymeredith, jspellman814, jazzsequence]
 layout: guide
 showtoc: true
 permalink: docs/guides/wordpress-composer/wordpress-composer-managed
-anchorid: create-wp-site-composer-ci-auto-test
+anchorid: wordpress-composer-managed
 ---
 
 <Alert title="Early Access" type="info" icon="leaf">

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -13,7 +13,7 @@ anchorid: wordpress-composer-managed
 
 <Alert title="Early Access" type="info" icon="leaf">
 
-The WordPress Composer Managed upstream is available for Early Access participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. To learn how you can enroll in our Early Access program, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K).
+The WordPress Composer Managed upstream is available for [Early Access](https://pantheon.io/docs/oss-support-levels#early-access) participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. To learn how you can enroll in our Early Access program, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K).
 
 </Alert>
 

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -13,7 +13,7 @@ anchorid: wordpress-composer-managed
 
 <Alert title="Early Access" type="info" icon="leaf">
 
-The WordPress Composer Managed upstream is available for [Early Access](https://pantheon.io/docs/oss-support-levels#early-access) participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. To learn how you can enroll in our Early Access program, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K).
+The WordPress Composer Managed upstream is available for [Early Access](https://pantheon.io/docs/oss-support-levels#early-access) participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. Visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K) (you can sign up for the [Pantheon Slack channel here](https://slackin.pantheon.io/) if you don't already have an account) to learn how you can enroll in our Early Access program.
 
 </Alert>
 
@@ -31,19 +31,19 @@ WordPress does not natively support [Composer](https://getcomposer.org/), howeve
 
 There are two ways you can spin up a site using the WordPress Composer Managed upstream:
 
-1. Running the following terminus command: 
+- Running the following terminus command: 
 
     ```bash
     terminus site:create --org ORG --region REGION -- <site_name> <label> "WordPress (Composer Managed)"
     ```
 
-1. Using this [site create link](https://dashboard.pantheon.io/sites/create?upstream_id=90a683cd-4e03-4832-9b49-be97ab2a0be4).
+- Using this [site create link](https://dashboard.pantheon.io/sites/create?upstream_id=90a683cd-4e03-4832-9b49-be97ab2a0be4).
 
 The site you create will be based on the Pantheon-maintained [WordPress Composer Managed](https://github.com/pantheon-upstreams/wordpress-composer-managed) upstream. Once this install completes, visit the Dev environment and follow the prompts to complete the CMS installation.
 
 Review the sections below for important information about your site, including an explanation of the directory structure and essential configuration actions.
 
-## Using Roots Bedrock
+## Use Roots Bedrock
 
 ### Environment Variables
 
@@ -55,13 +55,13 @@ The `wp-config.php` file is located in the `web` directory. As with other WordPr
 
 You can learn more about WordPress configuration with Bedrock in the [Bedrock Configuration docs](https://docs.roots.io/bedrock/master/configuration/).
 
-### Understanding the WordPress codebase
+### Understand the WordPress Codebase
 
 Bedrock installs WordPress as a required package so updates can be managed by Composer. As such, the contents of the `wp-content` directory have been moved outside the WordPress codebase so changes can be made safely to files within those directories without conflicts. Learn more about [Bedrock's folder structure here](https://docs.roots.io/bedrock/master/folder-structure/).
 
-* Theme are installed into `web/app/themes/`.
-* Plugins are installed into `web/app/plugins`.
-* Must-use plugins are installed into `web/app/mu-plugins`.
+* Theme are installed into `web/app/themes/`
+* Plugins are installed into `web/app/plugins`
+* Must-use plugins are installed into `web/app/mu-plugins`
 * The WordPress admin dashboard is available at `https://example.com/wp/wp-admin/`
 
 ### Using Composer to manage plugins and themes
@@ -70,9 +70,9 @@ Bedrock installs WordPress as a required package so updates can be managed by Co
 
 [WPackagist](https://wpackagist.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box. 
 
-You may install packages from Packagist or WPackagist without any additional configuration using `composer upstream-require`.
+You can install packages from Packagist or WPackagist without any additional configuration using `composer upstream-require`.
 
-#### Requiring a package from Packagist
+#### Require a Package from Packagist
 
 Some WordPress developers push their packages to Packagist in addition to the WordPress plugin and theme repositories. In this way, it may be beneficial to pull those packages directly from Packagist to get the latest code directly from the source.
 
@@ -99,13 +99,14 @@ composer upstream-require wpackagist-plugin/advanced-custom-fields
 - The WordPress Composer Managed upstream is not yet compatible with WordPress Multisite with subdirectories.
 - There is a bug with WordPress Multisite with subdomains when running the site locally with Lando and running WP-CLI commands. There is a [gist](https://gist.github.com/jazzsequence/8b68c35aa7668b77776fc1b9df216304) to fix this, which will eventually be incorporated into the upstream.
 
-## Reporting an Issue
+## Report an Issue
 
-If you discover an issue with the WordPress Composer Managed upstream, create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address.
+Create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address if you discover an issue with the WordPress Composer Managed upstream. 
 
-To discuss the WordPress Composer Managed upstream while in Early Access, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K)
+Visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K) (you can sign up for the [Pantheon Slack channel here](https://slackin.pantheon.io/) if you don't already have an account) to learn how you can enroll in our Early Access program.
 
-## See Also
+## More Resources
 
 - [Bedrock Documentation](https://roots.io/bedrock/)
+
 - [Install and Configure Lando for WordPress](/guides/lando-wordpress)

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -19,7 +19,7 @@ The WordPress Composer Managed upstream is available for Early Access participan
 
 This section provides information on how to use Bedrock with Integrated Composer on a WordPress site.
 
-WordPress does not natively support [Composer](https://getcomposer.org/), however, [Bedrock](https://roots.io/bedrock/) is a WordPress-specific framework for using Composer on WordPress sites. Bedrock also provides a custom [WordPress project structure](https://docs.roots.io/bedrock/master/folder-structure/) that helps simplify working on large projects with multiple plugins and custom code.
+WordPress does not natively support [Composer](https://getcomposer.org/), however, [Bedrock](https://roots.io/bedrock/) is a WordPress-specific framework for using Composer on WordPress sites.
 
 ## Requirements
 
@@ -57,7 +57,7 @@ You can learn more about WordPress configuration with Bedrock in the [Bedrock Co
 
 ### Understanding the WordPress codebase
 
-Bedrock installs WordPress as a required package so updates can be managed by Composer. As such, the contents of the `wp-content` directory have been moved outside the WordPress codebase so changes can be made safely to files within those directories without conflicts.
+Bedrock installs WordPress as a required package so updates can be managed by Composer. As such, the contents of the `wp-content` directory have been moved outside the WordPress codebase so changes can be made safely to files within those directories without conflicts. Learn more about [Bedrock's folder structure here](https://docs.roots.io/bedrock/master/folder-structure/).
 
 * Theme are installed into `web/app/themes/`.
 * Plugins are installed into `web/app/plugins`.
@@ -103,7 +103,7 @@ composer upstream-require wpackagist-plugin/advanced-custom-fields
 
 If you discover an issue with the WordPress Composer Managed upstream, create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address.
 
-If you wish to discuss the WordPress Composer Managed upstream with Pantheon, please use the [community slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K) `#wordpress` channel.
+To discuss the WordPress Composer Managed upstream while in Early Access, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K)
 
 ## See Also
 

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -1,0 +1,111 @@
+---
+title: WordPress with Composer on Pantheon
+subtitle: Create a Composer-managed WordPress Site with Bedrock
+description: Learn more about Bedrock and Composer-managed WordPress sites.
+categories: [develop]
+tags: [wordpress]
+contributors: [whitneymeredith, jspellman814, jazzsequence]
+layout: guide
+showtoc: true
+permalink: docs/guides/wordpress-composer/wordpress-composer-managed
+anchorid: create-wp-site-composer-ci-auto-test
+---
+
+<Alert title="Early Access" type="info" icon="leaf">
+
+The WordPress Composer Managed upstream is available for Early Access participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. To learn how you can enroll in our Early Access program, visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K).
+
+</Alert>
+
+This section provides information on how to use Bedrock with Integrated Composer on a WordPress site.
+
+WordPress does not natively support [Composer](https://getcomposer.org/), however, [Bedrock](https://roots.io/bedrock/) is a WordPress-specific framework for using Composer on WordPress sites. Bedrock also provides a custom [WordPress project structure](https://docs.roots.io/bedrock/master/folder-structure/) that helps simplify working on large projects with multiple plugins and custom code.
+
+## Requirements
+
+- [PHP version](/php-versions#verify-current-php-versions) 7.4 or greater
+
+- [Composer](https://getcomposer.org/)
+
+## Create Your Site
+
+There are two ways you can spin up a site using the WordPress Composer Managed upstream:
+
+1. Running the following terminus command: 
+
+    ```bash
+    terminus site:create --org ORG --region REGION -- <site_name> <label> "WordPress (Composer Managed)"
+    ```
+
+1. Using this [site create link](https://dashboard.pantheon.io/sites/create?upstream_id=90a683cd-4e03-4832-9b49-be97ab2a0be4).
+
+The site you create will be based on the Pantheon-maintained [WordPress Composer Managed](https://github.com/pantheon-upstreams/wordpress-composer-managed) upstream. Once this install completes, visit the Dev environment and follow the prompts to complete the CMS installation.
+
+Review the sections below for important information about your site, including an explanation of the directory structure and essential configuration actions.
+
+## Using Roots Bedrock
+
+### Environment Variables
+
+Bedrock makes use of an `.env` file to store environment variables. Pantheon takes care of many of these variabled in `.env.pantheon`. You may set your own environment variables in a new .env or environment variables that are local-only in `.env.local` using the `.env.example` as a guide. Wrap values that may contain non-alphanumeric characters with quotes, or they may be incorrectly parsed.
+
+### WordPress Config
+
+The `wp-config.php` file is located in the `web` directory. As with other WordPress sites on Pantheon, much of this is taken care of for you in `wp-config-pantheon.php`. Application-level configuration takes place in `config/application.php`. This can be referenced as a guide to understand how the constants are set up and how the `.env` files work, but modifying this file may result in merge conflicts and is not recommended. Any configuration changes should be made to your `wp-config.php` file directly.
+
+You can learn more about WordPress configuration with Bedrock in the [Bedrock Configuration docs](https://docs.roots.io/bedrock/master/configuration/).
+
+### Understanding the WordPress codebase
+
+Bedrock installs WordPress as a required package so updates can be managed by Composer. As such, the contents of the `wp-content` directory have been moved outside the WordPress codebase so changes can be made safely to files within those directories without conflicts.
+
+* Theme are installed into `web/app/themes/`.
+* Plugins are installed into `web/app/plugins`.
+* Must-use plugins are installed into `web/app/mu-plugins`.
+* The WordPress admin dashboard is available at `https://example.com/wp/wp-admin/`
+
+### Using Composer to manage plugins and themes
+
+[Packagist](https://packagist.org) is a repository of Composer packages that are available by default to projects managed by Composer. Packagist libraries receive updates from their source GitHub repositories automatically.
+
+[WPackagist](https://wpackagist.org) is a Packagist-like mirror of the WordPress.org [plugin](https://wordpress.org/plugins) and [theme](https://wordpress.org/themes) repositories and is included with Bedrock out of the box. 
+
+You may install packages from Packagist or WPackagist without any additional configuration using `composer upstream-require`.
+
+#### Requiring a package from Packagist
+
+Some WordPress developers push their packages to Packagist in addition to the WordPress plugin and theme repositories. In this way, it may be beneficial to pull those packages directly from Packagist to get the latest code directly from the source.
+
+```
+composer upstream-require yoast/wordpress-seo
+```
+
+Packages that are flagged as `wordpress-plugin`, `wordpress-theme` or `wordpress-muplugin` in their `composer.json` files will be installed automatically in the appropriate `web/app/` directory by Composer.
+
+#### Requiring a package from WPackagist
+
+For all other plugins and themes that are not managed on Packagist, you can use `composer upstream-require` as well, using `wpackagist-plugin` or `wpackagist-theme` as the vendor and the plugin or theme slug as the package name.
+
+```
+composer upstream-require wpackagist-theme/twentytwentytwo
+```
+
+```
+composer upstream-require wpackagist-plugin/advanced-custom-fields
+```
+
+## Known Issues
+
+- The WordPress Composer Managed upstream is not yet compatible with WordPress Multisite with subdirectories.
+- There is a bug with WordPress Multisite with subdomains when running the site locally with Lando and running WP-CLI commands. There is a [gist](https://gist.github.com/jazzsequence/8b68c35aa7668b77776fc1b9df216304) to fix this, which will eventually be incorporated into the upstream.
+
+## Reporting an Issue
+
+If you discover an issue with the WordPress Composer Managed upstream, create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address.
+
+If you wish to discuss the WordPress Composer Managed upstream with Pantheon, please use the [community slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K) `#wordpress` channel.
+
+## See Also
+
+- [Bedrock Documentation](https://roots.io/bedrock/)
+- [Install and Configure Lando for WordPress](/guides/lando-wordpress)

--- a/source/content/guides/wordpress-composer/03-create-wp-site-composer-ci-auto-test.md
+++ b/source/content/guides/wordpress-composer/03-create-wp-site-composer-ci-auto-test.md
@@ -223,6 +223,6 @@ Do NOT push/pull code between Lando and Pantheon directly. All code should be pu
 
 </Alert>
 
-## See Also
+## More Resources
 
 - [Install and Configure Lando for WordPress](/guides/lando-wordpress)

--- a/source/content/guides/wordpress-composer/06-wordpress-ic.md
+++ b/source/content/guides/wordpress-composer/06-wordpress-ic.md
@@ -84,7 +84,7 @@ Follow the steps in this section to create a new WordPress site using Integrated
     - [Custom Upstream Configurations](/pantheon-yml#custom-upstream-configurations)
 
 
-## See Also
+## More Resources
 
 - [Best Practices for Maintaining Custom Upstreams](/guides/custom-upstream/maintain-custom-upstream) 
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Adds EA docs for the WordPress Composer Managed upstream.

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
