### PR TITLE
Revert "[CMSP-221] Release notes for contact support line removal"

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -19,14 +19,6 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
-### 2023-TBD-TBD
-
-<a name="20230203" class="release-update"></a>Removes contact support line.
-
-Pantheon Customer Support Engineers are no longer needed to shuffle salt keys. You will no longer see the contact support line in the `wp-pantheon-config.php` file. You can visit https://api.wordpress.org/secret-key/1.1/salt/ to replace the values provided by the platform.
-
-## Previous Releases
-
 ### 2023-01-17
 
 <a name="20230117" class="release-update"></a>Fixes a bug where a fatal error for an undefined variable was thrown on PHP 8+.
@@ -40,6 +32,8 @@ A previous update that added a loader to pull in the pantheon-mu-plugin introduc
 This commit aligns the mu-plugin format to [our standalone repository](https://github.com/pantheon-systems/pantheon-mu-plugin), and will allow for the mu-plugin to receive updates from that repo whenever an updated version of WordPress is released. If you'd like to suggest changes to our mu-plugin, create an issue or open a PR [in `pantheon-mu-plugin` issues](https://github.com/pantheon-systems/pantheon-mu-plugin/issues). 
 
 The commit also adds a standardized mu-plugin `loader.php` file that additional mu-plugins can be added to manually if more are necessary to include in our default upstreams in the future.
+
+## Previous Releases
 
 ### 2022-08-30
 


### PR DESCRIPTION
Reverts pantheon-systems/documentation#8101 because we still don't have a date for this release: https://docs.pantheon.io/start-states/wordpress#2023-tbd-tbd