### PR TITLE
[CMSP-375] remove links to very old drupal and WordPress projects

### DIFF
--- a/source/content/guides/frontend-performance/05-media.md
+++ b/source/content/guides/frontend-performance/05-media.md
@@ -29,10 +29,6 @@ Pantheon supports a maximum upload resolution of 3999 pixels for images.
 
 Lazy loading images is a JavaScript technique that saves bandwidth and lowers load times by delaying the loading of images until they appear in the viewport. Lazy-loading media elements, especially images, is a powerful way to increase perceived performance and reduce time-to-first-render.
 
-Lazy-loading images is default behavior in WordPress 5.5 and the latest version of Drupal.
-
-Try the [BJ Lazy Load](https://wordpress.org/plugins/bj-lazy-load/) plugin for WordPress and the [Image Lazyloader](https://www.drupal.org/project/lazyloader) module for Drupal.
-
 ### WordPress
 
 WordPress 5.5 [lazy-loads images by default](https://make.wordpress.org/core/2020/04/08/lazy-loading-of-images-is-in-core/).


### PR DESCRIPTION
## Summary
**[Frontend Performance: Images & Media](https://docs.pantheon.io/guides/frontend-performance/media)** - Removes old information and links to unmaintained WordPress plugin and old Drupal module.

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
