### PR TITLE
WordPress 6.4.3 Release Note

### DIFF
--- a/source/releasenotes/2024-01-31-wordpress-6-4-3.md
+++ b/source/releasenotes/2024-01-31-wordpress-6-4-3.md
@@ -9,7 +9,7 @@ The latest version of WordPress, 6.4.3, became available on Pantheon as of Janua
 <!--- // TODO insert link to https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/ somewhere in here -->
 <h3>Highlights</h3>
 
-* **Security updates:** Addressed two security vulnerabilities, including a PHP file upload bypass (limited to administrators), and a object injection gadget that could be used to exploit an existing Remote Code Execution (RCE) vulnerability. For a detailed analysis of the two security patches, see [this article from Patchstack](https://patchstack.com/articles/wordpress-6-4-3-security-release/).
+* **Security updates:** Addressed two security vulnerabilities, including a PHP file upload bypass (limited to administrators), and a object injection mechanism that could be used to exploit an existing Remote Code Execution (RCE) vulnerability. For a detailed analysis of the two security patches, see [this article from Patchstack](https://patchstack.com/articles/wordpress-6-4-3-security-release/).
 * 5 bug fixes in Core
 * 16 bug fixes in the Block Editor
 

--- a/source/releasenotes/2024-01-31-wordpress-6-4-3.md
+++ b/source/releasenotes/2024-01-31-wordpress-6-4-3.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress 6.4.3 security updates
+title: WordPress 6.4.3 Security Updates
 published_date: "2024-01-31"
 categories: [wordpress, security]
 ---
@@ -11,6 +11,6 @@ The latest version of WordPress, 6.4.3, became available on Pantheon as of Janua
 
 * **Security updates:** Addressed two security vulnerabilities, including a PHP file upload bypass (limited to administrators), and a object injection gadget that could be used to exploit an existing Remote Code Execution (RCE) vulnerability. For a detailed analysis of the two security patches, see [this article from Patchstack](https://patchstack.com/articles/wordpress-6-4-3-security-release/).
 * 5 bug fixes in Core
-* 16 Bug fixes in the Block Editor
+* 16 bug fixes in the Block Editor
 
 Upgrade to WordPress 6.4.3 right from your Pantheon dashboard or Terminus for added security. 

--- a/source/releasenotes/2024-01-31-wordpress-6-4-3.md
+++ b/source/releasenotes/2024-01-31-wordpress-6-4-3.md
@@ -6,7 +6,6 @@ categories: [wordpress, security]
 
 The latest version of WordPress, [6.4.3](https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/), became available on Pantheon as of January 30, 2024.
 
-<!--- // TODO insert link to https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/ somewhere in here -->
 <h3>Highlights</h3>
 
 * **Security updates:** Addressed two security vulnerabilities, including a PHP file upload bypass (limited to administrators), and a object injection mechanism that could be used to exploit an existing Remote Code Execution (RCE) vulnerability. For a detailed analysis of the two security patches, see [this article from Patchstack](https://patchstack.com/articles/wordpress-6-4-3-security-release/).

--- a/source/releasenotes/2024-01-31-wordpress-6-4-3.md
+++ b/source/releasenotes/2024-01-31-wordpress-6-4-3.md
@@ -1,0 +1,16 @@
+---
+title: WordPress 6.4.3 security updates
+published_date: "2024-01-31"
+categories: [wordpress, security]
+---
+
+The latest version of WordPress, 6.4.3, became available on Pantheon as of January 30, 2024.
+
+<!--- // TODO insert link to https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/ somewhere in here -->
+<h3>Highlights</h3>
+
+* **Security updates:** Addressed two security vulnerabilities, including a PHP file upload bypass (limited to administrators), and a object injection gadget that could be used to exploit an existing Remote Code Execution (RCE) vulnerability. For a detailed analysis of the two security patches, see [this article from Patchstack](https://patchstack.com/articles/wordpress-6-4-3-security-release/).
+* 5 bug fixes in Core
+* 16 Bug fixes in the Block Editor
+
+Upgrade to WordPress 6.4.3 right from your Pantheon dashboard or Terminus for added security. 

--- a/source/releasenotes/2024-01-31-wordpress-6-4-3.md
+++ b/source/releasenotes/2024-01-31-wordpress-6-4-3.md
@@ -4,7 +4,7 @@ published_date: "2024-01-31"
 categories: [wordpress, security]
 ---
 
-The latest version of WordPress, 6.4.3, became available on Pantheon as of January 30, 2024.
+The latest version of WordPress, [6.4.3](https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/), became available on Pantheon as of January 30, 2024.
 
 <!--- // TODO insert link to https://wordpress.org/news/2024/01/wordpress-6-4-3-maintenance-and-security-release/ somewhere in here -->
 <h3>Highlights</h3>


### PR DESCRIPTION

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Pantheon Release Notes](https://docs.pantheon.io/release-notes/)** - Adds release note for WordPress 6.4.3

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] Copy Editing
- [x] I'd like to include a link to the WordPress.org blog post in this post, but unsure of where/phrasing.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
