### PR TITLE
[CMSP-363] Update the doc to add more accurate guidance for OCP on WP Multisite

### DIFF
--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -316,11 +316,11 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 
 	- If you are using WordPress Multisite, subsites do not get their own configuration or graphs. Navigate to `/wp-admin/network/settings.php?page=objectcache` to view network-wide configuration and graphs. This is the only screen throughout the network that displays this information.
 
-### Installing Object Cache Pro on WordPress Multisite
+## Installing Object Cache Pro on WordPress Multisite
 
 When using WordPress Multisite, the recommended installation is to install Object Cache Pro as an `mu-plugin`. This allows Object Cache Pro to handle each individual site separately, while also allowing Super Admins to flush the network cache.
 
-#### Traditional WordPress Multisite
+### Traditional WordPress Multisite
 For normal WordPress installations, you will need to do the following:
 
 1. Move the `object-cache-pro` plugin directory to your `wp-content/mu-plugins/` folder.
@@ -333,7 +333,7 @@ For normal WordPress installations, you will need to do the following:
 		'object-cache-pro/object-cache-pro.php',
 	];
 	```
-#### Composer-Managed WordPress Multisite
+### Composer-Managed WordPress Multisite
 For Composer-managed WordPress multisites using the [WordPress (Composer Managed) upstream](/guides/wordpress-composer/pre-ga/wordpress-composer-managed), the only change is to add a line to your `composer.json` file.
 
 1. In the `"extra"` section of your `composer.json`, add `"rhubarbgroup/object-cache-pro"` to the installer path for `"web/app/mu-plugins/{$name}"`. Your final `"installer-paths"` might look like this:
@@ -349,7 +349,7 @@ For Composer-managed WordPress multisites using the [WordPress (Composer Managed
     },
 	```
 
-#### Additional Considerations
+### Additional Considerations
 - When installed as a `mu-plugin`, Object Cache Pro handles each subsite separately. The dashboard widget applies to the current site and none of the other sites on the network.
 - Flushing the network cache from the network admin will flush all caches across the network.
 - Subsites do not get their own configuration or graphs.
@@ -363,7 +363,7 @@ For Composer-managed WordPress multisites using the [WordPress (Composer Managed
 
 	</Alert>
 
-#### More Resources About `mu-plugin`s
+### More Resources About `mu-plugin`s
 
 * [Create a WordPress MU-Plugin for Actions and Filters](/guides/wordpress-configurations/mu-plugin)
 * [Must Use Plugins](https://wordpress.org/documentation/article/must-use-plugins/)

--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -241,7 +241,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 		] );
 		```
 
-	You can put this directly under the `WP_DEBUG` rules so it looks like this:
+You can put this directly under the `WP_DEBUG` rules so it looks like this:
 
 		```php
 		/**

--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -15,7 +15,7 @@ cms: [wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2023-03-27"
+reviewed: "2023-04-25"
 ---
 
 <Alert title="Early Access Software" type="info">
@@ -33,18 +33,6 @@ Before you can install and activate Object Cache Pro, verify that you have:
 	- You can [activate Redis](/guides/object-cache/enable-object-cache) either from the Pantheon dashboard or with Terminus.
 
 - You have received an email in response to [signing up for the Early Access program](https://forms.gle/3EpZcELcYqB2VRKC8). The email should contain a download link and a license token. Throughout this process the license token will be displayed as `<LICENSE-TOKEN>`.
-
-### WordPress Multisite Considerations
-
-- Object Cache Pro applies to all subsites when activated.
-- Subsites do not get their own configuration or graphs.
-- The Flush cache button in the subsite dashboard widget flushes the cache of the entire network, not just the subsite cache.
-
-	<Alert title="Note" type="info">
-
-	You can use Object Cache Pro's documentation to [hide the dashboard widget](https://objectcache.pro/docs/customizations#dashboard-widget).
-
-	</Alert>
 
 ### Activate Redis on the Dashboard
 
@@ -253,7 +241,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 		] );
 		```
 
-		You can put this directly under the `WP_DEBUG` rules so it looks like this:
+	You can put this directly under the `WP_DEBUG` rules so it looks like this:
 
 		```php
 		/**
@@ -327,3 +315,54 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 1. Navigate to `/wp-admin/options-general.php?page=objectcache` to see the current status of Object Cache Pro on your site as well as live graphs of requests, memory usage, and more.
 
 	- If you are using WordPress Multisite, subsites do not get their own configuration or graphs. Navigate to `/wp-admin/network/settings.php?page=objectcache` to view network-wide configuration and graphs. This is the only screen throughout the network that displays this information.
+
+### Installing Object Cache Pro on WordPress Multisite
+
+When using WordPress Multisite, the recommended installation is to install Object Cache Pro as an `mu-plugin`. This allows Object Cache Pro to handle each individual site separately, while also allowing Super Admins to flush the network cache.
+
+#### Traditional WordPress Multisite
+For normal WordPress installations, you will need to do the following:
+
+1. Move the `object-cache-pro` plugin directory to your `wp-content/mu-plugins/` folder.
+1. Add a line in `wp-content/mu-plugins/loader.php` to point to `object-cache-pro/object-cache-pro.php` under the `pantheon-mu-plugin/pantheon.php` line in the `$pantheon_mu_plugins` array. The result should look like this:
+
+	```php
+	// Add mu-plugins here.
+	$pantheon_mu_plugins = [
+		'pantheon-mu-plugin/pantheon.php',
+		'object-cache-pro/object-cache-pro.php',
+	];
+	```
+#### Composer-Managed WordPress Multisite
+For Composer-managed WordPress multisites using the [WordPress (Composer Managed) upstream](/guides/wordpress-composer/pre-ga/wordpress-composer-managed), the only change is to add a line to your `composer.json` file.
+
+1. In the `"extra"` section of your `composer.json`, add `"rhubarbgroup/object-cache-pro"` to the installer path for `"web/app/mu-plugins/{$name}"`. Your final `"installer-paths"` might look like this:
+
+	```json
+    "installer-paths": {
+      "web/app/mu-plugins/{$name}/": [
+        "type:wordpress-muplugin",
+        "rhubarbgroup/object-cache-pro"
+      ],
+      "web/app/plugins/{$name}/": ["type:wordpress-plugin"],
+      "web/app/themes/{$name}/": ["type:wordpress-theme"]
+    },
+	```
+
+#### Additional Considerations
+- When installed as a `mu-plugin`, Object Cache Pro handles each subsite separately. The dashboard widget applies to the current site and none of the other sites on the network.
+- Flushing the network cache from the network admin will flush all caches across the network.
+- Subsites do not get their own configuration or graphs.
+- If installed as a normal plugin on a WordPress multisite, the Flush cache button in the subsite dashboard widget flushes the cache of the entire network, not just the subsite cache.
+- You will need to manually click the "Enable Cache" button in the Network Admin Object Cache Pro settings page while in SFTP mode to enable Object Cache Pro or use the Terminus commands above and commit the `object-cache.php` drop-in to your repository.
+
+	<Alert title="Note" type="info">
+
+	You can use Object Cache Pro's documentation to [hide the dashboard widget](https://objectcache.pro/docs/customizations#dashboard-widget).
+
+	</Alert>
+
+#### More Resources About `mu-plugin`s
+
+* [Create a WordPress MU-Plugin for Actions and Filters](/guides/wordpress-configurations/mu-plugin)
+* [Must Use Plugins](https://wordpress.org/documentation/article/must-use-plugins/)

--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -224,6 +224,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 
 	```bash{promptUser: user}
 	git add composer.* && git commit -m "Require Object Cache Pro"
+
 	```
 
 1. Add the license token your `config/application.php` file. Note that in the future, the license key will be provided by the platform. Currently, you are responsible for adding it to your repository.
@@ -233,24 +234,6 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 1. Locate the `Config::apply()` line at the bottom of the file and add the following code above the line:
 
 	```php
-		/**
-		 * Object Cache Pro config
-		 */
-		Config::define( 'WP_REDIS_CONFIG', [
-			'token' => '<LICENSE-TOKEN>',
-		] );
-		```
-
-You can put this directly under the `WP_DEBUG` rules so it looks like this:
-
-		```php
-		/**
-		 * Debugging Settings
-		 */
-		Config::define('WP_DEBUG_DISPLAY', false);
-		Config::define('WP_DEBUG_LOG', false);
-		Config::define('SCRIPT_DEBUG', false);
-		ini_set('display_errors', '0');
 
 		/**
 		 * Object Cache Pro config
@@ -258,7 +241,27 @@ You can put this directly under the `WP_DEBUG` rules so it looks like this:
 		Config::define( 'WP_REDIS_CONFIG', [
 			'token' => '<LICENSE-TOKEN>',
 		] );
+
 	```
+	You can put this directly under the `WP_DEBUG` rules so it looks like this:
+	```php
+
+			/**
+			 * Debugging Settings
+			 */
+			Config::define('WP_DEBUG_DISPLAY', false);
+			Config::define('WP_DEBUG_LOG', false);
+			Config::define('SCRIPT_DEBUG', false);
+			ini_set('display_errors', '0');
+
+			/**
+			 * Object Cache Pro config
+			 */
+			Config::define( 'WP_REDIS_CONFIG', [
+				'token' => '<LICENSE-TOKEN>',
+			] );
+
+		```
 
 1. Add Object Cache Pro configuration options after `Config::define( 'WP_REDIS_CONFIG', [` in `config/application.php` for **WordPress (Composer Managed)** sites. The full, recommended contents of the WP_REDIS_CONFIG constant are:
 
@@ -334,9 +337,10 @@ For normal WordPress installations, you will need to do the following:
 	];
 	```
 ### Composer-Managed WordPress Multisite
-For Composer-managed WordPress multisites using the [WordPress (Composer Managed) upstream](/guides/wordpress-composer/pre-ga/wordpress-composer-managed), the only change is to add a line to your `composer.json` file.
 
-1. In the `"extra"` section of your `composer.json`, add `"rhubarbgroup/object-cache-pro"` to the installer path for `"web/app/mu-plugins/{$name}"`. Your final `"installer-paths"` might look like this:
+You must add a line to your `composer.json` file if you have Composer-managed WordPress multisites using the [WordPress (Composer Managed) upstream](/guides/wordpress-composer/pre-ga/wordpress-composer-managed).
+
+1. Navigate to the `"extra"` section of your `composer.json` file and add `"rhubarbgroup/object-cache-pro"` to the installer path for `"web/app/mu-plugins/{$name}"`. Your final `"installer-paths"` might look like this:
 
 	```json
     "installer-paths": {
@@ -354,8 +358,8 @@ For Composer-managed WordPress multisites using the [WordPress (Composer Managed
 - Flushing the network cache from the network admin will flush all caches across the network.
 - Subsites do not get their own configuration or graphs.
 - If installed as a normal plugin on a WordPress multisite, the Flush cache button in the subsite dashboard widget flushes the cache of the entire network, not just the subsite cache.
-- You will need to manually click the "Enable Cache" button in the Network Admin Object Cache Pro settings page while in SFTP mode to enable Object Cache Pro or use the Terminus commands above and commit the `object-cache.php` drop-in to your repository.
-- As noted in the [Caveats](https://wordpress.org/documentation/article/must-use-plugins/#caveats) section of the Must Use Plugins documentation in the Developer Hub, `mu-plugin`s do not receive plugin update notifications and updates need to be handled manually.
+- You must manually click the **Enable Cache** button in the Network Admin Object Cache Pro settings page while in SFTP mode to enable Object Cache Pro. Alternatively, you can use the Terminus commands above and commit the `object-cache.php` drop-in to your repository.
+- As noted in the [Caveats](https://wordpress.org/documentation/article/must-use-plugins/#caveats) section of the Must Use Plugins documentation in the Developer Hub, `mu-plugin`s do not receive plugin update notifications. Updates must be handled manually.
 
 	<Alert title="Note" type="info">
 
@@ -363,7 +367,7 @@ For Composer-managed WordPress multisites using the [WordPress (Composer Managed
 
 	</Alert>
 
-### More Resources About `mu-plugin`s
+### More Resources
 
-* [Create a WordPress MU-Plugin for Actions and Filters](/guides/wordpress-configurations/mu-plugin)
-* [Must Use Plugins](https://wordpress.org/documentation/article/must-use-plugins/)
+- [Create a WordPress MU-Plugin for Actions and Filters](/guides/wordpress-configurations/mu-plugin)
+- [Must Use Plugins](https://wordpress.org/documentation/article/must-use-plugins/)

--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -355,6 +355,7 @@ For Composer-managed WordPress multisites using the [WordPress (Composer Managed
 - Subsites do not get their own configuration or graphs.
 - If installed as a normal plugin on a WordPress multisite, the Flush cache button in the subsite dashboard widget flushes the cache of the entire network, not just the subsite cache.
 - You will need to manually click the "Enable Cache" button in the Network Admin Object Cache Pro settings page while in SFTP mode to enable Object Cache Pro or use the Terminus commands above and commit the `object-cache.php` drop-in to your repository.
+- As noted in the [Caveats](https://wordpress.org/documentation/article/must-use-plugins/#caveats) section of the Must Use Plugins documentation in the Developer Hub, `mu-plugin`s do not receive plugin update notifications and updates need to be handled manually.
 
 	<Alert title="Note" type="info">
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Install and Configure Object Cache Pro](https://docs.pantheon.io/guides/object-cache-pro/installing-configuring/)** - Updates the existing Object Cache Pro installation instructions to add guidance and usage for installing Object Cache Pro on WordPress multisite installs.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
