### PR TITLE
[CMSP-967] Release Note for Pantheon MU Plugin 1.3.4

### DIFF
--- a/source/releasenotes/2024-03-27-pantheon-mu-plugin-1-3-2.md
+++ b/source/releasenotes/2024-03-27-pantheon-mu-plugin-1-3-2.md
@@ -1,0 +1,7 @@
+---
+title: Pantheon MU Plugin v1.3.4 update
+published_date: "2024-03-27"
+categories: [wordpress, plugins]
+---
+
+On March 25, 2024, [it was announced in the WordPress development blog](https://make.wordpress.org/core/2024/03/25/wordpress-6-5-release-delayed-1-week/) that the default storage location for the Font Library (added in WordPress 6.5) will be `wp-content/uploads/fonts`. Previously, we had added a feature to our [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) to support the new Font Library feature by changing the previous default path (`wp-content/fonts`) to `wp-content/uploads/fonts`. This change to our MU plugin removes that override as it is no longer necessary. You can read more about the Font Library feature in our [guide to using the Font Library on Pantheon](/guides/wordpress-configurations/wordpress-font-library).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for Pantheon MU Plugin 1.3.4 which will be released after https://github.com/pantheon-systems/pantheon-mu-plugin/pull/35 is merged.

## Remaining Work and Prerequisites

- [x] Release Pantheon MU Plugin 1.3.4

### Dependencies and Timing

- [x] https://github.com/pantheon-systems/pantheon-mu-plugin/pull/35 is merged and a new release is created

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
