### PR TITLE
Add intro text to release notes listing pages

### DIFF
--- a/source/data/releasenotes.yaml
+++ b/source/data/releasenotes.yaml
@@ -1,0 +1,2 @@
+- id: releasenotes
+  introText: "Your destination for staying informed about our latest innovations and product updates."

--- a/src/templates/releaseNotesListing.js
+++ b/src/templates/releaseNotesListing.js
@@ -92,6 +92,9 @@ const ReleaseNotesListingTemplate = ({ data }) => {
   const renderedReleaseNotes =
     releasenotes.length !== 0 ? renderedTeasers : noResultsMessage
 
+  // Preprocess intro text.
+  const introText = data.releasenotesYaml.introText
+
   return (
     <Layout containerWidth={containerWidth} excludeSearch footerBorder>
       <SEO
@@ -105,6 +108,7 @@ const ReleaseNotesListingTemplate = ({ data }) => {
           className="pds-spacing-mar-block-start-3xl"
         >
           <h1>Pantheon release notes</h1>
+          <div className="pds-lead-text pds-lead-text--sm">{introText}</div>
           <FlexContainer
             style={{
               borderBottom: "1px solid var(--pds-color-border-default)",
@@ -160,6 +164,9 @@ export const pageQuery = graphql`
           }
         }
       }
+    }
+    releasenotesYaml {
+      introText
     }
   }
 `

--- a/src/templates/releaseNotesListingByCategory.js
+++ b/src/templates/releaseNotesListingByCategory.js
@@ -96,9 +96,6 @@ const ReleaseNotesListingByCategoryTemplate = ({ data, pageContext }) => {
   const renderedReleaseNotes =
     releasenotes.length !== 0 ? renderedTeasers : noResultsMessage
 
-  // Preprocess intro text.
-  const introText = data.releasenotesYaml.introText
-
   return (
     <Layout containerWidth={containerWidth} excludeSearch footerBorder>
       <SEO
@@ -114,7 +111,6 @@ const ReleaseNotesListingByCategoryTemplate = ({ data, pageContext }) => {
           <h1>
             Pantheon release notes: <em>{categoryData["displayName"]}</em>
           </h1>
-          <div className="pds-lead-text pds-lead-text--sm">{introText}</div>
           <FlexContainer
             style={{
               borderBottom: "1px solid var(--pds-color-border-default)",
@@ -171,9 +167,6 @@ export const pageQuery = graphql`
           ...theReleaseNoteFields
         }
       }
-    }
-    releasenotesYaml {
-      introText
     }
   }
 `

--- a/src/templates/releaseNotesListingByCategory.js
+++ b/src/templates/releaseNotesListingByCategory.js
@@ -96,6 +96,9 @@ const ReleaseNotesListingByCategoryTemplate = ({ data, pageContext }) => {
   const renderedReleaseNotes =
     releasenotes.length !== 0 ? renderedTeasers : noResultsMessage
 
+  // Preprocess intro text.
+  const introText = data.releasenotesYaml.introText
+
   return (
     <Layout containerWidth={containerWidth} excludeSearch footerBorder>
       <SEO
@@ -111,6 +114,7 @@ const ReleaseNotesListingByCategoryTemplate = ({ data, pageContext }) => {
           <h1>
             Pantheon release notes: <em>{categoryData["displayName"]}</em>
           </h1>
+          <div className="pds-lead-text pds-lead-text--sm">{introText}</div>
           <FlexContainer
             style={{
               borderBottom: "1px solid var(--pds-color-border-default)",
@@ -167,6 +171,9 @@ export const pageQuery = graphql`
           ...theReleaseNoteFields
         }
       }
+    }
+    releasenotesYaml {
+      introText
     }
   }
 `


### PR DESCRIPTION
Adds an introductory text area to the release notes home page and provides a mechanism to edit it via a yaml file.

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
