### PR TITLE
[CMSP-1034] add release note for solr-power 2.5.3

### DIFF
--- a/source/releasenotes/2024-04-24-solr-power-2-5-3.md
+++ b/source/releasenotes/2024-04-24-solr-power-2-5-3.md
@@ -1,13 +1,13 @@
 ---
-title: Solr Power 2.5.3 update
+title: Solr Search for WordPress 2.5.3 update
 published_date: "2024-04-24"
 categories: [wordpress, plugins]
 ---
 
-The latest version of Solr Power, the Solr plugin for WordPress, version [2.5.3](https://wordpress.org/plugins/solr-power/), became available as of April 24, 2024.
+The latest version of Solr Search for WordPress, version [2.5.3](https://wordpress.org/plugins/solr-power/), became available as of April 24, 2024.
 
 <h3>Highlights</h3>
 
 * **Bug fixes:** Fixed an issue identified by a user ([offshorealert](https://wordpress.org/support/users/offshorealert/) on [WordPress.org](https://wordpress.org/support/topic/issue-building-query-when-you-are-parsing-the-tax_query)) that prevented `tax_query` arguments from being parsed correctly by Solr.
 
-You can upgrade to Solr Power 2.5.3 from your WordPress dashboard on your Pantheon development environment to get this update.
+You can upgrade to Solr Search for WordPress 2.5.3 from your WordPress dashboard on your Pantheon development environment to get this update.

--- a/source/releasenotes/2024-04-24-solr-power-2-5-3.md
+++ b/source/releasenotes/2024-04-24-solr-power-2-5-3.md
@@ -1,0 +1,13 @@
+---
+title: Solr Power 2.5.3 update
+published_date: "2024-04-24"
+categories: [wordpress, plugins]
+---
+
+The latest version of Solr Power, the Solr plugin for WordPress, version [2.5.3](https://wordpress.org/plugins/solr-power/), became available as of April 24, 2024.
+
+<h3>Highlights</h3>
+
+* **Bug fixes:** Fixed an issue identified by a user ([offshorealert](https://wordpress.org/support/users/offshorealert/) on [WordPress.org](https://wordpress.org/support/topic/issue-building-query-when-you-are-parsing-the-tax_query)) that prevented `tax_query` arguments from being parsed correctly by Solr.
+
+You can upgrade to Solr Power 2.5.3 from your WordPress dashboard on your Pantheon development environment to get this update.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for [Solr Power](https://wordpress.org/plugins/solr-power/) 2.5.3 update 

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)