### PR TITLE
[LOPS-2149] add code formatting to the other pantheon.yml in the NR release note

### DIFF
--- a/source/releasenotes/2024-04-03-new-relic-agent.md
+++ b/source/releasenotes/2024-04-03-new-relic-agent.md
@@ -12,7 +12,7 @@ By staying up-to-date with the latest agent, you will benefit from improved perf
 
 ## Action Required: Default behavior of New Relic Drupal Hooks is changing
 
-After the release of this agent update, Pantheon will no longer support Drupal Hooks reporting by default. However, the functionality is still available. If this is crucial for troubleshooting your sites, please add these lines to your site’s pantheon.yml file to enable this reporting:
+After the release of this agent update, Pantheon will no longer support Drupal Hooks reporting by default. However, the functionality is still available. If this is crucial for troubleshooting your sites, please add these lines to your site’s `pantheon.yml` file to enable this reporting:
 
 ```
 new_relic:


### PR DESCRIPTION
## Summary

**[Upcoming New Relic PHP Agent update changes Drupal hooks default behavior [Action Required]](https://docs.pantheon.io/release-notes/2024/04/new-relic-agent)** - adds backticks around the first `pantheon.yml` for consistency, which was missed in the original PR

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
