### PR TITLE
[BUGS-7429] Pantheon Advanced Page Cache 1.5.0 release note

### DIFF
--- a/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
+++ b/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
@@ -1,10 +1,10 @@
 ---
-title: Pantheon Advanced Page Cache
+title: Enhancements in Pantheon Advanced Page Cache v1.5.0
 published_date: "2024-03-11"
 categories: [wordpress]
 ---
 
-Pantheon Advanced Page Cache version 1.5.0 is now available on [WordPress.org](https://wordpress.org/plugins/pantheon-advanced-page-cache/) and [GitHub](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/tag/1.5.0). This release adds a new filter to make cache purges less aggressive and provide more flexibility for developers and the sites they maintain. You can learn about the filter in the plugin's [README file](https://github.com/pantheon-systems/pantheon-advanced-page-cache?tab=readme-ov-file#ignoring-specific-post-types) which includes an example of how to use it.
+Pantheon Advanced Page Cache v1.5.0 is now available on [WordPress.org](https://wordpress.org/plugins/pantheon-advanced-page-cache/) and [GitHub](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/tag/1.5.0). This release adds a new filter to make cache purges less aggressive and provide more flexibility for developers and the sites they maintain. You can learn about the filter in the plugin's [README file](https://github.com/pantheon-systems/pantheon-advanced-page-cache?tab=readme-ov-file#ignoring-specific-post-types) which includes an example of how to use it.
 
 Additionally, this update implements our recently updated [WPUnit Helpers](https://github.com/pantheon-systems/wpunit-helpers) project to simplify PHP Unit tests as well as our recently developed [Plugin Release Actions](https://github.com/pantheon-systems/plugin-release-actions) to automate steps in the release process.
 

--- a/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
+++ b/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
@@ -1,0 +1,11 @@
+---
+title: Pantheon Advanced Page Cache
+published_date: "2024-03-11"
+categories: [wordpress]
+---
+
+Pantheon Advanced Page Cache version 1.5.0 is now available on [WordPress.org](https://wordpress.org/plugins/pantheon-advanced-page-cache/) and [GitHub](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/tag/1.5.0). This release adds a new filter to make cache purges less aggressive and provide more flexibility for developers and the sites they maintain. You can learn about the filter in the plugin's [README file](https://github.com/pantheon-systems/pantheon-advanced-page-cache?tab=readme-ov-file#ignoring-specific-post-types) which includes an example of how to use it.
+
+Additionally, this update implements our recently updated [WPUnit Helpers](https://github.com/pantheon-systems/wpunit-helpers) project to simplify PHP Unit tests as well as our recently developed [Plugin Release Actions](https://github.com/pantheon-systems/plugin-release-actions) to automate steps in the release process.
+
+You can read the full changelog in the [GitHub release notes](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/tag/1.5.0).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for latest version of Pantheon Advanced Page Cache plugin for WordPress.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
