### PR TITLE
Minor update caching-advanced-topics.md

### DIFF
--- a/source/content/caching-advanced-topics.md
+++ b/source/content/caching-advanced-topics.md
@@ -225,7 +225,7 @@ Pantheon strips cookies for any file ending with the following extensions, even 
 
 ## 404s
 
-Pantheon’s default is to not cache 404s, but if your application sets `Cache-Control:max-age headers`, the Global CDN will respect them. Depending on your use case, that may be the desired result.
+Pantheon’s default is to not cache 404s, but if your application sets `Cache-Control:max-age` headers, the Global CDN will respect them. Depending on your use case, that may be the desired result.
 
 <TabList>
 


### PR DESCRIPTION
Fixed a technical snippet that had a regular word captured in the wrong text style.

## Summary

**[Caching: Advanced Topics](https://docs.pantheon.io/caching-advanced-topics)** - word corrected with change to its text style.

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)