### PR TITLE
WIP - DRYing out mdx component

### DIFF
--- a/src/components/MdxWithShortcodes/index.js
+++ b/src/components/MdxWithShortcodes/index.js
@@ -1,0 +1,59 @@
+import React from "react"
+
+import { MDXRenderer } from "gatsby-plugin-mdx"
+import { MDXProvider } from "@mdx-js/react"
+
+
+import Callout from "../callout"
+import Alert from "../alert"
+import Accordion from "../accordion"
+import ExternalLink from "../externalLink"
+import Icon from "../icon"
+import Popover from "../popover"
+import TabList from "../tabList"
+import Tab from "../tab"
+import Card from "../card"
+import CardGroup from "../cardGroup"
+import Releases from "../releases"
+import TerminusVersion from "../terminusVersion"
+import Download from "../download"
+import Commands from "../commands"
+import ReviewDate from "../reviewDate"
+import Check from "../check.js"
+import Partial from "../partial"
+import Youtube from "../youtube"
+import Wistia from "../wistia"
+
+const shortcodes = {
+  Callout,
+  Alert,
+  Accordion,
+  ExternalLink,
+  Icon,
+  Popover,
+  TabList,
+  Tab,
+  Card,
+  CardGroup,
+  Releases,
+  TerminusVersion,
+  Download,
+  Partial,
+  Commands,
+  ReviewDate,
+  Check,
+  Youtube,
+  Wistia,
+}
+
+const mdxWithShortcodes = ({ mdxContent }) => {
+
+
+  return (
+      <MDXProvider components={shortcodes}>
+        <MDXRenderer>{mdxContent}</MDXRenderer>
+      </MDXProvider>
+  )
+}
+
+export default mdxWithShortcodes

--- a/src/templates/certificationpage.js
+++ b/src/templates/certificationpage.js
@@ -1,59 +1,21 @@
 import React from "react"
 import { graphql } from "gatsby"
-import { MDXRenderer } from "gatsby-plugin-mdx"
-import { MDXProvider } from "@mdx-js/react"
 
 import GuideLayout from "../layout/GuideLayout"
 import HeaderBody from "../components/headerBody"
-import Callout from "../components/callout"
-import Alert from "../components/alert"
-import Accordion from "../components/accordion"
-import ExternalLink from "../components/externalLink"
-import Icon from "../components/icon"
-import Popover from "../components/popover"
-import TabList from "../components/tabList"
-import Tab from "../components/tab"
 import TOC from "../components/toc"
 import GetFeedback from "../components/getFeedback"
-import Card from "../components/card"
-import CardGroup from "../components/cardGroup"
 import Navbar from "../components/navbar"
 import NavButtons from "../components/navButtons"
 import SEO from "../layout/seo"
-import Releases from "../components/releases"
-import TerminusVersion from "../components/terminusVersion"
-import Download from "../components/download"
-import Commands from "../components/commands"
-import ReviewDate from "../components/reviewDate"
-import Check from "../components/check.js"
-import Partial from "../components/partial"
-import Youtube from "../components/youtube"
 import SearchBar from "../layout/SearchBar"
-import Wistia from "../components/wistia"
+
+import MdxWithShortcodes from "../components/MdxWithShortcodes"
+
 
 import { Container, SidebarLayout } from "@pantheon-systems/pds-toolkit-react"
 
-const shortcodes = {
-  Callout,
-  Alert,
-  Accordion,
-  ExternalLink,
-  Icon,
-  Popover,
-  TabList,
-  Tab,
-  Card,
-  CardGroup,
-  Releases,
-  TerminusVersion,
-  Download,
-  Partial,
-  Commands,
-  ReviewDate,
-  Check,
-  Youtube,
-  Wistia,
-}
+
 
 // @TODO relocate this list
 // - To a YAML file and use GraphQL to pull data.
@@ -201,9 +163,11 @@ class CertificationTemplate extends React.Component {
                 reviewDate={ifCommandsDate}
                 isoDate={ifCommandsISO}
               />
-              <MDXProvider components={shortcodes}>
-                <MDXRenderer>{node.body}</MDXRenderer>
-              </MDXProvider>
+
+
+              <MdxWithShortcodes mdxContent={node.body} />
+
+
               <NavButtons
                 prev={node.frontmatter.previousurl}
                 next={node.frontmatter.nexturl}


### PR DESCRIPTION
We have a lot of MDX embeds that reused overlapping sets of "shortcodes". I think the codebase will be more comprehensible if we abstract it out.