### PR TITLE
Release notes messaging added to Changelogs 

### DIFF
--- a/source/changelogs/2024-01-25-release-notes.md
+++ b/source/changelogs/2024-01-25-release-notes.md
@@ -1,10 +1,14 @@
 ---
-title: So long changelog, long live release notes!
+title: We've launched Pantheon release notes, your new destination for product updates
 changelog: true
 reviewed: "2023-12-01"
 ---
 <Alert title="We're moving!" type="danger" >
 
-Soon this section of our site will be removed and redirected to our new release notes resource. Check it out over at https://docs.pantheon.io/release-notes
+We're thrilled to announce the launch of [Pantheon release notes](/release-notes/) - a rebrand of our beloved changelog! This upgraded platform brings you better navigation and the latest product announcements. 
+
+This changelog site is still accessible, and a redirection to the new site will be implemented shortly.
+
+Visit Pantheon release notes: https://docs.pantheon.io/release-notes/
 
 </Alert>

--- a/source/changelogs/2024-01-25-release-notes.md
+++ b/source/changelogs/2024-01-25-release-notes.md
@@ -1,5 +1,5 @@
 ---
-title: We've launched Pantheon release notes, your new destination for product updates
+title: We've launched Pantheon release notes
 changelog: true
 reviewed: "2023-12-01"
 ---

--- a/source/changelogs/2024-01-25-release-notes.md
+++ b/source/changelogs/2024-01-25-release-notes.md
@@ -1,0 +1,10 @@
+---
+title: So long changelog, long live release notes!
+changelog: true
+reviewed: "2023-12-01"
+---
+<Alert title="We're moving!" type="danger" >
+
+Soon this section of our site will be removed and redirected to our new release notes resource. Check it out over at https://docs.pantheon.io/release-notes
+
+</Alert>

--- a/src/templates/changelog.js
+++ b/src/templates/changelog.js
@@ -89,17 +89,8 @@ class ChangelogTemplate extends React.Component {
             <h1>{node.frontmatter.title}</h1>
             <div className="pds-spacing-mar-block-end-3xl">
               <p className="pds-lead-text pds-lead-text--sm">
-                Sign up for the Pantheon Changelog Newsletter to receive a
-                monthly email on what's new and improved across the platform.
+              We're transitioning away from Changelogs published in this area of our docs site in favor of <a href="/release-notes"> release notes</a>!
               </p>
-              <a
-                className="pds-button"
-                href="https://learn.pantheon.io/Changelog-Opt-In.html"
-                target="_blank"
-              >
-                Subscribe Now
-                <Icon iconName="externalLink" />
-              </a>
             </div>
             <hr />
 

--- a/src/templates/changelogs.js
+++ b/src/templates/changelogs.js
@@ -97,17 +97,8 @@ class ChangelogsTemplate extends React.Component {
             <h1>Pantheon Changelog</h1>
             <div className="pds-spacing-mar-block-end-3xl">
               <p className="pds-lead-text pds-lead-text--sm">
-                Sign up for the Pantheon Changelog Newsletter to receive a
-                monthly email on what's new and improved across the platform.
+              We're transitioning away from Changelogs published in this area of our docs site in favor of <a href="/release-notes"> release notes</a>!
               </p>
-              <a
-                className="pds-button"
-                href="https://learn.pantheon.io/Changelog-Opt-In.html"
-                target="_blank"
-              >
-                Subscribe Now
-                <Icon iconName="externalLink" />
-              </a>
             </div>
             <hr />
             <SidebarLayout sidebarMobileLocation="before">


### PR DESCRIPTION
For the interim, while we work to backfill all changelog entries and eventually delete and redirect this area of the site to release notes. Adding placeholder copy, and handing over to @IngridKwok to update with revised copy