### PR TITLE
Add references on using quick silver search replace script

### DIFF
--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -115,6 +115,8 @@ Refreshing data in Test or Dev from Live is simply a matter of reversing the ste
 
 You can now develop against production data.
 
+Note: You can also automate the search-replace process after doing a DB clone by using a [Quicksilver](https://pantheon.io/docs/guides/quicksilver) [search-replace script](https://github.com/pantheon-systems/quicksilver-examples/tree/main/wp_search_replace).
+
 ## Work with Large Databases
 If you have a really large database (gigabytes and gigabytes) or dozens upon dozens of tables, you may notice that `wp search-replace` can take a really long time — or even time out.
 

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -60,7 +60,7 @@ In this example:
 - `--network` tells WP-CLI to perform the procedure on all Site Network tables. Its default behavior is to limit search and replace to the current site.
 - `--url=<old-domain>` sets the request context, which is how WordPress knows which site to load. Without this, you'll likely see “Error: Site not found.”
 
-See the [full documentation](https://developer.wordpress.org/cli/commands/search-replace/) for all supported features.
+Refer to the [full documentation](https://developer.wordpress.org/cli/commands/search-replace/) for all supported features.
 
 Using WP-CLI with Terminus is simply a matter of calling Terminus with the correct `<site>` and `<env>` arguments:
 
@@ -115,7 +115,7 @@ Refreshing data in Test or Dev from Live is simply a matter of reversing the ste
 
 You can now develop against production data.
 
-Note: You can also automate the search-replace process after doing a DB clone by using a [Quicksilver](https://pantheon.io/docs/guides/quicksilver) [search-replace script](https://github.com/pantheon-systems/quicksilver-examples/tree/main/wp_search_replace).
+Note: You can also automate the search-replace process after performing a database clone with the [Quicksilver](https://pantheon.io/docs/guides/quicksilver) [search-replace script](https://github.com/pantheon-systems/quicksilver-examples/tree/main/wp_search_replace).
 
 ## Work with Large Databases
 If you have a really large database (gigabytes and gigabytes) or dozens upon dozens of tables, you may notice that `wp search-replace` can take a really long time — or even time out.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes https://github.com/pantheon-systems/documentation/issues/7808

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**WordPress Site Networks Doc Update to add quicksilver to automate the search-replace process**

## Effect

Possibly point out the example QS script to help out automate the search replace process https://github.com/pantheon-systems/quicksilver-examples/tree/main/wp_search_replace

The following changes are already committed:

* Added references to the said script


**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
