### PR TITLE
WIP - Remove reference to "new dashboard"

### DIFF
--- a/source/content/guides/autopilot/01-introduction.md
+++ b/source/content/guides/autopilot/01-introduction.md
@@ -18,7 +18,7 @@ product: [autopilot]
 integration: [--]
 ---
 
-[Autopilot](https://pantheon.io/autopilot?docs) is part of Pantheon's [New Dashboard](/guides/new-dashboard) experience. Pantheon Autopilot automatically detects, performs, and deploys updates for WordPress and Drupal. Autopilot also features automated visual regression testing (VRT) to ensure that your site's user experience (UX) is consistent while securing your site and implementing new features.
+[Autopilot](https://pantheon.io/autopilot?docs) automatically detects, performs, and deploys updates for WordPress and Drupal. Autopilot also features automated visual regression testing (VRT) to ensure that your site's user experience (UX) is consistent while securing your site and implementing new features.
 
 ## What Autopilot Does
 


### PR DESCRIPTION
@rachelwhitton this change is not urgent but it stood out to me as I was reading the Autopilot section. We've chatted about how docs work best without emphasizing new/old. The docs site just needs to describe what is.

There might be more such references to update.