### PR TITLE
Align Enable Redis Drupal condition with Wordpress snippet

### DIFF
--- a/source/content/guides/object-cache/02-enable-object-cache.md
+++ b/source/content/guides/object-cache/02-enable-object-cache.md
@@ -135,7 +135,7 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
   ```php:title=settings.php
   // All Pantheon Environments.
-  if (defined('PANTHEON_ENVIRONMENT')) {
+  if (!empty($_ENV['CACHE_HOST'])) {
     // Use Redis for caching.
     $conf['redis_client_interface'] = 'PhpRedis';
     // Point Drupal to the location of the Redis plugin.
@@ -206,7 +206,7 @@ After enabling Redis, there are cache tables in the database that are no longer 
    ```php:title=sites/default/settings.php
    // Configure Redis
 
-   if (defined('PANTHEON_ENVIRONMENT')) {
+   if (!empty($_ENV['CACHE_HOST'])) {
      // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
      $settings['container_yamls'][] = 'modules/redis/example.services.yml';
 

--- a/source/content/guides/object-cache/02-enable-object-cache.md
+++ b/source/content/guides/object-cache/02-enable-object-cache.md
@@ -35,7 +35,7 @@ This section provides information on how to enable Object Cache.
   ```php:title="object-cache.php"
   <?php
   # This is a Windows-friendly symlink
-  if (!empty($_ENV['CACHE_HOST'])) {
+  if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
     require_once WP_CONTENT_DIR . '/plugins/wp-redis/object-cache.php';
   }
   ```
@@ -135,7 +135,7 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
   ```php:title=settings.php
   // All Pantheon Environments.
-  if (!empty($_ENV['CACHE_HOST'])) {
+  if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
     // Use Redis for caching.
     $conf['redis_client_interface'] = 'PhpRedis';
     // Point Drupal to the location of the Redis plugin.
@@ -206,7 +206,7 @@ After enabling Redis, there are cache tables in the database that are no longer 
    ```php:title=sites/default/settings.php
    // Configure Redis
 
-   if (!empty($_ENV['CACHE_HOST'])) {
+   if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
      // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
      $settings['container_yamls'][] = 'modules/redis/example.services.yml';
 


### PR DESCRIPTION
## Summary

**[Object Cache](https://pantheon.io/docs/guides/object-cache/enable-object-cache)** - Add environmental variable check on Drupal Redis settings

## Effect

Checking the $_ENV variable's existence will prevent downtime on Drupal sites when they disable their Redis add-on accidentally or downgraded their site to the basic plan.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
