### PR TITLE
[BUGS-6115] Add separate environment indicator docs for d7 and d8+

### DIFF
--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -108,9 +108,7 @@ terminus drush $site.$env -- en environment_indicator -y
 
 Add the following within `settings.php` for your version of Drupal:
 
-<Tablist>
-
-<Tab title="Drupal 8/9/10+" id="d10" active={true}>
+<Accordion title="Drupal 8/9/10+" id="d10">
 
 ```php
   /*
@@ -156,9 +154,9 @@ Add the following within `settings.php` for your version of Drupal:
   }
 ```
 
-</Tab>
+</Accordion>
 
-<Tab title="Drupal 7" id="d7">
+<Accordion title="Drupal 7" id="d7">
 
 ```php
   /*
@@ -208,9 +206,7 @@ Add the following within `settings.php` for your version of Drupal:
     }
 ```
 
-</Tab>
-
-</Tablist>
+</Accordion>
 
 Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -96,15 +96,15 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
 [Set the connection mode to SFTP](/guides/sftp) for the Dev or Multidev environment via the Pantheon Dashboard or with [Terminus](/terminus):
 
- ```bash{promptUser: user}
- terminus connection:set $site.$env sftp
- ```
+```bash{promptUser: user}
+terminus connection:set $site.$env sftp
+```
 
 Install and enable the [Environment Indicator](https://www.drupal.org/project/environment_indicator) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with Terminus:
 
- ```bash{promptUser: user}
- terminus drush $site.$env -- en environment_indicator -y
- ```
+```bash{promptUser: user}
+terminus drush $site.$env -- en environment_indicator -y
+```
 
 Add the following within `settings.php` for your version of Drupal:
 
@@ -214,19 +214,19 @@ Add the following within `settings.php` for your version of Drupal:
 
 Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
 
- ```bash{promptUser: user}
- terminus env:deploy $site.test --sync-content --updatedb --note="Install and configure Environment Indicator"
- terminus env:clear-cache <site>.test
- ```
+```bash{promptUser: user}
+terminus env:deploy $site.test --sync-content --updatedb --note="Install and configure Environment Indicator"
+terminus env:clear-cache <site>.test
+```
 
   If you're working from a Multidev environment, merge to Dev first. Remember that the module will need to be activated again for each new environment.
 
 Deploy the module to the Live environment within the Site Dashboard or with Terminus, and clear the site cache:
 
-  ```bash{promptUser: user}
-  terminus env:deploy $site.live --updatedb --note="Install and configure Environment Indicator"
-  terminus env:clear-cache <site>.live
-  ```
+```bash{promptUser: user}
+terminus env:deploy $site.live --updatedb --note="Install and configure Environment Indicator"
+terminus env:clear-cache <site>.live
+```
 
 All environments will now show a color-coded environment indicator, as defined within the above `settings.php` snippet.
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -94,21 +94,23 @@ add_filter( 'pantheon_hud_current_user_can_view', function(){
 
 The [Environment Indicator](https://www.drupal.org/project/environment_indicator) module is officially supported for Drupal sites.
 
-1. [Set the connection mode to SFTP](/guides/sftp) for the Dev or Multidev environment via the Pantheon Dashboard or with [Terminus](/terminus):
+[Set the connection mode to SFTP](/guides/sftp) for the Dev or Multidev environment via the Pantheon Dashboard or with [Terminus](/terminus):
 
  ```bash{promptUser: user}
  terminus connection:set $site.$env sftp
  ```
 
-1. Install and enable the [Environment Indicator](https://www.drupal.org/project/environment_indicator) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with Terminus:
+Install and enable the [Environment Indicator](https://www.drupal.org/project/environment_indicator) module using the [Drupal interface](https://drupal.org/documentation/install/modules-themes) or with Terminus:
 
  ```bash{promptUser: user}
  terminus drush $site.$env -- en environment_indicator -y
  ```
 
-1. Add the following within `settings.php` for your version of Drupal:
+Add the following within `settings.php` for your version of Drupal:
 
-<Accordion title="Drupal 8/9/10+" id="d10" icon="wrench">
+<Tablist>
+
+<Tab title="Drupal 8/9/10+" id="d10" active={true}>
 
 ```php
   /*
@@ -154,9 +156,9 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
   }
 ```
 
-</Accordion>
+</Tab>
 
-<Accordion title="Drupal 7" id="d7" icon="wrench">
+<Tab title="Drupal 7" id="d7">
 
 ```php
   /*
@@ -206,9 +208,11 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
     }
 ```
 
-</Accordion>
+</Tab>
 
-1. Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
+</Tablist>
+
+Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
 
  ```bash{promptUser: user}
  terminus env:deploy $site.test --sync-content --updatedb --note="Install and configure Environment Indicator"
@@ -217,7 +221,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
   If you're working from a Multidev environment, merge to Dev first. Remember that the module will need to be activated again for each new environment.
 
-1. Deploy the module to the Live environment within the Site Dashboard or with Terminus, and clear the site cache:
+Deploy the module to the Live environment within the Site Dashboard or with Terminus, and clear the site cache:
 
   ```bash{promptUser: user}
   terminus env:deploy $site.live --updatedb --note="Install and configure Environment Indicator"

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -108,9 +108,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
 1. Add the following within `settings.php` for your version of Drupal:
 
-<Tablist>
-
-<Tab title="Drupal 8/9/10+" id="d10" active={true}>
+<Accordion title="Drupal 8/9/10+" id="d10" active={true} icon="wrench">
 
 ```php
   /*
@@ -156,9 +154,9 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
   }
 ```
 
-</Tab>
+</Accordion>
 
-<Tab title="Drupal 7" id="d7">
+<Accordion title="Drupal 7" id="d7" icon="wrench">
 
 ```php
   /*
@@ -208,9 +206,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
     }
 ```
 
-</Tab>
-
-</Tablist>
+</Accordion>
 
 1. Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -112,7 +112,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
 <Tab title="Drupal 8/9/10+" id="d10" active={true}>
 
-    ```php
+  ```php
     /*
      * Environment Indicator module settings.
      * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
@@ -154,13 +154,13 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
           break;
       }
     }
-    ```
+  ```
 
 </Tab>
 
 <Tab title="Drupal 7" id="d7">
 
-    ```php
+  ```php
     /*
     * Environment Indicator module settings.
     * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
@@ -206,7 +206,8 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
               break;
           }
       }
-    ```
+  ```
+
 </Tab>
 
 </Tablist>
@@ -228,7 +229,6 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
   ```
 
 All environments will now show a color-coded environment indicator, as defined within the above `settings.php` snippet.
-
 
 ## More Resources
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -106,7 +106,59 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
  terminus drush $site.$env -- en environment_indicator -y
  ```
 
-1. Add the following within `settings.php` for Drupal:
+1. Add the following within `settings.php` for your version of Drupal:
+
+<Tablist>
+
+<Tab title="Drupal 8/9/10+" id="d10" active={true}>
+
+    ```php
+    /*
+     * Environment Indicator module settings.
+     * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
+     */
+
+    if (!defined('PANTHEON_ENVIRONMENT')) {
+      $config['environment_indicator.indicator']['name'] = 'Local';
+      $config['environment_indicator.indicator']['bg_color'] = '#505050';
+      $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+    }
+    // Pantheon Env Specific Configig
+    if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+      switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+        case 'lando': // Localdev or Lando environments
+          $config['environment_indicator.indicator']['name'] = 'Local Dev';
+          $config['environment_indicator.indicator']['bg_color'] = '#990055';
+          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+          break;
+        case 'dev':
+          $config['environment_indicator.indicator']['name'] = 'Dev';
+          $config['environment_indicator.indicator']['bg_color'] = '#307b24';
+          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+          break;
+        case 'test':
+          $config['environment_indicator.indicator']['name'] = 'Test';
+          $config['environment_indicator.indicator']['bg_color'] = '#b85c00';
+          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+          break;
+        case 'live':
+          $config['environment_indicator.indicator']['name'] = 'Live!';
+          $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
+          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+          break;
+        default:
+          //Multidev catchall
+          $config['environment_indicator.indicator']['name'] = 'Multidev';
+          $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
+          $config['environment_indicator.indicator']['fg_color'] = '#000000';
+          break;
+      }
+    }
+    ```
+
+</Tab>
+
+<Tab title="Drupal 7" id="d7">
 
     ```php
     /*
@@ -127,9 +179,9 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
       if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
           switch ($_ENV['PANTHEON_ENVIRONMENT']) {
             case 'lando': // Localdev or Lando environments
-              $config['environment_indicator.indicator']['name'] = 'Local Dev';
-              $config['environment_indicator.indicator']['bg_color'] = '#990055';
-              $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+              $conf['environment_indicator_overwritten_name'] = 'Local Dev';
+              $conf['environment_indicator_overwritten_color'] = '#990055';
+              $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
               break;
             case 'dev':
               $conf['environment_indicator_overwritten_name'] = 'Dev';
@@ -155,6 +207,9 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
           }
       }
     ```
+</Tab>
+
+</Tablist>
 
 1. Deploy the module to the Test environment within the Site Dashboard or with Terminus, and clear the site cache:
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -3,7 +3,7 @@ title: Environment Configuration
 subtitle: Configuring Environment Indicators
 description: Learn how to implement an environment indicator for Drupal and WordPress sites running on Pantheon.
 tags: [site, terminus, workflow, webops]
-contributors: [whitneymeredith]
+contributors: [whitneymeredith, jazzs3quence]
 showtoc: true
 permalink: docs/guides/environment-configuration/environment-indicator
 contenttype: [guide]

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -112,101 +112,101 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
 <Tab title="Drupal 8/9/10+" id="d10" active={true}>
 
-  ```php
-    /*
-     * Environment Indicator module settings.
-     * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
-     */
+```php
+  /*
+    * Environment Indicator module settings.
+    * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
+    */
 
-    if (!defined('PANTHEON_ENVIRONMENT')) {
-      $config['environment_indicator.indicator']['name'] = 'Local';
-      $config['environment_indicator.indicator']['bg_color'] = '#505050';
-      $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+  if (!defined('PANTHEON_ENVIRONMENT')) {
+    $config['environment_indicator.indicator']['name'] = 'Local';
+    $config['environment_indicator.indicator']['bg_color'] = '#505050';
+    $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+  }
+  // Pantheon Env Specific Configig
+  if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+    switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+      case 'lando': // Localdev or Lando environments
+        $config['environment_indicator.indicator']['name'] = 'Local Dev';
+        $config['environment_indicator.indicator']['bg_color'] = '#990055';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'dev':
+        $config['environment_indicator.indicator']['name'] = 'Dev';
+        $config['environment_indicator.indicator']['bg_color'] = '#307b24';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'test':
+        $config['environment_indicator.indicator']['name'] = 'Test';
+        $config['environment_indicator.indicator']['bg_color'] = '#b85c00';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      case 'live':
+        $config['environment_indicator.indicator']['name'] = 'Live!';
+        $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
+        $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
+        break;
+      default:
+        //Multidev catchall
+        $config['environment_indicator.indicator']['name'] = 'Multidev';
+        $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
+        $config['environment_indicator.indicator']['fg_color'] = '#000000';
+        break;
     }
-    // Pantheon Env Specific Configig
-    if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-      switch ($_ENV['PANTHEON_ENVIRONMENT']) {
-        case 'lando': // Localdev or Lando environments
-          $config['environment_indicator.indicator']['name'] = 'Local Dev';
-          $config['environment_indicator.indicator']['bg_color'] = '#990055';
-          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
-          break;
-        case 'dev':
-          $config['environment_indicator.indicator']['name'] = 'Dev';
-          $config['environment_indicator.indicator']['bg_color'] = '#307b24';
-          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
-          break;
-        case 'test':
-          $config['environment_indicator.indicator']['name'] = 'Test';
-          $config['environment_indicator.indicator']['bg_color'] = '#b85c00';
-          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
-          break;
-        case 'live':
-          $config['environment_indicator.indicator']['name'] = 'Live!';
-          $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
-          $config['environment_indicator.indicator']['fg_color'] = '#ffffff';
-          break;
-        default:
-          //Multidev catchall
-          $config['environment_indicator.indicator']['name'] = 'Multidev';
-          $config['environment_indicator.indicator']['bg_color'] = '#e7131a';
-          $config['environment_indicator.indicator']['fg_color'] = '#000000';
-          break;
-      }
-    }
-  ```
+  }
+```
 
 </Tab>
 
 <Tab title="Drupal 7" id="d7">
 
-  ```php
-    /*
-    * Environment Indicator module settings.
-    * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
-    */
+```php
+  /*
+  * Environment Indicator module settings.
+  * see: https://docs.pantheon.io/guides/environment-configuration/environment-indicator
+  */
 
-    $conf['environment_indicator_overwrite'] = TRUE;
-      $conf['environment_indicator_overwritten_position'] = 'top';
-      $conf['environment_indicator_overwritten_fixed'] = FALSE;
+  $conf['environment_indicator_overwrite'] = TRUE;
+    $conf['environment_indicator_overwritten_position'] = 'top';
+    $conf['environment_indicator_overwritten_fixed'] = FALSE;
 
-      if (!defined('PANTHEON_ENVIRONMENT')) {
-          $conf['environment_indicator_overwritten_name'] = 'Local';
-          $conf['environment_indicator_overwritten_color'] = '#505050';
-          $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
-      }
-      // Pantheon Env Specific Config
-      if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-          switch ($_ENV['PANTHEON_ENVIRONMENT']) {
-            case 'lando': // Localdev or Lando environments
-              $conf['environment_indicator_overwritten_name'] = 'Local Dev';
-              $conf['environment_indicator_overwritten_color'] = '#990055';
-              $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
-              break;
-            case 'dev':
-              $conf['environment_indicator_overwritten_name'] = 'Dev';
-              $conf['environment_indicator_overwritten_color'] = '#307b24';
-              $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
-              break;
-            case 'test':
-              $conf['environment_indicator_overwritten_name'] = 'Test';
-              $conf['environment_indicator_overwritten_color'] = '#b85c00';
-              $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
-              break;
-            case 'live':
-              $conf['environment_indicator_overwritten_name'] = 'Live!';
-              $conf['environment_indicator_overwritten_color'] = '#e7131a';
-              $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
-              break;
-            default:
-              //Multidev catchall
-              $conf['environment_indicator_overwritten_name'] = 'Multidev';
-              $conf['environment_indicator_overwritten_color'] = '#e7131a';
-              $conf['environment_indicator_overwritten_text_color'] = '#000000';
-              break;
-          }
-      }
-  ```
+    if (!defined('PANTHEON_ENVIRONMENT')) {
+        $conf['environment_indicator_overwritten_name'] = 'Local';
+        $conf['environment_indicator_overwritten_color'] = '#505050';
+        $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
+    }
+    // Pantheon Env Specific Config
+    if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+        switch ($_ENV['PANTHEON_ENVIRONMENT']) {
+          case 'lando': // Localdev or Lando environments
+            $conf['environment_indicator_overwritten_name'] = 'Local Dev';
+            $conf['environment_indicator_overwritten_color'] = '#990055';
+            $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
+            break;
+          case 'dev':
+            $conf['environment_indicator_overwritten_name'] = 'Dev';
+            $conf['environment_indicator_overwritten_color'] = '#307b24';
+            $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
+            break;
+          case 'test':
+            $conf['environment_indicator_overwritten_name'] = 'Test';
+            $conf['environment_indicator_overwritten_color'] = '#b85c00';
+            $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
+            break;
+          case 'live':
+            $conf['environment_indicator_overwritten_name'] = 'Live!';
+            $conf['environment_indicator_overwritten_color'] = '#e7131a';
+            $conf['environment_indicator_overwritten_text_color'] = '#ffffff';
+            break;
+          default:
+            //Multidev catchall
+            $conf['environment_indicator_overwritten_name'] = 'Multidev';
+            $conf['environment_indicator_overwritten_color'] = '#e7131a';
+            $conf['environment_indicator_overwritten_text_color'] = '#000000';
+            break;
+        }
+    }
+```
 
 </Tab>
 

--- a/source/content/guides/environment-configuration/03-environment-indicator.md
+++ b/source/content/guides/environment-configuration/03-environment-indicator.md
@@ -108,7 +108,7 @@ The [Environment Indicator](https://www.drupal.org/project/environment_indicator
 
 1. Add the following within `settings.php` for your version of Drupal:
 
-<Accordion title="Drupal 8/9/10+" id="d10" active={true} icon="wrench">
+<Accordion title="Drupal 8/9/10+" id="d10" icon="wrench">
 
 ```php
   /*


### PR DESCRIPTION
Closes #8240 

## Summary

**[Configuring Environment Indicators](https://docs.pantheon.io/guides/environment-configuration/environment-indicator)** - Fixes error in configuration documentation for Environment Indicator in Drupal. Breaks the configuration into D7 / D8/9/10+ versions as the configuration is different for each version.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
