### PR TITLE
Update 04-shibboleth-sso.md

### DIFF
--- a/source/content/guides/sso/04-shibboleth-sso.md
+++ b/source/content/guides/sso/04-shibboleth-sso.md
@@ -91,10 +91,10 @@ The commands below require a [nested docroot](/nested-docroot) structure and mus
  ```json:title=composer.json
 "scripts": {
     "post-update-cmd": [
-        "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
+        "rm-rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ],
     "post-install-cmd": [
-        "ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
+        "rm-rf vendor/simplesamlphp/simplesamlphp/config && ln -sf ../../../private/simplesamlphp/config vendor/simplesamlphp/simplesamlphp/config"
     ]
 },
  ```


### PR DESCRIPTION
When using this on a clean install (no vendor dir) the symlink was placed inside the already existing directory. Removing before linking did the trick for me.
