### PR TITLE
TEST - Merge permissions to main for release notes

### DIFF
--- a/source/releasenotes/2024-02-07-example-release-note.md
+++ b/source/releasenotes/2024-02-07-example-release-note.md
@@ -1,0 +1,6 @@
+---
+title: "Test: Understand merge permissions to main for CODEOWNERS"
+published_date: "2024-02-07"
+categories: [general, documentation]
+---
+This is a test, because I'm curious to see if members of this [GitHub team](https://github.com/orgs/pantheon-systems/teams/release-note-authors) have permission to merge PRs to main like we expect given they are listed in the CODEOWNERS file for `source/releasenotes/` 


### PR DESCRIPTION
This is a test, because I'm curious to see if members of this [GitHub team](https://github.com/orgs/pantheon-systems/teams/release-note-authors) have permission to merge PRs to main like we expect given they are listed in the CODEOWNERS file for `source/releasenotes/` 
