### PR TITLE
Some text from require-dev section was accidentally included in the require section

### DIFF
--- a/source/content/guides/integrated-composer/02-dependencies.md
+++ b/source/content/guides/integrated-composer/02-dependencies.md
@@ -19,9 +19,7 @@ It's important to understand how `require` and `require dev` are used on the Pan
 
 ### Composer `require` Section
 
-You should use the `require` section of your `composer.json` file for dependencies your web project needs, even dependencies only used on non-Live environments. Drupal modules / themes and WordPress plugins / themes should always be in the `require` section, not the `require-dev` section. All dependencies in the `require` section are pushed to Pantheon Dev and Multidev environments, but not to Test and Live environments.
-
-You do not need to pass the `--no-dev` option to prevent dependencies from being pushed to your Test and Live environments. This option is passed automatically for Drupal modules / themes and WordPress plugins / themes in the `require` section.
+You should use the `require` section of your `composer.json` file for dependencies your web project needs, even dependencies only used on non-Live environments. Drupal modules / themes and WordPress plugins / themes should always be in the `require` section, not the `require-dev` section. Dependencies in the `require` section are pushed to all Pantheon environments.
 
 ### Composer `require dev` Section
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Integrated Composer Site Dependencies](https://pantheon.io/docs/guides/integrated-composer/dependencies)** - Fixed typos from https://github.com/pantheon-systems/documentation/pull/7656.

## Effect

Remove comment that described behavior of require-dev dependencies that was copied into the require section.

## Remaining Work and Prerequisites

n/a

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
