### PR TITLE
Alternate SMTP port for AWS SES

### DIFF
--- a/source/content/email.md
+++ b/source/content/email.md
@@ -45,7 +45,7 @@ Pantheon strongly encourages using ports other than `25`, `465` or `587` to send
 
 | Provider   | Port Documentation                                                                                          |
 |:---------- |:----------------------------------------------------------------------------------------------------------- |
-| Amazon SES | [587 (STARTTLS), 2465 (TLSWRAPPER)](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html) |
+| Amazon SES | [2587 (STARTTLS), 2465 (TLSWRAPPER)](http://docs.aws.amazon.com/ses/latest/DeveloperGuide/smtp-connect.html) |
 | Mailgun    | [2525](http://blog.mailgun.com/25-465-587-what-port-should-i-use/)                                          |
 | Mandrill   | [2525](https://mandrill.zendesk.com/hc/en-us/articles/205582167-Which-SMTP-ports-can-I-use-)                |
 | Sendgrid   | [2525](https://sendgrid.com/docs/API_Reference/SMTP_API/integrating_with_the_smtp_api.html)                 |


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[CMS Email Service on Pantheon](https://docs.pantheon.io/email#smtp-providers--configurations)** - Replaces port 587 with 2587 as recommend STARTTLS port for AWS SES SMTP connections.

Amazon SES supports port 2587 for STARTTLS. 

https://docs.aws.amazon.com/ses/latest/dg/smtp-connect.html

We've run into issues using port 587 recently but these issues seem to be resolved by using 2587 instead.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
