### PR TITLE
Terminus release 3.2.2.

### DIFF
--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,8 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date      | EOL Date        |
 |------------------|-------------------|-----------------|
-| 3.2.2            | September X, 2023 |                 |
-| 3.2.1            | June 1, 2023      | September X, 2024 |
+| 3.2.2            | September 28, 2023 |                 |
+| 3.2.1            | June 1, 2023      | September 28, 2024 |
 | 3.2.0            | May 22 , 2023     | June 1, 2024    |
 | 3.1.5            | April 6, 2023     | May 22, 2024    |
 | 3.1.4            | March 1, 2023     | April 6, 2024   |

--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date      | EOL Date        |
 |------------------|-------------------|-----------------|
-| 3.2.1            | June 1, 2023      |                 |
+| 3.2.2            | September X, 2023 |                 |
+| 3.2.1            | June 1, 2023      | September X, 2024 |
 | 3.2.0            | May 22 , 2023     | June 1, 2024    |
 | 3.1.5            | April 6, 2023     | May 22, 2024    |
 | 3.1.4            | March 1, 2023     | April 6, 2024   |
@@ -40,6 +41,7 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | PHP Version | Terminus 3.x |
 | ----------- | :-----------: |
+| 8.3 (pre-release) | <span style="color:green">✔</span>         |
 | 8.2 | <span style="color:green">✔</span>         |
 | 8.1 | <span style="color:green">✔</span>         |
 | 8.0 | <span style="color:green">✔</span>        |


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Terminus Release 3.2.2

## Effect

The following changes are already committed:

* https://github.com/pantheon-systems/terminus/pull/2502

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)