### PR TITLE
Document build_step, add ToC

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -10,6 +10,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [quicksilver]
+showtoc: true
 ---
 
 Hook into platform workflows and manage advanced site configuration via the `pantheon.yml` file. Add it to the root of your site's codebase, and deploy it along with the rest of your code.
@@ -113,6 +114,16 @@ web_docroot: true
 The name of the nested directory is not configurable.
 
 For more information, see [Serving Sites from the Web Subdirectory](/nested-docroot).
+
+### Integrated Composer Build Step
+
+Enables or disables Integrated Composer, for example to enable Integrated Composer:
+
+```yaml:title=pantheon.yml
+build_step: true
+```
+
+For more information, see [Integrated Composer](/guides/integrated-composer).
 
 ### PHP Version
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -83,7 +83,7 @@ protected_web_paths_override: true
 The standard protected web paths can be important to the security of your site. If you override protection with this property, be sure to copy all of the standard protected web paths into your `pantheon.yml` file, and only remove those that you are certain are safe to expose.
 
 For a list of standard protected paths, see the `pantheon.upstream.yml` for:
- 
+
 * [Drupal](https://github.com/pantheon-systems/drops-7/blob/default/pantheon.upstream.yml)
 * [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/pantheon.upstream.yml)
 
@@ -117,13 +117,13 @@ For more information, see [Serving Sites from the Web Subdirectory](/nested-docr
 
 ### Integrated Composer Build Step
 
-Enables or disables Integrated Composer, for example to enable Integrated Composer:
+You can enable or disable Integrated Composer in the `pantheon.yml` file. For example, to enable Integrated Composer:
 
 ```yaml:title=pantheon.yml
 build_step: true
 ```
 
-For more information, see [Integrated Composer](/guides/integrated-composer).
+Refer to [Integrated Composer](/guides/integrated-composer) for more information.
 
 ### PHP Version
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Pantheon YAML Configuration Files](https://docs.pantheon.io/pantheon-yml)** - Document the build_step flag and add a Table of Contents for better navigation

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
