### PR TITLE
Drush 11 is incompatible with D8

### DIFF
--- a/source/partials/drupal-9/core-version-remain-on-d8.md
+++ b/source/partials/drupal-9/core-version-remain-on-d8.md
@@ -1,5 +1,6 @@
   ```bash{promptUser:user}
   composer require --no-update drupal/core-recommended:^8.9
+  composer require --no-update drush/drush:^10
   composer require --dev drupal/core-dev:^8.9
   git add composer.*
   git commit -m "Remain on Drupal 8"


### PR DESCRIPTION
## Summary

This is a partial file used in guides to set Drupal to remain on Drupal 8 during an update. Without specifying an older version of Drush at the same time, Composer will not be able to satisfy the required package versions and will error out.

**[Create the Drupal 9 Site](https://pantheon.io/docs/guides/drupal-9-hosted/create-site)** - Include Drush 10 alongside Drupal 8

**Release**:
- [x] When ready


--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
