### PR TITLE
Update 02-create-multidev.md name length nitpick

### DIFF
--- a/source/content/guides/multidev/02-create-multidev.md
+++ b/source/content/guides/multidev/02-create-multidev.md
@@ -29,7 +29,7 @@ You can create a new fork in a Pantheon environment by using the code from the D
 
 1. Specify the name for the Multidev in the **Create Multidev Environment** modal:
 
-   - Multidev branch names must be all lowercase, less than 11 characters, and can contain a dash (`-`).
+   - Multidev branch names must be all lowercase, no more than 11 characters, and can contain a dash (`-`).
 
    - Environments cannot be created with the following reserved names:
 


### PR DESCRIPTION
"less than 11 characters" would mean that the max length is 10. It is in fact 11.

## Summary

**[Create a Multidev Environment](https://docs.pantheon.io/guides/multidev/create-multidev)** - Corrects inaccurately documented environment name length requirement.


**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
