### PR TITLE
Specify key type for ssh-keygen

### DIFF
--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -40,7 +40,7 @@ Pantheon supports ECDSA and RSA SSH keys. Currently, we do not support `ed25519`
 1. Open your terminal and enter the following command to generate a key:
 
    ```bash{promptUser: user}
-   ssh-keygen
+   ssh-keygen -t rsa
    ```
 
   This command works on Linux, MacOS, and Windows 10.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Some OSes are changing the default key type generated by `ssh-keygen` to `ed25519`. Pantheon only supports `rsa` and `ecdsa` key types, so we should specify one so customers don't accidentally create a key of the wrong type by using the default.

## Summary

**[Generate and Add SSH Keys](https://pantheon.io/docs/ssh-keys#generate-ssh-key)** - Adds `-t rsa` to the `ssh-keygen` command.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
