### PR TITLE
[CMSP-1002] add release note for WP 6.5.2

### DIFF
--- a/source/releasenotes/2024-04-10-wordpress-6-5-2.md
+++ b/source/releasenotes/2024-04-10-wordpress-6-5-2.md
@@ -1,0 +1,19 @@
+---
+title: WordPress 6.5.2 security update
+published_date: "2024-04-10"
+categories: [wordpress, security, action-required]
+---
+
+The latest version of WordPress, [6.5.2](https://wordpress.org/news/2024/04/wordpress-6-5-2-maintenance-and-security-release/), became available on Pantheon as of April 10, 2024.
+
+<h3>Highlights</h3>
+
+* **Security updates:** Addressed one security vulnerabilities in the Avatar block type.
+* [2 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!60398&milestone=6.5.2&group=status&order=priority)
+* [12 bug fixes in the Block Editor](https://github.com/WordPress/gutenberg/pull/60577)
+
+<h3>>What happened to 6.5.1?</h3>
+
+**6.5.2** is the _first_ minor release for WordPress 6.5 rather than 6.5.1. Yesterday, it was [disclosed on the Make WordPress Core development site](https://make.wordpress.org/core/2024/04/09/what-happened-to-wordpress-6-5-1/) that due to an error with the initial package, 6.5.1 could not be released.
+
+Upgrade to WordPress 6.5.2 right from your Pantheon dashboard or Terminus for added security. 

--- a/source/releasenotes/2024-04-10-wordpress-6-5-2.md
+++ b/source/releasenotes/2024-04-10-wordpress-6-5-2.md
@@ -12,7 +12,7 @@ The latest version of WordPress, [6.5.2](https://wordpress.org/news/2024/04/word
 * [2 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!60398&milestone=6.5.2&group=status&order=priority)
 * [12 bug fixes in the Block Editor](https://github.com/WordPress/gutenberg/pull/60577)
 
-<h3>>What happened to 6.5.1?</h3>
+<h3>What happened to 6.5.1?</h3>
 
 **6.5.2** is the _first_ minor release for WordPress 6.5 rather than 6.5.1. Yesterday, it was [disclosed on the Make WordPress Core development site](https://make.wordpress.org/core/2024/04/09/what-happened-to-wordpress-6-5-1/) that due to an error with the initial package, 6.5.1 could not be released.
 


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - adds release note for WordPress 6.5.2 https://github.com/pantheon-systems/WordPress/pull/380

### Dependencies and Timing
**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
