### PR TITLE
[EDRT-1782] Update supported browsers

### DIFF
--- a/source/content/guides/platform-considerations/01-introduction.md
+++ b/source/content/guides/platform-considerations/01-introduction.md
@@ -27,7 +27,7 @@ The Pantheon Dashboard supports the following browsers to maintain platform secu
   - [Opera](https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Release_compatibility)
   - [Safari](https://developer.apple.com/documentation/safari-release-notes)
 
-Visit <https://www.whatsmybrowser.org> to confirm which browser version you are using and compare your browser's version with the latest available.
+Visit <https://www.whatsmybrowser.org> to confirm which browser version you are using and compare your browser's version with the latest available. Panthoen recommends using 'Evergreen' browsers. These are browsers that have the ability to update themselves and do not require the user to manually download new packages.
 
 
 ## More Resources

--- a/source/content/guides/platform-considerations/01-introduction.md
+++ b/source/content/guides/platform-considerations/01-introduction.md
@@ -21,19 +21,13 @@ This guide features common platform considerations specific to Pantheon's distri
 
 The Pantheon Dashboard supports the following browsers to maintain platform security measures and to focus internal development and engineering work: 
 
-+------------------------+--------+---------+-------+------+---------------------+
-|                        | Chrome | Firefox | Opera | Edge | Safari              |
-+========================+========+=========+=======+======+=====================+
-| **Versions Supported** | Evergreen Browsers - Last 4     | Current + Last Year |
-+------------------------+---------------------------------+---------------------+
-
-Visit <https://www.whatsmybrowser.org> to confirm which browser version you are using and compare your browser's version with the latest available:
-
   - [Chrome](https://chromereleases.googleblog.com/search/label/chrome)
   - [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge#New_Edge_release_history)
   - [Firefox](https://en.wikipedia.org/wiki/Firefox_version_history#Current_supported_official_releases)
   - [Opera](https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Release_compatibility)
   - [Safari](https://en.wikipedia.org/wiki/Safari_version_history#Version_compatibility)
+
+Visit <https://www.whatsmybrowser.org> to confirm which browser version you are using and compare your browser's version with the latest available.
 
 
 ## More Resources

--- a/source/content/guides/platform-considerations/01-introduction.md
+++ b/source/content/guides/platform-considerations/01-introduction.md
@@ -21,11 +21,11 @@ This guide features common platform considerations specific to Pantheon's distri
 
 The Pantheon Dashboard supports the following browsers to maintain platform security measures and to focus internal development and engineering work: 
 
-  - [Chrome](https://chromereleases.googleblog.com/search/label/chrome)
-  - [Edge](https://en.wikipedia.org/wiki/Microsoft_Edge#New_Edge_release_history)
-  - [Firefox](https://en.wikipedia.org/wiki/Firefox_version_history#Current_supported_official_releases)
+  - [Google Chrome](https://chromereleases.googleblog.com/search/label/chrome)
+  - [Microsoft Edge](https://learn.microsoft.com/en-us/deployedge/microsoft-edge-relnote-stable-channel)
+  - [Mozilla Firefox](https://www.mozilla.org/en-US/firefox/releases/)
   - [Opera](https://en.wikipedia.org/wiki/History_of_the_Opera_web_browser#Release_compatibility)
-  - [Safari](https://en.wikipedia.org/wiki/Safari_version_history#Version_compatibility)
+  - [Safari](https://developer.apple.com/documentation/safari-release-notes)
 
 Visit <https://www.whatsmybrowser.org> to confirm which browser version you are using and compare your browser's version with the latest available.
 


### PR DESCRIPTION
Closes # EDRT-1782

## Summary
During the TLS Cipher Deprecation project, we found some outdate information on the types of browsers we support.

**[Introduction | Platform Considerations](https://docs.pantheon.io/guides/platform-considerations#browser-support-for-pantheons-dashboard)** 
- Remove out of date and inaccurate table about supported browser versions

## Effect

The following changes are already committed:

* Removes the table about Evergreen versions (supporting the Last 4 etc...)
* Adds further verbiage about using browsers that stay up to date.

## Remaining Work and Prerequisites

No dependancies or pre-reqs

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
