### PR TITLE
Update cli.md to fix headline link

### DIFF
--- a/source/content/addons/object-cache/howto/cli.md
+++ b/source/content/addons/object-cache/howto/cli.md
@@ -79,7 +79,7 @@ Drupal deletes and regenerates cached entries during a cache rebuild or cache cl
 
 #### WordPress
 
-If [WP Redis](https://wordpress.org/plugins/wp-redis/) or [Object Cache Pro](/object-cache/wordpress/) are installed, any operation that calls the WordPress function `wp_cache_flush()` will also clear the entire Redis database cache. This happens during WordPress core upgrades, and when clearing the cache via the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache) plugin, the Pantheon dashboard, or Terminus.
+If [WP Redis](https://wordpress.org/plugins/wp-redis/) or [Object Cache Pro](/object-cache/wordpress/) are installed, any operation that calls the WordPress function `wp_cache_flush()` will also clear the entire Redis database cache. This happens during WordPress core upgrades and when clearing the cache via the [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache) plugin, the Pantheon dashboard, or Terminus.
 
 Refer to the Redis CLI section on [Clear All Keys](#clear-all-keys) as a backup method if necessary.
 
@@ -87,7 +87,7 @@ Refer to the Redis CLI section on [Clear All Keys](#clear-all-keys) as a backup 
 
 Use the `flushall` command to clear all keys from the cache.
 
-**Note:** If the [CMS cache clearing](#clearing-cached-data) is functioning as expected, this is generally not necessary. Be aware that in Drupal, it is possible that custom programming may rely on values stored here that are not meant to be temporary.
+**Note:** If the [CMS cache clearing](#clear-cached-data) is functioning as expected, this is generally not necessary. Be aware that in Drupal, it is possible that custom programming may rely on values stored here that are not meant to be temporary.
 
 ```bash
 redis> flushall


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes: (n/a)

## Summary

**[Use the Redis CLI - Clear All Keys](https://docs.pantheon.io/object-cache/cli#clear-all-keys)** - Updates link for "CMS cache clearing" to point to the correct headline. Also removes extra comma in a sentence where it wasn't required.


## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The follow change was added:
- Link fix:
    - Old: `/object-cache/cli#clearing-cached-data`
    - New: `/object-cache/cli#clear-cached-data`
- Comma was removed

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
