### PR TITLE
[CMSO-1398] Add details to plugin release.

### DIFF
--- a/source/content/terminus/07-create.md
+++ b/source/content/terminus/07-create.md
@@ -145,6 +145,8 @@ You can specify this in the `compatible-version` section of your `composer.json`
 
 1. Make sure that your constraint expression does not accidentally include the next major version of Terminus if you change `compatible-version`. For example, `>=3.0 <4.0.0` is fine, but `>=3.0` is not.
 
+1. To release a new plugin version you should add a new git tag to the repository so that it gets published as a new version in Packagist. Note that additional steps may be required depending on your plugin needs.
+
 ## Test Plugins
 
 Automated plugin testing is an important step to complete before you distribute your plugins. Automated tests give prospective new users the assurance that the plugin works, and provides a basis for evaluating changes to the plugin.

--- a/source/content/terminus/07-create.md
+++ b/source/content/terminus/07-create.md
@@ -145,7 +145,7 @@ You can specify this in the `compatible-version` section of your `composer.json`
 
 1. Make sure that your constraint expression does not accidentally include the next major version of Terminus if you change `compatible-version`. For example, `>=3.0 <4.0.0` is fine, but `>=3.0` is not.
 
-1. To release a new plugin version you should add a new git tag to the repository so that it gets published as a new version in Packagist. Note that additional steps may be required depending on your plugin needs.
+1. Add a new Git tag to the repository. This publishes the plugin as a new version in Packagist. Note that additional steps may be required depending on your plugin needs.
 
 ## Test Plugins
 


### PR DESCRIPTION
Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Create Terminus Plugins](https://docs.pantheon.io/terminus/create)** - Add details on how to release a new plugin version

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
