### PR TITLE
No longer recommend PHP 7.4

### DIFF
--- a/source/partials/_php-versions.md
+++ b/source/partials/_php-versions.md
@@ -3,7 +3,7 @@ Click the links below to display complete PHP information for each version, incl
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
 | [8.1](https://v81-php-info.pantheonsite.io/)\*   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
-| [8.0](https://v80-php-info.pantheonsite.io/)\* | <span style="color:green">✔</span>         | <span style="color:green">✔</span>          |
+| [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | <span style="color:green">✔</span>          |
 | [7.4](https://v74-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌          |
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.2](https://v72-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
@@ -13,5 +13,5 @@ Click the links below to display complete PHP information for each version, incl
 
 Sites that run older PHP versions not listed above will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
 
-\* WordPress is not fully compatible with PHP 8+.
+\* WordPress is not fully compatible with PHP 8.1+.
 

--- a/source/partials/_php-versions.md
+++ b/source/partials/_php-versions.md
@@ -4,7 +4,7 @@ Click the links below to display complete PHP information for each version, incl
 | ------------------------------------------------ | :---------: | :---------: |
 | [8.1](https://v81-php-info.pantheonsite.io/)\*   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/)\* | <span style="color:green">✔</span>         | <span style="color:green">✔</span>          |
-| [7.4](https://v74-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | <span style="color:green">✔</span>          |
+| [7.4](https://v74-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌          |
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.2](https://v72-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.1](https://v71-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>          | ❌           |


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

PHP 7.4 reached EOL on [November 28th](https://twitter.com/official_php/status/1597203297537957888), and we do not want to recommend EOL software.

### Dependencies and Timing

**Release**:
- [x] After approval from at least one cms-ecosystem enginneer

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
