### PR TITLE
Improve Clarity of Quicksilver Install Scripts page

### DIFF
--- a/source/content/guides/quicksilver/02-install-script.md
+++ b/source/content/guides/quicksilver/02-install-script.md
@@ -20,7 +20,7 @@ This section provides information on script type and location, as well as how to
 
 Quicksilver currently supports `webphp` scripting, which runs a PHP script through the same runtime environment as the website. PHP scripts are subject to the same limits as any code on the platform, such as [timeouts](/timeouts). PHP scripts cannot be batched, and run continuously and sequentially. Each command executes after the previous command has finished or timed out.
 
-We recommend setting the `web_docroot` to `true` to create a dedicated directory in the docroot (for example, `private/scripts`). This tracks files by instructing Quicksilver to look for the files inside the `web` folder. If your site uses this [nested docroot](/nested-docroot) setting, the scripts directory must be located in the `web` subdirectory of your site's code repository (for example, `web/private/scripts`).
+We recommend setting the `web_docroot` to `true` and to create a dedicated directory under the docroot (for example, `web/private/scripts`). This tracks files by instructing Quicksilver to look for the files inside the `web` folder. If your site uses this [nested docroot](/nested-docroot) setting, the scripts directory must be located in the `web` subdirectory of your site's code repository (for example, `web/private/scripts`).
 
 <Alert type="info" title="Nested Docroots">
 
@@ -28,6 +28,14 @@ If your site uses a [nested docroot](/nested-docroot), the script paths in your 
 
 - `private/scripts/new_relic_deploy.php`
 - `private/scripts/slack_deploy_notification.php`
+
+Even though the pantheon.yml `script` section does not include the `web` folder, the location the file is located in is inside `web`. For example, if this line is set in the `pantheon.yml`:
+
+`private/scripts/new_relic_deploy.php`
+
+The file needs to be located in this location:
+
+`web/private/scripts/new_relic_deploy.php`
 
 </Alert>
 

--- a/source/content/guides/quicksilver/02-install-script.md
+++ b/source/content/guides/quicksilver/02-install-script.md
@@ -20,7 +20,7 @@ This section provides information on script type and location, as well as how to
 
 Quicksilver currently supports `webphp` scripting, which runs a PHP script through the same runtime environment as the website. PHP scripts are subject to the same limits as any code on the platform, such as [timeouts](/timeouts). PHP scripts cannot be batched, and run continuously and sequentially. Each command executes after the previous command has finished or timed out.
 
-We recommend setting the `web_docroot` to `true` and to create a dedicated directory under the docroot (for example, `web/private/scripts`). This tracks files by instructing Quicksilver to look for the files inside the `web` folder. If your site uses this [nested docroot](/nested-docroot) setting, the scripts directory must be located in the `web` subdirectory of your site's code repository (for example, `web/private/scripts`).
+We recommend that you set the `web_docroot` to `true` and that you create a dedicated directory under the docroot (for example, `web/private/scripts`). This tracks files by instructing Quicksilver to look for the files inside the `web` folder. If your site uses this [nested docroot](/nested-docroot) setting, the scripts directory must be located in the `web` subdirectory of your site's code repository (for example, `web/private/scripts`).
 
 <Alert type="info" title="Nested Docroots">
 
@@ -29,11 +29,11 @@ If your site uses a [nested docroot](/nested-docroot), the script paths in your 
 - `private/scripts/new_relic_deploy.php`
 - `private/scripts/slack_deploy_notification.php`
 
-Even though the pantheon.yml `script` section does not include the `web` folder, the location the file is located in is inside `web`. For example, if this line is set in the `pantheon.yml`:
+Even though the `script` section in the `pantheon.yml` file does not include the `web` folder, the file is located inside `web`. For example, if this line is set in the `pantheon.yml` file:
 
 `private/scripts/new_relic_deploy.php`
 
-The file needs to be located in this location:
+The file must be located in:
 
 `web/private/scripts/new_relic_deploy.php`
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Quicksilver Install Scripts](https://docs.pantheon.io/guides/quicksilver/install-script)** - The "Script Type and Location" for Quicksilver is very confusing for customers.

## Effect

Many customers contact Support and need's Support's help to understand how to set this up correctly. They also regularly comment that this section of the Docs is confusing.

This sentence is particularly meaningless in my opinion: "We recommend setting the web_docroot to true to create a dedicated directory in the docroot (for example, private/scripts)." The "setting a web_docroot to true" and "create a dedicated directory" really have no relation as I understand it and the "to" between doesn't make sense technically.

What needs to be communicated is that the "pantheon.yml" file never should have "web" in the "scripts" path. But if "web_docroot" is set to "true", then the location of the file has to be inside "web" and then whatever is in the "scripts" path.

The following changes are already committed:

* Trying to make it more clear.
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Maybe trying to improve my work further?

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
