### PR TITLE
[CMSP-992] pantheon mu-plugin 1.4.3 release note

### DIFF
--- a/source/releasenotes/2024-05-22-pantheon-mu-plugin-1-4-3-update.md
+++ b/source/releasenotes/2024-05-22-pantheon-mu-plugin-1-4-3-update.md
@@ -1,0 +1,7 @@
+---
+title: Pantheon MU Plugin v1.4.3 update
+published_date: "2024-05-22"
+categories: [wordpress, plugins]
+---
+
+The latest [1.4.3 update](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) of the Pantheon MU Plugin is now available. This update adds filters and CSS selectors on the Pantheon Page Cache page, allowing them to be customized with plugins and custom code. This update will be included with the next WordPress release. Composer-based WordPress installs can get the update today by running `composer update`.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Release note for [Pantheon MU Plugin 1.4.3 update](https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.4.3)

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)