### PR TITLE
Updates changelog to reflect updates to WordPress.

### DIFF
--- a/source/content/wordpress.md
+++ b/source/content/wordpress.md
@@ -17,6 +17,11 @@ For the most part, [Pantheon's WordPress upstream](https://github.com/pantheon-s
 
 ## Latest Release
 
+### 2023-08-14
+This update bumps the default PHP version to 8.1. We will continue to support sites running PHP 7.4 despite its EOL status (see https://www.php.net/supported-versions.php).
+
+Please test your site thoroughly before deploying this update to your live site. If your site requires an older version of PHP or if you'd like to upgrade to PHP 8.2, please see https://docs.pantheon.io/guides/php/php-versions for more information on using pantheon.yml to set your PHP version.
+
 ### 2023-03-29
 
 <a name="20230203" class="release-update"></a>Removes contact support line.


### PR DESCRIPTION
Closes #CMSP-321

## Summary

**[WordPress](https://docs.pantheon.io/wordpress)** - Updates WordPress changelog to reflect new PHP Default version.

### Dependencies and Timing

Should be released with the merging of https://github.com/pantheon-systems/wordpress-composer-managed/pull/109/

**Release**:
- [X] When ready -- with coordination with CMS-Eco


--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
