### PR TITLE
Add note on site name length to Add Site page

### DIFF
--- a/source/content/guides/getstarted/06-addsite.md
+++ b/source/content/guides/getstarted/06-addsite.md
@@ -39,6 +39,12 @@ To create a CMS site:
 
    ![Enter site information](../../../images/create-new-site-info.png)
 
+   <Alert title="Note" type="info">
+
+   Site names are limited to 51 characters.
+
+   </Alert>
+
    <Alert title="Note" type="info" >
 
    You can navigate away from this page during this process, but later, you'll have to go to the **Sites** tab to access your site.  If possible, stay on this tab to simplify accessing the site when the creation is complete.


### PR DESCRIPTION
Since there is a hard limit of 51 characters in the site name, we should let folks know ahead of time about it instead of having to guess.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Add a Site](https://docs.pantheon.io/guides/getstarted/addsite)** - Adds a callout note about site name length restrictions in step 3.

**Release**:
- [x] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)