### PR TITLE
[BUGS-6308] Updates to Github Actions section of terminus auth scripting guide.

### DIFF
--- a/source/content/terminus/05-scripting.md
+++ b/source/content/terminus/05-scripting.md
@@ -48,7 +48,7 @@ You can run a complete backend authorization in Terminus by accessing Auth0 behi
         }
         ```
 
-1. Restore the session file in a CI context to allow Terminus to log in using `terminus auth:login` with no `--machine-token`. Instructions for specific CI pipelines are listed below.
+1. Restore the session file in a CI context to stay logged in without needing to reauthenticate every time. Instructions for specific CI pipelines are listed below.
 
     - [Bitbucket](/terminus/ci/bitbucket)
     - [CircleCI](/terminus/ci/circleci)

--- a/source/content/terminus/05-scripting.md
+++ b/source/content/terminus/05-scripting.md
@@ -48,7 +48,7 @@ You can run a complete backend authorization in Terminus by accessing Auth0 behi
         }
         ```
 
-1. Restore the session file in a CI context to stay logged in without needing to reauthenticate every time. Instructions for specific CI pipelines are listed below.
+1. Restore the session file in a CI context to stay logged in without re-authenticating every time. Instructions for specific CI pipelines are listed below.
 
     - [Bitbucket](/terminus/ci/bitbucket)
     - [CircleCI](/terminus/ci/circleci)

--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -27,8 +27,8 @@ You can use the example script in this section for a full start-to-finish Termin
 This pipeline does the following:
 
 - Uses the `ubuntu:latest` Docker image.
-- Updates the system and installs necessary tools like PHP, curl, perl, sudo, and git before the script stages.
-- Defines a cache for the `$HOME/.terminus` directory and the terminus binary. The pipeline system will save and restore the cache for subsequent runs.
+- Updates the system and installs necessary tools like PHP, curl, perl, sudo, and Git before the script stages.
+- Defines a cache for the `$HOME/.terminus` directory and the Terminus binary. The pipeline system will save and restore the cache for subsequent runs.
 - Determines the latest release of Terminus from the GitHub API and stores it in the `TERMINUS_RELEASE` variable.
 - Creates a directory for Terminus, downloads it into that directory, makes it executable, and then creates a symbolic link to it in `/usr/local/bin` so that you can run it from anywhere.
 - Checks that Terminus is authenticated with `terminus auth:whoami`.


### PR DESCRIPTION

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Authenticate Terminus in a GitHub Actions Pipeline](https://docs.pantheon.io/terminus/ci/github-actions)** - Update script to actually use cache session.

### Dependencies and Timing

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
