### PR TITLE
Fix asterisk usage for footnotes

### DIFF
--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -26,7 +26,7 @@ Click the links below to display complete PHP information for each version, incl
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
 | [8.2](https://v82-php-info.pantheonsite.io/)\*   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
-| [8.1](https://v81-php-info.pantheonsite.io/)\*   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
+| [8.1](https://v81-php-info.pantheonsite.io/)\**   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |
 | [7.4](https://v74-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌          |
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
@@ -41,7 +41,7 @@ Sites that run older PHP versions not listed above will continue to serve pages.
 
 \* New Relic is not supported in PHP 8.2
 
-\* WordPress is not fully compatible with PHP 8.1+.
+\** WordPress is not fully compatible with PHP 8.1+.
 
 ## Drush Compatibility
 


### PR DESCRIPTION
Adding additional asterisk to add clarification for which version of PHP the footnote is referring to.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[PHP on Pantheon Introduction](https://docs.pantheon.io/guides/php#supported-php-versions)** - Fix asterisk notation to clarify footnotes for each PHP version.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Added additional asterisk

## Remaining Work and Prerequisites

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
