### PR TITLE
[CMSP-963] Troubleshooting EoS PHP

### DIFF
--- a/source/content/guides/custom-upstream/09-troubleshooting.md
+++ b/source/content/guides/custom-upstream/09-troubleshooting.md
@@ -219,7 +219,7 @@ It might be necessary to reset the site's upstream via [Terminus](/terminus/exam
 
 ## Unsupported PHP Versions in a Custom Upstream
 
-As PHP versions are moved to "end-of-sale", existing sites will continue to run, but new sites will error during the creation step if the `php_version` value in `pantheon.upstream.yml` is no longer supported. In order to create new sites from your Custom Upstream,  update your upstream's PHP version to a supported version of PHP. For details on what PHP versions Pantheon currently supports and reccomended, see [the PHP documentation](/guides/php#supported-php-versions).
+As PHP versions are moved to "End of Sale", existing sites will continue to run, but new sites will error during the creation step if the `php_version` value in `pantheon.upstream.yml` is no longer supported. In order to create new sites from your Custom Upstream,  update your upstream's PHP version to a supported version of PHP. For details on what PHP versions Pantheon currently supports and reccomended, see [the PHP documentation](/guides/php#supported-php-versions).
 
 ## More Resources
 

--- a/source/content/guides/custom-upstream/09-troubleshooting.md
+++ b/source/content/guides/custom-upstream/09-troubleshooting.md
@@ -219,7 +219,7 @@ It might be necessary to reset the site's upstream via [Terminus](/terminus/exam
 
 ## Unsupported PHP Versions in a Custom Upstream
 
-As PHP versions are moved to "end-of-sale", existing sites will continue to run, but new sites will error during the creation step if the `php_version` value in `pantheon.upstream.yml` is no longer supported. In order to create new sites from your Custom Upstream,  update your upstream's PHP version to a supported version of PHP. For details on what PHP Pantheon currently supports and reccomended, see [the PHP documentation](/guides/php#supported-php-versions).
+As PHP versions are moved to "end-of-sale", existing sites will continue to run, but new sites will error during the creation step if the `php_version` value in `pantheon.upstream.yml` is no longer supported. In order to create new sites from your Custom Upstream,  update your upstream's PHP version to a supported version of PHP. For details on what PHP versions Pantheon currently supports and reccomended, see [the PHP documentation](/guides/php#supported-php-versions).
 
 ## More Resources
 

--- a/source/content/guides/custom-upstream/09-troubleshooting.md
+++ b/source/content/guides/custom-upstream/09-troubleshooting.md
@@ -217,6 +217,10 @@ This will trigger a "Code Cache Clear" to verify that the Site Dashboard has fet
 
 It might be necessary to reset the site's upstream via [Terminus](/terminus/examples/#switch-upstreams) if updates are still not showing on the site. Please note that only the Site Owner or owning Organization Administrators can change a site's upstream.
 
+## Unsupported PHP Versions in a Custom Upstream
+
+As PHP versions are moved to "end-of-sale", existing sites will continue to run, but new sites will error during the creation step if the `php_version` value in `pantheon.upstream.yml` is no longer supported. In order to create new sites from your Custom Upstream,  update your upstream's PHP version to a supported version of PHP. For details on what PHP Pantheon currently supports and reccomended, see [the PHP documentation](/guides/php#supported-php-versions).
+
 ## More Resources
 
 - [Clear Upstream Cache](/terminus/commands/site-upstream-clear-cache)


### PR DESCRIPTION
## Summary

**[Troubleshoot a Custom Upstream](https://docs.pantheon.io/guides/custom-upstream/troubleshooting)** - Adds a troubleshooting step for site creation failure due to End of Sale PHP


**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)