### PR TITLE
[CMSO-1299] Drupal 10 Availability

### DIFF
--- a/source/content/drupal-10.md
+++ b/source/content/drupal-10.md
@@ -73,10 +73,6 @@ This process requires [Composer](https://getcomposer.org/doc/01-basic-usage.md) 
 
 ## FAQ
 
-### When Drupal 10 is released, which version will appear in the dashboard?
-
-Drupal 9 will still be the version used when creating a Drupal Composer Managed Site until mid-January. You can upgrade new sites to Drupal 10 by [following these instructions](/drupal-10#update-a-drupal-9-site-to-drupal-10).
-
 ### When Drupal 10 is released, will my Drupal 9 site be forced to use Drupal 10?
 
 No, Drupal 9 sites can continue to use Drupal 9 and receive Drupal 9 updates.

--- a/source/content/drupal-10.md
+++ b/source/content/drupal-10.md
@@ -21,7 +21,7 @@ Drupal 10 is now available on the Pantheon platform. This page will be updated f
 |---|---|---|
 | Create a Drupal 10 site on Pantheon | Available | [Create a Drupal 10 Site](/drupal-10#create-a-drupal-10-site)|
 | Upgrade a Drupal 9 site to Drupal 10 manually | Available | [Upgrade from Drupal 9 to Drupal 10](/drupal-10#upgrade-a-drupal-9-site-to-drupal-10) |
-| Create a Drupal 10 site from the Pantheon Dashboard | Planned availability February 2023 | |
+| Create a Drupal 10 site from the Pantheon Dashboard | Available | |
 | Upgrade a Drupal 9 site to Drupal 10 using the [Terminus Conversion Tools plugin](https://github.com/pantheon-systems/terminus-conversion-tools-plugin) | Early Access | Use the following command: `terminus conversion:upgrade-d10` |
 
 

--- a/source/content/drupal.md
+++ b/source/content/drupal.md
@@ -13,7 +13,7 @@ product: [integrated-composer]
 integration: [--]
 ---
 
-Drupal 10 is available to all new sites, and is available as an [upgrade path for Drupal 9 sites](https://docs.pantheon.io/drupal-10#upgrade-a-drupal-9-site-to-drupal-10). See more information about [Drupal 10 on Pantheon](https://docs.pantheon.io/drupal-10).
+Drupal 10 is available to all new sites, and is available as an [upgrade path for Drupal 9 sites](/drupal-10#upgrade-a-drupal-9-site-to-drupal-10). Refer to [Drupal 10 on Pantheon](/drupal-10) for more information.
 
 Drupal 9 is similarly available on Pantheon to all new sites, and as an [upgrade path for Drupal 8+ sites](/drupal-migration).
 

--- a/source/content/drupal.md
+++ b/source/content/drupal.md
@@ -13,7 +13,9 @@ product: [integrated-composer]
 integration: [--]
 ---
 
-Drupal 9 is available on Pantheon to all new sites, and is available as an [upgrade path for Drupal 8+ sites](/drupal-migration).  For information regarding Drupal 10, see [Drupal 10 on Pantheon](/drupal-10).
+Drupal 10 is available to all new sites, and is available as an [upgrade path for Drupal 9 sites](https://docs.pantheon.io/drupal-10#upgrade-a-drupal-9-site-to-drupal-10). See more information about [Drupal 10 on Pantheon](https://docs.pantheon.io/drupal-10).
+
+Drupal 9 is similarly available on Pantheon to all new sites, and as an [upgrade path for Drupal 8+ sites](/drupal-migration).
 
 Since Drupal itself is in active development and each new version brings a number of significant changes from previous versions, this doc outlines the biggest changes and answers frequently asked questions.
 
@@ -53,13 +55,13 @@ Learn more about working with upstream and site dependencies in the [Integrated 
 
 [Create a new Drupal site from the Dashboard](/guides/legacy-dashboard/create-sites) as you would with any new site. Integrated Composer is built in and ready to use.
 
-## Upgrade or Migrate to Drupal 
+## Upgrade or Migrate to Drupal
 
 To upgrade or migrate an existing Drupal site to Drupal with Integrated Composer, see the [Drupal Migration Guide](/drupal-migration).
 
 To check an existing site's compatibility to upgrade, visit the appropriate [Drupal Migration Guide](/drupal-migration).
 
-## Gutenberg for Drupal 
+## Gutenberg for Drupal
 
 After you upgrade to Drupal you may consider upgrading the authoring experience for your content creators as well. We recommend using [Gutenberg](https://www.drupal.org/project/gutenberg) for a better user experience, including:
 

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -18,7 +18,7 @@ The following table indicates availability of the specified Drupal version, as w
 | ----------- | :---------: | :---------: | :---------: |
 | 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
 | 9           | <span style="color:green">✔</span>          | <span style="color:green">✔</span>           | <span style="color:green">✔</span>         |
-| 8           | ❌          | ❌           | <span style="color:green">✔</span>         |
+| 8           | <span style="color:green">✔</span>          | ❌           | <span style="color:green">✔</span>         |
 | 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span>          |
 | 6           | ❌          | ❌           | ❌          |
 

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -16,7 +16,7 @@ The following table indicates availability of the specified Drupal version, as w
 
 | Drupal Version | Available | Recommended | Supported |
 | ----------- | :---------: | :---------: | :---------: |
-| 10          | <span style="color:green">✔</span>         | ❌           | ❌          |
+| 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
 | 9           | <span style="color:green">✔</span>          | <span style="color:green">✔</span>           | <span style="color:green">✔</span>         |
 | 8           | ❌          | ❌           | <span style="color:green">✔</span>         |
 | 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span>          |


### PR DESCRIPTION
## Summary

Updates to reflect the fact that Drupal 10 is available on the dashboard

## Effect

The following changes are already committed:

- **[Supported Drupal Versions](https://docs.pantheon.io/supported-drupal)** - 
  - Adds green checkmarks to Drupal 10 "Recommended" and "Supported".  
  - Removes question "When Drupal 10 is released, which version will appear in the dashboard?"
  - Changes Drupal 8 "Available" to a green check, because it is available (just not via the dashboard)
- **[Drupal 10 on Pantheon](https://docs.pantheon.io/drupal-10)** - Updates status of "Create a Drupal 10 site from the Pantheon Dashboard" to "Available"
- **[Drupal on Pantheon](https://docs.pantheon.io/drupal)** - Updates beginning of first paragraph to:

    Drupal 10 is available to all new sites, and is available as an [upgrade path for Drupal 9 sites] 
    (https://docs.pantheon.io/drupal-10#upgrade-a-drupal-9-site-to-drupal-10). See more information about [Drupal 10 on 
    Pantheon](https://docs.pantheon.io/drupal-10). 

    Drupal 9 is similarly available on Pantheon to all new sites, and as an [upgrade path for Drupal 8+ sites] 
   (https://docs.pantheon.io/drupal-migration)."


## Remaining Work and Prerequisites

All "Done When"s on [CMSO-1299](https://getpantheon.atlassian.net/browse/CMSO-1299) have been fulfilled.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)


[CMSO-1299]: https://getpantheon.atlassian.net/browse/CMSO-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ