### PR TITLE
CMSP-866: WP-CLI 2.10 Release

### DIFF
--- a/source/releasenotes/2024-02-20-wp-cli-2-10.md
+++ b/source/releasenotes/2024-02-20-wp-cli-2-10.md
@@ -1,0 +1,20 @@
+---
+title: WP-CLI v2.10.0 release now available on Pantheon
+published_date: "2024-02-20"
+categories: [wordpress]
+---
+
+We're thrilled to announce the availability of WP-CLI v2.10.0 on the Pantheon platform.
+
+WP-CLI is easily accessible for any WordPress site on Pantheon through our CLI, [Terminus](/terminus). Manage your WordPress installations efficiently with the power of WP-CLI at your fingertips.
+
+<h3>Highlights</h3>
+
+* **New i18n "make-php" command**
+This new command lets site owners take advantage of WordPress Core's "Performant Translations" project even before it is released with WordPress Core.
+* **Adds minor and patch limitations to theme updates**
+Now, like plugins, themes can be updated only to their latest minor or patch releases
+* **Bug fixes**
+WP-CLI 2.10.0 fixes "a lot of small and not so small bugs" with more than 200 pull requests merged.
+
+For those who love diving into the details, we encourage you to explore the [detailed WP-CLI changelog](https://make.wordpress.org/cli/2024/02/08/wp-cli-v2-10-0-release-notes).

--- a/source/releasenotes/2024-02-20-wp-cli-2-10.md
+++ b/source/releasenotes/2024-02-20-wp-cli-2-10.md
@@ -10,11 +10,11 @@ WP-CLI is easily accessible for any WordPress site on Pantheon through our CLI, 
 
 <h3>Highlights</h3>
 
-* **New i18n "make-php" command**
+* **New i18n "make-php" command:**
 This new command lets site owners take advantage of WordPress Core's "Performant Translations" project even before it is released with WordPress Core.
-* **Adds minor and patch limitations to theme updates**
+* **Adds minor and patch limitations to theme updates:**
 Now, like plugins, themes can be updated only to their latest minor or patch releases
-* **Bug fixes**
+* **Bug fixes:**
 WP-CLI 2.10.0 fixes "a lot of small and not so small bugs" with more than 200 pull requests merged.
 
 For those who love diving into the details, we encourage you to explore the [detailed WP-CLI changelog](https://make.wordpress.org/cli/2024/02/08/wp-cli-v2-10-0-release-notes).


### PR DESCRIPTION
## Summary
Adds release note for WP-CLI 2.10 release
https://pr-8869-documentation.appa.pantheon.site/release-notes/2024/02/wp-cli-2-10
## Remaining Work and Prerequisites
- [x] Hold until https://github.com/pantheon-systems/cos-framework-clis/pull/144 released

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
