### PR TITLE
[BUGS-8085] release note for pantheon-mu-plugin 1.4.2

### DIFF
--- a/source/releasenotes/2024-05-1x-pantheon-mu-plugin-1-4-2-update.md
+++ b/source/releasenotes/2024-05-1x-pantheon-mu-plugin-1-4-2-update.md
@@ -1,0 +1,7 @@
+---
+title: Pantheon MU Plugin v1.4.2 update
+published_date: "2024-05-1x"
+categories: [wordpress, plugins]
+---
+
+The latest [1.4.2 update](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) of the Pantheon MU Plugin is now available. This update fixes a bug in the `pantheon_cache_default_max_age` filter added in 1.4.0 where the filtered value was not being used in the cache control headers. This bug was found by [Brian Perondi](https://github.com/brianperondi) in our community Slack. We appreciate the report and the fix will be available with the next WordPress release. Composer-based WordPress installs can get the update right away by running `composer update`.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)