### PR TITLE
WordPress session expiration was not documented

### DIFF
--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -91,6 +91,12 @@ Session cookie lifetime and session garbage collection can be overridden in your
 
 Session cookie lifetime and session garbage collection can be configured as `session.storage.options` parameters in a services.yml file. To override core session behavior, create a copy of the services.yml file (see [Creating a services.yml File for Drupal 9](/services-yml)), and adjust the `gc_maxlifetime` and `cookie_lifetime` values as needed.
 
+#### WordPress
+
+When using the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/ "Pantheon Session WordPress plugin") plugin, the session lifetime is set to 0, which is until the browser is closed. This may be overridden with the "pantheon_session_expiration" filter prior to the plugin being loaded.
+
+Session data will be removed from the database by PHP's garbage collection when it has not been used in the time set in `gc_maxlifetime` which is set to 200,000 seconds by default.
+
 ## Geolocation, Referral Tracking, Content Customization, and Cache Segmentation
 
 A site may need to deliver different content to different users without them logging in or starting a full session (either of which will cause them to bypass the page cache entirely). Pantheon recommends doing this on the client side using browser detection, orientation, or features like aspect ratio using HTML5, CSS3, and JavaScript. Advanced developers can also use STYXKEY.

--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -93,9 +93,11 @@ Session cookie lifetime and session garbage collection can be configured as `ses
 
 #### WordPress
 
-When using the [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/ "Pantheon Session WordPress plugin") plugin, the session lifetime is set to 0, which is until the browser is closed. This may be overridden with the "pantheon_session_expiration" filter prior to the plugin being loaded.
+The [WordPress Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) plugin automatically sets the session lifetime `0`, which is until the browser is closed. You can override this setting with the `pantheon_session_expiration` filter before the plugin loads.
 
-Session data will be removed from the database by PHP's garbage collection when it has not been used in the time set in `gc_maxlifetime` which is set to 200,000 seconds by default.
+Session data is removed from the database by PHP's garbage collection when it has not been used in the time set in `gc_maxlifetime`, which is set to `200,000` seconds by default.
+
+Refer to [WordPress and PHP Sessions](/guides/php/wordpress-sessions) for more information about WordPress and PHP Sessions on Pantheon.
 
 ## Geolocation, Referral Tracking, Content Customization, and Cache Segmentation
 


### PR DESCRIPTION
## Summary

**[Caching: Advanced Topics](https://pantheon.io/docs/caching-advanced-topics#session-and-cookie-lifetime)** - WordPress handling of cache timeouts in the Pantheon plugin was not documented

Based on code here:

https://github.com/pantheon-systems/wp-native-php-sessions/blob/4934e9a9fef9ea41c36623ea680cc0f175c1ea8f/pantheon-sessions.php#L155-L156

And here:
https://github.com/pantheon-systems/wp-native-php-sessions/blob/4934e9a9fef9ea41c36623ea680cc0f175c1ea8f/inc/class-session-handler.php#L97-L115

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
