### PR TITLE
Revert debug tab

### DIFF
--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -410,11 +410,12 @@ Configure this setting after connecting your Custom Upstream to Pantheon if new 
 
 1. Click **Settings** next to the existing upstream requiring an update.
 
-1. Select the desired connection mode > click **Update**:
+  - Enter a username and a password or token if prompted to authenticate your repository (this only applies to privately hosted repositories). Access tokens must be alpha-numeric and cannot contain symbols.
+
+1. Select if **Git** or **SFTP** mode should be enabled by default and then click **Update**. New sites created from this Custom Upstream will use this connection mode by default going forward.
 
   ![Modify initial connection mode](../../../images/dashboard/initial-connection-mode.png)
 
-New sites created from this Custom Upstream will use this connection mode by default going forward.
 
 ## More Resources
 

--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -410,7 +410,7 @@ Configure this setting after connecting your Custom Upstream to Pantheon if new 
 
 1. Click **Settings** next to the existing upstream requiring an update.
 
-  - Enter a username and a password or token if prompted to authenticate your repository (this only applies to privately hosted repositories). Access tokens must be alpha-numeric and cannot contain symbols.
+    - Enter a username and a password or token if prompted to authenticate your repository (this only applies to privately hosted repositories). Access tokens must be alpha-numeric and cannot contain symbols.
 
 1. Select if **Git** or **SFTP** mode should be enabled by default and then click **Update**. New sites created from this Custom Upstream will use this connection mode by default going forward.
 

--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -404,43 +404,17 @@ The default connection mode for new sites created from a Custom Upstream is Git 
 
 Configure this setting after connecting your Custom Upstream to Pantheon if new sites need to use an initial connection mode other than the default:
 
-1. Access the **Organization Dashboard** from your Admin dashboard.
+1. Navigate to the **[<span class="glyphicons glyphicons-group"></span> Organizations](https://dashboard.pantheon.io/#organizations" )** tab within the Pantheon Dashboard and select your organization.
 
-1. Select **Debug** > click the **<span class="upstreams-regular"></span> Upstreams** tab.
+1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
 
-1. Enter the following:
+1. Click **Settings** next to the existing upstream requiring an update.
 
-    - Upstream Name
-
-    - Description (optional)
-
-    - URL of Logo (optional)
-
-    - URL of Upstream Repository
-
-    - Repository Authentication
-
-      - This is only required if the repository is hosted privately. Enter username and a password or token. Access tokens must be alpha-numeric and cannot contain symbols.
-
-    - Repository Branch
-
-    - Visibility
-
-      - Private: Only allow members of your organization to use this upstream.
-
-      - Public: Allow this upstream to be used by any Pantheon user.
-
-    - Initial Connection Mode
-
-      - Select if **Git** or **SFTP** mode should be enabled by default > click **Update**. New sites created from this Custom Upstream will use this connection mode by default going forward.
-
-    - Framework
-
-    - Internal Notes (optional)
+1. Select the desired connection mode > click **Update**:
 
   ![Modify initial connection mode](../../../images/dashboard/initial-connection-mode.png)
 
-1. Click **Submit**.
+New sites created from this Custom Upstream will use this connection mode by default going forward.
 
 ## More Resources
 

--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -260,7 +260,7 @@ You must track Pantheon's corresponding upstream repository within the Custom Up
 
   ![Organization Dashboard](../../../images/dashboard/organizations.png)
 
-1. Select **Debug** > click the **Upstreams** tab.
+1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
 
 1. Click the **<span class="glyphicons glyphicons-plus"></span> Add New Upstream** button. You must be an Organization Administrator to add a new upstream.
 
@@ -309,7 +309,7 @@ You must track Pantheon's corresponding upstream repository within the Custom Up
 
   ![Organization Dashboard](../../../images/dashboard/organizations.png)
 
-1. Select **Debug** > click the **Upstreams** tab.
+1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
 
 1. Click the **<span class="glyphicons glyphicons-plus"></span> Add New Upstream** button. You must be an administrator of the organization to add a new upstream.
 
@@ -406,7 +406,7 @@ Configure this setting after connecting your Custom Upstream to Pantheon if new 
 
 1. Access the **Organization Dashboard** from your Admin dashboard.
 
-1. Select **Debug** > click the **Upstreams** tab.
+1. Select **Debug** > click the **<span class="upstreams-regular"></span> Upstreams** tab.
 
 1. Enter the following:
 

--- a/source/content/guides/custom-upstream/03-edit-custom-upstream.md
+++ b/source/content/guides/custom-upstream/03-edit-custom-upstream.md
@@ -16,15 +16,13 @@ This section provides information on editing an existing Custom Upstream.
 
 Follow the steps below if you want to change the name or description of your Custom Upstream.
 
-1. Access the **Organization Dashboard** from your Admin dashboard.
+1. Navigate to the **[<span class="glyphicons glyphicons-group"></span> Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
 
-1. Click the **<span class="upstreams-regular"></span> Upstreams** tab.
+1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
 
 1. Click **Settings** next to the existing upstream requiring an update.
 
-1. Make desired changes > click **Submit**.
-
-1. Update any sites with the upstream so they receive the new authentication.
+1. Make desired changes > click **Update**.
 
 ## Change Custom Upstream Repository URL or Password
 

--- a/source/content/guides/custom-upstream/05-delete-custom-upstream.md
+++ b/source/content/guides/custom-upstream/05-delete-custom-upstream.md
@@ -14,11 +14,11 @@ This section provides steps to delete a Custom Upstream. A Custom Upstream canno
 
 Follow these steps to delete your Custom Upstream.
 
-1. Access the **Organization Dashboard** from your Admin dashboard.
+1. Navigate to the Organization Dashboard > click **Upstreams**.
 
-1. Select **Debug** > click the **<span class="upstreams-regular"></span> Upstreams** tab.
+1. Click **Settings** next to the Upstream you want to delete.
 
-1. Click Delete Upstream and confirm.
+1. Select **Source** > click the **Delete Upstream** button:
 
   ![Delete Upstream Button](../../../images/dashboard/delete-upstream.png)
 


### PR DESCRIPTION
## Summary

The "Debug" tab referenced in commit 3b0c7a888fa34 and introduced in c0599feba is only available to Pantheon Administrators. The guides here referenced fields not available to Organization Administrators.

**[Create a Custom Upstream](https://pantheon.io/docs/guides/custom-upstream/create-custom-upstream)** - Revert these two commits

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
