### PR TITLE
Update instructions to install Drupal for FE using Umami demo data

### DIFF
--- a/source/content/guides/decoupled/drupal-backend-starters/02-create.md
+++ b/source/content/guides/decoupled/drupal-backend-starters/02-create.md
@@ -72,14 +72,13 @@ Use **Build Tools** if:
 
 1. Click the **Visit Development Site** button to install Drupal.
 
-1. Select either the `Pantheon Decoupled Profile`, or the `Pantheon Decoupled Umami Demo` profile. The same can be done via [`terminus remote:drush`](/terminus/commands/remote-drush).
+1. Select the `Pantheon Decoupled Profile` install profile. The same can be done via [`terminus remote:drush`](/terminus/commands/remote-drush).
 
-    - The Umami Demo contains additional demo data, and is not intended for use in a production site build.
-    - The Decoupled Umami Demo must first be added to your project as a dependency using composer:
+<Alert title="Note"  type="info" >
 
-        ```bash{promptUser: user}
-        composer require drupal/pantheon_decoupled_umami_demo
-        ```
+To instead install Drupal using a demo data set, select the `Demo: Umami Food Magazine` install profile. After installing, enable the Pantheon Decoupled module.
+
+</Alert>
 
 Your backend starter is ready to develop!
 
@@ -150,16 +149,6 @@ terminus self:plugin:uninstall terminus-power-tools
 ```
 
 ### Additional Options
-
-#### Install with Umami Demo Data
-
-The Build Tools installation process will create a backend with limited example content. To create a site with Drupal's Umami demo data set instead, change the profile flag to `--profile="pantheon_decoupled_umami_demo"` in the `terminus build:project:create` command.
-
-    - The Decoupled Umami Demo must first be added to your project as a dependency using composer:
-
-        ```bash{promptUser: user}
-        composer require drupal/pantheon_decoupled_umami_demo
-        ```
 
 #### Use Other Git Hosts or CI Services
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

The Pantheon Decoupled Umami Demo Profile was recently deprecated. This PR updates instructions to install Drupal for FE using Umami demo data using the main Umami install profile.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
