### PR TITLE
Add Release Note Categories for Plugins and Modules

### DIFF
--- a/source/releasenotescategories/releaseNoteCategories.json
+++ b/source/releasenotescategories/releaseNoteCategories.json
@@ -107,6 +107,18 @@
       "displayName": "WordPress",
       "color": "color-9",
       "description": "Tailored for updates specific to the WordPress content management system, helping WordPress users stay informed about platform changes that directly impact their workflows"
+    },
+    {
+      "slug": "plugins",
+      "displayName": "Plugins",
+      "color": "color-7",
+      "description": "Keeps users informed about updates to WordPress plugins that we maintain."
+    },
+    {
+      "slug": "modules",
+      "displayName": "Modules",
+      "color": "color-7",
+      "description": "Keeps users informed about updates to Drupal modules that we maintain."
     }
   ]
 }


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Does not affect an actual release note but adds new categories for the purpose of using in release notes.

## Effect

This adds two new Release Notes categories, `plugins` (for WordPress plugins we maintain) and `modules` (for Drupal modules we maintain).

The following changes are already committed:

* updated `source/releasenotescategories/releaseNoteCategories.json`

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
