### PR TITLE
Update 07-new-relic-faq.md

### DIFF
--- a/source/content/guides/new-relic/07-new-relic-faq.md
+++ b/source/content/guides/new-relic/07-new-relic-faq.md
@@ -77,6 +77,16 @@ Refer to [Log Files on Pantheon](/guides/logs-pantheon) for more information on 
 
 Pantheon provides New Relic Performance Monitoring for sites on [supported plans](/guides/new-relic#supported-site-plans). Certain components of New Relic fall outside this offering. Please [contact support](/guides/support/contact-support/) if you cannot access a New Relic feature that you should have access to.
 
+### Can I get New Relic&reg; Synthetics?
+
+Pantheon provides New Relic Synthetic Monitoring on a per request basis ([contact support](/guides/support/contact-support/ if you'd like to learn more). Pantheon allows up to 10K Synthetic checks per month per Pantheon workspace (these are shared across all Pantheon sites within a Pantheon workspace). 
+
+<Alert title="Note" type="info">
+  
+If a Pantheon workspace is using >10K checks per month, Pantheon will reduce the frequency of checks and number of locations in order to ensure Synthetics remains available to Pantheon customers.
+
+</Alert>
+
 ## More Resources
 
 - [MySQL Troubleshooting with New Relic&reg; Performance Monitoring](/guides/new-relic/debug-mysql-new-relic)


### PR DESCRIPTION
I am updating the docs to call out the 10K synthetic check limit per Pantheon workspace.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)