### PR TITLE
Add Cache Hit Ratio to Metrics

### DIFF
--- a/source/partials/traffic-dl.md
+++ b/source/partials/traffic-dl.md
@@ -38,6 +38,19 @@ For both metrics, the platform counts based on the total volume of requests, whi
 
 As shown here, visits and visitors have different meanings. If two visitors go to the site, and one opens another page but the other leaves, that would be tracked as two visitors and three pages served. If one of those visitors returns again the next day, it would be counted as two visitors, three visits, and four pages served.
 
+
+<dl>
+
+<dt>Cache Hit Ratio</dt>
+
+<dd>
+
+An important performance benchmark is the number of requests that are able to be served from the Global CDN. Serving from cache rather than by the CMS gives visitors a faster response and takes load off of the site's server resources. A cached request is served from the nearest edge endpoint without any delay, while a request to the CMS must be individually processed and loaded. The higher the Cache Hit Ratio the better. Learn about how to enable and improve caching in the [Pantheon Global CDN](/guides/global-cdn).
+
+</dd>
+
+</dl>
+
 ## How Do You Know if a Visit Counts?
 
 ### Counted Visits

--- a/source/partials/traffic-dl.md
+++ b/source/partials/traffic-dl.md
@@ -45,7 +45,7 @@ As shown here, visits and visitors have different meanings. If two visitors go t
 
 <dd>
 
-An important performance benchmark is the number of requests that can be served from the Global CDN. Serving requests from cache rather than by the CMS gives visitors a faster response and removes load from the site's server resources. A cached request is served from the nearest edge endpoint without any delay, while a request to the CMS must be individually processed and loaded. The higher the Cache Hit Ratio the better. Learn about how to enable and improve caching in the [Pantheon Global CDN](/guides/global-cdn) guide.
+An important performance benchmark is the number of requests that can be served from the Global CDN. Serving requests from cache rather than by the CMS allows visitors to experience a faster response and removes load from the site's server resources. A cached request is served from the nearest edge endpoint without any delay, while a request to the CMS must be individually processed and loaded. A high cache hit ratio greatly improves the browsing experience and site performance. Learn how to enable and improve caching with the [Pantheon Global CDN](/guides/global-cdn) guide.
 
 </dd>
 

--- a/source/partials/traffic-dl.md
+++ b/source/partials/traffic-dl.md
@@ -45,7 +45,7 @@ As shown here, visits and visitors have different meanings. If two visitors go t
 
 <dd>
 
-An important performance benchmark is the number of requests that are able to be served from the Global CDN. Serving from cache rather than by the CMS gives visitors a faster response and takes load off of the site's server resources. A cached request is served from the nearest edge endpoint without any delay, while a request to the CMS must be individually processed and loaded. The higher the Cache Hit Ratio the better. Learn about how to enable and improve caching in the [Pantheon Global CDN](/guides/global-cdn).
+An important performance benchmark is the number of requests that can be served from the Global CDN. Serving requests from cache rather than by the CMS gives visitors a faster response and removes load from the site's server resources. A cached request is served from the nearest edge endpoint without any delay, while a request to the CMS must be individually processed and loaded. The higher the Cache Hit Ratio the better. Learn about how to enable and improve caching in the [Pantheon Global CDN](/guides/global-cdn) guide.
 
 </dd>
 


### PR DESCRIPTION
## Summary

**[Metrics in the Site Dashboard](https://pantheon.io/docs/metrics#available-metrics)** - We now expose Cache Hit Ratio to customers via Terminus, work is pending to add this to the site dashboard

## Effect

* Describe the definition and utility of the cache hit ratio


### Dependencies and Timing

- [ ] Launch of Cache Hit Ratio in dashboard site metrics

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
