### PR TITLE
Provide Multisite requirements directly on multisite documentation

### DIFF
--- a/source/content/guides/multisite/01-introduction.md
+++ b/source/content/guides/multisite/01-introduction.md
@@ -38,7 +38,7 @@ We do not support uses of WordPress Multisite that run functionally-different or
 - [WordPress Multi-Network](https://wordpress.org/plugins/wp-multi-network/) installations where multiple domains can be added aside from subdomains and subdirectories.
 
 ## Request a WordPress Multisite
-WordPress Multisite requires a special configuration that is only available to select customers. Refer to [Pantheon Account Options & Site Hosting Pricing](https://pantheon.io/plans/pricing) to see if you qualify for a WordPress Multisite. A Pantheon employee must create a custom WordPress Multisite upstream in your Workspace for you to be able to create Multisites. Existing WordPress sites cannot be converted to a multisite, however they can be [migrated](/migrate-wordpress-multisite).
+WordPress Multisite requires a special configuration that is only available to select customers. Access to WordPress Multisite requires a Gold, Platinum, or Diamond level [Workspace plan](https://pantheon.io/plans/pricing). A Pantheon employee must create a custom WordPress Multisite upstream in your Workspace for you to be able to create Multisites. Existing WordPress sites cannot be converted to a multisite, however they can be [migrated](/migrate-wordpress-multisite).
 
 Reach out to your account manager to request that a new WordPress Multisite upstream be created for you. Once an employee of Pantheon has created the upstream, you will be able to use it create Multisites in your org. If you don't have an account manager, you can [contact sales](https://pantheon.io/contact-us).
 


### PR DESCRIPTION
Closes: N/A

## Summary
**[Multisite - Introduction](https://docs.pantheon.io/guides/multisite/#request-a-wordpress-multisite)** - Directly shares plan requirements for WordPress Multisite on the page where customers learn about WordPress Multisites.

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

* Removes description telling people to check the `/pricing` page for more information about Multisite access (this page did not contain any Multisite information at the time of my writing)
* Adds clear definitions of Multisite requirements to the Multisite docs themselves, saving customers a click and getting information in their hands faster. 
* Retains the link to the pricing page, if they want to learn more about the plans, but it is not required to visit.

## Remaining Work and Prerequisites
- [ ] none

### Dependencies and Timing
- [ ] none

**Release**:
- [x] When ready

**More Info**:
- [Pantheon Slack Thread](https://pantheon.slack.com/archives/C03SU7UCJ/p1708632069605499)

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
