### PR TITLE
Introduction looked like instructions

### DIFF
--- a/source/content/guides/logs-pantheon/02-access-logs.md
+++ b/source/content/guides/logs-pantheon/02-access-logs.md
@@ -12,13 +12,9 @@ anchorid: access-logs
 
 This section provides information on how to use SFTP to access your logs on Pantheon.
 
-Logs are stored within [application containers](/application-containers) that house your site's codebase and files.
+Logs are stored within [application containers](/application-containers) that house your site's codebase and files, as well as in the database containers.
 
-1. Navigate to **Site Dashboard**, click **Dev**, and then click **Code**. 
-
-1. Confirm your **Connection Mode** is set to SFTP.
-
-1. Click **Connection Info** in the User Dashboard. You can review the connection information to gain an understanding of the pattern used for the hostnames: `<env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in`
+To see the SFTP connection information, click **Connection Info** in the Site Dashboard for the environment you want to access. You can review the connection information to gain an understanding of the pattern used for the hostnames: `<env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in`
 
     | Type         | Env                                     | Site UUID                                                                                                 |
     |:------------ |:--------------------------------------- |:--------------------------------------------------------------------------------------------------------- |
@@ -60,6 +56,8 @@ Follow the steps below to download your application log files.
             └──nginx-error.log
             └──error.log
     ```
+
+Note that this will only connect to one application container. If you have multiple application servers you will need to use the example script in [Automate Log Downloads](/guides/logs-pantheon/automate-log-downloads)
 
 ### Database Log Files
 

--- a/source/content/guides/logs-pantheon/02-access-logs.md
+++ b/source/content/guides/logs-pantheon/02-access-logs.md
@@ -12,9 +12,9 @@ anchorid: access-logs
 
 This section provides information on how to use SFTP to access your logs on Pantheon.
 
-Logs are stored within [application containers](/application-containers) that house your site's codebase and files, as well as in the database containers.
+Logs are stored within [application containers](/application-containers) and database containers. Application containers house your site's codebase and files.
 
-To see the SFTP connection information, click **Connection Info** in the Site Dashboard for the environment you want to access. You can review the connection information to gain an understanding of the pattern used for the hostnames: `<env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in`
+Click **Connection Info** in the Site Dashboard of the desired environment to get your SFTP connection information. You can review the connection information to gain an understanding of the pattern used for the hostnames: `<env>.<site-uuid>@<type>.<env>.<site-uuid>.drush.in`
 
     | Type         | Env                                     | Site UUID                                                                                                 |
     |:------------ |:--------------------------------------- |:--------------------------------------------------------------------------------------------------------- |


### PR DESCRIPTION
## Summary

There were unnecessary steps and it may confuse people as this is an informational introduction not meant to be actioned on

**[Access Logs with SFTP](https://pantheon.io/docs/guides/logs-pantheon/access-logs)** - Removed steps and clarified application logs are per container

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
