### PR TITLE
Fix missing glyphicons

### DIFF
--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -550,7 +550,7 @@ h2 > .glyphicons {
 }
 
 @media screen and (max-width: 995px) {
-  
+
 	input[type="search"],
 	input[type="search"]:focus {
 		/* padding: 0px 0px 0px 45px; */
@@ -606,4 +606,9 @@ a.release-update::before {
 	height: 160px;
 	margin-top: -160px;
 	visibility: hidden;
+}
+
+@font-face {
+  font-family: 'Glyphicons Regular';
+  src: url(/fonts/glyphicons/glyphicons-regular-v192.woff2) format('woff2');
 }


### PR DESCRIPTION
Closes #8261 

## Summary

Fix legacy glyphicons across the docs site 

## Effect
Before: 
![glyphicons-before](https://github.com/pantheon-systems/documentation/assets/10119525/a9143b64-3533-4119-b5fb-e67ae9ae3791)


After: 
![glyphicons-after](https://github.com/pantheon-systems/documentation/assets/10119525/d58d3a58-656e-4b5d-94ff-755c929e2af7)

