### PR TITLE
[BUGS-7627] Document workaround to remove drupal scaffolded files.

### DIFF
--- a/source/content/guides/integrated-composer/07-ic-troubleshooting.md
+++ b/source/content/guides/integrated-composer/07-ic-troubleshooting.md
@@ -245,6 +245,32 @@ if [ -z "$PANTHEON_ENVIRONMENT" ]; then
 fi
 ```
 
+### Removing files previously scaffolded by drupal-scaffold
+
+The way that Integrated Composer works in Pantheon is by starting with your latest build to optimize the build time; this leads to an issue where if you decide to not scaffold a file anymore; the file will stay there unless you actually remove it. A possible way to do this is to add a `pre-install-cmd` to remove the file. So, the full process to remove files will be like this:
+
+1. Stop the file from being scaffolded by adding lines like this to your composer.json file
+    ```
+    "extra": {
+      "drupal-scaffold": {
+        "file-mapping": {
+          "[web-root]/robots.txt": false
+        },
+        ...
+      }
+    ```
+1. Add a pre-install-hook to actually remove the file
+    ```
+    "scripts": {
+      "pre-install-cmd": [
+        "rm -f web/robots.txt"
+      ],
+      ...
+    },
+    ```
+1. Commit and push your changes to the platform
+1. Once Integrated Composer runs for this commit, the file should be deleted from your environment.
+
 ## More Resources
 
 - [Integrated Composer FAQ](/guides/integrated-composer/ic-faq)


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Troubleshoot Integrated Composer](https://pr-9028-documentation.appa.pantheon.site/guides/integrated-composer/ic-troubleshooting#removing-files-previously-scaffolded-by-drupal-scaffold)** - Document workaround to remove drupal-scaffolded files when you do not need it to scaffold them anymore


### Dependencies and Timing

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)