### PR TITLE
[CMSP-791] WP-CLI changes did not use clear and consistent language

### DIFF
--- a/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
+++ b/source/content/guides/wp-cli/07-wp-cli-troubleshoot.md
@@ -60,12 +60,12 @@ Actions or filters that require CLI tools like WP-CLI might fail from `wp-config
 
 ## Changes to WP-CLI on the Platform (January 15th 2024)
 
-<Alert title="What's the TL;DR?"  type="info" >
-The appearance of PHP errors is changing when invoking WP-CLI. This is unlikely to affect you unless you have shell scripts that are specifically expecting to handle or parse PHP errors as part of the output of a WP-CLI command.
+<Alert title="Summary of changes"  type="info" >
+When using WP-CLI, the order of display for PHP errors and output is changing. This will affect CI/CD scripts that are specifically expecting to read and parse PHP errors as part of the output of a WP-CLI command. This is not a standard configuration and should not affect the majority of scripts.
 </Alert>
 
 ### Before January 15th 2024
-When a command is invoked in WP-CLI in a non-live environment, errors are sent to STDOUT as part of the output. When invoked over Terminus, errors are printed before the command output. In this example, I have called `trigger_error()` for a warning and notice in my `wp-config.php` file.
+When using WP-CLI in a non-live environment, errors are included in the standard output (`stdout`) part of the response. When used over Terminus, errors are printed before the command output. This example shows the current state with any notice or warning displayed before the command output of `wp_`.
 ```bash
 $ terminus wp <site>.<env> -- config get table_prefix
 
@@ -76,7 +76,7 @@ wp_
  [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
 ```
 
-This makes it especially difficult to script something that relies on capturing the value of a given command (i.e. `config get` or `plugin list`), as the errors also end up captured, and it takes convoluted shell gymnastics to work around.
+This makes it difficult to have a script that relies on capturing the value of a given command (i.e. `config get` or `plugin list`), as the errors also end up captured.
 ```bash
 $ PREFIX=$(terminus remote:wp <site>.<env> -- config get table_prefix)
  [notice] Command: <site>.<env> -- wp config get table_prefix [Exit: 0]
@@ -89,10 +89,10 @@ wp_
 ```
 
 ### Starting January 15th 2024
-When running WP-CLI, `display_errors` will be changed to `stderr` in `php.ini`, so that errors can be handled separate from the actual command output. Three changes are notable here:
+When running WP-CLI, `display_errors` will be changed to standard error (`stderr`) in `php.ini`, so that errors can be handled separately from the actual command output. Three changes are notable here:
 
-#### Errors go to STDERR
-The obvious and intentional change. With errors going to `stderr`, it is now possible to capture the output of a WP-CLI command with no extra steps.
+#### Errors go to stderr
+With errors going to `stderr`, it is now possible to use the output of a WP-CLI command with no extra steps.
 ```bash
 $ PREFIX=$(terminus remote:wp <site>.<env> -- config get table_prefix)
 Notice: A Notice. in phar:///opt/pantheon/wpcli/wp-cli-2.8.1.phar/vendor/wp-cli/config-command/src/Config_Command.php(444) : eval()'d code on line 78
@@ -102,11 +102,11 @@ $ echo $PREFIX
 wp_
 ```
 
-#### Live errors will display in WP-CLI
-The change to WP-CLI’s error handling is environment-agnostic, so while `display_errors` remains `off` (i.e. unchanged) on Live PHP-FPM configuration (i.e. in the browser), it will be `stderr` only for CLI interactions.
+#### PHP errors will display in WP-CLI output
+WP-CLI's error handling has been updated to direct PHP errors to `stderr` during CLI interactions across all environments. This change means that previously hidden notices or warnings from the Live environment are now visible in WP-CLI outputs. However, this update does not affect regular web requests and user interactions with the site, where these errors will continue to remain hidden.
 
 #### Terminus now displays error messages after the command output
-Because of Terminus’ specific handling of STDOUT and STDERR, PHP errors now display after the command output instead of before.
+Because of Terminus’ specific handling of `stdout` and `stderr`, PHP errors now display after the command output instead of before.
 ```bash
 $ terminus remote:wp <site>.<env> -- config get table_prefix
 wp_


### PR DESCRIPTION
## Summary

**[Troubleshoot WP-CLI](https://docs.pantheon.io/guides/wp-cli/wp-cli-troubleshoot#changes-to-wp-cli-on-the-platform-january-15th-2024)** - Changed to use clear language

**Clarity and accessibility:** The replacement of "What's the TL;DR?" with "Summary of changes" in the alert title improves clarity and accessibility. Avoiding internet slang and using straightforward language makes the document more accessible to screen readers and a global audience. 

The removal of colloquial language like "gymnastics" is also crucial for a global audience. Technical documentation should be written in a way that is easily understandable by people from various cultural and linguistic backgrounds. 

**Technical terms** All references now use the standard lowercase display of `stdout` instead of the previous mixed-case output. I have also defined the original term "standard output (`stdout`)" as this is a new term on the page. 

**Standard second person writing** Pantheon's documentation should address the user as "you" and define the speaking voice, for example "At Pantheon, **we** do..." instead of using "**I** have called..."

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
