### PR TITLE
[BUGS-5709] Add release notes for forthcoming WordPress upstream update

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -23,7 +23,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 <a name="20230117" class="release-update"></a>Fixes a bug where a fatal error for an undefined variable was thrown on PHP 8+.
 
-Our previous update that added a loader to pull in the pantheon-mu-plugin introduced an undefined variable which is a fatal error in PHP 8+. This update resolves the issue and fixes the mu-plugin loader. This may introduce merge conflicts if you have made changes to the loader.php file in your site repository.
+A previous update that added a loader to pull in the pantheon-mu-plugin introduced an undefined variable which is a fatal error in PHP 8+. This update resolves the issue and fixes the mu-plugin loader. This may introduce merge conflicts if you have made changes to the `loader.php` file in your site repository.
 
 ### 2022-11-01
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -19,6 +19,12 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
+### 2023-01-17
+
+<a name="20230117" class="release-update"></a>Fixes a bug where a fatal error for an undefined variable was thrown on PHP 8+.
+
+Our previous update that added a loader to pull in the pantheon-mu-plugin introduced an undefined variable which is a fatal error in PHP 8+. This update resolves the issue and fixes the mu-plugin loader. This may introduce merge conflicts if you have made changes to the loader.php file in your site repository.
+
 ### 2022-11-01
 
 #### <a name="20221018" class="release-update"></a>Replace mu-plugin with a format consistent with pantheon-systems/pantheon-mu-plugin


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Adds release notes update for release following the merge of https://github.com/pantheon-systems/WordPress/pull/352

**[Pantheon WordPress Upstream](https://pantheon.io/docs/start-states/wordpress)** - Adds release notes for 2023-01-17 upstream update.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Release notes

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
