### PR TITLE
[BUGS-7073] Fix incorrect grumphp scripts

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -7,3 +7,5 @@
 source/content/guides/domains/ @pantheon-systems/platform-edge-routing
 # The FileSystem team is responsible for managing static files on Pantheon
 source/content/guides/filesystem/ @pantheon-systems/filesystem
+# The lifecycle-ops team is responsible for Integrated Composer
+source/content/guides/integrated-composer/ @pantheon-systems/lifecycle-ops

--- a/source/content/guides/integrated-composer/07-ic-troubleshooting.md
+++ b/source/content/guides/integrated-composer/07-ic-troubleshooting.md
@@ -224,15 +224,14 @@ The solution is to set `EXEC_GRUMPHP_COMMAND` to run a script that tests for the
 ```bash{promptUser: user}
   grumphp:
    git_hook_variables:
-    EXEC_GRUMPHP_COMMAND: '.scripts/grumphp.sh' # YOUR SCRIPT NAME HERE
+    EXEC_GRUMPHP_COMMAND: './scripts/grumphp.sh' # YOUR SCRIPT NAME HERE
   ```
 
 Lando script example:
 
   ```bash{promptUser: user}
   #!/bin/sh
-  if command -v lando &> /dev/null
-  then
+  if command -v lando; then
     lando php "$@"
   fi
   ```
@@ -241,8 +240,7 @@ The test in the script can be whatever is needed in your particular case. The ex
 
 ```bash{promptUser: user}
 #!/bin/sh
-if [ -z "$PANTHEON_ENVIRONMENT" ]  &> /dev/null
-then
+if [ -z "$PANTHEON_ENVIRONMENT" ]; then
   lando php "$@"
 fi
 ```


### PR DESCRIPTION

Closes #

## Summary

Corrections to GrumPHP script examples on **[Troubleshoot Integrated Composer | Integrated Composer](https://docs.pantheon.io/guides/integrated-composer/ic-troubleshooting#grumphp-breaks-integrated-composer-when-using-lando-or-other-local-development-commands)** page.
<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->


## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Fix incorrect GrumPHP script examples


### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [x] none

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
