### PR TITLE
Add Drush 11 error on multi-devs

### DIFF
--- a/source/content/guides/drush/09-troubleshoot-drush.md
+++ b/source/content/guides/drush/09-troubleshoot-drush.md
@@ -227,6 +227,11 @@ This error indicates that the vendor directory contains Drush binaries that shou
 ```none
 Fatal error: require(): Failed opening required '/srv/bindings/.../code/vendor/bin/includes/preflight.inc' (include_path='.:/usr/share/pear:/usr/share/php') in /srv/bindings/.../vendor/bin/drush.php on line 11
 ```
+### Drush 11 error: Declaration of Drush\Sql\Sqlmysql::command() must be compatible with Drush\Sql\SqlBase::command()
+
+This error can occur on multi-devs that are using a [site-local installation](/guides/drush/drush-versions#site-local-drush-usage) version of Drush 11, where the drush version has been removed from the `pantheon.yml` file.  This error occurs because the mutli-dev does not recognize that there is a site-local installation and attempts to use the Pantheon installed version (which by default is Drush 8.4.12).  
+
+A workaround is to add a compatible drush version in `pantheon.yml` to refresh the environment.  For Drupal 9 and later, add `drush_version: 10` to the `pantheon.yml` file.
 
 ## More Resources
 


### PR DESCRIPTION
Added a work around for Drush 11 not working on multi-devs for Drupal 9 sites that are following the site-local installation drush guidelines.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Troubleshoot Drush](https://docs.pantheon.io/guides/drush/troubleshoot-drush)** - Added workaround for scenarios where mutli-devs do not recongize using the site-local installation of Drush 11.


**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
