### PR TITLE
CMSP-267: Updates Search and Replace documentation to include the dat…

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -31,8 +31,16 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 
 ## Subdirectory WordPress Multisite Search and Replace Configuration
 
+### For sites created _before_ August 1, 2023
+
 Enabling Search and Replace for Subdirectory Multisites requires a `true` value for the `search_replace` parameter in your `pantheon.yml`.
-<!--No additional configuration is needed for Subdirectory Multisite Search and Replace. Search and Replace will match the behavior of the platform’s Search and Replace for non-WPMS sites. TODO: Before GA, add note about explicitly DISABLING S&R.-->
+
+### For sites created _after_ August 1, 2023
+
+No additional configuration is needed for Subdirectory Multisite Search and Replace. Search and Replace will match the behavior of the platform’s Search and Replace for non-WPMS sites.
+
+If you wish to disable Multisite Search and Replace, alter your `pantheon.yml` file to include a `false` value for the `search_replace` parameter.
+
 
 ```yaml:title=pantheon.yml
 search_replace: true

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -35,6 +35,10 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 
 Enabling Search and Replace for Subdirectory Multisites requires a `true` value for the `search_replace` parameter in your `pantheon.yml`.
 
+```yaml:title=pantheon.yml
+search_replace: true
+```
+
 ### For sites created _after_ August 1, 2023
 
 No additional configuration is needed for Subdirectory Multisite Search and Replace. Search and Replace will match the behavior of the platform’s Search and Replace for non-Multisite sites.
@@ -43,7 +47,7 @@ If you wish to disable Multisite Search and Replace, alter your `pantheon.yml` f
 
 
 ```yaml:title=pantheon.yml
-search_replace: true
+search_replace: false
 ```
 
 ## Subdomain WordPress Multisite Search and Replace Configuration

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -37,7 +37,7 @@ Enabling Search and Replace for Subdirectory Multisites requires a `true` value 
 
 ### For sites created _after_ August 1, 2023
 
-No additional configuration is needed for Subdirectory Multisite Search and Replace. Search and Replace will match the behavior of the platform’s Search and Replace for non-WPMS sites.
+No additional configuration is needed for Subdirectory Multisite Search and Replace. Search and Replace will match the behavior of the platform’s Search and Replace for non-Multisite sites.
 
 If you wish to disable Multisite Search and Replace, alter your `pantheon.yml` file to include a `false` value for the `search_replace` parameter.
 


### PR DESCRIPTION
…e based default.

Closes #CMSP-267

## Summary

**[Search and Replace](https://docs.pantheon.io/guides/multisite/search-replace/)** - Provides an update to the Search and Replace documentation to include the new defaults based on site creation.


### Dependencies and Timing

NA -- defaults are already merged in and will take effect unless a new release removes them.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
