### PR TITLE
Update the link to report an issue to `pantheon-upstreams/wordpress-composer-managed`

### DIFF
--- a/source/content/guides/wordpress-composer/pre-ga/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/pre-ga/02-wordpress-composer-managed.md
@@ -109,7 +109,7 @@ composer require wpackagist-plugin/advanced-custom-fields
 
 ## Report an Issue
 
-Create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address if you discover an issue with the WordPress Composer Managed upstream.
+Create an [issue in the Github repo](https://github.com/pantheon-upstreams/wordpress-composer-managed/issues) for the team to review and address if you discover an issue with the WordPress Composer Managed upstream.
 
 Visit [#wordpress in our community Slack](https://pantheon-community.slack.com/archives/CT8MC5Y0K) (you can sign up for the [Pantheon Slack channel here](https://slackin.pantheon.io/) if you don't already have an account) to learn how you can enroll in our Early Access program.
 


### PR DESCRIPTION
## Summary

**[Create a Composer-managed WordPress Site with Bedrock](https://docs.pantheon.io/guides/wordpress-composer/pre-ga/wordpress-composer-managed#report-an-issue)** - Updates the link target for the Issues page to report issues to. `pantheon-systems/wordpress-composer-managed` was made private, so the correct link is the `pantheon-upstreams/wordpress-composer-managed` repository.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
