### PR TITLE
BUGS-5465: Remove workaround for SHA2 signatures not being supported

### DIFF
--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -157,64 +157,6 @@ You can still access the sites if you have active sites and no keys remaining. M
 
 <Partial file="host-keys.md" />
 
-### Connections Fail With: no matching host key type found. Their offer: ssh-rsa
-
-[OpenSSH 8.8](https://www.openssh.com/txt/release-8.8) disables RSA signatures like the key type Pantheon uses.
-
-While we are working to remedy this on the platform, OpenSSH 8.8 will return this error for CLI commands:
-
-```shell
-Unable to negotiate with 203.0.113.123 port 2222: no matching host key type found. Their offer: ssh-rsa
-```
-
-**Solution**: Until the key type is updated on the Pantheon platform, add `ssh-rsa` to the accepted algorithms in `~/.ssh/config`:
-
-   1. Look for `$HOME/.ssh/config file`. If none present, create it using `type`:
-   
-   ```bash{promptUser: winshell}
-   cd %HOMEPATH%/.ssh
-   type nul > config
-   ```
-   
-   2. Copy/paste the following into config:
-   
-   ```none:title=~/.ssh/config
-   Host *.drush.in
-       # The settings on the next two lines are temporary until Pantheon updates the available key types.
-       # If 'PubkeyAcceptedAlgorithms' causes an error, remove it.
-       HostkeyAlgorithms +ssh-rsa
-       PubkeyAcceptedAlgorithms +ssh-rsa
-   ```
-
-### MacOS Ventura unable to connect SSH-keys
-
-[MacOS Ventura](https://www.apple.com/newsroom/2022/10/macos-ventura-is-now-available/) was released on October 24, 2022.
-
-Some users have reported that their SSH suddenly fails to connect and returns the error below or a similar error.
-
-```bash
- no matching host key type found. Their offer: ssh-rsa
- ```
-
-**Solution**: You must add `ssh-rsa` to the accepted algorithms in the `~/.ssh/config` file as a workaround until the key type is updated on the Pantheon platform:
-
-1. Locate the `~/.ssh/config` file. If the file does not exist, create it using `touch`:
-
-   ```bash{promptUser: user}
-   cd ~/.ssh/
-   touch config
-   ```
-
-1. Add the code below to the `~/.ssh/config` file:
-
-   ```none:title=~/.ssh/config
-   Host *.drush.in
-       # The settings on the next two lines are temporary until Pantheon updates the available key types.
-       # If 'PubkeyAcceptedAlgorithms' causes an error, remove it.
-       HostkeyAlgorithms +ssh-rsa
-       PubkeyAcceptedAlgorithms +ssh-rsa
-   ```
-
 ### Control Path Error
 
 You may receive the following error:

--- a/source/partials/host-keys.md
+++ b/source/partials/host-keys.md
@@ -39,10 +39,6 @@ Open `~/.ssh/config` (or create a new file if one does not exist) and add the fo
 ```none:title=~/.ssh/config
 Host *.drush.in
     StrictHostKeyChecking no
-    # The settings on the next two lines are temporary until Pantheon updates the available key types.
-    # If 'PubkeyAcceptedAlgorithms' causes an error, remove it.
-    HostkeyAlgorithms +ssh-rsa
-    PubkeyAcceptedAlgorithms +ssh-rsa
 ```
 
 Now, requests to any `*.drush.in` server address should automatically accept the server's SSH key fingerprint without prompting you.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Generate and Add SSH Keys](https://pantheon.io/docs/ssh-keys)** - The platform now supports SHA2 signatures for SSH keys, so we can remove the workarounds for that.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Removed the workaround for SHA2 signatures not being supported from the `Generate and Add SSH Keys` page.
* Also updated the `Pro Tip: Trust All Pantheon Hosts` to remove the workaround from that as well.

## Remaining Work and Prerequisites

N/A

## Dependencies and Timing

N/A

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
