### PR TITLE
Explain how to select the version of NodeJS

### DIFF
--- a/source/content/guides/decoupled/overview/05-manage-settings.md
+++ b/source/content/guides/decoupled/overview/05-manage-settings.md
@@ -29,6 +29,16 @@ This section provides information on Settings. You can configure Front-End Site 
 
 You can change the Site Name, connect or disconnect your Git repository, and delete your Front-End Site in General Settings.
 
+### NodeJS Version
+
+Pantheon respects the setting in `.nvmrc` when selecting the NodeJS version for runtime. Currently supported versions are:
+
+- 14
+- 16
+- 18
+
+If you need to change the version of NodeJS for your Front End Site, you can test it out by pushing the change to `.nvmrc` to a branch first. 
+
 ### Change Site Name
 
 1. Navigate to your site dashboard and select the site you want to change the name of.


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->
https://docs.pantheon.io/guides/decoupled/overview/manage-settings does not (yet) explain how to select the version of NodeJS that is used for the Front End Site runtime. This is a very important thing for developers to know, as new versions of frameworks will require newer versions of NodeJS. 

Let's make sure people can find out that `.nvmrc` is the place to specify this.

