### PR TITLE
[CMSP-221] Release notes for contact support line removal

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -21,11 +21,9 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ### 2023-TBD-TBD
 
-<a name="20230203" class="release-update"></a>
+<a name="20230203" class="release-update"></a>Removes contact support line.
 
-Remove the contact support line from the `wp-pantheon-config.php` file.
-
-Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. You can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
+Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. You will no longer see the contact support line in the `wp-pantheon-config.php` file. You can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
 
 ## Previous Releases
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -23,7 +23,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 <a name="20230203" class="release-update"></a>Remove line to contact support from wp-pantheon-config.php
 
-Pantheon Customer Support Engineer's are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
+Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
 
 ## Previous Releases
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -21,9 +21,11 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ### 2023-TBD-TBD
 
-<a name="20230203" class="release-update"></a>Remove line to contact support from wp-pantheon-config.php
+<a name="20230203" class="release-update"></a>
 
-Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
+Remove the contact support line from the `wp-pantheon-config.php` file.
+
+Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. You can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
 
 ## Previous Releases
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -19,6 +19,14 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
+### 2023-TBD-TBD
+
+<a name="20230203" class="release-update"></a>Remove line to contact support from wp-pantheon-config.php
+
+Pantheon CSEs are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
+
+## Previous Releases
+
 ### 2023-01-17
 
 <a name="20230117" class="release-update"></a>Fixes a bug where a fatal error for an undefined variable was thrown on PHP 8+.
@@ -32,8 +40,6 @@ A previous update that added a loader to pull in the pantheon-mu-plugin introduc
 This commit aligns the mu-plugin format to [our standalone repository](https://github.com/pantheon-systems/pantheon-mu-plugin), and will allow for the mu-plugin to receive updates from that repo whenever an updated version of WordPress is released. If you'd like to suggest changes to our mu-plugin, create an issue or open a PR [in `pantheon-mu-plugin` issues](https://github.com/pantheon-systems/pantheon-mu-plugin/issues). 
 
 The commit also adds a standardized mu-plugin `loader.php` file that additional mu-plugins can be added to manually if more are necessary to include in our default upstreams in the future.
-
-## Previous Releases
 
 ### 2022-08-30
 

--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -23,7 +23,7 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 <a name="20230203" class="release-update"></a>Remove line to contact support from wp-pantheon-config.php
 
-Pantheon CSEs are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
+Pantheon Customer Support Engineer's are no longer needed to shuffle salt keys. Customers can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
 
 ## Previous Releases
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

Adds release notes to support [pantheon-systems/WordPress/pull/355](https://github.com/pantheon-systems/WordPress/pull/355).

### Dependencies and Timing

**Release**:
- [x] After [pantheon-systems/WordPress/pull/355](https://github.com/pantheon-systems/WordPress/pull/355) is merged
- [ ] After the next WP Core release (6.2 is scheduled for release March 28, 2023, but there could be a security and maintenance release before then)

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
