### PR TITLE
Fixes the early access links on the object cache pro pages

### DIFF
--- a/source/content/guides/object-cache-pro/01-introduction.md
+++ b/source/content/guides/object-cache-pro/01-introduction.md
@@ -20,7 +20,7 @@ reviewed: "2023-03-27"
 
 <Alert title="Early Access Software" type="info">
 
-Pantheon's Object Cache Pro is available for [Early Access](guides/support/early-access/) participants. Features for Object Cache Pro are in active development. However, Object Cache Pro is a stable product and is in use on production sites. Refer to the email you received when you signed up for Object Cache Pro Early Access if you have questions. Please review Pantheon's [Software Evaluation Licensing Terms](https://legal.pantheon.io/#contract-hkqlbwpxo) for more information about access to our software.
+Pantheon's Object Cache Pro is available for [Early Access](/guides/support/early-access/) participants. Features for Object Cache Pro are in active development. However, Object Cache Pro is a stable product and is in use on production sites. Refer to the email you received when you signed up for Object Cache Pro Early Access if you have questions. Please review Pantheon's [Software Evaluation Licensing Terms](https://legal.pantheon.io/#contract-hkqlbwpxo) for more information about access to our software.
 
 </Alert>
 

--- a/source/content/guides/object-cache-pro/01-introduction.md
+++ b/source/content/guides/object-cache-pro/01-introduction.md
@@ -24,7 +24,7 @@ Pantheon's Object Cache Pro is available for [Early Access](/guides/support/earl
 
 </Alert>
 
-This guide provides information on how to install and configure [Object Cache Pro](https://objectcache.pro) on the Pantheon platform. We are currently evaluating making Object Cache Pro available to users who have access to Redis object cache. Refer to the [How do I sign up for Object Cache Pro on Pantheon](#how-do-i-sign-up) section to join the Early Access program.
+This guide provides information on how to install and configure [Object Cache Pro](https://objectcache.pro) on the Pantheon platform. We are currently evaluating making Object Cache Pro available to users who have access to Redis object cache. Refer to the [How do I sign up for Object Cache Pro on Pantheon](/guides/object-cache-pro/#how-do-i-sign-up-for-object-cache-pro-on-pantheon) section to join the Early Access program.
 
 ## What is Object Cache Pro?
 

--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -20,7 +20,7 @@ reviewed: "2023-03-27"
 
 <Alert title="Early Access Software" type="info">
 
-Pantheon's Object Cache Pro is available for [Early Access](guides/support/early-access/) participants. Features for Object Cache Pro are in active development. However, Object Cache Pro is a stable product and is in use on production sites. Refer to the email you received when you signed up for Object Cache Pro Early Access if you have questions. Please review Pantheon's [Software Evaluation Licensing Terms](https://legal.pantheon.io/#contract-hkqlbwpxo) for more information about access to our software.
+Pantheon's Object Cache Pro is available for [Early Access](/guides/support/early-access/) participants. Features for Object Cache Pro are in active development. However, Object Cache Pro is a stable product and is in use on production sites. Refer to the email you received when you signed up for Object Cache Pro Early Access if you have questions. Please review Pantheon's [Software Evaluation Licensing Terms](https://legal.pantheon.io/#contract-hkqlbwpxo) for more information about access to our software.
 
 </Alert>
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Object Cache Pro on Pantheon](https://docs.pantheon.io/guides/object-cache-pro/)** and **[Install and Configure Object Cache Pro](https://docs.pantheon.io/guides/object-cache-pro/installing-configuring/)** - Fixes broken links to [Early Access Program](https://docs.pantheon.io/guides/support/early-access/) page

## Remaining Work and Prerequisites

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
