### PR TITLE
[CMSP-1007] PHP 8 patch updates

### DIFF
--- a/source/releasenotes/2024-04-15-php-81-82-82.md
+++ b/source/releasenotes/2024-04-15-php-81-82-82.md
@@ -13,4 +13,4 @@ Common Vulnerabilities and Exposures):
 * [CVE-2024-3096](https://github.com/php/php-src/security/advisories/GHSA-h746-cjrr-wfmr) "password_verify can erroneously return true, opening ATO risk"
 * [CVE-2024-2757](https://github.com/php/php-src/security/advisories/GHSA-fjp9-9hwx-59fq) "mb_encode_mimeheader runs endlessly for some inputs" (PHP 8.3 only)
 
-As a reminder, PHP 8.0 reached End-of-Life on 26 November 2023. For the best performance and security, Pantheon recommends running PHP 8.1 and above.
+As a reminder, PHP 8.0 reached End-of-Life on 26 November 2023. For the best performance and security, Pantheon recommends running PHP 8.2 and above.

--- a/source/releasenotes/2024-04-15-php-81-82-82.md
+++ b/source/releasenotes/2024-04-15-php-81-82-82.md
@@ -1,0 +1,16 @@
+---
+title: "PHP 8.1, 8.2 and 8.3 updated to their latest patch releases"
+published_date: "2024-04-15"
+categories: [infrastructure, security]
+---
+PHP [8.1.28](https://www.php.net/ChangeLog-8.php#PHP_8_1), [8.2.18](https://www.php.net/ChangeLog-8.php#PHP_8_2), and [8.3.6](https://www.php.net/ChangeLog-8.php#PHP_8_3) were released on the platform. They contain the latest bug fixes and security releases for PHP.
+
+Updates include patches for the following CVEs (
+Common Vulnerabilities and Exposures):
+
+* CVE-2024-1874
+* CVE-2024-2756
+* CVE-2024-3096
+* CVE-2024-2757 (PHP 8.3 only)
+
+As a reminder, PHP 8.0 reached End-of-Life on 26 November 2023. For the best performance and security, Pantheon recommends running PHP 8.1 and above.

--- a/source/releasenotes/2024-04-15-php-81-82-82.md
+++ b/source/releasenotes/2024-04-15-php-81-82-82.md
@@ -8,9 +8,9 @@ PHP [8.1.28](https://www.php.net/ChangeLog-8.php#PHP_8_1), [8.2.18](https://www.
 Updates include patches for the following CVEs (
 Common Vulnerabilities and Exposures):
 
-* CVE-2024-1874
-* CVE-2024-2756
-* CVE-2024-3096
-* CVE-2024-2757 (PHP 8.3 only)
+* [CVE-2024-1874](https://github.com/php/php-src/security/advisories/GHSA-pc52-254m-w9w7) "Command injection via array-ish $command parameter of proc_open even if bypass_shell option enabled on Windows"
+* [CVE-2024-2756](https://github.com/php/php-src/security/advisories/GHSA-wpj3-hf5j-x4v4) "__Host-/__Secure- cookie bypass due to partial CVE-2022-31629 fix"
+* [CVE-2024-3096](https://github.com/php/php-src/security/advisories/GHSA-h746-cjrr-wfmr) "password_verify can erroneously return true, opening ATO risk"
+* [CVE-2024-2757](https://github.com/php/php-src/security/advisories/GHSA-fjp9-9hwx-59fq) "mb_encode_mimeheader runs endlessly for some inputs" (PHP 8.3 only)
 
 As a reminder, PHP 8.0 reached End-of-Life on 26 November 2023. For the best performance and security, Pantheon recommends running PHP 8.1 and above.

--- a/source/releasenotes/2024-04-15-php-81-82-82.md
+++ b/source/releasenotes/2024-04-15-php-81-82-82.md
@@ -9,7 +9,7 @@ Updates include patches for the following CVEs (
 Common Vulnerabilities and Exposures):
 
 * [CVE-2024-1874](https://github.com/php/php-src/security/advisories/GHSA-pc52-254m-w9w7) "Command injection via array-ish $command parameter of proc_open even if bypass_shell option enabled on Windows"
-* [CVE-2024-2756](https://github.com/php/php-src/security/advisories/GHSA-wpj3-hf5j-x4v4) "__Host-/__Secure- cookie bypass due to partial CVE-2022-31629 fix"
+* [CVE-2024-2756](https://github.com/php/php-src/security/advisories/GHSA-wpj3-hf5j-x4v4) "\_\_Host-/\_\_Secure- cookie bypass due to partial CVE-2022-31629 fix"
 * [CVE-2024-3096](https://github.com/php/php-src/security/advisories/GHSA-h746-cjrr-wfmr) "password_verify can erroneously return true, opening ATO risk"
 * [CVE-2024-2757](https://github.com/php/php-src/security/advisories/GHSA-fjp9-9hwx-59fq) "mb_encode_mimeheader runs endlessly for some inputs" (PHP 8.3 only)
 


### PR DESCRIPTION

**[Pantheon Release Notes](https://docs.pantheon.io/release-notes/)** - Adds a release note for PHP 8.1, 8.2, and 8.3 security update

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)
