### PR TITLE
Drupal 10 upstream repository info

### DIFF
--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -180,16 +180,21 @@ You must track Pantheon's corresponding upstream repository within the Custom Up
 
     <Tab title="Drupal (Latest Version)" id="dlatest">
 
+    ```bash{promptUser: user}
+    git remote add pantheon-drupal https://github.com/pantheon-upstreams/drupal-10-composer-managed.git
+    ```
+
     <Alert title="Note" type="info" >
     
-    This repository has not yet been released.  This page will be updated with the correct code when it is released.
+    This repository is a "start state" upstream, and should only be used during the initial clone when creating your custom upstream. If you have already created your custom upstream, use the repository below to merge in any updates from Pantheon:
+
+    ```bash{promptUser: user}
+    git remote add pantheon-updates https://github.com/pantheon-upstreams/drupal-composer-managed.git
+    ```
 
     </Alert>
 
-    ```bash{promptUser: user}
-    git remote add pantheon-drupal https://github.com/pantheon-upstreams/---.git
-    ```
-    </Tab>
+  </Tab>
 
     <Tab title=" Drupal 7" id="d71">
 

--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -186,7 +186,7 @@ You must track Pantheon's corresponding upstream repository within the Custom Up
 
     <Alert title="Note" type="info" >
     
-    This repository is a "start state" upstream, and should only be used during the initial clone when creating your custom upstream. If you have already created your custom upstream, use the repository below to merge in any updates from Pantheon:
+    This repository is a "start state" upstream, and should only be used during the initial clone when creating your Custom Upstream. If you have already created your Custom Upstream, use the repository below to merge in any updates from Pantheon:
 
     ```bash{promptUser: user}
     git remote add pantheon-updates https://github.com/pantheon-upstreams/drupal-composer-managed.git


### PR DESCRIPTION
The Pantheon Drupal 10 upstream has been released, so the information about it may now be added to the Pantheon documentation.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #n/a

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Create a Custom Upstream](https://docs.pantheon.io/guides/custom-upstream/create-custom-upstream#pull-in-core-from-pantheons-upstream)** - Update custom upstream creation process to include information about the Drupal 10 start-state upstream.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Information on the location of the D10 custom upstream added to documentation.
* Caution provided to advise user to use pantheon-upstreams/drupal-composer-managed for subsequent updates.

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Docs team review

### Dependencies and Timing

Drupal 10 upstream has already been released; there are no blockers to this PR.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
