### PR TITLE
Delete duplicate entry for WordPress 6.4.2

### DIFF
--- a/source/releasenotes/2023-12-01-wordpress-6-4-2-now-available-for-enhanced-security.md
+++ b/source/releasenotes/2023-12-01-wordpress-6-4-2-now-available-for-enhanced-security.md
@@ -1,6 +1,0 @@
----
-title: "WordPress 6.4.2 Now Available for Enhanced Security"
-published_date: "2023-12-01"
-categories: [wordpress, security, action-required]
----
-In response to a critical security vulnerability, [WordPress 6.4.2](https://wordpress.org/news/2023/12/wordpress-6-4-2-maintenance-security-release/) was released on December 6, 2023. To ensure the safety of your site, Pantheon strongly advises an immediate upgrade. Prioritize your site's security – upgrade now!


### PR DESCRIPTION
Delete duplicate entry for WordPress 6.4.2

Keep: https://docs.pantheon.io/release-notes/2024/01/wordpress-6-4-2-security-update
Delete: https://docs.pantheon.io/release-notes/2023/12/wordpress-6-4-2-now-available-for-enhanced-security 