### PR TITLE
Adds main as an additional option

### DIFF
--- a/source/content/inclusive-language.md
+++ b/source/content/inclusive-language.md
@@ -82,7 +82,7 @@ Phrases like "one throat to choke" can be replaced with "one hand to shake" or "
 #### Examples & Alternatives
 
 - Avoid using "slave" in any context. Use a more accurate term, such as "worker," "replica", or "secondary," depending on your needs.
-- Related, avoid the word "master". "Primary", "original" or "controller" are possible alternatives.
+- Related, avoid the word "master". "Primary", "original", "main" or "controller" are possible alternatives.
 - "Grandfathered in" is a term rooted in [racist voter suppression](https://history.howstuffworks.com/american-civil-war/grandfathered-in.htm). Try "exempt from" or "legacy" instead.
 - Many terms appropriate and disrespect Native and Indigenous traditions. Rather than "have a pow-wow", try "have a quick chat." "Spirit animals" can be replaced with "mascot". "Hold down the fort," "on the warpath," and "circle the wagons" also have roots in the violent history of US colonization and should be avoided. ([Learn more](https://www.ictinc.ca/blog/culturally-offensive-phrases-you-should-use-at).)
 

--- a/source/content/inclusive-language.md
+++ b/source/content/inclusive-language.md
@@ -1,7 +1,7 @@
 ---
 title: Inclusive Language at Pantheon and in the Pantheon Community
 description: Elevate the way we communicate and support community and contributors in using more inclusive language.
-contributors: [sparklingrobots, carolynshannon, edwardangert, caitybishop, katiemac]
+contributors: [sparklingrobots, carolynshannon, edwardangert, caitybishop, katiemac, cdrmarks]
 tags: [collaborate]
 reviewed: "2020-11-01"
 newtype: doc


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Inclusive Language at Pantheon and in the Pantheon Community
](https://pantheon.io/docs/inclusive-language)** - Adds main as an additional option

In October 2020, the default branch for newly-created repositories on GitHub is now main ([blog post](https://github.blog/changelog/2020-10-01-the-default-branch-for-newly-created-repositories-is-now-main/)).  This adds main to the list of other acceptable alternatives.

### Dependencies and Timing

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
