### PR TITLE
Missing space

### DIFF
--- a/source/content/solr.md
+++ b/source/content/solr.md
@@ -34,7 +34,7 @@ All plans except for a Basic plan can use Pantheon Search. Pantheon Search is av
 
 ## Using Pantheon Search with WordPress or Drupal
 
-For installation instructions and additional details, refer to[Enabling Solr for WordPress](/wordpress-solr) or [Enabling Solr with Drupal](/guides/solr-drupal).
+For installation instructions and additional details, refer to [Enabling Solr for WordPress](/wordpress-solr) or [Enabling Solr with Drupal](/guides/solr-drupal).
 
 
 ## Known Limitations of Pantheon's Search Service


### PR DESCRIPTION
**[Pantheon Search (formerly Pantheon Solr)](https://pantheon.io/docs/solr)** - missing a space before the link

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
