### PR TITLE
[CMSP-754] Add PHP 8.3

### DIFF
--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,6 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
+| [8.3](https://v83-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,7 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
-| [8.3](https://v83-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | ❌           |
+| [8.3](https://v83-php-info.pantheonsite.io/)*   | <span style="color:green">✔</span>         | ❌           |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |
@@ -38,7 +38,7 @@ Click the links below to display complete PHP information for each version, incl
 
 Sites that run older PHP versions not listed above will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
 
-<Alert title="PHP 8.3 New Relic compatibility" type="info">
+<Alert title="* PHP 8.3 New Relic compatibility" type="info">
 
 Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
 

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,7 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
-| [8.3](https://v83-php-info.pantheonsite.io/)<sup>1</sup>   | <span style="color:green">✔</span>         | ❌           |
+| [8.3](https://v83-php-info.pantheonsite.io/) <sup>1</sup>   | <span style="color:green">✔</span>         | ❌           |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |
@@ -40,7 +40,7 @@ Sites that run older PHP versions not listed above will continue to serve pages.
 
 <Alert title="PHP 8.3 New Relic compatibility" type="info">
 
-<sup>1</sup>Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
+<sup>1</sup> Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
 
 </Alert>
 

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,7 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
-| [8.3](https://v83-php-info.pantheonsite.io/)*   | <span style="color:green">✔</span>         | ❌           |
+| [8.3](https://v83-php-info.pantheonsite.io/)<sup>1</sup>   | <span style="color:green">✔</span>         | ❌           |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |
@@ -38,9 +38,9 @@ Click the links below to display complete PHP information for each version, incl
 
 Sites that run older PHP versions not listed above will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
 
-<Alert title="* PHP 8.3 New Relic compatibility" type="info">
+<Alert title="PHP 8.3 New Relic compatibility" type="info">
 
-Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
+<sup>1</sup>Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
 
 </Alert>
 

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -38,6 +38,12 @@ Click the links below to display complete PHP information for each version, incl
 
 Sites that run older PHP versions not listed above will continue to serve pages. However, new development cannot be done because the development environment behavior is undefined and no longer supported. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
 
+<Alert title="PHP 8.3 New Relic compatibility" type="info">
+
+Currently, New Relic does not support PHP 8.3. As such, you will not be able to view your New Relic dashboard on any site that has been updated to PHP 8.3. We will be updating our platform to support New Relic on PHP 8.3 sites as soon as a compatible New Relic release is available to us.
+
+</Alert>
+
 ## Drush Compatibility
 
 Refer to [Managing Drush Versions on Pantheon](/guides/drush/drush-versions) for detailed compatibility information.

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -25,7 +25,7 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended |
 | ------------------------------------------------ | :---------: | :---------: |
-| [8.3](https://v83-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
+| [8.3](https://v83-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | ❌           |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           |
 | [8.0](https://v80-php-info.pantheonsite.io/) | <span style="color:green">✔</span>         | ❌          |


### PR DESCRIPTION
## Summary

**[PHP](https://docs.pantheon.io/guides/php#supported-php-versions)** - Updates the PHP version matrix to include PHP 8.3

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [x] PHP 8.3 final release (PHP 8.3 RC6 is available on the platform via a `pantheon.yml` change, but we are waiting for the final PHP release)

### Dependencies and Timing

- [x] Other prerequisites that must be completed before merging this PR

**Release**:
- [x] When ready
- [ ] After date: 23 November, 2023 (planned release of PHP 8.3, our update will likely go out after this due to Thanksgiving)

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
