### PR TITLE
[CMSP-967] Update font library docs

### DIFF
--- a/source/content/guides/wordpress-configurations/07-wordpress-font-library.md
+++ b/source/content/guides/wordpress-configurations/07-wordpress-font-library.md
@@ -16,9 +16,7 @@ permalink: docs/guides/wordpress-configurations/wordpress-font-library
 
 This section provides information on how to use the WordPress Font Library on Pantheon.
 
-WordPress 6.5 introduces a new [Font Library](https://make.wordpress.org/core/2024/03/14/new-feature-font-library/) feature. The Font Library allows you to upload fonts from your computer or add any of the fonts available on Google's font library to your WordPress site. In anticipation of this, Pantheon has added a feature to our [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) to store those fonts in a writeable directory (`wp-content/uploads/fonts/`), so that you can use the feature without any issues after updating your sites to 6.5. 
-
-By default, WordPress will install fonts into `wp-content/fonts/` if it is writeable. If `wp-content/fonts/` is not writeable, like on Pantheon environments, WordPress will install fonts into `wp-content/uploads/fonts/`. This can create inconsistency when developing locally if WordPress is using its default behavior because your `wp-content/fonts/` is likely to be writeable on your local environment. In this instance, fonts installed _on Pantheon_ would be stored in `wp-content/uploads/fonts` but fonts installed _locally_ would be stored in `wp-content/fonts`, which is why we have altered the behavior in the mu-plugin.
+WordPress 6.5 introduces a new [Font Library](https://make.wordpress.org/core/2024/03/14/new-feature-font-library/) feature. The Font Library allows you to upload fonts from your computer or add any of the fonts available on Google's font library to your WordPress site. By default, WordPress will install fonts into `wp-content/uploads/fonts/`. 
 
 ## Using the `font_dir` Filter
 
@@ -38,13 +36,17 @@ add_filter( 'font_dir', function( $defaults ) {
 } );
 ```
 
-The default priority for WordPress filters is `10`. We have set _our_ `font_dir` filter to priority `9` so it allows you to override our modification.
+<Alert title="Note" type="info" >
+
+If you choose to use the `font_dir` filter, you will need to ensure that the directory you are using is writeable by the web server. This is because WordPress will need to write to this directory when fonts are uploaded. On a Pantheon environment, the easiest way to ensure that a directory is writeable is to use the `wp-content/uploads/` directory. You can dynamically determing the path to the `uploads` directory using the `wp_upload_dir()` function.
+
+</Alert>
 
 ## Considerations
 
 WordPress handles fonts more like **media files** than **plugins or themes**. This means that when fonts are added to one Pantheon site environment, they will not necessarily exist in your other environments (e.g. installing a font on Dev does not mean it will push to Test when you deploy). In WordPress, fonts have two parts, there is a font post type (similar to the `attachment` post type for media files) and the font files themselves. Without the font post type existing in the database, WordPress has no way of knowing that a font is installed (in the same way that WordPress has no way that a particular image exists in the `/uploads` directory if it was not uploaded via the media library).
 
-If you intend to override the Pantheon behavior, know that committing font files to your repository will not make them available automatically on your other environments.
+If you intend to override the default behavior, know that committing font files to your repository (e.g. to a `wp-content/fonts` directory) will not make them available automatically on your other environments. There is no automatic reading of the contents of the Fonts directory in WordPress the way that there is for plugins, themes and mu-plugins.
 
 ## Troubleshooting
 


### PR DESCRIPTION
## Summary

**[Using the WordPress Font Library on Pantheon](https://docs.pantheon.io/guides/wordpress-configurations/wordpress-font-library)** - WordPress core [changed their minds](https://make.wordpress.org/core/2024/03/25/wordpress-6-5-release-delayed-1-week/) about the location of font storage again. This update changes our docs to remove references to our filter, which we will be removing in the mu-plugin.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
