### PR TITLE
[BUGS-7373] WPMS search-replace requires PHP 7.4+

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -21,7 +21,8 @@ This section provides information on how to configure automatic platform Search 
 
 You must have the following to enable Search and Replace:
 
-- A [WordPress Multisite](/guides/multisite)
+- A [WordPress Multisite](/guides/multisite).
+- A PHP version of 7.4 or later.
 
 <Alert title="Note"  type="info" >
 


### PR DESCRIPTION
Relates to: https://getpantheon.atlassian.net/browse/BUGS-7373
## Summary
Pantheon will not provide support for WPMS search-replace for sites running PHP < 7.4.

**[Search and Replace](https://docs.pantheon.io/guides/multisite/search-replace/)** - Adds a minimum supported PHP version of 7.4

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
