### PR TITLE
Remove D8 for Drupal Composer upstream

### DIFF
--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -114,7 +114,7 @@ Your **code** is all custom and contributed modules or plugins, themes, and libr
 The codebase for each CMS upstream offered by Pantheon can be found on GitHub:
 
  - [Drupal 7](https://github.com/pantheon-systems/drops-7)
- - [Drupal 8](https://github.com/pantheon-systems/drops-8)
+ - [Drupal 9+](https://github.com/pantheon-systems/drupal-composer-managed)
  - [WordPress](https://github.com/pantheon-systems/wordpress)
   
   <Alert title="Note" type="info">

--- a/source/content/migrate-manual.md
+++ b/source/content/migrate-manual.md
@@ -114,7 +114,7 @@ Your **code** is all custom and contributed modules or plugins, themes, and libr
 The codebase for each CMS upstream offered by Pantheon can be found on GitHub:
 
  - [Drupal 7](https://github.com/pantheon-systems/drops-7)
- - [Drupal 9+](https://github.com/pantheon-systems/drupal-composer-managed)
+ - [Drupal 9+](https://github.com/pantheon-upstreams/drupal-composer-managed)
  - [WordPress](https://github.com/pantheon-systems/wordpress)
   
   <Alert title="Note" type="info">


### PR DESCRIPTION
**[Manually Migrate Sites to Pantheon](https://docs.pantheon.io/migrate-manual)** - Remove old reference to Drupal 8 upstream in favor of Drupal Composer Managed

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
