### PR TITLE
[BUGS-7164] Umbrella more IC sites in search-replace known issues

### DIFF
--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -175,7 +175,7 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 ## Known Issues
 
-* WordPress Multisites that are using Integrated Composer, such as the WordPress (Composer Managed) upstream, are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
+* WordPress Multisites that are using [Integrated Composer](/guides/integrated-composer), such as the WordPress (Composer Managed) upstream, are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
 
 * When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL. We are working on handling this seamlessly in the future.
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -179,8 +179,6 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 * When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL. We are working on handling this seamlessly in the future.
 
-
-
 ## More Resources
 
 - [Pantheon YAML Configuration Files](/pantheon-yml)

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -23,6 +23,7 @@ You must have the following to enable Search and Replace:
 
 - A [WordPress Multisite](/guides/multisite).
 - A PHP version of 7.4 or later.
+- The site is *not* using [Integrated Composer](/guides/integrated-composer).
 
 <Alert title="Note"  type="info" >
 

--- a/source/content/guides/multisite/06-search-replace.md
+++ b/source/content/guides/multisite/06-search-replace.md
@@ -174,9 +174,11 @@ Sites configured for subdomain conversion will _only_ run the conversion step fr
 
 ## Known Issues
 
-* WordPress Multisites that are using the WordPress (Composer Managed) upstream are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
+* WordPress Multisites that are using Integrated Composer, such as the WordPress (Composer Managed) upstream, are currently unable to use Multisite Search and Replace. For those sites, we recommend setting the `search_replace` value to `false` and using WP-CLI via Terminus to perform the Search and Replace. See [Run WP-CLI `search-replace` Manually](/guides/multisite/workflows/#run-wp-cli-search-replace-manually) for more information.
 
 * When using the default Subdirectory search and replace, creating a new multidev with database and files pulled from the live environment will only search and replace the platform domain, i.e. `live-{site}.pantheonsite.io`. To search and replace the correct domain on your live site, immediately follow multidev creation with a database clone either through the dashboard or with Terminus, and select the correct domain as the "from" URL. We are working on handling this seamlessly in the future.
+
+
 
 ## More Resources
 


### PR DESCRIPTION
Closes #

## Summary

**[Multisite Search Replace](https://docs.pantheon.io/guides/multisite/search-replace/)** - Clarify that WPMS search-replace cannot be used with IC

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
