### PR TITLE
[UpdateTool - Terminus Information] Update commands and releases to version 3.1.4.

### DIFF
--- a/source/data/terminusReleases.json
+++ b/source/data/terminusReleases.json
@@ -71,7 +71,7 @@
         ],
         "tarball_url": "https:\/\/api.github.com\/repos\/pantheon-systems\/terminus\/tarball\/3.1.4",
         "zipball_url": "https:\/\/api.github.com\/repos\/pantheon-systems\/terminus\/zipball\/3.1.4",
-        "body": ""
+        "body": "### Added\r\n- Multiple tag filter support for org:site:list command (#2360)\r\n- Workflow wait command added as a copy of existing command in Build Tools plugin (#2435)\r\n\r\n### Fixed\r\n- Cache clear option is now used in the env:deploy command (#2432)\r\n\r\n### Changed\r\n\r\n- PHP compatibility errors are written to stderr instead of stdout (#2434)\r\n- Description for database import command (#2436)\r\n- Description for workflow:info:logs command (#2439)\r\n- Description for aliases command (#2438)"
     },
     {
         "url": "https:\/\/api.github.com\/repos\/pantheon-systems\/terminus\/releases\/91044822",


### PR DESCRIPTION
[UpdateTool - Terminus Information] Update commands and releases to the latest Terminus version.