### PR TITLE
Delete Legacy Plans

### DIFF
--- a/source/content/guides/account-mgmt/plans/03-resources.md
+++ b/source/content/guides/account-mgmt/plans/03-resources.md
@@ -37,25 +37,3 @@ The platform resources provided to your website depend on your current plan. Pan
 If the number of custom domains on a site exceeds that allowed by the new site plan, the site will be migrated to the next largest site plan that matches the number of custom domains used.
 
 </Alert>
-
-## Legacy Platform Resources
-
-<Alert title="Legacy Site Plans Only" type="info">
-
-This section reflects resources for legacy site plans. Sites that have been upgraded or launched to our new plans should refer to [the previous section](#current-plan-resources) for current information.
-
-</Alert>
-
-
-|                                | Personal                                               | Professional                                           | Business                                               | Elite                                                  |
-|--------------------------------|--------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------|--------------------------------------------------------|
-| Application Containers         | 1                                                      | 1                                                      | 2                                                      | 4+                                                     |
-| PHP Concurrency                | 4                                                      | 8                                                      | 8                                                      | 8                                                      |
-| PHP Memory Limit               | 256MB                                                  | 256MB                                                  | 512MB                                                  | 512MB <Popover   content = "Up to 1024MB is available for certain Elite plans.[Learn more about Pantheon Elite Plans](https://pantheon.io/pantheon-elite-plans) and contact Sales for information about plans with custom resources." />                                                                                       |
-| MySQL Buffer Pool              | 128MB                                                  | 512MB           | 1024MB                                                 | 2014MB+                                                |
-| Storage                        | 5GB                                                    | 20GB                                                   | 30GB                                                   | 100GB+                                                 |
-| Custom Domain Limit (per site) <Popover content="For details, see <a href='/guides/domains'>Domains and Redirects</a>." /> | 5                                                      | 25                                                     | 100                                                    | 200                                                    |
-| Free and managed HTTPS <Popover content="For details, see <a href='/https/'>HTTPS on Pantheon's Global CDN</a>." />        | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span>| <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> |
-| New Relic <Popover content="For details, see <a href='/guides/new-relic/'>New Relic APM Pro</a>." />                     | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> |
-| Object Cache  <Popover content="For details, see <a href='/object-cache'>Object Cache Overview</a>." />                 |                                                        | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> |
-| Multidev <Popover content="All sites associated with a Professional Workspace have access to <a href='/multidev/>Multidev</a> regardless of plan." />                      |                                                        |                                                        |<span  style= " color:green " > ✔ </span> | <span  style= " color:green " > ✔ </span> |

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -388,8 +388,6 @@
           url: "/guides/php/php-versions"
         - text: "Securely Working with phpinfo"
           url: "/guides/secure-development/phpinfo"
-        - text: "Platform Resources for Legacy Plans"
-          url: "/guides/account-mgmt/plans"
         - text: "Timeouts on Pantheon"
           url: "/timeouts"
         - text: "Cron for WordPress"


### PR DESCRIPTION
## Summary
1. This PR deletes the [Legacy Platform Resources section](https://docs.pantheon.io/guides/account-mgmt/plans/resources#legacy-platform-resources) since legacy plans are not around anymore
2. This PR removes the legacy link from the [`/platform` landing page](https://docs.pantheon.io/platform):
  
<img width="896" alt="Screenshot 2023-10-13 at 2 14 53 PM" src="https://github.com/pantheon-systems/documentation/assets/10119525/7ea7c182-b9e3-40f9-a221-aadfce40248d">

