### PR TITLE
[CMSO-1162] New Relic is now supported on PHP 8.2.

### DIFF
--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,7 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
-| [8.2](https://v82-php-info.pantheonsite.io/)\*   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
+| [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |
 | [7.4](https://v74-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌          |
@@ -36,10 +36,6 @@ Click the links below to display complete PHP information for each version, incl
 | [5.6](https://v56-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 
 Sites that run older PHP versions not listed above will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
-
-#### Compatibility Considerations
-
-\* New Relic is not supported in PHP 8.2
 
 ## Drush Compatibility
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[PHP Versions - Introduction](https://docs.pantheon.io/guides/php)** - Remove New Relic compatibility notice on 8.2.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* PHP 8.2 is now compatible with New Relic

## Remaining Work and Prerequisites

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
