### PR TITLE
removed the extra "the" from the pagerduty schedule page

### DIFF
--- a/source/content/guides/pagerduty/03-schedule.md
+++ b/source/content/guides/pagerduty/03-schedule.md
@@ -66,7 +66,7 @@ Next, we'll create an on-call Schedule, to configure a scalable custom alert wor
 
 4. Click **<Icon icon="check" />Create Schedule**.
 
-  Refer to the the **Final Schedule** at the bottom of the page to see who's on call and the first point of contact:
+  Refer to the **Final Schedule** at the bottom of the page to see who's on call and the first point of contact:
 
   ![Final Schedule](../../../images/pagerduty/pg-final-schedule.png)
 


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

There was an extra "the" in the pagerduty schedule page. This is removed now.

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)