### PR TITLE
[CMSP-348] Add WMSP search-replace subdirectory conversion

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -119,11 +119,13 @@ To configure this:
 
 1. Set `convert_to_subdirectory: true` in the `sites.yml` file.
 
-    ```yaml:title=private/sites.yml
-    ---
-    api_version: 1
-    convert_to_subdirectory: true
-    ```
+  ```yaml:title=private/sites.yml
+      ---
+      api_version: 1
+      convert_to_subdirectory: true
+
+      ```
+
 The domain map in the `sites.yml` file is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the Live site will convert with the following pattern:
 
 * `site.com`           => `test-site.pantheonsite.io`

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -123,7 +123,6 @@ To configure this:
       ---
       api_version: 1
       convert_to_subdirectory: true
-
       ```
 
 The domain map in the `sites.yml` file is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the Live site will convert with the following pattern:
@@ -134,7 +133,7 @@ The domain map in the `sites.yml` file is not necessary when converting from sub
 * `blog.com`           => `test-site.pantheonsite.io/blog-com/`
 * `blog.com/dir/`      => `test-site.pantheonsite.io/blog-com-dir/`
 
-Sites configured for subdomain conversion will _only_ run the conversion step from Live to a non-live environment. All other workflows assume a subdirectory-to-subdirectory search and replace.
+Sites configured for subdomain conversion will _only_ run the conversion step from Live to a non-live environment. All other workflows assume a subdirectory-to-subdirectory search and replace. There is no limit on domains when using the conversion step.
 
 ## More Resources
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -46,6 +46,10 @@ You can enable search and replace between environments on a WPMS site.
 
 Note, if `pantheon.yml` is different between environments, the `search_replace` value in the source environment’s `pantheon.yml` will determine if the job will be run or not. The source environment is where you clone the database and files from when you create a Multidev.
 
+### Subdirectory WPMS
+
+No additional configuration is needed if you already completed the steps in [Enable Search and Replace](/guides/multisite/search-replace/#enable-search-and-replace). Search and replace will match the behavior of the platform’s search and replace for non-WPMS sites.
+
 ### Subdomain WPMS
 
 For subdomain Multisites, environments to be replaced are defined and paired in the `sites.yml` file. Search and replace will run for each domain listed in the source environment that has a matching key in the target environment. If search and replace is enabled for an environment, but `sites.yml` does not exist, nothing will be updated. If `sites.yml` is different between environments, the `domain_maps` in the target environment’s `sites.yml` will be used to determine what to replace.
@@ -97,9 +101,31 @@ For subdomain Multisites, environments to be replaced are defined and paired in 
 
 1. Commit the  `sites.yml` file in the `private/sites.yml` in the site’s Git repository.
 
-### Subdirectory WPMS
+### Subdomain to Subdirectory Conversion
+Sites can also be configured to use subdomain Multisite on the live environment, and subdirectory in all other instances.
 
-No additional configuration is needed if you already completed the steps in [Enable Search and Replace](/guides/multisite/search-replace/#enable-search-and-replace). Search and replace will match the behavior of the platform’s search and replace for non-WPMS sites.
+This can be configured by making `SUBDOMAIN_INSTALL` conditional in `wp-config.php`,
+
+    ```php:title=wp-config.php
+    if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) && $_ENV['PANTHEON_ENVIRONMENT'] ==  'live' ) {
+      define( 'SUBDOMAIN_INSTALL', true );
+    }
+    ```
+and setting `convert_to_subdirectory: true` in `sites.yml`.
+
+    ```yaml:title=private/sites.yml
+    ---
+    api_version: 1
+    convert_to_subdirectory: true
+    ```
+The domain map in `sites.yml` is not neccisary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the live site will convert with the following pattern:
+* site.com           => test-site.pantheonsite.io
+* blog.site.com      => test-site.pantheonsite.io/blog/
+* blog.site.com/dir/ => test-site.pantheonsite.io/blog-dir/
+* blog.com           => test-site.pantheonsite.io/blog-com/
+* blog.com/dir/      => test-site.pantheonsite.io/blog-com-dir/
+
+Sites configured for subdomain conversion will _only_ run the conversion step from live to a non-live environment. All other workflows assume a subdirectory-to-subdirectory search-replace.
 
 ## More Resources
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -118,7 +118,7 @@ and setting `convert_to_subdirectory: true` in `sites.yml`.
     api_version: 1
     convert_to_subdirectory: true
     ```
-The domain map in `sites.yml` is not neccisary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the live site will convert with the following pattern:
+The domain map in `sites.yml` is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the live site will convert with the following pattern:
 * site.com           => test-site.pantheonsite.io
 * blog.site.com      => test-site.pantheonsite.io/blog/
 * blog.site.com/dir/ => test-site.pantheonsite.io/blog-dir/

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -48,13 +48,15 @@ Note, if `pantheon.yml` is different between environments, the `search_replace` 
 
 ### Subdirectory WPMS
 
-No additional configuration is needed if you already completed the steps in [Enable Search and Replace](/guides/multisite/search-replace/#enable-search-and-replace). Search and replace will match the behavior of the platform’s search and replace for non-WPMS sites.
+No additional configuration is needed if you have already completed the steps in the [Enable Search and Replace](/guides/multisite/search-replace/#enable-search-and-replace) section. Search and Replace will match the behavior of the platform’s Search and Replace for non-WPMS sites.
 
 ### Subdomain WPMS
 
-For subdomain Multisites, environments to be replaced are defined and paired in the `sites.yml` file. Search and replace will run for each domain listed in the source environment that has a matching key in the target environment. If search and replace is enabled for an environment, but `sites.yml` does not exist, nothing will be updated. If `sites.yml` is different between environments, the `domain_maps` in the target environment’s `sites.yml` will be used to determine what to replace.
+Environments that need to be replaced are defined and paired in the `sites.yml` file for subdomain Multisites. Search and replace runs for each domain listed in the source environment that has a matching key in the target environment. If Search and Replace is enabled for an environment, but the `sites.yml` file does not exist, nothing will be updated. If the `sites.yml` file is different between environments, the `domain_maps` in the target environment’s `sites.yml` file will be used to determine what is replaced.
 
-1. Create a `sites.yml` file inside the `private/` folder. Define and pair the environments to be replaced like the sample code below. 
+1. Create a `sites.yml` file inside the `private/` folder.
+
+1. Define and pair the environments to be replaced like the sample code below.
 
     ```yaml:title=private/sites.yml
     ---
@@ -97,35 +99,40 @@ For subdomain Multisites, environments to be replaced are defined and paired in 
 
     ```
 
-1. Validate the `sites.yml` file (recommended) with Pantheon's `sites-yml-validator` utility available [on Github](https://github.com/pantheon-systems/sites-yml-validator). The project's README includes details on how to install and use the utility.
+1. Validate the `sites.yml` file (recommended) with Pantheon's `sites-yml-validator` utility available [on GitHub](https://github.com/pantheon-systems/sites-yml-validator). The project's `README` file includes details on how to install and use the utility.
 
 1. Commit the  `sites.yml` file in the `private/sites.yml` in the site’s Git repository.
 
 ### Subdomain to Subdirectory Conversion
-Sites can also be configured to use subdomain Multisite on the live environment, and subdirectory in all other instances.
 
-This can be configured by making `SUBDOMAIN_INSTALL` conditional in `wp-config.php`,
+Sites can also be configured to use subdomain Multisite in the Live environment, and subdirectory in all other instances.
+
+To configure this:
+
+1. Make `SUBDOMAIN_INSTALL` conditional in the `wp-config.php` file:
 
     ```php:title=wp-config.php
     if ( ! empty( $_ENV['PANTHEON_ENVIRONMENT'] ) && $_ENV['PANTHEON_ENVIRONMENT'] ==  'live' ) {
       define( 'SUBDOMAIN_INSTALL', true );
     }
     ```
-and setting `convert_to_subdirectory: true` in `sites.yml`.
+
+1. Set `convert_to_subdirectory: true` in the `sites.yml` file.
 
     ```yaml:title=private/sites.yml
     ---
     api_version: 1
     convert_to_subdirectory: true
     ```
-The domain map in `sites.yml` is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the live site will convert with the following pattern:
-* site.com           => test-site.pantheonsite.io
-* blog.site.com      => test-site.pantheonsite.io/blog/
-* blog.site.com/dir/ => test-site.pantheonsite.io/blog-dir/
-* blog.com           => test-site.pantheonsite.io/blog-com/
-* blog.com/dir/      => test-site.pantheonsite.io/blog-com-dir/
+The domain map in the `sites.yml` file is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the Live site will convert with the following pattern:
 
-Sites configured for subdomain conversion will _only_ run the conversion step from live to a non-live environment. All other workflows assume a subdirectory-to-subdirectory search-replace.
+* `site.com`           => `test-site.pantheonsite.io`
+* `blog.site.com`      => `test-site.pantheonsite.io/blog/`
+* `blog.site.com/dir/` => `test-site.pantheonsite.io/blog-dir/`
+* `blog.com`           => `test-site.pantheonsite.io/blog-com/`
+* `blog.com/dir/`      => `test-site.pantheonsite.io/blog-com-dir/`
+
+Sites configured for subdomain conversion will _only_ run the conversion step from Live to a non-live environment. All other workflows assume a subdirectory-to-subdirectory search and replace.
 
 ## More Resources
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -123,7 +123,7 @@ To configure this:
       ---
       api_version: 1
       convert_to_subdirectory: true
-      ```
+  ```
 
 The domain map in the `sites.yml` file is not necessary when converting from subdomain to subdirectory structure. When cloned, subdomains, domains, and subdirectories on the Live site will convert with the following pattern:
 


### PR DESCRIPTION
## Summary
**[WordPress Multisite Search and Replace
](https://docs.pantheon.io/guides/multisite/search-replace/)** 
- Adds details for Subdirectory to Subdomain conversion
- Moved "Subdirectory WPMS" earlier than Subdomain as it is a simpler section.

### Dependencies and Timing
- [x] Merge & AC Test https://github.com/pantheon-systems/wpms-search-replace/pull/37

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
