### PR TITLE
docs: fix grammar in quicksilver variables

### DIFF
--- a/source/content/guides/quicksilver/04-variables.md
+++ b/source/content/guides/quicksilver/04-variables.md
@@ -34,7 +34,7 @@ Variables are made available through the `$_POST` global variable. You can use t
 |`user_role`|UUID of the user that initiated the task|All| |
 |`to_environment`|Target environment where the database is being cloned to|`clone_database`| |
 |`from_environment`|Source environment where the database is being cloned from|`clone_database`| |
-|`deploy_message`|Deploy message provided as part of a test of live deployment|`deploy`|This is only available if a deploy message is provided|
+|`deploy_message`|Deploy message provided as part of a test or live deployment|`deploy`|This is only available if a deploy message is provided|
 |`vrt_status`|Result of the visual regression test|`autopilot_vrt`| |
 |`vrt_result_url`|Page URL associated with an Autopilot VRT result|`autopilot_vrt`|[Autopilot](/guides/autopilot) is only available in the new Pantheon Dashboard|
 |`updates_info`|List of the plugins/modules/themes that were updated prior to the VRT|`autopilot_vrt`|Returns JSON data structure|


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Quicksilver Variables](https://docs.pantheon.io/guides/quicksilver/variables)** - Fix incorrect word usage.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] ~After date: $DATE~

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
