### PR TITLE
Indentation fix on simplesaml

### DIFF
--- a/source/content/shibboleth-sso.md
+++ b/source/content/shibboleth-sso.md
@@ -90,11 +90,11 @@ Commands below require a [nested docroot](/nested-docroot) structure and should 
 1. Add this symlink as a post-update script to `composer.json`. This allows the symlink to be recreated if we update or re-install SimpleSAMLphp using Composer:
 
  ```json:title=composer.json
-   "scripts": {
-      "post-update-cmd": [
+"scripts": {
+    "post-update-cmd": [
         "rm -rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ],
-      "post-install-cmd": [
+    "post-install-cmd": [
         "rm -rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ]
 },


### PR DESCRIPTION
## Summary

**[Using SimpleSAMLphp with Shibboleth SSO](https://pantheon.io/docs/shibboleth-sso#install-simplesamlphp)** - Indentation was confused

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
