### PR TITLE
Drupal Composer moved Pantheon upstreams

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -218,7 +218,7 @@ This process lets you manually resolve the conflict using the command line and a
   <Tab title="Drupal (Latest Version)" id="d9-1conflict" active={true}>
 
   ```bash{promptUser: user}
-  git remote add pantheon-drupal https://github.com/pantheon-systems/drupal-composer-managed
+  git remote add pantheon-drupal https://github.com/pantheon-upstreams/drupal-composer-managed
   ```
 
   </Tab>

--- a/source/content/drupal-commerce.md
+++ b/source/content/drupal-commerce.md
@@ -45,7 +45,7 @@ This guide covers installing [Drupal Commerce](https://drupalcommerce.org/), an 
 
 ## Create a New Drupal Site
 
-1. Use the Terminus Build Tools plugin to create a new Drupal site from the Pantheon [Drupal Recommended](https://github.com/pantheon-systems/drupal-composer-managed) repository on GitHub:
+1. Use the Terminus Build Tools plugin to create a new Drupal site from the Pantheon [Drupal Recommended](https://github.com/pantheon-upstreams/drupal-composer-managed) repository on GitHub:
 
  ```bash{promptUser: user}
  terminus build:project:create d9 $SITENAME

--- a/source/content/drupal-from-dist.md
+++ b/source/content/drupal-from-dist.md
@@ -46,7 +46,7 @@ You can review a list of commonly used distributions on the [Drupal Distribution
 
 Now you're going to copy files and folders from the Pantheon GitHub repository for use in your project.
 
-1. Clone https://github.com/pantheon-systems/drupal-composer-managed into another folder.
+1. Clone https://github.com/pantheon-upstreams/drupal-composer-managed into another folder.
 
     In the code samples included below, [`drupal-composer-managed-path`] should be replaced with the location of the the cloned repository.  In addition, they assume the commands are being run from the folder created from the `create-project` command.
 

--- a/source/content/guides/decoupled/drupal-backend-starters/05-build-hooks.md
+++ b/source/content/guides/decoupled/drupal-backend-starters/05-build-hooks.md
@@ -27,7 +27,7 @@ Refer to the Front-End Sites Overview guide for instructions on how to [create a
 
 ## Install the Build Hooks Module
 
-The Build Hooks module is already included as a Composer dependency if you are using the [Decoupled Drupal Composer Managed](https://github.com/pantheon-systems/drupal-composer-managed) starter template. For other projects:
+The Build Hooks module is already included as a Composer dependency if you are using the [Decoupled Drupal Composer Managed](https://github.com/pantheon-upstreams/drupal-composer-managed) starter template. For other projects:
 
 1. Run the following command to add the module as a dependency:
 

--- a/source/content/guides/drush/02-drush-versions.md
+++ b/source/content/guides/drush/02-drush-versions.md
@@ -82,7 +82,7 @@ Our default Composer-managed upstream has a start state for this dependency that
 "drush/drush": "^11 || ^12"
 ```
 
-Refer to [Pantheon's Drupal Composer-Managed upstream](https://github.com/pantheon-systems/drupal-composer-managed/blob/6522cbccb4a9c057d01a6fe67898cfee6d998aba/composer.json#L23) for a complete example of the `composer.json` file.
+Refer to [Pantheon's Drupal Composer-Managed upstream](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/6522cbccb4a9c057d01a6fe67898cfee6d998aba/composer.json#L23) for a complete example of the `composer.json` file.
 
 #### Permissions
 

--- a/source/content/guides/environment-configuration/05-environment-specific-config-drupal.md
+++ b/source/content/guides/environment-configuration/05-environment-specific-config-drupal.md
@@ -21,7 +21,7 @@ This section provides information on how to manage verbose debugging options and
 The following instructions enable Twig debugging and set development-friendly performance options across Pantheon's pre-production environments (Dev & Multidevs). This approach prevents debugging output and potentially harmful performance settings from being deployed to staging and production environments (Test and Live).
 
 ## Enable Twig Debugging on Dev & Multidevs
-Pantheon handles the inclusion of service configuration files. The [default file provided](https://github.com/pantheon-systems/drupal-composer-managed/tree/default/web/sites/default) has everything you need, so enabling Twig debugging is simple:
+Pantheon handles the inclusion of service configuration files. The [default file provided](https://github.com/pantheon-upstreams/drupal-composer-managed/tree/default/web/sites/default) has everything you need, so enabling Twig debugging is simple:
 
 1. Clone the site's codebase using the [Git command string provided on the Site Dashboard](/guides/git/git-config#clone-your-site-codebase) or via [Terminus](/terminus) if you haven't done so already. 
 

--- a/source/content/guides/php/03-settings-php.md
+++ b/source/content/guides/php/03-settings-php.md
@@ -50,7 +50,7 @@ Use the latest version of Drupal and Drupal 7 configuration snippets in the subs
 
 ### Drupal (Latest Version)
 
-1. Configure environment-specific settings within the `settings.local.php` file, which is ignored by Git in the Pantheon [Drupal upstream](https://github.com/pantheon-systems/drupal-composer-managed). Modifying the bundled `settings.php` file is not necessary, as it already includes `settings.local.php` if one exists.
+1. Configure environment-specific settings within the `settings.local.php` file, which is ignored by Git in the Pantheon [Drupal upstream](https://github.com/pantheon-upstreams/drupal-composer-managed). Modifying the bundled `settings.php` file is not necessary, as it already includes `settings.local.php` if one exists.
 
   ```php
     /**
@@ -231,7 +231,7 @@ if (defined('PANTHEON_ENVIRONMENT')) {
 
 ### Where can I get a copy of a default.settings.php file?
 
-- **Drupal (Latest Version):** There is no `default.settings.php` file in the latest version of Drupal repository on GitHub, but there is a `settings.php` file: [https://github.com/pantheon-systems/drupal-composer-managed/blob/default/web/sites/default/settings.php](https://github.com/pantheon-systems/drupal-composer-managed/blob/default/web/sites/default/settings.php)
+- **Drupal (Latest Version):** There is no `default.settings.php` file in the latest version of Drupal repository on GitHub, but there is a `settings.php` file: [https://github.com/pantheon-upstreams/drupal-composer-managed/blob/default/web/sites/default/settings.php](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/default/web/sites/default/settings.php)
 
 - **Drupal 7:** [https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php)
 


### PR DESCRIPTION
## Summary

The old pantheon-systems location of drupal-composer-managed is now deprecated. 


**Release**:
- [x] When ready
--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
