### PR TITLE
CMSP-599: Updates OCP documentation to reflect new defaults.

### DIFF
--- a/source/content/guides/object-cache-pro/02-installing-configuring.md
+++ b/source/content/guides/object-cache-pro/02-installing-configuring.md
@@ -255,8 +255,6 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 		'maxttl' => 86400 * 7,
 		'timeout' => 0.5,
 		'read_timeout' => 0.5,
-		'retries' => 3,
-		'backoff' => 'smart',
 		'split_alloptions' => true,
 		'prefetch' => true,
 		'debug' => false,
@@ -270,6 +268,8 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 		'prefix' => "ocppantheon", // This prefix can be changed. Setting a prefix helps avoid conflict when switching from other plugins like wp-redis.
 		'serializer' => 'igbinary',
 		'compression' => 'zstd',
+ 		'async_flush' => true,
+ 		'strict' => true,
 	```
 1. Make sure you `git push` your changes up to your repository before you activate the plugin.
 


### PR DESCRIPTION
Closes CMSP-599

## Summary

Small update to the OCP default configuration.

**[Install and Configure Object Cache Pro](https://docs.pantheon.io/guides/object-cache-pro/installing-configuring/)** - Updates default config file.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
