### PR TITLE
Update installation steps for SimpleSAMLphp (Composer Method)

### DIFF
--- a/source/content/guides/sso/04-shibboleth-sso.md
+++ b/source/content/guides/sso/04-shibboleth-sso.md
@@ -80,29 +80,21 @@ The commands below require a [nested docroot](/nested-docroot) structure and mus
  ```bash{promptUser: user}
  mkdir -p private/simplesamlphp
  mv vendor/simplesamlphp/simplesamlphp/config private/simplesamlphp/config
- cp vendor/simplesamlphp/simplesamlphp/config-templates/config.php private/simplesamlphp/config/
- cp vendor/simplesamlphp/simplesamlphp/config-templates/authsources.php private/simplesamlphp/config/
+ cp private/simplesamlphp/config/config.php.dist private/simplesamlphp/config/config.php
+ cp private/simplesamlphp/config/authsources.php.dist private/simplesamlphp/config/authsources.php
  ```
 
 1. Follow the directions in the next section to [set up your config file](#configure-simplesamlphp) (`private/simplesamlphp/config/config.php`).
-
-1. Add a symlink from SimpleSAMLphp's default config file over to your customized config, stored outside the vendor directory:
-
- ```bash{promptUser: user}
- # Remove existing config directory before adding symlink.
- rm -rf vendor/simplesamlphp/simplesamlphp/config
- ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config
- ```
 
 1. Add this symlink as a post-update script to `composer.json`. This allows the symlink to be recreated if you update or re-install SimpleSAMLphp using Composer:
 
  ```json:title=composer.json
 "scripts": {
     "post-update-cmd": [
-        "rm -rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
+        "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ],
     "post-install-cmd": [
-        "rm -rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
+        "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ]
 },
  ```


### PR DESCRIPTION
closes #8749 

[Use SimpleSAMLphp with Shibboleth SSO](https://docs.pantheon.io/guides/sso/shibboleth-sso#install-simplesamlphp): Update installation steps for SimpleSAMLphp (Composer Method)

Updates to step 3:

```
mkdir -p private/simplesamlphp
mv vendor/simplesamlphp/simplesamlphp/config private/simplesamlphp/config
cp private/simplesamlphp/config/config.php.dist private/simplesamlphp/config/config.php
cp private/simplesamlphp/config/authsources.php.dist private/simplesamlphp/config/authsources.php
```

Remove Steps 5, since this will be done by the composer on step 6 anyway.

For step 6:
No need to remove any files anymore, we only need symlinks.
```
"scripts": {
   "post-update-cmd": [
       "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
   ],
   "post-install-cmd": [
       "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
   ]
},
```