### PR TITLE
Update Edge Integrations WordPress - Broken Image

### DIFF
--- a/source/content/guides/edge-integrations/04-wordpress-sdk.md
+++ b/source/content/guides/edge-integrations/04-wordpress-sdk.md
@@ -50,7 +50,7 @@ If you do not use Composer on your project, you can still get started with the W
 
 * Download the most recent version of the Source Code (zip) file.
 
-![Release Assets](../../../images/guides/edge-integrations/ei-wp-plugin-assets.png)
+![Release Assets](../../../images/guides/edge-integrations/ei-wp-plugin-assets2.png)
 
 * Extract the plugin in your `wp-content/plugins` directory. You will get all of the compiled assets and included dependencies, including the CMS-agnostic, [global PHP library](https://github.com/pantheon-systems/pantheon-edge-integrations) in the package.
 


### PR DESCRIPTION
Broken image link, updated link to asset name in source images.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[WordPress SDK](https://docs.pantheon.io/guides/edge-integrations/wordpress-sdk/)** - Fix broken image asset.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

**Before**
<img width="632" alt="image" src="https://user-images.githubusercontent.com/1759794/236860419-8ebaa6ab-28ca-46b7-8234-fda20627eeb4.png">


The following changes are already committed:

* Fixed asset name

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
