### PR TITLE
adds a CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,4 @@
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence, @pantheon-systems/docs-admins, as primary maintainers will be requested for review when someone opens a Pull Request.
+# Additional code owners can be added for specific paths.
+# For more information about CODEOWNERS files, refer to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+* @pantheon-systems/docs-admins


### PR DESCRIPTION
## Summary
Adds a `CODEOWNERS` file. This file defines ownership for the repository as a whole. Code owners are automatically requested for PR review for all PRs in the repository.

Additionally, code owners can be defined for specific paths. For example, if we wanted to define the @pantheon-systems/cms-platform team as owners of anything relating to WordPress, we could do something like:

```
/source/content/guides/wordpress*/ @pantheon-systems/cms-platform
```

Teams (or individuals) would still need explicit write access to the repository to merge approved PRs, but teams would be notified and requested for review whenever files within the specified paths were modified.

Repositories can be set up to explicitly _request_ code owner approval before a PR can be merged once a `CODEOWNERS` file exists.

https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

### Note

The build is currently failing. I am assuming that this failure is because _no actual documents were modified in this PR_. Additionally, no builds are explicitly _required_ by this PR since it is a repository/infrastructure change rather than a documentation change that needs to be deployed. (As such, I'm not sure how much the post launch stuff matters in this case.)

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
