### PR TITLE
Adding require-dev clarification to the FAQ

### DIFF
--- a/source/content/guides/integrated-composer/08-ic-faq.md
+++ b/source/content/guides/integrated-composer/08-ic-faq.md
@@ -37,6 +37,10 @@ Try [composer-lock-diff](https://github.com/davidrjonas/composer-lock-diff) to s
 
 Pantheon does not offer support for Composer GUIs or any conflicts that might be caused by one.
 
+### On what environments does the require-dev section of composer.json get loaded?
+
+On the dev and multidev environments. Every time Integrated Composer does a build, it creates a dev artifact and live artifact. When you deploy from dev to test, Integrated Composer deploys the live artifact rather than the dev artifact.
+
 ### Why are contrib modules placed in /modules/composer instead of /modules/contrib?
 
 Contrib modules added by Integrated Composer from the now deprecated [Drupal Project](https://github.com/pantheon-upstreams/drupal-project/blob/master/composer.json#L29) upstream are placed in the `/modules/composer` directory in case a site already has non-Composer-managed modules in the standard `/modules/contrib` directory. If your site does not fall into this category, it is safe to rename the `composer` directory back to the standard `contrib` and alter the installer path to match.

--- a/source/content/guides/integrated-composer/08-ic-faq.md
+++ b/source/content/guides/integrated-composer/08-ic-faq.md
@@ -39,7 +39,7 @@ Pantheon does not offer support for Composer GUIs or any conflicts that might be
 
 ### On what environments does the require-dev section of composer.json get loaded?
 
-On the dev and multidev environments. Every time Integrated Composer does a build, it creates a dev artifact and live artifact. When you deploy from dev to test, Integrated Composer deploys the live artifact rather than the dev artifact.
+The `require-dev` section of the `composer.json` file is loaded on the Dev and Multidev environments. Every time Integrated Composer does a build, it creates a Dev artifact and a Live artifact. When you deploy from Dev to Test, Integrated Composer deploys the Live artifact rather than the Dev artifact.
 
 ### Why are contrib modules placed in /modules/composer instead of /modules/contrib?
 


### PR DESCRIPTION
How require-dev works isn't explained. Since they get loaded in dev, teams worry that those sections are loaded in test and live as well.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->


## Summary
Documenting how require-dev works

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://pantheon.io/docs/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* New line added to the FAQ

**Release**:
- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
