### PR TITLE
[CMSP-1247][CMSP-1253] Release Note spelling fixup

### DIFF
--- a/source/releasenotes/2024-06-05-drupal-7-101.md
+++ b/source/releasenotes/2024-06-05-drupal-7-101.md
@@ -6,6 +6,6 @@ categories: [drupal, action-required]
 
 The latest version of Drupal 7, *7.101*, became available on Pantheon as of June 5, 2024.
 
-For all major and minor changes in the release, see [the annoucement on drupal.org](https://www.drupal.org/project/drupal/releases/7.101). No security fixes are included in this release.
+For all major and minor changes in the release, see [the announcement on drupal.org](https://www.drupal.org/project/drupal/releases/7.101). No security fixes are included in this release.
 
 Upgrade your Drupal 7 site to Drupal 7.101 right from your Pantheon dashboard or Terminus.


### PR DESCRIPTION
<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Follows #9027 

## Summary
Fixes spelling in linked release note 

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)