### PR TITLE
[CMSP-1074] WP 6.5.3 release note

### DIFF
--- a/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
+++ b/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
@@ -1,0 +1,13 @@
+---
+title: WordPress 6.5.3 maintenance update
+published_date: "2024-05-07"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.5.3](https://wordpress.org/news/2024/05/wordpress-6-5-3-maintenance-release/), became available on Pantheon on May 7, 2024.
+
+<h3>Highlights</h3>
+
+*  [12 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&milestone=6.5.3&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=priority) 
+* [9 bug fixes for the block editor](https://github.com/WordPress/gutenberg/pull/61299)
+* You can review a summary of the updates in this release in the [6.5.3 release candidate announcement](https://make.wordpress.org/core/2024/05/02/wordpress-6-5-3-rc1-is-now-available/).

--- a/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
+++ b/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
@@ -8,7 +8,7 @@ categories: [wordpress, action-required]
 
 <h3>Highlights</h3>
 
-*  [12 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&milestone=6.5.3&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=priority) 
+* [12 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&milestone=6.5.3&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=priority) 
 * [9 bug fixes for the block editor](https://github.com/WordPress/gutenberg/pull/61299)
 
 You can review a summary of all the updates in the [6.5.3 release candidate announcement](https://make.wordpress.org/core/2024/05/02/wordpress-6-5-3-rc1-is-now-available/).

--- a/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
+++ b/source/releasenotes/2024-05-07-wordpress-6-5-3-update.md
@@ -1,13 +1,14 @@
 ---
-title: WordPress 6.5.3 maintenance update
+title: WordPress 6.5.3 Maintenance Update
 published_date: "2024-05-07"
 categories: [wordpress, action-required]
 ---
 
-The latest version of WordPress, [6.5.3](https://wordpress.org/news/2024/05/wordpress-6-5-3-maintenance-release/), became available on Pantheon on May 7, 2024.
+[WordPress 6.5.3](https://wordpress.org/news/2024/05/wordpress-6-5-3-maintenance-release/) is now available on the platform.
 
 <h3>Highlights</h3>
 
 *  [12 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&milestone=6.5.3&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=priority) 
 * [9 bug fixes for the block editor](https://github.com/WordPress/gutenberg/pull/61299)
-* You can review a summary of the updates in this release in the [6.5.3 release candidate announcement](https://make.wordpress.org/core/2024/05/02/wordpress-6-5-3-rc1-is-now-available/).
+
+You can review a summary of all the updates in the [6.5.3 release candidate announcement](https://make.wordpress.org/core/2024/05/02/wordpress-6-5-3-rc1-is-now-available/).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - WordPress 6.5.3 release note

## Remaining Work and Prerequisites

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)