### PR TITLE
Typo in config filename

### DIFF
--- a/source/content/guides/mariadb-mysql/06-hyperdb.md
+++ b/source/content/guides/mariadb-mysql/06-hyperdb.md
@@ -48,7 +48,7 @@ Complete the steps below after your site service level has been updated to Elite
 
 1. Deploy the `db.php` database drop-in to production. WordPress will start allocating MySQL database reads and writes based on the configuration details you’ve provided in `db-config.php`.
 
-The following sample configurations can be used in place of the `dp-config.php` file provided within the plugin archive. These examples require no additional edits for sites running on Pantheon. For more advanced options, refer to the `db-config.php` file provided in the HyperDB plugin archive.
+The following sample configurations can be used in place of the `db-config.php` file provided within the plugin archive. These examples require no additional edits for sites running on Pantheon. For more advanced options, refer to the `db-config.php` file provided in the HyperDB plugin archive.
 
 ### Split Reads Between Primary and Replica
 You can split reads between the primary and the replica database to distribute the load between two servers.


### PR DESCRIPTION
## Summary

**[Scale WordPress Sites with MySQL Replicas and HyperDB](https://docs.pantheon.io/guides/mariadb-mysql/hyperdb)** - config file was misspelled dp-config instead of db-config

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
