### PR TITLE
CMSP-9: Release notes for 2023-03-06

### DIFF
--- a/source/content/start-states/wordpress.md
+++ b/source/content/start-states/wordpress.md
@@ -19,6 +19,12 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
+### 2023-03-06
+
+<a name="20230306" class="release-update"></a> Adds the `WP_ALLOW_MULTISITE` constant to sites which are on the WordPress Multisite upstream.
+
+This update will remove the requirement to manually declare this variable for users of the Multisite upstream.
+
 ### 2023-01-17
 
 <a name="20230117" class="release-update"></a>Fixes a bug where a fatal error for an undefined variable was thrown on PHP 8+.


### PR DESCRIPTION
Documents new variable added to WordPress Multisites.

Closes CMSP-9

## Summary

**[Pantheon WordPress Upstream](https://docs.pantheon.io/start-states/wordpress)** - Provides release notes for changes to WordPress upstream.


## Remaining Work and Prerequisites


The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

- [ ] This should not be merged until Upstream Update is fully merged. 

**Release**:
- [ ] When CMSP-9 PR is merged

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
