### PR TITLE
Fix for content anchors not being lowercase

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -191,7 +191,7 @@ module.exports = {
             options: {
               icon: `<svg xmlns="http://www.w3.org/2000/svg" height="0.75em" viewBox="0 0 576 512"><path d="M0 256C0 167.6 71.6 96 160 96h64c17.7 0 32 14.3 32 32s-14.3 32-32 32H160c-53 0-96 43-96 96s43 96 96 96h64c17.7 0 32 14.3 32 32s-14.3 32-32 32H160C71.6 416 0 344.4 0 256zm576 0c0 88.4-71.6 160-160 160H352c-17.7 0-32-14.3-32-32s14.3-32 32-32h64c53 0 96-43 96-96s-43-96-96-96H352c-17.7 0-32-14.3-32-32s14.3-32 32-32h64c88.4 0 160 71.6 160 160zM192 224H384c17.7 0 32 14.3 32 32s-14.3 32-32 32H192c-17.7 0-32-14.3-32-32s14.3-32 32-32z"/></svg>`,
               className: `docs-header-anchor`,
-              maintainCase: true,
+              maintainCase: false,
               removeAccents: true,
               isIconAfterHeader: true,
             },

--- a/source/content/guides/mariadb-mysql/03-mysql-workbench.md
+++ b/source/content/guides/mariadb-mysql/03-mysql-workbench.md
@@ -66,7 +66,7 @@ You can now administer your database. There will be a new entry on the Workbench
 
 ## Troubleshooting MySQL Connections
 
-Refer to [Troubleshooting MySQL Connections](/guides/mariadb-mysql/mysql-access#Troubleshooting-MySQL-Connections) for more information.
+Refer to [Troubleshooting MySQL Connections](/guides/mariadb-mysql/mysql-access#troubleshooting-mysql-connections) for more information.
 
 ## More Resources
 

--- a/source/content/guides/mariadb-mysql/05-myisam-to-innodb.md
+++ b/source/content/guides/mariadb-mysql/05-myisam-to-innodb.md
@@ -153,7 +153,7 @@ Use the script below if you want to run the script from the command line instead
 Make sure you have:
 
 - PHP installed on your computer
-- Your [database connection info](/guides/mariadb-mysql/mysql-access#Access-Your-Database-Directly)
+- Your [database connection info](/guides/mariadb-mysql/mysql-access#access-your-database-directly)
 
 
 1. Copy the script below.

--- a/source/content/guides/mariadb-mysql/07-kill-mysql-queries.md
+++ b/source/content/guides/mariadb-mysql/07-kill-mysql-queries.md
@@ -27,7 +27,7 @@ Make your site faster. Check out our free on-demand training, where you'll learn
 
 ## Identify Long-Running Queries
 
-1. Create a local [MySQL connection](/guides/mariadb-mysql/mysql-access#Access-Your-Database-Directly) to the site's database.
+1. Create a local [MySQL connection](/guides/mariadb-mysql/mysql-access#access-your-database-directly) to the site's database.
 
 1. Run the following command to show a list of active threads:
 

--- a/source/content/guides/new-relic/05-debug-mysql-new-relic.md
+++ b/source/content/guides/new-relic/05-debug-mysql-new-relic.md
@@ -76,7 +76,7 @@ At times, systems like Drupal's Watchdog appear at the top of the results for sl
 
 1. Navigate back to the site's panel on the Dashboard and get the SFTP connection information.
 
-1. Follow the steps in the [MySQL Access](/guides/mariadb-mysql/mysql-access#Access-Your-Database-Directly) doc to connect to MySQL via SFTP through your terminal or an FTP program that supports the SFTP protocol.
+1. Follow the steps in the [MySQL Access](/guides/mariadb-mysql/mysql-access#access-your-database-directly) doc to connect to MySQL via SFTP through your terminal or an FTP program that supports the SFTP protocol.
 
 1. [Download database log files](/guides/logs-pantheon/access-logs#database-log-files) and review the `mysql-slow-query.log` file.
 

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -20,7 +20,7 @@ If you are importing a site and the database has custom prefixes for your DB tab
  - Update user metadata with `update wp_usermeta set meta_key = replace(meta_key, 'oldprefix_', 'wp_');`, replacing `oldprefix` with the previously used prefix.
 
 <Alert title="Note" type="info">
-Table prefixes are not supported or recommended by Pantheon. For more details see <a data-proofer-ignore href="/guides/mariadb-mysql/mariadb-mysql-faq#Are-table-prefixes-supported">Accessing MySQL Databases</a>.
+Table prefixes are not supported or recommended by Pantheon. For more details see <a data-proofer-ignore href="/guides/mariadb-mysql/mariadb-mysql-faq#are-table-prefixes-supported">Accessing MySQL Databases</a>.
 </Alert>
 
 ## Automatic Updates
@@ -41,9 +41,9 @@ It means you have some code (plugin or theme) that's using PHP Sessions, which r
 
 ### PHP Version Compatibility
 
-WordPress is not fully compatible with PHP 8.0 or 8.1. The remaining known issues with PHP 8.1 are deprecation notices. A deprecation notice is not an error, but an indicator of the compatibility work that is needed before PHP 9 is released and notices become fatal errors. The PHP code will continue to work with the deprecation notices. 
+WordPress is not fully compatible with PHP 8.0 or 8.1. The remaining known issues with PHP 8.1 are deprecation notices. A deprecation notice is not an error, but an indicator of the compatibility work that is needed before PHP 9 is released and notices become fatal errors. The PHP code will continue to work with the deprecation notices.
 
-For more information, refer to the [PHP Versions](/guides/php/php-versions) documentation. 
+For more information, refer to the [PHP Versions](/guides/php/php-versions) documentation.
 
 ## WordPress Multisite
 


### PR DESCRIPTION
## Summary

After recent updates, guide page anchors were being created with sentence case instead of lower case. An update to `gatsby-remark-autolink-headers` config fixes this.

This update will fix many broken in-content links.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
