### PR TITLE
[CMSP-903] Fix WordPress 6.5 release name in title

### DIFF
--- a/source/releasenotes/2024-04-02-wordpress-6-5.md
+++ b/source/releasenotes/2024-04-02-wordpress-6-5.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress 6.5 (release name) Release
+title: WordPress 6.5 (Regina) Release
 published_date: "2024-04-02"
 categories: [wordpress]
 ---


### PR DESCRIPTION

## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Fixes the release name in the release note title for WordPress 6.5

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
