### PR TITLE
[CMS-1179] Release notes for upcoming drupal-composer-managed release supporting D10

### DIFF
--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -15,13 +15,21 @@ product: [custom-upstreams]
 integration: [--]
 ---
 
-HELLO
+Composer-managed Drupal sites!
 
 ## Latest Release
 
 ### 2023-TBD-TBD
 
-<a name="20230222" class="release-update"></a>PLACEHOLDER D10 UPDATE MESSAGE
+<a name="20230222" class="release-update"></a>This release prepares sites that are on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
+
+- The "upstream-require" command was moved to a new project, pantheon-systems/upstream-management
+- A post-update hook is added to the site's top-level composer.json file; this hook is for potential future use, and does not do anything at present. If you remove it, Pantheon will add it again. Its purpose is to allow us to manage potential future changes that may be need to be applied to sites using this upstream.
+- The enable-patching flag is added to the site's top-level composer.json file. Patches from dependencies may not be applied if this option is missing, so we are including it to avoid confusion. The most recent version of `cweagans/composer-patches` still requires this flag, but it is slated to be removed in a future release. If you do not want this flag enabled in your project’s composer.json file, you may remove it, and it will not be replaced.
+- The phpstan/extension-enstaller Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
+
+These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream (see [https://github.com/pantheon-upstreams/drupal-10-composer-managed](https://github.com/pantheon-upstreams/drupal-10-composer-managed)).
+
 
 ## Previous Releases
 

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -19,9 +19,9 @@ Composer-managed Drupal sites!
 
 ## Latest Release
 
-### 2023-02-22
+### 2023-02-23
 
-<a name="20230222" class="release-update"></a>This release prepares sites that are on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
+<a name="20230223" class="release-update"></a>This release prepares sites that are on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
 
 - The "upstream-require" command was moved to a new project, pantheon-systems/upstream-management
 - A post-update hook is added to the site's top-level composer.json file; this hook is for potential future use, and does not do anything at present. If you remove it, Pantheon will add it again. Its purpose is to allow us to manage potential future changes that may be need to be applied to sites using this upstream.

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -1,0 +1,36 @@
+---
+title: Pantheon Drupal (Composer Managed) Upstream
+description: Release notes and customizations to the Pantheon Drupal (Composer Managed) Upstream
+tags: [code, site, upstreams]
+showtoc: true
+permalink: docs/start-states/drupal-composer-managed
+editpath: start-states/drupal-composer-managed.md/
+reviewed: "2023-02-22"
+contenttype: [doc]
+innav: [true]
+categories: [custom-upstreams]
+cms: [drupal]
+audience: [agency, business, development]
+product: [custom-upstreams]
+integration: [--]
+---
+
+HELLO
+
+## Latest Release
+
+### 2023-TBD-TBD
+
+<a name="20230222" class="release-update"></a>PLACEHOLDER D10 UPDATE MESSAGE
+
+## Previous Releases
+
+### 2023-THE-PAST
+
+<a name="20230117" class="release-update"></a>Do we want to actually put any historical release information in this document? 🤔
+
+
+## Related Links
+
+- [Pantheon Start States](/start-state)
+- [WordPress and Drupal Core Updates](/core-updates)

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -5,7 +5,7 @@ tags: [code, site, upstreams]
 showtoc: true
 permalink: docs/start-states/drupal-composer-managed
 editpath: start-states/drupal-composer-managed.md/
-reviewed: "2023-02-22"
+reviewed: "2023-02-23"
 contenttype: [doc]
 innav: [true]
 categories: [custom-upstreams]

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -19,14 +19,14 @@ Composer-managed Drupal sites!
 
 ## Latest Release
 
-### 2023-TBD-TBD
+### 2023-02-22
 
 <a name="20230222" class="release-update"></a>This release prepares sites that are on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
 
 - The "upstream-require" command was moved to a new project, pantheon-systems/upstream-management
 - A post-update hook is added to the site's top-level composer.json file; this hook is for potential future use, and does not do anything at present. If you remove it, Pantheon will add it again. Its purpose is to allow us to manage potential future changes that may be need to be applied to sites using this upstream.
 - The enable-patching flag is added to the site's top-level composer.json file. Patches from dependencies may not be applied if this option is missing, so we are including it to avoid confusion. The most recent version of `cweagans/composer-patches` still requires this flag, but it is slated to be removed in a future release. If you do not want this flag enabled in your project’s composer.json file, you may remove it, and it will not be replaced.
-- The phpstan/extension-enstaller Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
+- The phpstan/extension-installer Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
 
 These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream (see [https://github.com/pantheon-upstreams/drupal-10-composer-managed](https://github.com/pantheon-upstreams/drupal-10-composer-managed)).
 

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -15,21 +15,20 @@ product: [custom-upstreams]
 integration: [--]
 ---
 
-Composer-managed Drupal sites!
+This document provides additional context to platform-specific changes in Pantheon's Composer-managed Drupal upstream.
 
 ## Latest Release
 
 ### 2023-02-23
 
-<a name="20230223" class="release-update"></a>This release prepares sites that are on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
+<a name="20230223" class="release-update"></a>This release prepares sites on the Drupal (Composer Managed) upstream for Drupal 10.  The specific changes made in this release include:
 
-- The "upstream-require" command was moved to a new project, pantheon-systems/upstream-management
-- A post-update hook is added to the site's top-level composer.json file; this hook is for potential future use, and does not do anything at present. If you remove it, Pantheon will add it again. Its purpose is to allow us to manage potential future changes that may be need to be applied to sites using this upstream.
-- The enable-patching flag is added to the site's top-level composer.json file. Patches from dependencies may not be applied if this option is missing, so we are including it to avoid confusion. The most recent version of `cweagans/composer-patches` still requires this flag, but it is slated to be removed in a future release. If you do not want this flag enabled in your project’s composer.json file, you may remove it, and it will not be replaced.
-- The phpstan/extension-installer Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
+- The `upstream-require` command was moved to a new project, `pantheon-systems/upstream-management`
+- A `post-update` hook is added to the site's top-level `composer.json` file; this hook is for potential future use, and does not do anything at present. If you remove it, Pantheon will add it again. The hook's purpose is to allow us to manage potential future changes that must be applied to sites using this upstream.
+- The `enable-patching` flag is added to the site's top-level `composer.json` file. Patches from dependencies may not be applied if this option is missing, so we are including it to avoid confusion. The most recent version of `cweagans/composer-patches` still requires this flag, but it is slated to be removed in a future release. If you do not want this flag enabled in your project’s `composer.json` file, you may remove it, and it will not be replaced.
+- The `phpstan/extension-installer` Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
 
-These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream (see [pantheon-upstreams/drupal-10-composer-managed on GitHub](https://github.com/pantheon-upstreams/drupal-10-composer-managed)).
-
+These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream. Refer to [pantheon-upstreams/drupal-10-composer-managed on GitHub](https://github.com/pantheon-upstreams/drupal-10-composer-managed) for more information.
 
 ## Previous Releases
 
@@ -39,10 +38,10 @@ These changes have minimal impact on existing sites today, and are primarily int
 
 ### 2022-03-24
 
-<a name="20220324" class="release-update"></a>Allow sites to upgrade to Drush 12 once it becomes available
+<a name="20220324" class="release-update"></a>Allow sites to upgrade to Drush 12 when it becomes available
 
-
-## Related Links
+## More Resources
 
 - [Pantheon Start States](/start-state)
+- [Pantheon WordPress Upstream](/start-states/wordpress)
 - [WordPress and Drupal Core Updates](/core-updates)

--- a/source/content/start-states/drupal-composer-managed.md
+++ b/source/content/start-states/drupal-composer-managed.md
@@ -28,14 +28,18 @@ Composer-managed Drupal sites!
 - The enable-patching flag is added to the site's top-level composer.json file. Patches from dependencies may not be applied if this option is missing, so we are including it to avoid confusion. The most recent version of `cweagans/composer-patches` still requires this flag, but it is slated to be removed in a future release. If you do not want this flag enabled in your project’s composer.json file, you may remove it, and it will not be replaced.
 - The phpstan/extension-installer Composer plugin is enabled, if it isn't already, to reduce friction with future upgrades to Drupal 10, which includes this extension.
 
-These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream (see [https://github.com/pantheon-upstreams/drupal-10-composer-managed](https://github.com/pantheon-upstreams/drupal-10-composer-managed)).
+These changes have minimal impact on existing sites today, and are primarily intended to keep the Drupal (Composer Managed) upstream in a state where it is easy for Pantheon to maintain the new Drupal 10 "start state" upstream (see [pantheon-upstreams/drupal-10-composer-managed on GitHub](https://github.com/pantheon-upstreams/drupal-10-composer-managed)).
 
 
 ## Previous Releases
 
-### 2023-THE-PAST
+### 2022-12-13
 
-<a name="20230117" class="release-update"></a>Do we want to actually put any historical release information in this document? 🤔
+<a name="20221213" class="release-update"></a>Update to PHP 8.1
+
+### 2022-03-24
+
+<a name="20220324" class="release-update"></a>Allow sites to upgrade to Drush 12 once it becomes available
 
 
 ## Related Links


### PR DESCRIPTION

## Summary

Adds a new start-state document for Drupal, alongside the existing one for WordPress, to house changelog information for us to link to from dashboard updates, and creates a placeholder for our upcoming drupal-composer-managed update which provides some D10 compatibility updates.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

Adds a new start-state document for Drupal, alongside the existing one for WordPress, to house changelog information for us to link to from dashboard updates, and creates a placeholder for our upcoming drupal-composer-managed update which provides some D10 compatibility updates.

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* creation of source/content/start-states/drupal-composer-managed.md
* placeholder for upcoming release notes

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] Add actual language for the upcoming release

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
