### PR TITLE
[BUGS-5663] Remove binding string from env config

### DIFF
--- a/source/content/guides/environment-configuration/02-read-environment-config.md
+++ b/source/content/guides/environment-configuration/02-read-environment-config.md
@@ -123,13 +123,13 @@ array(63) {
     ["USER"]=>
     string(32) "non-static-binding-string-inserted-here"
     ["HOME"]=>
-    string(46) "/srv/bindings/non-static-binding-string-inserted-here"
+    string(46) "/"
     ["SCRIPT_NAME"]=>
     string(10) "/index.php"
     ["DOCUMENT_URI"]=>
     string(10) "/index.php"
     ["DOCUMENT_ROOT"]=>
-    string(51) "/srv/bindings/non-static-binding-string-inserted-here/code"
+    string(51) "/code"
     ["SERVER_PROTOCOL"]=>
     string(8) "HTTP/1.1"
     ["GATEWAY_INTERFACE"]=>
@@ -147,11 +147,11 @@ array(63) {
     ["REDIRECT_STATUS"]=>
     string(3) "200"
     ["PATH_TRANSLATED"]=>
-    string(51) "/srv/bindings/non-static-binding-string-inserted-here/code"
+    string(51) "/code"
     ["HTTPS"]=>
     string(3) "OFF"
     ["SCRIPT_FILENAME"]=>
-    string(62) "/srv/bindings/non-static-binding-string-inserted-here/code//index.php"
+    string(62) "/code//index.php"
     ["HTTP_HOST"]=>
     string(25) "example-wp-site.pantheonsite.io"
     ["HTTP_USER_AGENT"]=>


### PR DESCRIPTION


Closes https://getpantheon.atlassian.net/browse/BUGS-5663

## Summary
[Reading Pantheon Environment Configuration](https://docs.pantheon.io/guides/environment-configuration/read-environment-config)
Removes outdated reference to the binding string in various elements of the `$_SERVER` example. The binding ID no longer appears in these paths.

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
