### PR TITLE
[BUGS-6329] Document platform limitation.

### DIFF
--- a/source/content/guides/drush/08-drush-known-limitations.md
+++ b/source/content/guides/drush/08-drush-known-limitations.md
@@ -51,6 +51,10 @@ The following Drush commands are not supported and will not work on Pantheon sit
  __ROOT__/sites/default/drushrc.php
  ```
 
+## Cancelling confirmation prompts with Ctrl + c is not supported
+
+Attempting to cancel a Drush confirmation prompt using `ctrl+c` will have the unintended consequence of sending the default response to the server. This happens because for SSH to correctly handle signals like `SIGINT` (`ctrl+c`), it requires a PTY and that is not supported in Pantheon.
+
 ## More Resources
 
 - [MariaDB and MySQL on Pantheon](/guides/mariadb-mysql/mysql-workbench)

--- a/source/content/guides/drush/08-drush-known-limitations.md
+++ b/source/content/guides/drush/08-drush-known-limitations.md
@@ -51,9 +51,9 @@ The following Drush commands are not supported and will not work on Pantheon sit
  __ROOT__/sites/default/drushrc.php
  ```
 
-## Cancelling confirmation prompts with Ctrl + c is not supported
+## Cancelling Confirmation Prompts with Ctrl + c is not Supported
 
-Attempting to cancel a Drush confirmation prompt using `ctrl+c` will have the unintended consequence of sending the default response to the server. This happens because for SSH to correctly handle signals like `SIGINT` (`ctrl+c`), it requires a PTY and that is not supported in Pantheon.
+Attempting to cancel a Drush confirmation prompt using `ctrl+c` will send the default response to the server. This happens because SSH requires a PTY to correctly handle signals like `SIGINT` (`ctrl+c`), which is not supported on Pantheon.
 
 ## More Resources
 


### PR DESCRIPTION
Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Drush Known Limitations with Pantheon](https://docs.pantheon.io/guides/drush/drush-known-limitations)** - Add new drush limitation in Pantheon.


## Remaining Work and Prerequisites

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
