### PR TITLE
Fix Popover component; add skiplink

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -8,7 +8,7 @@ import "./node_modules/@pantheon-systems/pds-toolkit-react/_dist/css/pds-compone
 
 // Global styles
 import "./src/styles/main.css"
-import "./src/styles/hacks.css"
+import "./src/styles/pds-additions.css"
 
 // custom typefaces
 import "prismjs/themes/prism-okaidia.css"

--- a/package-lock.json
+++ b/package-lock.json
@@ -4185,15 +4185,13 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.44",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.44.tgz",
-      "integrity": "sha512-EGybLhd5lBssrVAu0XdEquftvyWebd9vrJxplxoEU2ACZH24zu9FfMu50JIBLYs2Q9GEZEyFWlrz+PJTLQWuTw==",
+      "version": "1.0.0-dev.46",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.46.tgz",
+      "integrity": "sha512-J/fL77cPtFEAwA9dL708mKn0SHErOyomNHXCyr5i0LPUFuoDjEsqQqVA6qUhMiA4dpYCZjyCr0lK9z8H7omdSA==",
       "dependencies": {
         "@floating-ui/react": "^0.24.3",
-        "@tippy.js/react": "^3.1.1",
         "focus-trap-react": "^10.2.1",
-        "react-router-dom": "^6.13.0",
-        "tippy.js": "^6.3.7"
+        "react-router-dom": "^6.13.0"
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
@@ -4223,28 +4221,6 @@
       "peerDependencies": {
         "react": ">=16.8.0",
         "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/@tippy.js/react": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/@tippy.js/react/-/react-3.1.1.tgz",
-      "integrity": "sha512-KF45vW/jKh/nBXk/2zzTFslv/T46zOMkIoDJ56ymZ+M00yHttk58J5wZ29oqGqDIUnobWSZD+cFpbR4u/UUvgw==",
-      "deprecated": "This package has moved to @tippyjs/react (the same but without a dot in the scoped organization) due to issues some shells had with the dot when installing the package.",
-      "dependencies": {
-        "prop-types": "^15.6.2",
-        "tippy.js": "^5.1.1"
-      },
-      "peerDependencies": {
-        "react": ">=16.8",
-        "react-dom": ">=16.8"
-      }
-    },
-    "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/@tippy.js/react/node_modules/tippy.js": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
-      "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
-      "dependencies": {
-        "popper.js": "^1.16.0"
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/focus-trap-react": {
@@ -5199,15 +5175,6 @@
       "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@remix-run/router": {
@@ -20845,16 +20812,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
-    "node_modules/popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==",
-      "deprecated": "You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1",
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/popperjs"
-      }
-    },
     "node_modules/postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -24836,14 +24793,6 @@
       "dependencies": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
-      }
-    },
-    "node_modules/tippy.js": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
-      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
-      "dependencies": {
-        "@popperjs/core": "^2.9.0"
       }
     },
     "node_modules/title-case": {
@@ -29528,15 +29477,13 @@
       }
     },
     "@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.44",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.44.tgz",
-      "integrity": "sha512-EGybLhd5lBssrVAu0XdEquftvyWebd9vrJxplxoEU2ACZH24zu9FfMu50JIBLYs2Q9GEZEyFWlrz+PJTLQWuTw==",
+      "version": "1.0.0-dev.46",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.46.tgz",
+      "integrity": "sha512-J/fL77cPtFEAwA9dL708mKn0SHErOyomNHXCyr5i0LPUFuoDjEsqQqVA6qUhMiA4dpYCZjyCr0lK9z8H7omdSA==",
       "requires": {
         "@floating-ui/react": "^0.24.3",
-        "@tippy.js/react": "^3.1.1",
         "focus-trap-react": "^10.2.1",
-        "react-router-dom": "^6.13.0",
-        "tippy.js": "^6.3.7"
+        "react-router-dom": "^6.13.0"
       },
       "dependencies": {
         "@floating-ui/react": {
@@ -29555,25 +29502,6 @@
               "integrity": "sha512-5qhlDvjaLmAst/rKb3VdlCinwTF4EYMiVxuuc/HVUjs46W0zgtbMmAZ1UTsDrRTxRmUEzl92mOtWbeeXL26lSQ==",
               "requires": {
                 "@floating-ui/dom": "^1.5.1"
-              }
-            }
-          }
-        },
-        "@tippy.js/react": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/@tippy.js/react/-/react-3.1.1.tgz",
-          "integrity": "sha512-KF45vW/jKh/nBXk/2zzTFslv/T46zOMkIoDJ56ymZ+M00yHttk58J5wZ29oqGqDIUnobWSZD+cFpbR4u/UUvgw==",
-          "requires": {
-            "prop-types": "^15.6.2",
-            "tippy.js": "^5.1.1"
-          },
-          "dependencies": {
-            "tippy.js": {
-              "version": "5.2.1",
-              "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-5.2.1.tgz",
-              "integrity": "sha512-66UT6JRVn3dXNCORE+0UvUK3JZqV/VhLlU6HTDm3FmrweUUFUxUGvT8tUQ7ycMp+uhuLAwQw6dBabyC+iKf/MA==",
-              "requires": {
-                "popper.js": "^1.16.0"
               }
             }
           }
@@ -30170,11 +30098,6 @@
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA=="
         }
       }
-    },
-    "@popperjs/core": {
-      "version": "2.11.8",
-      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@remix-run/router": {
       "version": "1.9.0",
@@ -41885,11 +41808,6 @@
       "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
       "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg=="
     },
-    "popper.js": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
-      "integrity": "sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ=="
-    },
     "postcss": {
       "version": "8.4.21",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
@@ -44840,14 +44758,6 @@
       "requires": {
         "es5-ext": "~0.10.46",
         "next-tick": "1"
-      }
-    },
-    "tippy.js": {
-      "version": "6.3.7",
-      "resolved": "https://registry.npmjs.org/tippy.js/-/tippy.js-6.3.7.tgz",
-      "integrity": "sha512-E1d3oP2emgJ9dRQZdf3Kkn0qJgI6ZLpyS5z6ZkY1DF3kaQaBsGZsndEpHwx+eC+tYM41HaSNvNtLx8tU57FzTQ==",
-      "requires": {
-        "@popperjs/core": "^2.9.0"
       }
     },
     "title-case": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4185,9 +4185,9 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.46",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.46.tgz",
-      "integrity": "sha512-J/fL77cPtFEAwA9dL708mKn0SHErOyomNHXCyr5i0LPUFuoDjEsqQqVA6qUhMiA4dpYCZjyCr0lK9z8H7omdSA==",
+      "version": "1.0.0-dev.47",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.47.tgz",
+      "integrity": "sha512-vqKbHVGhXj4HZ5TO+2K6U4At4MR6KuHNLBvdJhu8/JzmFGn+9i8Q8oc14pfHybj1p/tBtR9xGznsTthYfSvA/Q==",
       "dependencies": {
         "@floating-ui/react": "^0.24.3",
         "focus-trap-react": "^10.2.1",
@@ -29477,9 +29477,9 @@
       }
     },
     "@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.46",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.46.tgz",
-      "integrity": "sha512-J/fL77cPtFEAwA9dL708mKn0SHErOyomNHXCyr5i0LPUFuoDjEsqQqVA6qUhMiA4dpYCZjyCr0lK9z8H7omdSA==",
+      "version": "1.0.0-dev.47",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.47.tgz",
+      "integrity": "sha512-vqKbHVGhXj4HZ5TO+2K6U4At4MR6KuHNLBvdJhu8/JzmFGn+9i8Q8oc14pfHybj1p/tBtR9xGznsTthYfSvA/Q==",
       "requires": {
         "@floating-ui/react": "^0.24.3",
         "focus-trap-react": "^10.2.1",

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -775,6 +775,7 @@
 - title: "Guides"
   subtitle: ""
   path: "guides"
+  footer_border: true
   guides:
     - title: ""
       type: "normal"
@@ -1166,6 +1167,7 @@
 - title: "Account Management at Pantheon"
   subtitle: "Learn how to set up your teams, use your dashboards, and how billing works. You should be able to comfortably develop an organization plan and administer your Pantheon platform after reading these guides."
   path: "manage"
+  footer_border: true
   guides:
     - title: ""
       type: "normal"

--- a/src/components/card/index.js
+++ b/src/components/card/index.js
@@ -29,7 +29,11 @@ const Card = ({ title, isOfficial, author, authorLink, link, children }) => {
       </div>
 
       <div className="plugin-card__link">
-        <a href={link} target="_blank" className="pds-button">
+        <a
+          href={link}
+          target="_blank"
+          className="pds-button pds-button--secondary"
+        >
           Get plugin
           <Icon
             iconName="externalLink"

--- a/src/components/headerBody/index.js
+++ b/src/components/headerBody/index.js
@@ -40,11 +40,7 @@ const HeaderBody = ({
             {lastReviewed}
           </time>
         </p> */}
-        {!subtitle && (
-          <h1 className="docs-title" id="docs-main">
-            {title}
-          </h1>
-        )}
+        {!subtitle && <h1 className="docs-title">{title}</h1>}
 
         {subtitle && <h1>{subtitle}</h1>}
 

--- a/src/components/navButtons/index.js
+++ b/src/components/navButtons/index.js
@@ -18,7 +18,7 @@ const NavButtons = ({
     >
       {prev && (
         <ul className="pagination pager-guides">
-          <li>
+          <li className="pagination__prev">
             <Link to={prev} rel="prev" className="pds-button">
               <Icon iconName="angleLeft"></Icon>
               {prevTitle}
@@ -28,8 +28,8 @@ const NavButtons = ({
       )}
       {next && (
         <ul className="pagination pager-guides">
-          <li>
-            <Link to={next} rel="prev" className="pds-button">
+          <li className="pagination__next">
+            <Link to={next} rel="next" className="pds-button">
               {nextTitle}
               <Icon iconName="angleRight"></Icon>
             </Link>

--- a/src/components/navButtons/index.js
+++ b/src/components/navButtons/index.js
@@ -16,26 +16,24 @@ const NavButtons = ({
       justifyContent="between"
       className="pds-spacing-mar-block-start-m pds-spacing-mar-block-end-xl"
     >
-      {prev && (
-        <ul className="pagination pager-guides">
+      <ul className="pagination pager-guides">
+        {prev && (
           <li className="pagination__prev">
             <Link to={prev} rel="prev" className="pds-button">
               <Icon iconName="angleLeft"></Icon>
               {prevTitle}
             </Link>
           </li>
-        </ul>
-      )}
-      {next && (
-        <ul className="pagination pager-guides">
+        )}
+        {next && (
           <li className="pagination__next">
             <Link to={next} rel="next" className="pds-button">
               {nextTitle}
               <Icon iconName="angleRight"></Icon>
             </Link>
           </li>
-        </ul>
-      )}
+        )}
+      </ul>
     </FlexContainer>
   )
 }

--- a/src/components/navButtons/style.css
+++ b/src/components/navButtons/style.css
@@ -1,9 +1,11 @@
 ul.pagination {
   list-style-type: none;
   padding: 0;
+  display: flex;
+  justify-content: flex-end;
   width: 100%;
 }
 
-li.pagination__next {
-  float: right;
+ul.pagination:has(li.pagination__prev) {
+  justify-content: space-between;
 }

--- a/src/components/navButtons/style.css
+++ b/src/components/navButtons/style.css
@@ -1,4 +1,9 @@
 ul.pagination {
   list-style-type: none;
   padding: 0;
+  width: 100%;
+}
+
+li.pagination__next {
+  float: right;
 }

--- a/src/components/navbar/index.js
+++ b/src/components/navbar/index.js
@@ -1,40 +1,50 @@
 import React from "react"
 import NavbarItem from "../navbarItem"
+
+import { ExpansionPanel } from "@pantheon-systems/pds-toolkit-react"
+
 import "./style.css"
 
 const Navbar = ({ title, items, activePage }) => {
+  const menu = (
+    <ul id="manual-guide-toc" className="manual-guide-toc__menu">
+      {items.map((item) => {
+        return (
+          <NavbarItem
+            key={`${item.id}-item-key`}
+            item={item}
+            activePage={activePage}
+          />
+        )
+      })}
+    </ul>
+  )
+
   return (
-    <nav className="manual-guide-toc" aria-labelledby="guide-nav">
-      <button
-        type="button"
-        className="navbar-toggle"
-        data-toggle="collapse"
-        data-target="#guide-collapse"
-        data-original-title=""
-        title=""
+    <>
+      {/* Mobile nav */}
+      <nav
+        className="manual-guide-toc guide-nav--mobile"
+        aria-labelledby="guide-nav"
       >
-        <span className="sr-only">Toggle navigation</span>
-        <i className="fa fa-bars" />
-      </button>
-      <h2 id="guide-nav" className="manual-guide-toc__heading">
-        {title}
-      </h2>
-      <div className="collapse navbar-collapse" id="guide-collapse">
-        {items && (
-          <ul id="manual-guide-toc" className="manual-guide-toc__menu">
-            {items.map((item) => {
-              return (
-                <NavbarItem
-                  key={`${item.id}-item-key`}
-                  item={item}
-                  activePage={activePage}
-                />
-              )
-            })}
-          </ul>
-        )}
-      </div>
-    </nav>
+        <ExpansionPanel
+          items={[{ label: title, content: menu }]}
+          className="guide-nav__expansion-panel"
+        />
+      </nav>
+
+      {/* Desktop/default nav */}
+      <nav
+        className="manual-guide-toc guide-nav--default"
+        aria-labelledby="guide-nav"
+      >
+        <h2 id="guide-nav" className="manual-guide-toc__heading">
+          {title}
+        </h2>
+
+        {items && menu}
+      </nav>
+    </>
   )
 }
 

--- a/src/components/navbar/style.css
+++ b/src/components/navbar/style.css
@@ -1,12 +1,36 @@
-.manual-guide-toc {
-  padding-block-start: var(--pds-spacing-xl);
-  padding-inline-end: var(--pds-spacing-xl);
+/* Show menu variants based on breakpoint */
+
+/* Mobile menu */
+@media (max-width: 640px) {
+  .guide-nav--mobile {
+    margin-block-end: var(--pds-spacing-3xl);
+  }
+
+  .guide-nav--default {
+    display: none;
+  }
+
+  .guide-nav--mobile .pds-expansion-panel__content {
+    padding-block: 0;
+    padding-inline-start: var(--pds-spacing-xl);
+  }
 }
 
-h2.manual-guide-toc__heading {
-  font-size: var(--pds-typography-size-l);
-  line-height: var(--pds-typography-line-height-m);
-  margin-block-end: var(--pds-spacing-s);
+/* Default menu */
+@media (min-width: 641px) {
+  .guide-nav--mobile {
+    display: none;
+  }
+  .manual-guide-toc {
+    padding-block-start: var(--pds-spacing-xl);
+    padding-inline-end: var(--pds-spacing-xl);
+  }
+
+  h2.manual-guide-toc__heading {
+    font-size: var(--pds-typography-size-l);
+    line-height: var(--pds-typography-line-height-m);
+    margin-block-end: var(--pds-spacing-s);
+  }
 }
 
 .manual-guide-toc__menu {
@@ -15,8 +39,4 @@ h2.manual-guide-toc__heading {
   list-style-type: none;
   padding: 0;
   row-gap: var(--pds-spacing-3xs);
-}
-
-.navbar-toggle {
-  display: none;
 }

--- a/src/components/popover.js
+++ b/src/components/popover.js
@@ -1,11 +1,11 @@
 import React from "react"
 
-import { Tooltip } from "@pantheon-systems/pds-toolkit-react"
+import { Popover as PDSPopover } from "@pantheon-systems/pds-toolkit-react"
 
 const Popover = ({ icon, title, content }) => {
-  const tooltipContent = title ? [title, ": ", content] : content
+  const processedContent = <div dangerouslySetInnerHTML={{ __html: content }} />
 
-  return <Tooltip iconName="circleInfo" tooltipText={tooltipContent} />
+  return <PDSPopover content={processedContent} title={title} />
 }
 
 export default Popover

--- a/src/layout/GuideLayout/index.js
+++ b/src/layout/GuideLayout/index.js
@@ -39,7 +39,7 @@ const GuideLayout = ({ children, pageType = "default" }) => {
         </div>
         <div slot="content">{guideContent}</div>
       </SidebarLayout>
-      <Footer />
+      <Footer className="with-border" />
     </div>
   )
 }

--- a/src/layout/GuideLayout/style.css
+++ b/src/layout/GuideLayout/style.css
@@ -2,6 +2,11 @@
 @import "../../styles/codeBlocks.css";
 
 .guide-sidebar {
-  border-right: 1px solid var(--pds-color-border-default);
   height: 100%;
+}
+
+@media (min-width: 641px) {
+  .guide-sidebar {
+    border-right: 1px solid var(--pds-color-border-default);
+  }
 }

--- a/src/layout/call-to-action/styles.css
+++ b/src/layout/call-to-action/styles.css
@@ -5,6 +5,7 @@
   flex-direction: column;
   padding: var(--pds-spacing-l);
   row-gap: var(--pds-spacing-2xs);
+  background-color: var(--pds-color-background-default);
 }
 
 @media (min-width: 641px) {

--- a/src/layout/footer/style.css
+++ b/src/layout/footer/style.css
@@ -1,4 +1,4 @@
-.pds-site-footer:not(.with-cta) {
+.pds-site-footer.with-border {
   border-top: 1px solid var(--pds-color-border-default);
 }
 

--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -116,30 +116,36 @@ const mainNavigationLinks = [
 const mobileMenuBreakpoint = 900
 
 const Header = ({ page }) => (
-  <Navbar mobileMenuMaxWidth={mobileMenuBreakpoint}>
-    <NavMenu
-      slot="items-left"
-      ariaLabel="Main Navigation"
-      menuItems={mainNavigationLinks}
-      mobileMenuMaxWidth={mobileMenuBreakpoint}
-    />
-    <div slot="items-right" className="pds-button-group">
-      <a
-        className="pds-button pds-button--brand-secondary"
-        href="https://dashboard.pantheon.io"
-        target="_blank"
-      >
-        Log in
-      </a>
-      <a
-        className="pds-button pds-button--brand"
-        href="https://pantheon.io/register"
-        target="_blank"
-      >
-        Get free account
-      </a>
-    </div>
-  </Navbar>
+  <>
+    <a id="skip-to-main" className="pds-skiplink" href="#docs-main">
+      Skip to main content
+    </a>
+
+    <Navbar mobileMenuMaxWidth={mobileMenuBreakpoint}>
+      <NavMenu
+        slot="items-left"
+        ariaLabel="Main Navigation"
+        menuItems={mainNavigationLinks}
+        mobileMenuMaxWidth={mobileMenuBreakpoint}
+      />
+      <div slot="items-right" className="pds-button-group">
+        <a
+          className="pds-button pds-button--brand-secondary"
+          href="https://dashboard.pantheon.io"
+          target="_blank"
+        >
+          Log in
+        </a>
+        <a
+          className="pds-button pds-button--brand"
+          href="https://pantheon.io/register"
+          target="_blank"
+        >
+          Get free account
+        </a>
+      </div>
+    </Navbar>
+  </>
 )
 
 export default Header

--- a/src/layout/header/style.css
+++ b/src/layout/header/style.css
@@ -1,0 +1,29 @@
+a.pds-skiplink {
+  background-color: var(--pds-color-button-primary-background-default);
+  border-bottom-right-radius: var(--pds-border-radius-container);
+  color: var(--pds-color-button-primary-foreground-active);
+  display: inline-block;
+  left: 0;
+  overflow: hidden;
+  padding: var(--pds-spacing-s) var(--pds-spacing-m);
+  position: absolute;
+  text-decoration: underline;
+  top: -200px;
+  transition: var(--pds-animation-button-transition);
+  z-index: 100;
+}
+
+a.pds-skiplink:hover {
+  background-color: var(--pds-color-button-primary-background-hover);
+  color: var(--pds-color-button-primary-foreground-active);
+}
+
+a.pds-skiplink:focus {
+  box-shadow: var(--pds-elevation-overlay);
+  height: auto;
+  outline-color: transparent;
+  position: absolute;
+  top: 0;
+  transition: var(--pds-animation-button-transition);
+  width: auto;
+}

--- a/src/layout/layout/index.js
+++ b/src/layout/layout/index.js
@@ -19,7 +19,13 @@ const secondaryCTA = {
   url: "https://pantheon.io/developers/office-hours?docs",
 }
 
-const Layout = ({ children, containerWidth, hasCta, pageType = "default" }) => {
+const Layout = ({
+  children,
+  containerWidth,
+  hasCta,
+  footerBorder,
+  pageType = "default",
+}) => {
   return (
     <div className="pantheon-docs">
       <Header page={pageType} />
@@ -36,7 +42,7 @@ const Layout = ({ children, containerWidth, hasCta, pageType = "default" }) => {
           className="pre-footer-slice"
         />
       )}
-      <Footer className={hasCta ? "with-cta" : null} />
+      <Footer className={footerBorder ? "with-border" : null} />
     </div>
   )
 }

--- a/src/layout/subtopic-group/index.js
+++ b/src/layout/subtopic-group/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import PropTypes from "prop-types"
 import { Link } from "gatsby"
 
-import { Icon, Panel } from "@pantheon-systems/pds-toolkit-react"
+import { Container, Icon, Panel } from "@pantheon-systems/pds-toolkit-react"
 
 import "./style.css"
 
@@ -15,36 +15,38 @@ const propTypes = {
 function SubtopicGroup(props) {
   const { title, subTitle, topics } = props
   return (
-    <Panel className="subtopic__container">
-      <h2 className="subtopic__heading">{title}</h2>
-      {subTitle && (
-        <p className="pds-lead-text pds-lead-text--small">{subTitle}</p>
-      )}
-      <hr />
-      {topics &&
-        topics.map((topic) => (
-          <div key={topic.title} className="subtopic__list-group">
-            {topic.title && <h3>{topic.title}</h3>}
-            <ul className="subtopic__list">
-              {topic.links &&
-                topic.links.map((link) => (
-                  <li key={link.url}>
-                    <Link to={link.url}>
-                      {link.icon && (
-                        <Icon
-                          iconName={link.icon}
-                          iconSize="lg"
-                          className="subtopic__icon"
-                        />
-                      )}
-                      {link.text}
-                    </Link>
-                  </li>
-                ))}
-            </ul>
-          </div>
-        ))}
-    </Panel>
+    <Container>
+      <Panel>
+        <h2 className="subtopic__heading">{title}</h2>
+        {subTitle && (
+          <p className="pds-lead-text pds-lead-text--small">{subTitle}</p>
+        )}
+        <hr />
+        {topics &&
+          topics.map((topic) => (
+            <div key={topic.title} className="subtopic__list-group">
+              {topic.title && <h3>{topic.title}</h3>}
+              <ul className="subtopic__list">
+                {topic.links &&
+                  topic.links.map((link) => (
+                    <li key={link.url}>
+                      <Link to={link.url}>
+                        {link.icon && (
+                          <Icon
+                            iconName={link.icon}
+                            iconSize="lg"
+                            className="subtopic__icon"
+                          />
+                        )}
+                        {link.text}
+                      </Link>
+                    </li>
+                  ))}
+              </ul>
+            </div>
+          ))}
+      </Panel>
+    </Container>
   )
 }
 

--- a/src/layout/subtopic-group/index.js
+++ b/src/layout/subtopic-group/index.js
@@ -15,7 +15,7 @@ const propTypes = {
 function SubtopicGroup(props) {
   const { title, subTitle, topics } = props
   return (
-    <Container>
+    <Container width="narrow">
       <Panel>
         <h2 className="subtopic__heading">{title}</h2>
         {subTitle && (

--- a/src/layout/subtopic-group/style.css
+++ b/src/layout/subtopic-group/style.css
@@ -17,10 +17,10 @@
 }
 
 .subtopic__list a {
+  align-items: center;
+  display: inline-flex;
   font-size: 1rem;
   text-decoration: none;
-  display: inline-flex;
-  align-items: center;
 }
 
 .subtopic__list a:hover {

--- a/src/pages/404.js
+++ b/src/pages/404.js
@@ -19,7 +19,7 @@ class NotFoundPage extends React.Component {
             description="Zoinks! You've hit a URL that doesn't exist. Let's try a search:"
           />
           <div style={{ textAlign: "center" }}>
-            <main id="docs-main">
+            <main id="docs-main" tabindex="-1">
               <div>
                 <h1 className="pds-spacing-mar-block-end-3xl">
                   Sorry, there's no page at that URL.

--- a/src/pages/contributors.js
+++ b/src/pages/contributors.js
@@ -32,7 +32,7 @@ class Contributors extends React.Component {
     return (
       <Layout containerWidth={containerWidth} footerBorder>
         <SEO title="Contributors" />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth} className="docs-contributors">
             <h1 className="title">Contributors</h1>
             <AvatarTileList listItems={contributorsList} />

--- a/src/pages/contributors.js
+++ b/src/pages/contributors.js
@@ -30,7 +30,7 @@ class Contributors extends React.Component {
     })
 
     return (
-      <Layout containerWidth={containerWidth}>
+      <Layout containerWidth={containerWidth} footerBorder>
         <SEO title="Contributors" />
         <main id="docs-main">
           <Container width={containerWidth} className="docs-contributors">

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -140,7 +140,7 @@ class Glossary extends React.Component {
           title="Glossary"
           description="A collection of terms and definitions through Pantheon's Documentation"
         />
-        <main id="doc">
+        <main id="docs-main" tabindex="-1">
           <Container
             width={containerWidth}
             className="pds-spacing-pad-block-end-4xl"

--- a/src/pages/glossary.js
+++ b/src/pages/glossary.js
@@ -135,7 +135,7 @@ class Glossary extends React.Component {
     ]
 
     return (
-      <Layout containerWidth={containerWidth}>
+      <Layout containerWidth={containerWidth} footerBorder>
         <SEO
           title="Glossary"
           description="A collection of terms and definitions through Pantheon's Documentation"

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -26,7 +26,7 @@ class Index extends React.Component {
           description="Information for building, launching, and running dynamic sites on the Pantheon Website Management Platform"
           image={"/images/assets/default-thumb-doc.png"}
         />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth}>
             <HeroCTA
               title={homeYaml.title}

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -67,7 +67,7 @@ class Search extends React.Component {
     return (
       <Layout footerBorder>
         <SEO image={"/images/assets/default-thumb-doc.png"} title="Search" />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width="standard" className="search-results">
             <div className="search-results__heading">
               <h1>Search Results</h1>

--- a/src/pages/search.js
+++ b/src/pages/search.js
@@ -65,7 +65,7 @@ class Search extends React.Component {
 
   render() {
     return (
-      <Layout>
+      <Layout footerBorder>
         <SEO image={"/images/assets/default-thumb-doc.png"} title="Search" />
         <main id="docs-main">
           <Container width="standard" className="search-results">

--- a/src/styles/codeBlocks.css
+++ b/src/styles/codeBlocks.css
@@ -100,6 +100,7 @@ code {
 
 pre > code {
   background-color: inherit;
+  color: #ffffff;
   font-weight: var(--pds-typography-font-weight-regular);
 }
 

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -23,6 +23,10 @@ table {
   width: 80%;
 }
 
+h2.landing-page__section-heading {
+  margin-block-start: 0 !important;
+}
+
 .landing-page__video-background {
   background: linear-gradient(
     to top,

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -40,20 +40,16 @@ h2.landing-page__section-heading {
   box-shadow: var(--pds-elevation-raised);
 }
 
-.landing-page__subtopics {
-  width: 100%;
-}
-
 hr.landing-page__guides-separator {
-  width: 96%;
   margin-block: var(--pds-spacing-m);
+  width: 96%;
 }
 
 .landing-page__guides-title {
-  padding-block-start: var(--pds-spacing-xl);
-  text-align: center;
   font-size: var(--pds-typography-size-l);
   font-weight: var(--pds-typography-font-weight-semibold);
+  padding-block-start: var(--pds-spacing-xl);
+  text-align: center;
 }
 
 .landing-page__guide-items {
@@ -132,8 +128,8 @@ a.individual-changelog-link:hover {
 .docs-contributor__list {
   display: flex;
   flex-direction: column;
-  row-gap: var(--pds-spacing-s);
   margin-block-end: var(--pds-spacing-4xl);
+  row-gap: var(--pds-spacing-s);
 }
 
 /* Temporary hacks for marketo forms */

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -1,5 +1,4 @@
 /* For local styles not coming from PDS. */
-
 html,
 body {
   overflow-x: hidden;
@@ -7,6 +6,10 @@ body {
 
 body {
   position: relative;
+}
+
+#docs-main:focus {
+  outline: none;
 }
 
 table {

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -9,6 +9,14 @@ body {
   position: relative;
 }
 
+table {
+  margin-block-end: var(--pds-spacing-4xl);
+}
+
+.pds-callout table {
+  margin-block-end: var(--pds-spacing-m) !important;
+}
+
 /* Landing pages */
 .landing-page__header {
   text-align: center;

--- a/src/styles/pds-additions.css
+++ b/src/styles/pds-additions.css
@@ -1,7 +1,4 @@
 /* Temporary global styles that should be incorporated back into PDS */
-.pds-tooltip {
-  display: inline;
-}
 
 /* Set explicit image width/height for tile images. */
 .pds-tile__image img {

--- a/src/templates/certificationpage.js
+++ b/src/templates/certificationpage.js
@@ -185,7 +185,13 @@ class CertificationTemplate extends React.Component {
         />
         <ContentLayoutType slot="guide-content">
           <SearchBar slot="content" page="default" />
-          <main slot="content" id="doc" className="certification terminus">
+
+          <main
+            slot="content"
+            id="docs-main"
+            tabindex="-1"
+            className="certification terminus"
+          >
             <article className="doc guide-doc-body">
               <HeaderBody
                 title={node.frontmatter.title}

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -81,7 +81,7 @@ class ChangelogTemplate extends React.Component {
           authors={node.frontmatter.contributors}
           image={"/images/assets/default-thumb-doc.png"}
         />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth}>
             <div className="pds-overline-text pds-spacing-mar-block-end-xs">
               Pantheon Changelog

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -74,7 +74,7 @@ class ChangelogTemplate extends React.Component {
     const node = this.props.data.mdx
 
     return (
-      <Layout containerWidth={containerWidth}>
+      <Layout containerWidth={containerWidth} footerBorder>
         <SEO
           title={node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}

--- a/src/templates/changelogs.js
+++ b/src/templates/changelogs.js
@@ -92,7 +92,7 @@ class ChangelogsTemplate extends React.Component {
           description="Pantheon Changelog"
           image={"assets/images/default-thumb-doc.png"}
         />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth}>
             <h1>Pantheon Changelog</h1>
             <div className="pds-spacing-mar-block-end-3xl">

--- a/src/templates/changelogs.js
+++ b/src/templates/changelogs.js
@@ -86,7 +86,7 @@ class ChangelogsTemplate extends React.Component {
   render() {
     const changelogs = this.props.data.allMdx.edges
     return (
-      <Layout containerWidth={containerWidth}>
+      <Layout containerWidth={containerWidth} footerBorder>
         <SEO
           title="Pantheon Changelog"
           description="Pantheon Changelog"

--- a/src/templates/contributor.js
+++ b/src/templates/contributor.js
@@ -50,7 +50,7 @@ class ContributorTemplate extends React.Component {
       <Layout containerWidth={containerWidth} footerBorder>
         <SEO title={contributor.name} />
         <title>{contributor.name}</title>
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth} className="docs-contributor">
             <div className="article">
               <TwoItemLayout layoutVariant="one-third-start">

--- a/src/templates/contributor.js
+++ b/src/templates/contributor.js
@@ -47,7 +47,7 @@ class ContributorTemplate extends React.Component {
     console.log(contributor)
 
     return (
-      <Layout containerWidth={containerWidth}>
+      <Layout containerWidth={containerWidth} footerBorder>
         <SEO title={contributor.name} />
         <title>{contributor.name}</title>
         <main id="docs-main">

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -99,7 +99,7 @@ class DocTemplate extends React.Component {
     const isoDate = this.props.data.date
 
     return (
-      <Layout>
+      <Layout footerBorder>
         <SEO
           title={node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -110,7 +110,7 @@ class DocTemplate extends React.Component {
           reviewed={isoDate.frontmatter.reviewed}
           type={node.frontmatter.type}
         />
-        <main id="doc">
+        <main id="docs-main" tabindex="-1">
           <Container
             width={containerWidth}
             className="pds-spacing-pad-block-end-4xl"

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -133,7 +133,7 @@ class GuideTemplate extends React.Component {
         />
         <ContentLayoutType slot="guide-content">
           <SearchBar slot="content" page="default" />
-          <main slot="content" id="doc">
+          <main slot="content" id="docs-main" tabindex="-1">
             <article className="doc guide-doc-body pds-spacing-pad-block-end-2xl">
               <HeaderBody
                 title={node.frontmatter.title}

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -45,7 +45,7 @@ class LandingTemplate extends Component {
         footerBorder={topic.footer_border}
       >
         <SEO title={topic.title} />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth} className="landing-page__header">
             <FlexContainer
               alignItems="center"

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -118,17 +118,14 @@ class LandingTemplate extends Component {
             >
               {topic.subtopics &&
                 topic.subtopics.map((subtopic) => (
-                  <Container
-                    width={containerWidth}
-                    className="landing-page__subtopics"
-                  >
+                  <div className="landing-page__subtopics">
                     <SubTopicGroup
                       key={subtopic.title}
                       title={subtopic.title}
                       subTitle={subtopic.subtitle}
                       topics={subtopic.subtopic_lists}
                     />
-                  </Container>
+                  </div>
                 ))}
             </FlexContainer>
           )}

--- a/src/templates/landing.js
+++ b/src/templates/landing.js
@@ -40,7 +40,10 @@ class LandingTemplate extends Component {
       groupLength === 2 || groupLength === 4 ? "two" : "three"
 
     return !topic ? null : (
-      <Layout containerWidth={containerWidth}>
+      <Layout
+        containerWidth={containerWidth}
+        footerBorder={topic.footer_border}
+      >
         <SEO title={topic.title} />
         <main id="docs-main">
           <Container width={containerWidth} className="landing-page__header">
@@ -111,7 +114,7 @@ class LandingTemplate extends Component {
               flexDirection="column"
               mobileFlex="same"
               spacing="wide"
-              className="pds-spacing-pad-block-5xl"
+              className="pds-spacing-pad-block-start-5xl"
             >
               {topic.subtopics &&
                 topic.subtopics.map((subtopic) => (
@@ -132,7 +135,7 @@ class LandingTemplate extends Component {
 
           {/* Topic groups */}
           {topic.topics_groups && (
-            <div className="pds-background-default-secondary pds-spacing-pad-block-5xl">
+            <div className="pds-spacing-pad-block-5xl">
               <Container
                 width={containerWidth}
                 className="landing-page__topics pds-grid"
@@ -159,31 +162,32 @@ class LandingTemplate extends Component {
 
           {/* Related resources */}
           {(topic.cta || topic.cta_alt) && (
-            <Container
-              width={containerWidth}
-              className="landing-page__related pds-spacing-pad-block-end-5xl"
-            >
-              <h2>Related Resources</h2>
-              <FlexContainer spacing="wide">
-                {topic.cta && (
-                  <CallToAction
-                    title={topic.cta.title}
-                    type={topic.cta.type}
-                    subTitle={topic.cta.subtitle}
-                    url={topic.cta.url}
-                  />
-                )}
-                {topic.cta_alt && (
-                  <CallToAction
-                    title={topic.cta_alt.title}
-                    type={topic.cta_alt.type}
-                    subTitle={topic.cta_alt.subtitle}
-                    url={topic.cta_alt.url}
-                    dark
-                  />
-                )}
-              </FlexContainer>
-            </Container>
+            <div className="landing-page__related pds-background-default-secondary pds-spacing-pad-block-start-4xl pds-spacing-pad-block-end-5xl">
+              <Container width={containerWidth}>
+                <h2 className="landing-page__section-heading">
+                  Related Resources
+                </h2>
+                <FlexContainer spacing="wide">
+                  {topic.cta && (
+                    <CallToAction
+                      title={topic.cta.title}
+                      type={topic.cta.type}
+                      subTitle={topic.cta.subtitle}
+                      url={topic.cta.url}
+                    />
+                  )}
+                  {topic.cta_alt && (
+                    <CallToAction
+                      title={topic.cta_alt.title}
+                      type={topic.cta_alt.type}
+                      subTitle={topic.cta_alt.subtitle}
+                      url={topic.cta_alt.url}
+                      dark
+                    />
+                  )}
+                </FlexContainer>
+              </Container>
+            </div>
           )}
         </main>
       </Layout>
@@ -201,6 +205,7 @@ export const pageQuery = graphql`
       id
       title
       subtitle
+      footer_border
       video_id
       path
       cta {

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -201,7 +201,7 @@ class CommandsTemplate extends React.Component {
         />
         <Container slot="guide-content">
           <SearchBar slot="content" page="default" />
-          <main slot="content" id="doc">
+          <main slot="content" id="docs-main" tabindex="-1">
             <article className="doc guide-doc-body pds-spacing-pad-block-end-2xl">
               <div className="pds-overline-text pds-spacing-pad-block-xs">
                 Command

--- a/src/templates/terminuspage.js
+++ b/src/templates/terminuspage.js
@@ -185,7 +185,12 @@ class TerminusTemplate extends React.Component {
         />
         <ContentLayoutType slot="guide-content">
           <SearchBar slot="content" page="default" />
-          <main slot="content" id="doc" className="terminus">
+          <main
+            slot="content"
+            id="docs-main"
+            tabindex="-1"
+            className="terminus"
+          >
             <article className="doc guide-doc-body pds-spacing-pad-block-end-xl">
               <HeaderBody
                 title={node.frontmatter.title}

--- a/src/templates/video.js
+++ b/src/templates/video.js
@@ -91,7 +91,7 @@ class VideoTemplate extends React.Component {
           image={"/images/assets/default-thumb-doc.png"}
           type={node.frontmatter.type}
         />
-        <main id="docs-main">
+        <main id="docs-main" tabindex="-1">
           <Container width={containerWidth} className="docs-video">
             <HeaderBody
               title={node.frontmatter.title}


### PR DESCRIPTION
Closes #8727 

## Summary

This PR contains two time-sensitive fixes for issues that happened as a result of the site theme update. 
1. Updating the Popover component to render markup correctly.
2. Re-adding a skiplink component that was likely accidentally removed during the retheme. 

This PR also includes some style clean up as well, including the following:
- Landing page background color updates for sections.
- Fix mobile overflow on landing pages.
- Better logic for when the footer has a top border or not.
- Update guide nav buttons to make sure "continue" is always on the right.
- Put mobile side nav in an expansion panel for mobile view.
- Update buttons on terminus cards.
- Add extra space after data tables.

## Effect

Popover has been updated/fixed:
<img width="1073" alt="Screenshot 2023-10-10 at 11 31 13 AM" src="https://github.com/pantheon-systems/documentation/assets/1753611/5fc6e72e-78c7-4a11-9724-be192f92f15b">

Skiplink: 
<img width="448" alt="Screenshot 2023-10-10 at 12 23 38 PM" src="https://github.com/pantheon-systems/documentation/assets/1753611/f47e21ea-9860-4c42-9ea5-6c1679a3613a">


### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
