### PR TITLE
Update Maintenance Mode code to 504

### DIFF
--- a/source/content/guides/errors-and-server-responses/03-5xx-errors.md
+++ b/source/content/guides/errors-and-server-responses/03-5xx-errors.md
@@ -65,12 +65,6 @@ This response can also occur on Drupal 8 sites using the cacheability debug serv
 
 You can reduce the number of set-cookie headers in the response to resolve this error if you receive a 503 error and your cookie size is smaller than 10KB.
 
-### Pantheon 503 Target in Maintenance
-
-> The web site you were looking for is currently undergoing maintenance.
-
-This is **not** a web application (WordPress or Drupal) maintenance mode error. This is a manually toggled emergency message reserved for unusual circumstances when a site is known to be unavailable.
-
 ### Pantheon 503 Database not Responding
 
 > The web page you were looking for could not be delivered.
@@ -104,6 +98,12 @@ This error can be caused by sustained spikes in traffic (often caused by search 
 There are two possible causes for this error. Pantheon's routing and caching layer can only sustain open HTTP requests for a set time period. You may encounter this message if your application takes too long to respond. The other option is that there was an application problem, resulting in php-fpm or MySQL timing out. Refer to [Timeouts on Pantheon](/timeouts) for more information.
 
 Typically the request timeout is much shorter than the hard timeout for PHP. While you may be able to let an operation run for several minutes in your local development environment, this isn't possible on Pantheon. However, there are ways to solve the problem. There are many things that could cause your site to exceed the request timeout limit. The first step to fixing any problem is to identify the root cause. Refer to [Timeouts on Pantheon](/timeouts) for troubleshooting tips, and consider using [New Relic](/guides/new-relic) to monitor and improve your site performance.
+
+### Pantheon 504 Target in Maintenance
+
+> The web site you were looking for is currently undergoing maintenance.
+
+This is **not** a web application (WordPress or Drupal) maintenance mode error. This is a manually toggled emergency message reserved for unusual circumstances when a site is known to be unavailable.
 
 ### Error 561 No site Detected
 


### PR DESCRIPTION
When a site is in Maintenance Mode on the server side (either through actual maintenance or because it's been taken offline for various reasons), the server response is
> HTTP/1.1 504 Target in maintenance.

This change updates that code and move the section down to the other 504 examples.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[5xx Level Errors](https://docs.pantheon.io/guides/errors-and-server-responses/5xx-errors#pantheon-503-target-in-maintenance)** - Corrects the server response code for Maintenance Mode.

## Effect

May break links since the anchor will change.

## Release

- [ ] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
