### PR TITLE
Add defaults for WPMU Search and Replace

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -32,7 +32,7 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 ## Defaults
 See the following Search and Replace defaults for new and existing WordPress Multisites on Pantheon:
 
-| WP Multisite Configuration      | Default Search and Replace |
+| WP Multisite Configuration      | Default `search_replace` value |
 | ------------- | -------------------------------------- |
 | Existing Subdirectory <Popover content="Created before August 1, 2023"/> | `false` |
 | New Subdirectory | `true` |

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -29,6 +29,17 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 
 </Alert>
 
+## Defaults
+See the following Search and Replace defaults for new and existing WordPress Site Networks on Pantheon:
+
+| WPMU Configuration      | Default Search and Replace |
+| ------------- | -------------------------------------- |
+| Existing Subdirectory <Popover content="Created before August 1, 2023"/> | False |
+| New Subdirectory | True |
+| Existing Subdomain <Popover content="Created before August 1, 2023"/> | False |
+| New Subdomain | False |
+
+
 ## Subdirectory WordPress Multisite Search and Replace Configuration
 
 ### For sites created _before_ August 1, 2023

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -34,10 +34,10 @@ See the following Search and Replace defaults for new and existing WordPress Mul
 
 | WP Multisite Configuration      | Default `search_replace` value |
 | ------------- | -------------------------------------- |
-| Existing Subdirectory <Popover content="Created before August 1, 2023"/> | `false` |
-| New Subdirectory | `true` |
-| Existing Subdomain <Popover content="Created before August 1, 2023"/> | `false` |
-| New Subdomain | `false` |
+| Existing Multisite - Subdirectory <Popover content="Created before August 1, 2023"/> | `false` |
+| New Multisite - Subdirectory | `true` |
+| Existing Multisite - Subdomain <Popover content="Created before August 1, 2023"/> | `false` |
+| New Multisite - Subdomain | `false` |
 
 
 ## Subdirectory WordPress Multisite Search and Replace Configuration

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -30,7 +30,7 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 </Alert>
 
 ## Defaults
-See the following Search and Replace defaults for new and existing WordPress Site Networks on Pantheon:
+See the following Search and Replace defaults for new and existing WordPress Multisites on Pantheon:
 
 | WP Multisite Configuration      | Default Search and Replace |
 | ------------- | -------------------------------------- |

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -32,12 +32,12 @@ If your `pantheon.yml` file is different between environments, the `search_repla
 ## Defaults
 See the following Search and Replace defaults for new and existing WordPress Site Networks on Pantheon:
 
-| WPMU Configuration      | Default Search and Replace |
+| WP Multisite Configuration      | Default Search and Replace |
 | ------------- | -------------------------------------- |
-| Existing Subdirectory <Popover content="Created before August 1, 2023"/> | False |
-| New Subdirectory | True |
-| Existing Subdomain <Popover content="Created before August 1, 2023"/> | False |
-| New Subdomain | False |
+| Existing Subdirectory <Popover content="Created before August 1, 2023"/> | `false` |
+| New Subdirectory | `true` |
+| Existing Subdomain <Popover content="Created before August 1, 2023"/> | `false` |
+| New Subdomain | `false` |
 
 
 ## Subdirectory WordPress Multisite Search and Replace Configuration


### PR DESCRIPTION
## Summary

**[Search and Replace](https://docs.pantheon.io/guides/multisite/search-replace/)** - Add a new section titled Defaults towards top of the page which captures the default configuration for new and existing WPMU sites 


<img width="854" alt="Screenshot 2023-08-23 at 12 35 06 PM" src="https://github.com/pantheon-systems/documentation/assets/10119525/46fddc02-815d-4b77-98f0-b27d0020a299">
<hr>
<img width="876" alt="Screenshot 2023-08-23 at 12 36 09 PM" src="https://github.com/pantheon-systems/documentation/assets/10119525/368e4749-c93b-40a0-95b3-06bbbc8058b1">
