### PR TITLE
WordFence symlinks are relative to code root

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1027,21 +1027,21 @@ export ENV=dev
 1. Change to the site's `wp-content` directory:
 
    ```bash{promptUser: user}
-   cd $SITE/wp-content
+   cd $SITE
    ```
 
 1. If `/wp-content/wflogs` exists, remove it before you create the symlinks in the next steps:
 
   ```bash{promptUser: user}
-  rm wflogs
+  rm ./wp-content/wflogs
   ```
 
 1. Create the following symlinks:
 
   ```bash{promptUser: user}
-  ln -s ../../files/private/wflogs ./wflogs
-  ln -s ../../files/private/wordfence-waf.php ./../wordfence-waf.php
-  ln -s ../../files/private/.user.ini ./../.user.ini
+  ln -s ../../files/private/wflogs ./wp-content/wflogs
+  ln -s ../files/private/wordfence-waf.php ./wordfence-waf.php
+  ln -s ../files/private/.user.ini ./.user.ini
   ```
 
 1. Open `pantheon.yml` and add a [protected web path](/guides/secure-development/private-paths) for `.user.ini`:


### PR DESCRIPTION
## Summary

**[WordPress Plugins and Themes with Known Issues: Wordfence](https://docs.pantheon.io/plugins-known-issues#wordfence)** - Symlink location is was incorrectly pointing two directories up from the code directory

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Reverts changes made as part of PR #8027 

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
