### PR TITLE
Removed step from Next Drupal caching code sample that is no longer necessary

### DIFF
--- a/source/content/guides/decoupled/drupal-nextjs-frontend-starters/03-caching.md
+++ b/source/content/guides/decoupled/drupal-nextjs-frontend-starters/03-caching.md
@@ -122,12 +122,6 @@ Follow the steps below if you need to create a **new** route.
 In the example below, the code sets the headers necessary for
 cache purging on an article list page.
 
-1. Open your `next.config.js` file and add the following to the `nextConfig` object:
-
-	```js
-	transpilePackages: ['@pantheon-systems/drupal-kit'],
-	```
-
 1. Create an instance of `DrupalState` in your article list page:
 
 	```js


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

Due to an update to the drupal-state and drupal-kit packages, the step related to modifying next.config.js can now be removed from the Next Drupal caching code sample.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
