### PR TITLE
[BUGS-7429] Add 'plugin' tag to last release

### DIFF
--- a/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
+++ b/source/releasenotes/2024-03-11-pantheon-advanced-page-cache-1.5.0.md
@@ -1,7 +1,7 @@
 ---
 title: Enhancements in Pantheon Advanced Page Cache v1.5.0
 published_date: "2024-03-11"
-categories: [wordpress]
+categories: [wordpress,plugins]
 ---
 
 Pantheon Advanced Page Cache v1.5.0 is now available on [WordPress.org](https://wordpress.org/plugins/pantheon-advanced-page-cache/) and [GitHub](https://github.com/pantheon-systems/pantheon-advanced-page-cache/releases/tag/1.5.0). This release adds a new filter to make cache purges less aggressive and provide more flexibility for developers and the sites they maintain. You can learn about the filter in the plugin's [README file](https://github.com/pantheon-systems/pantheon-advanced-page-cache?tab=readme-ov-file#ignoring-specific-post-types) which includes an example of how to use it.


### PR DESCRIPTION
## Summary
Adds new "plugins" tag to PAPC release note. Follows #8889  #8888 
**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
