### PR TITLE
Use PHP 8.1 in PHP version configuration examples

### DIFF
--- a/source/content/guides/php/02-php-versions.md
+++ b/source/content/guides/php/02-php-versions.md
@@ -69,10 +69,10 @@ You can use SFTP or Git mode to create or change the `pantheon.yml` file. Follow
    ```yaml:title=pantheon.yml
    api_version: 1
 
-   php_version: 8.0
+   php_version: 8.1
    ```
 
-   - You do not need to specify the PHP version's exact point release (for example, `8.0.19`), as these are managed by the platform and deployed automatically.
+   - You do not need to specify the PHP version's exact point release (for example, `8.1.10`), as these are managed by the platform and deployed automatically.
 
 1. Navigate to your SFTP client and refresh the `/code` directory to verify that the `pantheon.yml` file has been created and contains the changed version.
 
@@ -109,10 +109,10 @@ If the contents of `pantheon.yml` are valid, you can commit normally. If there i
    ```yaml:title=pantheon.yml
    api_version: 1
 
-   php_version: 8.0
+   php_version: 8.1
    ```
 
-   - You do not need to specify the PHP version's exact point release (for example, `8.0.19`), as these are managed by the platform and deployed automatically.
+   - You do not need to specify the PHP version's exact point release (for example, `8.1.10`), as these are managed by the platform and deployed automatically.
 
 1. Add and commit the changes and push them to your site.
 


### PR DESCRIPTION
## Summary

Use PHP 8.1 in `php_version` examples.

### Dependencies and Timing

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
