### PR TITLE
Solve build errors by fixing 404s used within GITHUB-EMBED instances

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -396,9 +396,9 @@ This issue happens when you attempt to update very outdated core files from the 
 
  <Tab title="Drupal (Latest Version)" id="d9-2conflict-merge" active={true}>
 
-  GITHUB-EMBED https://github.com/pantheon-systems/drupal-composer-managed/blob/default/pantheon.upstream.yml yaml:title=pantheon.yml GITHUB-EMBED
+  GITHUB-EMBED https://github.com/pantheon-upstreams/drupal-composer-managed/blob/main/pantheon.upstream.yml yaml:title=pantheon.yml GITHUB-EMBED
 
- [View on GitHub](https://github.com/pantheon-systems/drupal-composer-managed/blob/default/pantheon.upstream.yml)
+ [View on GitHub](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/main/pantheon.upstream.yml)
 
  </Tab>
 


### PR DESCRIPTION

## Summary

**[WordPress and Drupal Core Updates](https://docs.pantheon.io/core-updates)** - Fixes the broken GH links in [this section](https://docs.pantheon.io/core-updates#error-updating-conflict-modifydelete-pantheonupstreamyml-deleted-in-head-and-modified-in-upstreammaster-version-upstreammaster-of-pantheonupstreamyml-left-in-tree) on the tab titled "Drupal (Latest Version)"

## Effect


* Should resolve failed builds on Pantheon Front-End Sites: 
<img width="1520" alt="Screenshot 2023-10-11 at 4 22 58 PM" src="https://github.com/pantheon-systems/documentation/assets/10119525/8154de03-3314-4b4f-bd76-b135be837191">

