### PR TITLE
Remove unavailable configuration details

### DIFF
--- a/source/content/guides/object-cache/05-troubleshoot-object-cache.md
+++ b/source/content/guides/object-cache/05-troubleshoot-object-cache.md
@@ -115,7 +115,7 @@ This declaration means use of `wp_cache_set( 'foo', 'bar', 'bad-actor' );` and `
 
 ### Out of Memory Errors
 
-You can use the `info memory` option to view your site's memory metrics. Object Cache will always use more memory than declared in `maxmemory`. Out of Memory errors can be avoided by configuring a max memory limit **and** an [eviction policy](https://docs.redis.com/latest/rs/concepts/memory-performance/#eviction-policies). Without an eviction policy, the server will not evict any keys, which prevents any writes until memory is freed. With an eviction policy in place, the server will evict keys when memory usage reaches the `maxmemory` limit.
+You can use the `info memory` option to view your site's memory metrics. Running out of storage is a regular occurrance and is handled by the eviction policy. Memory limits per plan and more details about the eviction policy are in the [Object Cache FAQs](/guides/object-cache/faq-object-cache#how-much-object-cache-is-available-for-each-plan-level)
 
 Run the following command to access your site's memory usage metrics:
 


### PR DESCRIPTION

## Summary

**[Troubleshoot Object Cache](https://pantheon.io/docs/guides/object-cache/troubleshoot-object-cache)** - Details on expiration policy and memory limit are not user-configurable

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
