### PR TITLE
[CMSP-319] Refrence sites-yml-validator util in WPMS search-replace docs

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -28,7 +28,7 @@ Search and replace runs on the platform as part of creating an environment, depl
 
 ## Requirements
 
-You must have the following to enable search and replace.
+You must have the following to enable search and replace:
 
 - A [WordPress Multisite](/guides/multisite)
 
@@ -50,9 +50,9 @@ Note, if `pantheon.yml` is different between environments, the `search_replace` 
 
 For subdomain Multisites, environments to be replaced are defined and paired in the `sites.yml` file. Search and replace will run for each domain listed in the source environment that has a matching key in the target environment. If search and replace is enabled for an environment, but `sites.yml` does not exist, nothing will be updated. If `sites.yml` is different between environments, the `domain_maps` in the target environment’s `sites.yml` will be used to determine what to replace.
 
-1. Define and pair the environments to be replaced. Refer to [this gist](https://gist.github.com/scottbuscemi/b051ad6510ef8494aff80d0f43afeeb2) for an example of how `sites.yml` might look. 
+1. Define and pair the environments to be replaced. Refer to [this gist](https://gist.github.com/scottbuscemi/b051ad6510ef8494aff80d0f43afeeb2) for an example of how `sites.yml` might look.
 
-1. The `sites.yml` file can be validated before committing using Pantheon's `sites-yml-validator` utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
+1. Validate the `sites.yml` file (recommended) with Pantheon's `sites-yml-validator` utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
 
 1. Commit the  `sites.yml` file in the `private/sites.yml` in the site’s Git repository.
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -50,7 +50,9 @@ Note, if `pantheon.yml` is different between environments, the `search_replace` 
 
 For subdomain Multisites, environments to be replaced are defined and paired in the `sites.yml` file. Search and replace will run for each domain listed in the source environment that has a matching key in the target environment. If search and replace is enabled for an environment, but `sites.yml` does not exist, nothing will be updated. If `sites.yml` is different between environments, the `domain_maps` in the target environment’s `sites.yml` will be used to determine what to replace.
 
-1. Define and pair the environments to be replaced. Refer to [this gist](https://gist.github.com/scottbuscemi/b051ad6510ef8494aff80d0f43afeeb2) for an example of how `sites.yml` might look.
+1. Define and pair the environments to be replaced. Refer to [this gist](https://gist.github.com/scottbuscemi/b051ad6510ef8494aff80d0f43afeeb2) for an example of how `sites.yml` might look. 
+
+1. The `sites.yml` file can be validated before committing using Pantheon's sites-yml-validator utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
 
 1. Commit the  `sites.yml` file in the `private/sites.yml` in the site’s Git repository.
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -52,7 +52,7 @@ For subdomain Multisites, environments to be replaced are defined and paired in 
 
 1. Define and pair the environments to be replaced. Refer to [this gist](https://gist.github.com/scottbuscemi/b051ad6510ef8494aff80d0f43afeeb2) for an example of how `sites.yml` might look. 
 
-1. The `sites.yml` file can be validated before committing using Pantheon's sites-yml-validator utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
+1. The `sites.yml` file can be validated before committing using Pantheon's `sites-yml-validator` utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
 
 1. Commit the  `sites.yml` file in the `private/sites.yml` in the site’s Git repository.
 


### PR DESCRIPTION
## Summary
[WPMS Search Replace](https://docs.pantheon.io/guides/multisite/search-replace/) - Adds direction to the sites-yml-validator tool.


### Dependencies and Timing

- [x] Move pantheon-systems/sites-yml-validator to be a public repo

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
