### PR TITLE
[CMSP-766] Add known issue to WPMS search-replace

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -9,3 +9,5 @@ source/content/guides/domains/ @pantheon-systems/platform-edge-routing
 source/content/guides/filesystem/ @pantheon-systems/filesystem
 # The lifecycle-ops team is responsible for Integrated Composer
 source/content/guides/integrated-composer/ @pantheon-systems/lifecycle-ops
+# The cms-platform team is responsible for WordPress Multisite
+source/content/guides/multisite/ @pantheon-systems/cms-platform

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -175,6 +175,8 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 * WordPress Multisites that are using the WordPress (Composer Managed) upstream are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
 
+* When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL.
+
 ## More Resources
 
 - [Pantheon YAML Configuration Files](/pantheon-yml)

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -175,7 +175,7 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 * WordPress Multisites that are using the WordPress (Composer Managed) upstream are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
 
-* When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL.
+* When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL. We are working on handling this seamlessly in the future.
 
 ## More Resources
 


### PR DESCRIPTION
## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[WordPress Multisite Search and Replace](https://docs.pantheon.io/guides/multisite/search-replace/)** - Adds a known issue with multidev creation and search-replace for subdirectory WPMS.


https://getpantheon.atlassian.net/browse/BUGS-6762
https://getpantheon.atlassian.net/browse/CMSP-766
**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
