### PR TITLE
[CMSP-245] Add known limitation to WordPress i18n features on Pantheon

### DIFF
--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -74,3 +74,8 @@ add_filter( 'wp_image_editors', 'force_use_gdlib' );
 ```
 
 See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress.org for more information.
+
+## Language Packs
+Since WordPress 4.7, admins have been able to add additional language packs to WordPress from the General Settings screen. On Pantheon, this is only possible on Dev environments in SFTP mode. This is because WordPress will attempt to download the language packs for the requested language, and file writes are disabled in all environments other than Dev.
+
+In WordPress 6.2, this feature has been extended to user profiles -- now users can install language packs from their Edit Profile pages. However, this feature, again, is not available on Pantheon outside a Dev environment in SFTP mode.

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -76,6 +76,7 @@ add_filter( 'wp_image_editors', 'force_use_gdlib' );
 See this [core issue](https://core.trac.wordpress.org/ticket/43310) on WordPress.org for more information.
 
 ## Language Packs
-Since WordPress 4.7, admins have been able to add additional language packs to WordPress from the General Settings screen. On Pantheon, this is only possible on Dev environments in SFTP mode. This is because WordPress will attempt to download the language packs for the requested language, and file writes are disabled in all environments other than Dev.
 
-In WordPress 6.2, this feature has been extended to user profiles -- now users can install language packs from their Edit Profile pages. However, this feature, again, is not available on Pantheon outside a Dev environment in SFTP mode.
+WordPress 4.7 introduced the ability for admins to add additional language packs to WordPress from the General Settings screen. On Pantheon, this is only possible on Dev environments in SFTP mode. This is because WordPress attempts to download the language packs for the requested language, and file writes are disabled in all environments other than Dev.
+
+WordPress 6.2 extends this feature to user profiles. You can install language packs from your Edit Profile page. Note that this feature is still not available on Pantheon outside of a Dev environment in SFTP mode.


### PR DESCRIPTION
## Summary

**[WordPress Known Issues](https://docs.pantheon.io/wordpress-known-issues)** - Adds notes about known issues with WordPress i18n features.

## Effect

The following changes are already committed:

* Added WordPress internationalization feature note

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
