### PR TITLE
Update 03-overages.md

### DIFF
--- a/source/content/guides/account-mgmt/traffic/03-overages.md
+++ b/source/content/guides/account-mgmt/traffic/03-overages.md
@@ -57,8 +57,6 @@ If you have an overage during any particular calendar month, you will be require
 
 To avoid future overage fees, you can [upgrade your plan](/guides/account-mgmt/plans) to a plan that is more appropriate for your current traffic volumes to avoid additional overage fees going forward. This new subscription will apply prospectively and will not retroactively change past overages.
 
-One benefit you’ll receive if you do upgrade to a new subscription, though, is you will restart your Overage Protection. For example, if you upgrade you plan on October 1, you will receive 1 month of free overage protection through the end of the calendar year.
-
 ## FAQs
 ### What environments count towards traffic limits?
 Only traffic for the Live environment is counted towards a site plan's traffic limit. Traffic for non-live environments (Dev, Test, and Multidev environments) are not counted towards the plan's traffic limit.


### PR DESCRIPTION
Removed a paragraph concerning overage protection and plan changes that is not supported.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)