### PR TITLE
[CMSP-496] multisite workflows update

### DIFF
--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -19,12 +19,12 @@ This section provides information on important Multisite fundamentals.
 ## Create Test and Live Environments from Dev
 After you've configured a WordPress Multisite in the Dev environment, you'll quickly want to promote it to Test and then Live. Before you use these environments, you'll need to initialize them.
 
-1. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicons glyphicons-equalizer" aria-hidden="true"></span> Test** tab.
+1. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicon glyphicon-equalizer" aria-hidden="true"></span> Test** tab.
 2. Click **Create Test Environment**.
 
   This takes a few moments.
 
-3. Click **<span class="glyphicons glyphicons-new-window-alt" aria-hidden="true"></span> Visit Test Site**. This will open your Test site in a new browser tab with the URL `test-YOURSITE.pantheonsite.io`. At this point, it will show a database connection error.
+3. Click **<span class="glyphicon glyphicon-new-window-alt" aria-hidden="true"></span> Visit Test Site**. This will open your Test site in a new browser tab with the URL `test-YOURSITE.pantheonsite.io`. At this point, it will show a database connection error.
 
 4. Navigate to the command line, and perform a `wp search-replace` on the Test environment's database via Terminus:
 

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -59,7 +59,7 @@ Terminus allows you to run WP-CLI commands yourself and, using that, you can man
 terminus remote:wp <site>.<env> -- search-replace "<old-domain>" "<new-domain>" --network --url=<old-domain>
 ```
 
-Using WP-CLI with Terminus is simply a matter of calling Terminus with the correct `<site>` and `<env>` arguments:
+**You should only need to run `wp search-replace` manually via Terminus if you are explicitly _not_ using the built-in [WordPress Multisite Search and Replace](/guides/multisite/search-replace).** Using WP-CLI with Terminus is simply a matter of calling Terminus with the correct `<site>` and `<env>` arguments:
 
 In this example:
 

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -31,7 +31,7 @@ WordPress stores full URLs in the database. These URLs can be links within the p
     Refer to the [WordPress Multisite Search and Replace](/guides/multisite/search-replace) guide for detailed instructions.
 
     <Alert title="Note" type="info">
-        After August 1, 2023, `true` will be the default value for Multisite Search and Replace whether or not it exists in the `pantheon.yml` explicitly.
+        After July 31, 2023, `true` will be the default value for Multisite Search and Replace whether or not it exists in the `pantheon.yml` explicitly.
     </Alert>
 
 2. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicon glyphicon-equalizer" aria-hidden="true"></span> Test** tab.

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -17,7 +17,7 @@ editpath: multisite/05-workflows.md
 This section provides information on important Multisite fundamentals.
 
 ## Create Test and Live Environments from Dev
-After you've configured a WordPress Multisite in the Dev environment, you'll quickly want to promote it to Test and then Live. Before you use these environments, you'll need to initialize them.
+After you've configured a WordPress Multisite in the Dev environment, you'll want to promote it to Test and then Live. Before you use these environments, you'll need to initialize them.
 
 WordPress stores full URLs in the database. These URLs can be links within the post content, as well as configuration values. This implementation detail means you need to perform a search and replace procedure when moving a database between environments. WP-CLI's `search-replace` command is a good tool for this job, in large part because it also gracefully handles URL references inside of PHP serialized data. Pantheon's [WordPress Multisite Search and Replace](/guides/multisite/search-replace) can handle this step for you and provides multiple configuration options depending on your desired workflow.
 

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -21,14 +21,7 @@ After you've configured a WordPress Multisite in the Dev environment, you'll wan
 
 WordPress stores full URLs in the database. These URLs can be links within the post content, as well as configuration values. This implementation detail means you need to perform a search and replace procedure when moving a database between environments. WP-CLI's `search-replace` command is a good tool for this job, in large part because it also gracefully handles URL references inside of PHP serialized data. Pantheon's [WordPress Multisite Search and Replace](/guides/multisite/search-replace) can handle this step for you and provides multiple configuration options depending on your desired workflow.
 
-1. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicon glyphicon-equalizer" aria-hidden="true"></span> Test** tab.
-2. Click **Create Test Environment**.
-
-  This takes a few moments.
-
-3. Click **<span class="glyphicon glyphicon-new-window-alt" aria-hidden="true"></span> Visit Test Site**. This will open your Test site in a new browser tab with the URL `test-YOURSITE.pantheonsite.io`.
-
-4. Configure the `search_replace` value in your `pantheon.yml` file based on what type of Multisite you are setting up and what your preferences are: 
+1. Configure the `search_replace` value in your `pantheon.yml` file based on what type of Multisite you are setting up and what your preferences are: 
 
     * `true` for Subdirectory Multisite, 
     * `custom` for Subdomain Multisite with a `sites.yml` file, 
@@ -36,6 +29,18 @@ WordPress stores full URLs in the database. These URLs can be links within the p
     * `false` for no automatic URL conversion at all.
     
     Refer to the [WordPress Multisite Search and Replace](/guides/multisite/search-replace) guide for detailed instructions.
+
+    <Alert title="Note" type="info">
+        After August 1, 2023, `true` will be the default value for Multisite Search and Replace whether or not it exists in the `pantheon.yml` explicitly.
+    </Alert>
+
+2. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicon glyphicon-equalizer" aria-hidden="true"></span> Test** tab.
+
+3. Click **Create Test Environment**.
+
+  This takes a few moments.
+
+4. Click **<span class="glyphicon glyphicon-new-window-alt" aria-hidden="true"></span> Visit Test Site**. This will open your Test site in a new browser tab with the URL `test-YOURSITE.pantheonsite.io`.
 
 5. Deploy your code change from Dev to Test and refresh the Pantheon Dashboard.
 

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -70,7 +70,7 @@ In this example:
 
 Refer to the [full documentation](https://developer.wordpress.org/cli/commands/search-replace/) for all supported features.
 
-## Refresh Data from Live
+### Refresh Data from Live
 Refreshing data in Test or Dev from Live is simply a matter of using the Database Clone feature in the Pantheon Dashboard. reversing the steps you took to initially create the Live environment when you have a production environment. 
 
 1. Clone the content from Live into Dev:
@@ -93,9 +93,7 @@ Refreshing data in Test or Dev from Live is simply a matter of using the Databas
 
 You can now develop against production data.
 
-Note: You can also automate the search-replace process after performing a database clone with the [Quicksilver](/guides/quicksilver) [search-replace script](https://github.com/pantheon-systems/quicksilver-examples/tree/main/wp_search_replace).
-
-## Work with Large Databases
+### Work with Large Databases
 If you have a really large database (gigabytes and gigabytes) or dozens upon dozens of tables, you may notice that `wp search-replace` can take a really long time — or even time out.
 
 To better understand what's going on, it's helpful to have some background knowledge.

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -70,28 +70,6 @@ In this example:
 
 Refer to the [full documentation](https://developer.wordpress.org/cli/commands/search-replace/) for all supported features.
 
-##  Flush Cache Globally after Search and Replace
-If you use Redis as a persistent storage backend for your object cache, you'll need to flush your cache each time you complete a set of search and replace operations to ensure it doesn't serve stale values.
-
-With Terminus and WP-CLI, you can flush cache globally with one operation:
-
-```bash
-terminus remote:wp <site>.<env> -- cache flush
-```
-
-The Terminus command to clear all caches for an environment is:
-
-```bash
-terminus env:clear-cache <site>.<env>
-```
-
-Running into “Error: Site Not Found”? See [Troubleshoot](/guides/multisite/debug) for the cause and resolution.
-
-
-<Alert title="Note" type="info">
-Because the WordPress object cache stores its data as key => value pairs and WordPress Multisite simply adds the blog ID to the key, flushing cache is a global operation for those using persistent storage backends.
-</Alert>
-
 ## Refresh Data from Live
 Refreshing data in Test or Dev from Live is simply a matter of using the Database Clone feature in the Pantheon Dashboard. reversing the steps you took to initially create the Live environment when you have a production environment. 
 
@@ -145,6 +123,28 @@ In this example:
 If the WordPress Multisite works as expected after you run `wp search-replace`, then you're good to go. If it doesn't quite work as expected, there may be some plugins storing URL data in other locations that you'll need to debug and further assess.
 
 Ultimately, the key idea is to only perform a search and replace where you absolutely need it, instead of globally against the entire database.
+
+##  Flush Cache Globally after Search and Replace
+If you use Redis as a persistent storage backend for your object cache, you'll need to flush your cache each time you complete a set of search and replace operations to ensure it doesn't serve stale values.
+
+With Terminus and WP-CLI, you can flush cache globally with one operation:
+
+```bash
+terminus remote:wp <site>.<env> -- cache flush
+```
+
+The Terminus command to clear all caches for an environment is:
+
+```bash
+terminus env:clear-cache <site>.<env>
+```
+
+Running into “Error: Site Not Found”? See [Troubleshoot](/guides/multisite/debug) for the cause and resolution.
+
+
+<Alert title="Note" type="info">
+Because the WordPress object cache stores its data as key => value pairs and WordPress Multisite simply adds the blog ID to the key, flushing cache is a global operation for those using persistent storage backends.
+</Alert>
 
 ## Go for Launch
 In reading through this guide and participating along the way, you're now fully up to speed on managing a WordPress Multisite on Pantheon. Check out the [Launch Essentials Guide](/guides/launch) when you're ready to push your site live — launching a WordPress Multisite isn't much different than launching a standard WordPress site.

--- a/source/content/guides/multisite/05-workflows.md
+++ b/source/content/guides/multisite/05-workflows.md
@@ -31,7 +31,7 @@ WordPress stores full URLs in the database. These URLs can be links within the p
     Refer to the [WordPress Multisite Search and Replace](/guides/multisite/search-replace) guide for detailed instructions.
 
     <Alert title="Note" type="info">
-        After July 31, 2023, `true` will be the default value for Multisite Search and Replace whether or not it exists in the `pantheon.yml` explicitly.
+        After July 31, 2023, true will be the default value for Multisite Search and Replace whether or not it exists in the pantheon.yml explicitly.
     </Alert>
 
 2. [Go to the Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) and click the **<span class="glyphicon glyphicon-equalizer" aria-hidden="true"></span> Test** tab.

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -140,11 +140,13 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 ## `search_replace` Parameter Reference
 
-* `_null_`: No `search_replace` value. Defaults to `false`.<!-- TODO: ADD NOTE THAT THIS DEFAULTS TO TRUE IN GA -->
+* `_null_`: No `search_replace` value. Defaults to `false`. Sites created after July 31, 2023 will default to `true`.
 * `true`: Runs a Search and Replace for a Subdirectory multisite.
 * `false`: Do not run Search and Replace at all.
 * `custom`: Run Search and Replace based on the domain map in `sites.yml`. Requires a valid `sites.yml` to exist.
 * `convert`: Run Subdomain to Subdirectory conversion when cloning from the Pantheon Live environment, and Subdirectory to Subdirectory in all other cases.
+
+
 
 ## Known Issues
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Multisite Workflows](https://docs.pantheon.io/guides/multisite/workflows/)** - Updates the WordPress Multisite Workflows doc page with information updated for WordPress Multisite Search and Replace

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
