### PR TITLE
Markdown fix on Style Guide page

### DIFF
--- a/source/content/style-guide.md
+++ b/source/content/style-guide.md
@@ -1044,6 +1044,7 @@ Given two new sites with slugs <Popover title="Slugs" content="Generally, are UR
 ```
 
 </Example>
+
 ## Variables
 
 When writing multi-step processes, repeated variables and constants should be defined before providing the first set of commands. If the doc has a "Before You Begin" section, define varables here. Provide them using the callout below, and follow common conventions (lowercase for variables, uppercase for constants).


### PR DESCRIPTION
Without this linebreak, the "Variables" heading doesn't render as a heading.

https://docs.pantheon.io/style-guide
<img width="853" alt="the-pound-signs-are-visible" src="https://github.com/pantheon-systems/documentation/assets/211029/1a91c84e-a6ac-493d-b93a-013043727428">
