### PR TITLE
ROPE-1627 - Added notes to indicate that a site plan must also be purchased separately.

### DIFF
--- a/source/content/guides/account-mgmt/plans/09-workspace-plans.md
+++ b/source/content/guides/account-mgmt/plans/09-workspace-plans.md
@@ -43,7 +43,7 @@ To upgrade your Professional Workspace Account Plan to Gold:
 
 <Alert title="Note"  type="info" >
 
-Now that you have a Professional Workspace with a Gold Account Plan, you can [add it as a Supporting Workspace](/guides/account-mgmt/workspace-sites-teams/teams#add-a-supporting-organization-to-site) to your site(s) to take advantage of your new features.
+Now that you have a Professional Workspace with a Gold Account Plan, you can [add it as a Supporting Workspace](/guides/account-mgmt/workspace-sites-teams/teams#add-a-supporting-organization-to-site) to your site(s) to take advantage of your new features. If you do not yet have a paid site plan, you must purchase one separately from your gold account tier. Site plans are not included in your purchase of a Professional Gold Account Plan.
 
 </Alert>
 


### PR DESCRIPTION
We've recently seen an uptick in refund requests for our Self Service Gold Offering as customers don't understand that site plans are not included with our Gold Account Plan. Added notes to indicate that a site plan must also be purchased separately.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes [ROPE-1627](https://getpantheon.atlassian.net/browse/ROPE-1627)

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/guides/account-mgmt/plans/workspace-plans)** - Added notes to indicate that a site plan must also be purchased separately.


## Remaining Work and Prerequisites

None

### Dependencies and Timing

None

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)


[ROPE-1627]: https://getpantheon.atlassian.net/browse/ROPE-1627?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ