### PR TITLE
WIP - Alternative IA for cert pages

### DIFF
--- a/source/content/certification/certification.md
+++ b/source/content/certification/certification.md
@@ -1,19 +1,8 @@
 ---
-title: WebOps Certification
-subtitle: Certification Program
-certificationpage: true
+title: "WebOps Certification: About"
 showtoc: true
-type: certificationpage
-layout: certificationpage
 contributors: []
-contenttype: [guide]
-innav: [true]
-categories: []
-cms: [drupal, wordpress]
-integration: [--]
-tags: []
-permalink: docs/certification
-nexturl: /certification/study-guide
+permalink: docs/certification/about
 ---
 
 Pantheon is introducing a certification program that validates knowledge of our core CMS Sites offering. This program is presently invite-only for [Pantheon Heroes](https://pantheon.io/developer-community/heroes) and developers at [Partners agencies](https://pantheon.io/partners/become-pantheon-partner). We expect to open it more widely in 2024.

--- a/source/content/certification/exam-faq.md
+++ b/source/content/certification/exam-faq.md
@@ -1,19 +1,9 @@
 ---
-title: WebOps Certification
-subtitle: Exam Topics
-certificationpage: true
-showtoc: true
-type: certificationpage
-layout: certificationpage
+title: "WebOps Certification: Exam Topics"
 contributors: []
+showtoc: false
 contenttype: [guide]
-innav: [true]
-categories: []
-cms: [drupal, wordpress]
-integration: [--]
-tags: []
 permalink: docs/certification/exam-faq
-previousurl: /certification/exam-instructions
 
 ---
 
@@ -124,6 +114,3 @@ When you have finished taking the exam, you will see a message on the screen ind
 
 
 </Accordion>
-
-
-

--- a/source/content/certification/exam-instructions.md
+++ b/source/content/certification/exam-instructions.md
@@ -1,21 +1,8 @@
 ---
-title: WebOps Certification
-subtitle: Exam Instructions
-certificationpage: true
-showtoc: true
-type: certificationpage
-layout: certificationpage
+title: "WebOps Certification: Exam Instructions"
 contributors: []
-contenttype: [guide]
-innav: [true]
-categories: []
-cms: [drupal, wordpress]
-integration: [--]
-tags: []
+showtoc: false
 permalink: docs/certification/exam-instructions
-previousurl: /certification/exam-topics
-nexturl: /certification/exam-faq
-
 ---
 
 The following directions and instructions were captured by a user on a MacOS device. However, most of the steps here should also be applicable for Windows users. If you run into any technical difficulties or have any questions, you can launch a support session with ProctorFree by clicking the Support Chat icon in the lower right-hand portion of the screen.
@@ -40,9 +27,3 @@ The following directions and instructions were captured by a user on a MacOS dev
 | ![15](../../images/certification/exam-instructions/exam-15.png)      | Next, select the web camera that you will use during the exam session. This is typically the default web camera for your device.  |
 | ![16](../../images/certification/exam-instructions/exam-16.png)      | Once the hardware compatibility check is complete, ProctorFree will authenticate you by snapping a quick screenshot of your face. This will take around 5 seconds, and you will need to keep relatively still.  <br /> <br/>This screenshot is used during the results validation process after you have taken the exam, allowing the validator to match the picture of your face with the video that is captured of you taking the exam.  |
 | ![17](../../images/certification/exam-instructions/exam-17.png)      | Now that you have completed the validation and registration process, you are ready to launch your exam. <br /> <br />Click the button labeled “Launch Proctored Session”  |
-
-
-
-
-
-

--- a/source/content/certification/exam-topics.md
+++ b/source/content/certification/exam-topics.md
@@ -1,21 +1,7 @@
 ---
-title: WebOps Certification
-subtitle: Exam Topics
-certificationpage: true
+title: "WebOps Certification: Exam Topics"
 showtoc: true
-type: certificationpage
-layout: certificationpage
-contributors: []
-contenttype: [guide]
-innav: [true]
-categories: []
-cms: [drupal, wordpress]
-integration: [--]
-tags: []
 permalink: docs/certification/exam-topics
-previousurl: /certification/study-guide/custom-upstreams
-nexturl: /certification/exam-instructions
-
 ---
 ### Autopilot
 

--- a/source/content/certification/study-guide-cms/00-intro.md
+++ b/source/content/certification/study-guide-cms/00-intro.md
@@ -14,7 +14,6 @@ cms: [drupal, wordpress]
 audience: []
 product: []
 integration: [--]
-previousurl: /certification
 nexturl: /certification/study-guide/webops
 ---
 

--- a/source/content/certification/study-guide-cms/10-custom-upstreams.md
+++ b/source/content/certification/study-guide-cms/10-custom-upstreams.md
@@ -15,7 +15,6 @@ audience: []
 product: []
 integration: [--]
 previousurl: /certification/study-guide/automate
-nexturl: /certification/exam-topics
 ---
 
 <Alert title="By the end of this chapter, you will be able to:"  type="info" >

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -1567,3 +1567,23 @@
               url: "/object-cache/cli"
             - text: "Safely Remove Object Cache"
               url: "/object-cache/remove"
+- title: "Pantheon WebOps Certification"
+  subtitle: "Learn about the benefits of certification, prepare using our study guide, and understand the exam."
+  path: "certification"
+  topics-groups:
+    - title: "Benefits of the program"
+      links:
+        - text: "Why become certified?"
+          url: "/certification/about"
+    - title: "Study for the exam"
+      links:
+        - text: "WebOps Certification Study Guide"
+          url: "/certification/study-guide"
+    - title: "What to expect"
+      links:
+        - text: "Exam Topics"
+          url: "/certification/exam-topics"
+        - text: "Exam Instructions"
+          url: "/certification/exam-instructions"
+        - text: "Exam FAQ"
+          url: "/certification/exam-faq"

--- a/src/templates/certificationpage.js
+++ b/src/templates/certificationpage.js
@@ -60,11 +60,6 @@ const shortcodes = {
 // - To a GraphQL query order by frontmatter weight/order/index field.
 const items = [
   {
-    id: "docs-certification",
-    link: "/certification",
-    title: "Certification Program",
-  },
-  {
     id: "docs-certification-chapter-0",
     link: "/certification/study-guide",
     title: "Introduction",
@@ -118,21 +113,6 @@ const items = [
     id: "docs-certification-chapter-10",
     link: "/certification/study-guide/custom-upstreams",
     title: "Chapter 10: Custom Upstreams",
-  },
-  {
-    id: "docs-certification-exam-topics",
-    link: "/certification/exam-topics",
-    title: "Exam Topics",
-  },
-  {
-    id: "docs-certification-exam-instructions",
-    link: "/certification/exam-instructions",
-    title: "Exam Instructions",
-  },
-  {
-    id: "docs-certification-exam-faq",
-    link: "/certification/exam-faq",
-    title: "Exam FAQ",
   },
 ]
 


### PR DESCRIPTION
Alternative IA for cert pages

Publish a landing page at `/certification` with 3 topic groups:
- Benefits of the program 
  - Relocate out of multi-page guide into a single doc page, at an updated path: `/certification/about` 
- Study for the exam
  - The study guide remains a multi-page guide, at the existing path: `certification/study-guide`
- What to expect
  - Exam Topics with the path: `certification/exam-topics`
  - Exam Instructions with the path: `certification/exam-instructions`
  - Exam FAQ with the path: `certification/exam-faq`

The three separate pages for what to expect during the exam might could be consolidated into a single doc page  

![screencapture-localhost-8000-certification-2024-01-31-17_03_06](https://github.com/pantheon-systems/documentation/assets/10119525/ae8d7eb0-4666-45db-a0d5-9d2b61bbbe52)
