### PR TITLE
[CMSP-870] Release notes: add PHP version bump updates

### DIFF
--- a/source/releasenotes/2024-02-21-php-8.3.3-8.2.16-8.1.27.md
+++ b/source/releasenotes/2024-02-21-php-8.3.3-8.2.16-8.1.27.md
@@ -1,0 +1,7 @@
+---
+title: PHP 8.1.27, 8.2.16, and 8.3.3 now available
+published_date: "2024-02-21"
+categories: [infrastructure]
+---
+
+The latest versions of PHP 8.x are now available on the Pantheon platform. PHP [8.1.27](https://www.php.net/archive/2023.php#2023-12-21-2), [8.2.16](https://www.php.net/archive/2024.php#2024-02-15-2), and [8.3.3](https://www.php.net/archive/2024.php#2024-02-15-1) are all bug fix releases. No action is required on your part if you are using one of these PHP versions (8.1, 8.2 or 8.3).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes/)** - Documents the release of updated PHP 8.x versions on the platform

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
