### PR TITLE
[CMSP-1259] add release note for php 8.1, 8.2, 8.3

### DIFF
--- a/source/releasenotes/2024-06-06-php-81-82-83-updates.md
+++ b/source/releasenotes/2024-06-06-php-81-82-83-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "PHP 8.1, 8.2 and 8.3 updated to their latest patch releases"
-published_date: "2024-05-14"
+published_date: "2024-06-06"
 categories: [infrastructure]
 ---
 PHP [8.1.29](https://www.php.net/ChangeLog-8.php#8.1.29), [8.2.20](https://www.php.net/ChangeLog-8.php#8.2.20) and [8.3.8](https://www.php.net/ChangeLog-8.php#8.3.8) were released on the platform. They contain the latest bug fixes and security updates for PHP.

--- a/source/releasenotes/2024-06-06-php-81-82-83-updates.md
+++ b/source/releasenotes/2024-06-06-php-81-82-83-updates.md
@@ -1,0 +1,10 @@
+---
+title: "PHP 8.1, 8.2 and 8.3 updated to their latest patch releases"
+published_date: "2024-05-14"
+categories: [infrastructure]
+---
+PHP [8.1.29](https://www.php.net/ChangeLog-8.php#8.1.29), [8.2.20](https://www.php.net/ChangeLog-8.php#8.2.20) and [8.3.8](https://www.php.net/ChangeLog-8.php#8.3.8) were released on the platform. They contain the latest bug fixes and security updates for PHP.
+
+As a reminder, PHP 8.0 reached End-of-Life and PHP 8.1 was moved to security-only updates on 26 November 2023. PHP 8.1 will reach End-of-Life in December 2025. For the best performance and security, Pantheon recommends running PHP 8.2 and above.
+
+* [PHP Supported Versions](https://www.php.net/supported-versions.php)


### PR DESCRIPTION
## Summary
**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for PHP 8.x security updates

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)