### PR TITLE
removing "the the" typo in deploy to dev guide

### DIFF
--- a/source/content/guides/drupal/drupal-hosted-createempty-md/09-deploy-dev.md
+++ b/source/content/guides/drupal/drupal-hosted-createempty-md/09-deploy-dev.md
@@ -73,4 +73,4 @@ After you confirm that the site works in the Multidev, replace the `master` bran
    git push --force origin master
    ```
 
-Your site's Dev environment is now set up to use the the latest version of Drupal Integrated Composer upstream.
+Your site's Dev environment is now set up to use the latest version of Drupal Integrated Composer upstream.


### PR DESCRIPTION
fixing "the the typo" in https://docs.pantheon.io/guides/drupal-hosted-createempty-md/deploy-dev