### PR TITLE
Encrypt session cache

### DIFF
--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -87,7 +87,7 @@ jobs:
         env:
           TERMINUS_RELEASE: ${{ inputs.terminus-version || env.TERMINUS_RELEASE }}
       - name: Authenticate Terminus (with session cache)
-        uses: lullabot/terminus-auth-with-session-cache@v2
+        uses: lullabot/terminus-auth-with-session-cache@v3
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Whoami
@@ -119,7 +119,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-terminus-binary-
       - name: Authenticate Terminus (with session cache)
-        uses: lullabot/terminus-auth-with-session-cache@v2
+        uses: lullabot/terminus-auth-with-session-cache@v3
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Whoami

--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -121,7 +121,7 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-terminus-binary-
       - name: Authenticate Terminus (with session cache)
-        uses: lullabot/terminus-auth-with-session-cache@v3
+        uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Whoami

--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -39,7 +39,7 @@ This pipeline does the following:
 
 Before you use this script:
 
-- Add a Pantheon account machine token to your GitHub **environment** (preferred) or **repository** secrets named `TERMINUS_TOKEN`. _(Always store production secrets in a GitHub "Environment" that restricts which branches can deploy to it, and protect those branches with rules including code review and security tests)._
+- Add a Pantheon account machine token to your GitHub **environment** (preferred) or **repository** secrets named `TERMINUS_TOKEN`. _(Always store production secrets in a GitHub "Environment" that restricts which branches can deploy to it, and protect those branches with rules including code reviews and security tests)._
 
 </Alert>
 

--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -28,6 +28,7 @@ This pipeline does the following:
 
 - Uses the `ubuntu:latest` Docker image.
 - Updates the system and installs necessary tools like PHP, curl, perl, sudo, and Git before the script stages.
+- Defines a cache for the Terminus binary. The pipeline system will save and restore the cache for subsequent runs.
 - Determines the latest release of Terminus from the GitHub API and stores it in the `TERMINUS_RELEASE` variable.
 - Creates a directory for Terminus, downloads it into that directory, makes it executable, and then creates a symbolic link to it in `/usr/local/bin` so that you can run it from anywhere.
 - Ensures there is a valid Terminus session populated in the encrypted cache.
@@ -52,6 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     # Uncomment this line if your TERMINUS_TOKEN secret belongs to a GitHub
     # Environment (preferred for security, see note above).
+    # environment: <environment-name>
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP
@@ -97,7 +99,7 @@ jobs:
     runs-on: ubuntu-latest
     # Uncomment this line if your TERMINUS_TOKEN secret belongs to a GitHub
     # Environment (preferred for security, see note above).
-    # environment: Pantheon
+    # environment: <environment-name>
     steps:
       - uses: actions/checkout@v3
       - name: Setup PHP

--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -89,7 +89,7 @@ jobs:
         env:
           TERMINUS_RELEASE: ${{ inputs.terminus-version || env.TERMINUS_RELEASE }}
       - name: Authenticate Terminus (with session cache)
-        uses: lullabot/terminus-auth-with-session-cache@v3
+        uses: pantheon-systems/terminus-github-actions@v1
         with:
           pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
       - name: Whoami


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Authenticate Terminus in a GitHub Actions Pipeline](https://docs.pantheon.io/terminus/ci/github-actions)** - Replaces session cache with encrypted session cache. It would be great to transfer this action to the Pantheon GitHub org and then publish it to the GitHub Marketplace, but okay to leave under the Lullabot org for now.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* A new GitHub Action (https://github.com/Lullabot/terminus-auth-with-session-cache/) to handle saving and restoring an encrypted session from cache.

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] Pantheon engineering review of the [docs changes](https://github.com/pantheon-systems/documentation/pull/8666/files) (this PR)
- [x] Pantheon engineering review of the action referenced in the docs: https://github.com/Lullabot/terminus-auth-with-session-cache

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [x] Consider transferring action from the Lullabot GitHub org to Pantheon's and update this PR before merging

**Release**:
- [x] When ready
- [x] ~~After date: $DATE~~

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
