### PR TITLE
Update technical note for Object Cache with Drupal

### DIFF
--- a/source/content/addons/object-cache/howto/drupal.md
+++ b/source/content/addons/object-cache/howto/drupal.md
@@ -119,6 +119,26 @@ contributors: [cityofoaksdesign, carolynshannon, jms-pantheon, whitneymeredith]
 
    </Alert>
 
+   <Accordion title="Database Cleanup (recommended)" id="database-cleanup-drupal" icon="lightbulb">
+   
+   After enabling Redis, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting, and backing up the database.
+   
+   1. [Connect directly to MySQL](/guides/mariadb-mysql/mysql-access) and run the command below to view the cache:
+   
+     ```sql
+     SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
+     ```
+   
+    This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
+   
+   1. Run the command below on each table, replacing `<tablename>` with the name of the cache table, to empty the cache:
+   
+     ```sql
+     TRUNCATE TABLE `<tablename>`;
+     ```
+   
+   </Accordion>
+
 ## Drupal 7
 
 <Alert title="Note" type="info">
@@ -168,23 +188,9 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 1. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
 
-<Accordion title="Database Cleanup (optional)" id="database-cleanup-d7" icon="lightbulb">
+<Accordion title="Database Cleanup (recommended)" id="database-cleanup-d7" icon="lightbulb">
 
-After enabling Redis, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting, and backing up the database.
-
-1. [Connect directly to MySQL](/guides/mariadb-mysql/mysql-access) and run the command below to view the cache:
-
-  ```sql
-  SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
-  ```
-
- This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
-
-1. Run the command below on each table, replacing `<tablename>` with the name of the cache table, to empty the cache:
-
-  ```sql
-  TRUNCATE TABLE `<tablename>`;
-  ```
+After enabling Redis, there are cache tables in the database that are no longer being used. Refer to the "Database Cleanup" section above for steps on how to truncate the existing cache tables to make sure the latest data populates object cache properly.
 
 </Accordion>
 


### PR DESCRIPTION
D9 and D7 needed the steps that are no longer considered optional.

Closes #

## Summary

[Object Cache for Drupal](https://docs.pantheon.io/object-cache/drupal) - changes optional to recommended and makes sure D9 people see the info. 

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [X] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)