### PR TITLE
[CMSP-791] Document changes to stderr in WP-CLI

### DIFF
--- a/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
+++ b/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
@@ -58,13 +58,13 @@ ini_set('arg_separator.output', '&');
 
 Actions or filters that require CLI tools like WP-CLI might fail from `wp-config.php`, because the functions required are not yet accessible. Put these directives in an [MU Plugin](/guides/wordpress-configurations/mu-plugin) to resolve this issue.
 
-## Changes to WP-CLI on the Platform (January 2024)
+## Changes to WP-CLI on the Platform (January 15th 2024)
 
 <Alert title="What's the TL;DR?"  type="info" >
 The appearance of PHP errors is changing when invoking WP-CLI. This is unlikely to affect you unless you have shell scripts that are specifically expecting to handle or parse PHP errors as part of the output of a WP-CLI command.
 </Alert>
 
-### Before (The Current State)
+### Before January 15th
 When a command is invoked in WP-CLI in a non-live environment, errors are sent to STDOUT as part of the output. When invoked over Terminus, errors are printed before the command output. In this example, I have called `trigger_error()` for a warning and notice in my wp-config.php file.
 ```bash
 $ terminus wp {site}.{env} -- config get table_prefix
@@ -88,7 +88,7 @@ Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cl
 wp_
 ```
 
-### After (The Future State)
+### Starting January 15th
 When running WP-CLI, ”display_errors” will be changed to “stderr” in php.ini, so that errors can be handled separate from the actual command output. Three changes are notable here:
 
 #### Errors go to STDERR
@@ -108,11 +108,11 @@ The change to WP-CLI’s error handling is environment-agnostic, so while displa
 #### Terminus now displays error messages after the command output
 Because of Terminus’ specific handling of STDOUT and STDERR, PHP errors now display after the command output instead of before.
 ```bash
-$ terminus remote:wp pwtyler.wpclidemo -- config get table_prefix
+$ terminus remote:wp {site}.{env} -- config get table_prefix
 wp_
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
 Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 79
- [notice] Command: pwtyler.wpclidemo -- wp config get table_prefix [Exit: 0]
+ [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
 ```
 
 ## More Resources

--- a/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
+++ b/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
@@ -89,10 +89,10 @@ wp_
 ```
 
 ### After (The Future State)
-When running WP-CLI, ”display_errors” will be changed to “stderr” in php.ini, so that errors can be handled separate from the actual command output. Three changes are notable here—
+When running WP-CLI, ”display_errors” will be changed to “stderr” in php.ini, so that errors can be handled separate from the actual command output. Three changes are notable here:
 
 #### Errors go to STDERR
-The obvious and intentional change. With errors going to stderr, it is now possible to capture the output of a WP-CLI command with no extra steps
+The obvious and intentional change. With errors going to stderr, it is now possible to capture the output of a WP-CLI command with no extra steps.
 ```bash
 $ PREFIX=$(terminus remote:wp {site}.{env} -- config get table_prefix)
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
@@ -100,7 +100,6 @@ Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cl
  [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
 $ echo $PREFIX
 wp_
-
 ```
 
 #### Live errors will display in WP-CLI

--- a/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
+++ b/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
@@ -65,21 +65,21 @@ The appearance of PHP errors is changing when invoking WP-CLI. This is unlikely 
 </Alert>
 
 ### Before January 15th
-When a command is invoked in WP-CLI in a non-live environment, errors are sent to STDOUT as part of the output. When invoked over Terminus, errors are printed before the command output. In this example, I have called `trigger_error()` for a warning and notice in my wp-config.php file.
+When a command is invoked in WP-CLI in a non-live environment, errors are sent to STDOUT as part of the output. When invoked over Terminus, errors are printed before the command output. In this example, I have called `trigger_error()` for a warning and notice in my `wp-config.php` file.
 ```bash
-$ terminus wp {site}.{env} -- config get table_prefix
+$ terminus wp <site>.<env> -- config get table_prefix
 
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
 
 Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 79
 wp_
- [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
+ [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
 ```
 
 This makes it especially difficult to script something that relies on capturing the value of a given command (i.e. `config get` or `plugin list`), as the errors also end up captured, and it takes convoluted shell gymnastics to work around.
 ```bash
-$ PREFIX=$(terminus remote:wp {site}.{env} -- config get table_prefix)
- [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
+$ PREFIX=$(terminus remote:wp <site>.<env> -- config get table_prefix)
+ [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
 $ echo $PREFIX
 
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
@@ -89,30 +89,30 @@ wp_
 ```
 
 ### Starting January 15th
-When running WP-CLI, ”display_errors” will be changed to “stderr” in php.ini, so that errors can be handled separate from the actual command output. Three changes are notable here:
+When running WP-CLI, `display_errors` will be changed to `stderr` in `php.ini`, so that errors can be handled separate from the actual command output. Three changes are notable here:
 
 #### Errors go to STDERR
-The obvious and intentional change. With errors going to stderr, it is now possible to capture the output of a WP-CLI command with no extra steps.
+The obvious and intentional change. With errors going to `stderr`, it is now possible to capture the output of a WP-CLI command with no extra steps.
 ```bash
-$ PREFIX=$(terminus remote:wp {site}.{env} -- config get table_prefix)
+$ PREFIX=$(terminus remote:wp <site>.<env> -- config get table_prefix)
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
 Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 79
- [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
+ [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
 $ echo $PREFIX
 wp_
 ```
 
 #### Live errors will display in WP-CLI
-The change to WP-CLI’s error handling is environment-agnostic, so while display_errors remains off (i.e. unchanged) on live PHP-FPM configuration (i.e. in the browser), it will be “stderr” only for CLI interactions.
+The change to WP-CLI’s error handling is environment-agnostic, so while `display_errors` remains `off` (i.e. unchanged) on Live PHP-FPM configuration (i.e. in the browser), it will be `stderr` only for CLI interactions.
 
 #### Terminus now displays error messages after the command output
 Because of Terminus’ specific handling of STDOUT and STDERR, PHP errors now display after the command output instead of before.
 ```bash
-$ terminus remote:wp {site}.{env} -- config get table_prefix
+$ terminus remote:wp <site>.<env> -- config get table_prefix
 wp_
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
 Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 79
- [notice] Command: {site}.{env} -- wp config get table_prefix [Exit: 0]
+ [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
 ```
 
 ## More Resources

--- a/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
+++ b/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
@@ -64,7 +64,7 @@ Actions or filters that require CLI tools like WP-CLI might fail from `wp-config
 The appearance of PHP errors is changing when invoking WP-CLI. This is unlikely to affect you unless you have shell scripts that are specifically expecting to handle or parse PHP errors as part of the output of a WP-CLI command.
 </Alert>
 
-### Before January 15th
+### Before January 15th 2024
 When a command is invoked in WP-CLI in a non-live environment, errors are sent to STDOUT as part of the output. When invoked over Terminus, errors are printed before the command output. In this example, I have called `trigger_error()` for a warning and notice in my `wp-config.php` file.
 ```bash
 $ terminus wp <site>.<env> -- config get table_prefix
@@ -88,7 +88,7 @@ Warning: A Warning. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cl
 wp_
 ```
 
-### Starting January 15th
+### Starting January 15th 2024
 When running WP-CLI, `display_errors` will be changed to `stderr` in `php.ini`, so that errors can be handled separate from the actual command output. Three changes are notable here:
 
 #### Errors go to STDERR


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes: https://getpantheon.atlassian.net/browse/CMSP-791

## Summary
Documents upcoming changes to WP-CLI's stderr changes. Language around current/future state should be adjusted when the change is rolled out, and then this section removed in 2-3 months.

[WP-CLI Troubleshooting](https://docs.pantheon.io/guides/wp-cli/wp-cli-troubleshoot)

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
