### PR TITLE
Instructions missed name of button

### DIFF
--- a/source/partials/remove-addons/drupal-redis.md
+++ b/source/partials/remove-addons/drupal-redis.md
@@ -6,4 +6,4 @@
 
 1. Navigate to <span class="glyphicons glyphicons-cogwheel"></span> Settings > **Add Ons** and click **Remove** for Redis.
 
-1. From the Site Dashboard, click <span class="glyphicons glyphicons-cleaning"></span>.
+1. From the Site Dashboard, click <span class="glyphicons glyphicons-cleaning"></span> Clear Caches.

--- a/source/partials/remove-addons/wp-redis.md
+++ b/source/partials/remove-addons/wp-redis.md
@@ -6,4 +6,4 @@
 
 1. Go to <span class="glyphicons glyphicons-cogwheel"></span> Settings > **Add Ons** and click the **Remove** button for Redis.
 
-1. From the Site Dashboard, click on <span class="glyphicons glyphicons-cleaning"></span>.
+1. From the Site Dashboard, click on <span class="glyphicons glyphicons-cleaning"></span> Clear Caches.


### PR DESCRIPTION
## Summary

Removal instruction partials just referenced an icon to indicate clearing the cache, not accessible and not easy to understand.

**[Object Cache](https://pantheon.io/docs/object-cache)** - Added text for button

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
