### PR TITLE
Fixed broken link

### DIFF
--- a/source/content/migrate-cpanel.md
+++ b/source/content/migrate-cpanel.md
@@ -35,4 +35,4 @@ There are some hosting providers that block complete site exports from cPanel, m
 
 1. Test the site.
 
-1. Now that you have the site exported and running locally, you can [migrate to Pantheon](/guides/guided/.
+1. Now that you have the site exported and running locally, you can [migrate to Pantheon](/guides/guided/).


### PR DESCRIPTION
## Summary

[Exporting Sites from GoDaddy with cPanel](https://docs.pantheon.io/migrate-cpanel)
Fixed typo that led to broken link leading to Pantheon Migration Guide.

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
