### PR TITLE
Add Terminus Carbon plugin to plugin list

### DIFF
--- a/source/content/terminus/08-directory.md
+++ b/source/content/terminus/08-directory.md
@@ -35,6 +35,12 @@ Create a [GitHub](https://github.com) PR Workflow to test Pantheon sites on [Cir
 
   </Card>
 
+  <Card title={"Carbon"} isOfficial author={"Kyle Taylor"} authorLink={"https://github.com/kyletaylored"} link={"https://github.com/pantheon-systems/terminus-carbon-plugin"}>
+
+Fetch carbon impact and other sustainability data on your Pantheon sites.
+
+  </Card>
+  
   <Card title={"Composer"} isOfficial author={"Brian Thompson"} authorLink={"https://github.com/rvtraveller"} link={"https://github.com/pantheon-systems/terminus-composer-plugin"}>
 
 Run [Composer](https://getcomposer.org/) commands on Pantheon sites.


### PR DESCRIPTION
## Summary

Adds the [Terminus Carbon Plugin](https://github.com/pantheon-systems/terminus-carbon-plugin) to the Terminus plugin list.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Terminus Plugin Directory](https://docs.pantheon.io/terminus/directory)** - Adds Terminus Carbon Plugin to plugin list.

### Dependencies and Timing

No depedencies.

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
