### PR TITLE
Use "terminus" instead of Pantheon CLI in Pantheon WebOps Certification

### DIFF
--- a/source/content/certification/study-guide-cms/05-cms.md
+++ b/source/content/certification/study-guide-cms/05-cms.md
@@ -241,7 +241,7 @@ In addition to On-Demand backups, Pantheon automatically backs up your site with
 * **All sites: **You can run manual backups for free, and choose to keep them for one month or six months.
 * **Paid sites: **You can enable or disable automatic backups. A nightly backup is created and stored for a week and your weekly backup is stored for a month when automatic backups is enabled.
 
-Backups can also be triggered with Pantheon's CLI's [backup:create](/terminus/commands/backup-create) command. That command can be part of a multi-step script that also includes the cloning of the database from one environment to another.
+Backups can also be triggered with terminus' [backup:create](/terminus/commands/backup-create) command. That command can be part of a multi-step script that also includes the cloning of the database from one environment to another.
 
 ####  Connecting to Your Database
 


### PR DESCRIPTION
## Summary

**[WebOps Certification: Chapter 5: CMS Infrastructure (backups section)](https://docs.pantheon.io/certification/study-guide/cms#backups-on-pantheon)** -  Since we use "terminus" throughout the rest of the certification docs, it can appear confusing to use "Pantheon CLI" here. As I was reading it, I had to make sure this was referring to terminus by checking the URL it was pointed to.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
