### PR TITLE
Removing frivolous trailing bracket from page

### DIFF
--- a/source/content/guides/multisite/03-config.md
+++ b/source/content/guides/multisite/03-config.md
@@ -177,7 +177,7 @@ Explore the WordPress Network Dashboard to become familiar with the variety of a
 
 ## More Resources
 
-- [Environment-Specific Configuration for WordPress Sites](/guides/environment-configuration/environment-specific-config)]
+- [Environment-Specific Configuration for WordPress Sites](/guides/environment-configuration/environment-specific-config)
 
 - [WordPress Pantheon Cache Plugin Configuration](/guides/wordpress-configurations/wordpress-cache-plugin)
 


### PR DESCRIPTION
Closes # N/A

## Summary
Was reading through our documentation when I noticed a trailing closing-bracket within the page, this request removes it so that the docs remain typo free as much as possible.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://pantheon.io/docs/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Configure](https://pantheon.io/docs/guides/multisite/config/)** - Removes extra trailing bracket from page. 

## Effect
Cleans up the "More Resources" section by removing a trailing bracket from the documentation, resulting in a cleaner looking page. 

### Dependencies and Timing

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/docs/old-path/` => `/docs/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
