### PR TITLE
Inform users that FS_METHOD is set for them  by Pantheon

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -80,7 +80,7 @@ Plugins and themes with issues resolved (at least partially) by this include the
 
 <Alert title="Note"  type="info" >
 
-If your site is using an up-to-date version of the Pantheon WordPress upstream, FS_METHOD will automatically be set for you.
+If your site is using an up-to-date version of the Pantheon WordPress upstream, `FS_METHOD` will automatically be set for you.
 
 </Alert>
 

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -78,6 +78,13 @@ Plugins and themes with issues resolved (at least partially) by this include the
 - [YotuWP Easy YouTube Embed](https://wordpress.org/plugins/yotuwp-easy-youtube-embed/)
 - [WPML - The WordPress Multilingual Plugin](https://wpml.org/)
 
+<Alert title="Note"  type="info" >
+
+If your site is using an up-to-date version of the Pantheon WordPress upstream, FS_METHOD will automatically be set for you.
+
+</Alert>
+
+
 ## AdThrive Ads
 
 <ReviewDate date="2022-10-10" />


### PR DESCRIPTION
Closes #n/a

## Summary

**[WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/plugins-known-issues#define-fs_method)** - Docs tell users they should define FS_METHOD, but this is already done for them.

See [conversation in slack](https://pantheon.slack.com/archives/C052MLV6T6Y/p1695155578990299).

## Effect

Users may be confused or prompted to do work they don't need to do.

## Resolution

Advised user that the constant is set for them. Retain existing text, as not all customers will necessarily be on a recommended upstream.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
