### PR TITLE
Add 

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -392,3 +392,36 @@ This issue happens when you attempt to update very outdated core files from the 
 1. Set the Site Connection Mode to Git and reapply updates
 
 1. Modify `.gitignore` and remove the `#` before the `pantheon.upstream.yml` line to instruct Git to ignore the file again
+
+
+
+### Unable to update older Drupal versions (e.g. 7.68) using one-click update
+
+Older versions can have a huge version gap causing the workflow to fail.
+
+Sample error:
+`Requested database version 10.4 is not compatible with your framework and version: Drupal 7.67`
+
+#### Solution
+
+You will need to update the core versions from the upstream version. But older versions of the site may not be able to directly. So the safest route is to update it one by one.
+
+#### How to
+
+1. Clone the repository locally.
+
+1. Normally, you can pull up to the latest version, but this can have larger conflicts due to version differences. So pulling one version increment at a time can be the safe route.
+`git pull -Xtheirs https://github.com/pantheon-systems/drops-7.git 7.69`
+You can also try updating starting at drupal v7.84.
+`git pull -Xtheirs https://github.com/pantheon-systems/drops-7.git 7.84`
+
+1. Then fix potential conflicts.
+
+1. Don’t forget to commit and push to the Pantheon repository.
+
+1. Run database updates to dev environment.
+`terminus drush <site>.dev updb`
+
+1. Deploy to Test Live and run the database for each environment.
+
+1. Increment the version of the upstream and repeat step 2. Repeat these steps until you reach the latest version of the site.


### PR DESCRIPTION
Adding public docs based on the detected BUG due to an older version of Drupal 7 causing the one-click update workflow to fail:
https://docs.google.com/document/d/15ZhFmdbvHb5brqCvN6HC57V0R8HV4kYXBuzj0H9BAxM/edit#