### PR TITLE
Update 04-rsync-and-sftp.md

### DIFF
--- a/source/content/guides/sftp/04-rsync-and-sftp.md
+++ b/source/content/guides/sftp/04-rsync-and-sftp.md
@@ -17,7 +17,7 @@ This section provides information on how to use your SFTP client or rsync to tra
 
 ## File Size Limits
 
-You can't use your Pantheon Dashboard to import files over 500 MB. You must use an SFTP client or rsync to transfer files larger than 500 MB to your `/files` directory.
+You can't use your Pantheon Dashboard to import files over 500 MB.
 
 - **Drupal:** `sites/default/files`
 - **WordPress:** `wp-content/uploads`

--- a/source/content/guides/sftp/04-rsync-and-sftp.md
+++ b/source/content/guides/sftp/04-rsync-and-sftp.md
@@ -17,7 +17,7 @@ This section provides information on how to use your SFTP client or rsync to tra
 
 ## File Size Limits
 
-You can't use your Pantheon Dashboard to import files over 500 MB.
+The Pantheon Filesystem supports files up to 256 MiB.  Attempting to write a file larger than that will fail.
 
 - **Drupal:** `sites/default/files`
 - **WordPress:** `wp-content/uploads`


### PR DESCRIPTION
Removing the misleading statement:
`You must use an SFTP client or rsync to transfer files larger than 500 MB to your `/files` directory.`

This is also not allowed since we can only have a 256MB limit on the filesystem:
https://docs.pantheon.io/guides/filesystem/large-files#large-file-restrictions