### PR TITLE
updated redis instructions

### DIFF
--- a/source/content/guides/object-cache/02-enable-object-cache.md
+++ b/source/content/guides/object-cache/02-enable-object-cache.md
@@ -186,7 +186,7 @@ After enabling Redis, there are cache tables in the database that are no longer 
 
 </Tab>
 
-<Tab title="Drupal 9 / Composer-managed" id="d9-install">
+<Tab title="Drupal 9.3+ / Composer-managed" id="d9-install">
 
 1. Navigate to your Pantheon Site Dashboard, select **Settings**, select **Add Ons**, then select **Add** to enable the Redis cache server. It might take a couple of minutes for the Redis server to come online.
 
@@ -213,25 +213,77 @@ After enabling Redis, there are cache tables in the database that are no longer 
    ```php:title=sites/default/settings.php
    // Configure Redis
 
-   if (!empty($_ENV['PANTHEON_ENVIRONMENT']) && !empty($_ENV['CACHE_HOST'])) {
-     // Include the Redis services.yml file. Adjust the path if you installed to a contrib or other subdirectory.
-     $settings['container_yamls'][] = 'modules/redis/example.services.yml';
+   if (defined(
+    'PANTHEON_ENVIRONMENT'
+  ) && !\Drupal\Core\Installer\InstallerKernel::installationAttempted(
+  ) && extension_loaded('redis')) {
+    // Set Redis as the default backend for any cache bin not otherwise specified.
+    $settings['cache']['default'] = 'cache.backend.redis';
 
-     //phpredis is built into the Pantheon application container.
-     $settings['redis.connection']['interface'] = 'PhpRedis';
-     // These are dynamic variables handled by Pantheon.
-     $settings['redis.connection']['host']      = $_ENV['CACHE_HOST'];
-     $settings['redis.connection']['port']      = $_ENV['CACHE_PORT'];
-     $settings['redis.connection']['password']  = $_ENV['CACHE_PASSWORD'];
+    //phpredis is built into the Pantheon application container.
+    $settings['redis.connection']['interface'] = 'PhpRedis';
 
-     $settings['redis_compress_length'] = 100;
-     $settings['redis_compress_level'] = 1;
+    // These are dynamic variables handled by Pantheon.
+    $settings['redis.connection']['host'] = $_ENV['CACHE_HOST'];
+    $settings['redis.connection']['port'] = $_ENV['CACHE_PORT'];
+    $settings['redis.connection']['password'] = $_ENV['CACHE_PASSWORD'];
 
-     $settings['cache']['default'] = 'cache.backend.redis'; // Use Redis as the default cache.
-     $settings['cache_prefix']['default'] = 'pantheon-redis';
+    $settings['redis_compress_length'] = 100;
+    $settings['redis_compress_level'] = 1;
 
-     $settings['cache']['bins']['form'] = 'cache.backend.database'; // Use the database for forms
-   }
+    $settings['cache_prefix']['default'] = 'pantheon-redis';
+
+    $settings['cache']['bins']['form'] = 'cache.backend.database'; // Use the database for forms
+
+    // Apply changes to the container configuration to make better use of Redis.
+    // This includes using Redis for the lock and flood control systems, as well
+    // as the cache tag checksum. Alternatively, copy the contents of that file
+    // to your project-specific services.yml file, modify as appropriate, and
+    // remove this line.
+    $settings['container_yamls'][] = 'modules/contrib/redis/example.services.yml';
+
+    // Allow the services to work before the Redis module itself is enabled.
+    $settings['container_yamls'][] = 'modules/contrib/redis/redis.services.yml';
+
+    // Manually add the classloader path, this is required for the container
+    // cache bin definition below.
+    $class_loader->addPsr4('Drupal\\redis\\', 'modules/contrib/redis/src'); 
+
+    // Use redis for container cache.
+    // The container cache is used to load the container definition itself, and
+    // thus any configuration stored in the container itself is not available
+    // yet. These lines force the container cache to use Redis rather than the
+    // default SQL cache.
+    $settings['bootstrap_container_definition'] = [
+      'parameters' => [],
+      'services' => [
+        'redis.factory' => [
+          'class' => 'Drupal\redis\ClientFactory',
+        ],
+        'cache.backend.redis' => [
+          'class' => 'Drupal\redis\Cache\CacheBackendFactory',
+          'arguments' => [
+            '@redis.factory',
+            '@cache_tags_provider.container',
+            '@serialization.phpserialize',
+          ],
+        ],
+        'cache.container' => [
+          'class' => '\Drupal\redis\Cache\PhpRedis',
+          'factory' => ['@cache.backend.redis', 'get'],
+          'arguments' => ['container'],
+        ],
+        'cache_tags_provider.container' => [
+          'class' => 'Drupal\redis\Cache\RedisCacheTagsChecksum',
+          'arguments' => ['@redis.factory'],
+        ],
+        'serialization.phpserialize' => [
+          'class' => 'Drupal\Component\Serialization\PhpSerialize',
+        ],
+      ],
+    ];
+}
+
    ```
 
    <Alert title="Note" type="info">


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://pantheon.io/docs/contribute)
- [Style Guide](https://pantheon.io/docs/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

Object Cache (formerly Redis) - Updated redis instructions for D8/9/10

## Effect

Eliminates a race condition where Drupal can't find the redis server

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
