### PR TITLE
Object Cache: add recommended alternatives for clarity

### DIFF
--- a/source/content/addons/object-cache/concepts/overview.md
+++ b/source/content/addons/object-cache/concepts/overview.md
@@ -28,7 +28,7 @@ Object Cache provides an alternative caching backend that resides in memory rath
 
 ## Object Cache Requirements
 
-All plans, except for the Basic plan, can use Object Cache. Sandbox site plans can enable and use Object Cache for development purposes, but if the site plan is upgraded to Basic the feature will be disabled. Object Cache Pro, the premium WordPress plugin, is not available for Sandbox sites, however you may enable Redis for Sandbox sites and use [wp-redis](https://github.com/pantheon-systems/wp-redis), or any other reputable Redis plugin for WordPress.
+All plans, except for the Basic plan, can use Object Cache. Sandbox site plans can enable and use Object Cache for development purposes, but if the site plan is upgraded to Basic the feature will be disabled. Object Cache Pro, the premium WordPress plugin, is not available for Sandbox sites, however you may enable Redis for Sandbox sites and use Pantheon's [wp-redis](https://github.com/pantheon-systems/wp-redis) plugin, or any other reputable Redis plugin for WordPress.
 
 | Plans         | Object Cache Support <Popover content="Available across all environments, including Multidevs."/> |
 | ------------- | -------------------------------------- |

--- a/source/content/addons/object-cache/concepts/overview.md
+++ b/source/content/addons/object-cache/concepts/overview.md
@@ -28,7 +28,7 @@ Object Cache provides an alternative caching backend that resides in memory rath
 
 ## Object Cache Requirements
 
-All plans, except for the Basic plan, can use Object Cache. Sandbox site plans can enable and use Object Cache for development purposes, but if the site plan is upgraded to Basic, the feature will be disabled. Object Cache Pro, the premium WordPress plugin, is not available for Sandbox sites, however you may enable Redis for Sandbox sites and use another reputable plugin to enable Redis for WordPress.
+All plans, except for the Basic plan, can use Object Cache. Sandbox site plans can enable and use Object Cache for development purposes, but if the site plan is upgraded to Basic the feature will be disabled. Object Cache Pro, the premium WordPress plugin, is not available for Sandbox sites, however you may enable Redis for Sandbox sites and use [wp-redis](https://github.com/pantheon-systems/wp-redis), or any other reputable Redis plugin for WordPress.
 
 | Plans         | Object Cache Support <Popover content="Available across all environments, including Multidevs."/> |
 | ------------- | -------------------------------------- |


### PR DESCRIPTION
## Summary
**[Object Cache Overview](https://docs.pantheon.io/object-cache#object-cache-requirements)** - Updates our Object Cache plugin section to explicitly list one recommended alternative, to help avoid confusion on options available.

## Effect
The following changes are already committed:
* Adds [wp-redis](https://github.com/pantheon-systems/wp-redis) as a recommended alternative for sites that cannot use Object Cache Pro

### Dependencies and Timing
**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
