### PR TITLE
Update 03-private-repo-package.md

### DIFF
--- a/source/content/guides/integrated-composer/03-private-repo-package.md
+++ b/source/content/guides/integrated-composer/03-private-repo-package.md
@@ -48,11 +48,10 @@ For this procedure, a GitHub token will be added to your code repository. It all
     ],
     ```
 
-1. Run the command below to require the package and specify the branch, prefixed with `dev-`
-   ```json:title=composer.json
-    "require": {
-        "mycompany/my-private-repo": "dev-branch-name"
-    },
+1. Run the command below to require the package and specify the branch, prefixed with `dev-`:
+   
+   ```bash{promptUser: user
+   composer require mycompany/my-private-repo:dev-branch-name
    ```
 
 1. Run the `composer update` command to install the new package.

--- a/source/content/guides/integrated-composer/03-private-repo-package.md
+++ b/source/content/guides/integrated-composer/03-private-repo-package.md
@@ -20,16 +20,30 @@ The following steps outline a method for adding a package from a private GitHub 
 
 For this procedure, a GitHub token will be added to your code repository. It allows anyone with the token to read and write to any private repositories associated with the issuing account. To limit the scope of the GitHub token access, you can create a new GitHub user and give that user permission to only the private repositories needed for your Composer packages and ensure your site repository code is not published publicly. 
 
-1. Go to GitHub's [Personal Access Tokens](https://github.com/settings/tokens) page and generate a new token. 
+1. Go to:
+   - GitHub's [Personal Access Tokens](https://github.com/settings/tokens) page (Ensure that the `repo` scope is selected.)
+   - GitLab's [Personal Access Tokens](https://gitlab.com/-/profile/personal_access_tokens) page (Ensure that the `read repository` scope is selected.)
+   
+   and generate a new token. 
 
-1. Ensure that the `repo` scope is selected.
+1. Add the private repository to `composer.json`, replacing `<token>` with your newly generated token.
 
-1. Add the private GitHub repository to `composer.json`, replacing `<token>` with your newly generated token.
+   GitHub syntax:
    ```json:title=composer.json
    "repositories": [
         {
             "type": "vcs",
             "url": "https://<token>@github.com/mycompany/my-private-repo"
+        }
+    ],
+    ```
+    
+    GitLab syntax: 
+    ```json:title=composer.json
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://oauth2:<token>@gitlab.com/mycompany/my-private-repo.git"
         }
     ],
     ```


### PR DESCRIPTION
## Summary

**[Add a Package from a Private Repository](https://pantheon.io/docs/guides/integrated-composer/private-repo-package)** - Adding GitLab instructions and syntax as it's slightly different from GitHub. 

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
