### PR TITLE
[OTTO-3085][OTTO-3082] Autopilot Error: Upstreams Could Not Be Merged

### DIFF
--- a/source/content/guides/autopilot/07-troubleshoot.md
+++ b/source/content/guides/autopilot/07-troubleshoot.md
@@ -406,11 +406,11 @@ Update the database on the target environment, and then retry Autopilot. You wil
 
 ## Upstreams Could Not Be Merged
 
-<Accordion title="Autopilot was unable to apply upstream updates because the upstreams could not be merged." id="upstream-no-common-ancestor" icon="info-sign">
+<Accordion title="We could not apply upstream updates because the upstreams could not be merged." id="upstream-no-common-ancestor" icon="info-sign">
 
 ### Issue
 
-Distinct from a merge conflict, this is encountered when there is no shared git history between the site's commits and the upstreams commits. This is most often encountered if the site's upstream has been changed, or if a different git history has been force-pushed for the site's code repository.
+Distinct from a merge conflict, this is encountered when there is no shared git history between the site's commits and the upstream's commits. This is most often encountered if the site's upstream has been changed, or if a different git history has been force-pushed for the site's code repository.
 
 ### Solution
 

--- a/source/content/guides/autopilot/07-troubleshoot.md
+++ b/source/content/guides/autopilot/07-troubleshoot.md
@@ -404,6 +404,22 @@ Update the database on the target environment, and then retry Autopilot. You wil
   
 </Accordion>
 
+## Upstreams Could Not Be Merged
+
+<Accordion title="Autopilot was unable to apply upstream updates because the upstreams could not be merged." id="upstream-no-common-ancestor" icon="info-sign">
+
+### Issue
+
+Distinct from a merge conflict, this is encountered when there is no shared git history between the site's commits and the upstreams commits. This is most often encountered if the site's upstream has been changed, or if a different git history has been force-pushed for the site's code repository.
+
+### Solution
+
+Update the site's code or the upstream so that the site and upstream share a common history.
+
+If you do not want Autopilot to maintain upstream updates (including core updates), you can also disable upstream updates, and Autopilot will continue to update plugins, themes, and modules.
+
+</Accordion>
+
 ## More Resources
 
 - [Autopilot Setup and Configuration](/guides/autopilot/enable-autopilot)

--- a/source/content/guides/autopilot/07-troubleshoot.md
+++ b/source/content/guides/autopilot/07-troubleshoot.md
@@ -410,13 +410,13 @@ Update the database on the target environment, and then retry Autopilot. You wil
 
 ### Issue
 
-Distinct from a merge conflict, this is encountered when there is no shared git history between the site's commits and the upstream's commits. This is most often encountered if the site's upstream has been changed, or if a different git history has been force-pushed for the site's code repository.
+This error is distinct from a merge conflict, and is encountered when there is no shared Git history between the site's commits and the upstream's commits. This error is most often encountered when the site's upstream has been changed, or when a different Git history has been force-pushed for the site's code repository.
 
 ### Solution
 
 Update the site's code or the upstream so that the site and upstream share a common history.
 
-If you do not want Autopilot to maintain upstream updates (including core updates), you can also disable upstream updates, and Autopilot will continue to update plugins, themes, and modules.
+You can also disable upstream updates if you do not want Autopilot to maintain upstream updates, including core updates. Autopilot will continue to update plugins, themes, and modules.
 
 </Accordion>
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Troubleshoot Autopilot Error Messages](https://pantheon.io/docs/guides/autopilot/troubleshoot-autopilot/)** - Documents a new Autopilot error message, `FAILED_UPSTREAM_UPDATES_NO_COMMON_ANCESTOR` ("Upstream Updates Could Not Be Merged")


## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Once merged, update Autopilot activity feed to support this error and link to docs (OTTO-3085)

### Dependencies and Timing


**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
