### PR TITLE
Update DB cleanup portion of drupal.md

### DIFF
--- a/source/content/addons/object-cache/howto/drupal.md
+++ b/source/content/addons/object-cache/howto/drupal.md
@@ -119,6 +119,26 @@ contributors: [cityofoaksdesign, carolynshannon, jms-pantheon, whitneymeredith]
 
    </Alert>
 
+ ```
+### Database Cleanup (Recommended)
+
+After enabling Redis, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting, and backing up the database.
+
+1. [Connect directly to MySQL](/guides/mariadb-mysql/mysql-access) and run the command below to view the cache:
+
+  ```sql
+  SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
+  ```
+
+ This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
+
+1. Run the command below on each table, replacing `<tablename>` with the name of the cache table, to empty the cache:
+
+  ```sql
+  TRUNCATE TABLE `<tablename>`;
+  ```
+
+
 ## Drupal 7
 
 <Alert title="Note" type="info">
@@ -168,26 +188,11 @@ This configuration uses the `Redis_CacheCompressed` class for better performance
 
 1. Visit `/admin/config/development/performance/redis` and open **Connection Information** to verify the connection.
 
-<Accordion title="Database Cleanup (optional)" id="database-cleanup-d7" icon="lightbulb">
+<Alert title="Note" type="info">
 
-After enabling Redis, there are cache tables in the database that are no longer being used. Even when the Drupal cache is cleared, these tables will not be emptied. For sites that were live for awhile before Redis was enabled, there could be significant amounts of data in these tables. Removing this data could increase the speed of cloning, exporting, and backing up the database.
+Review the [Database Cleanup](#database-cleanup) section should be reviewed and implemented accordingly for Drupal 7 sites.
 
-1. [Connect directly to MySQL](/guides/mariadb-mysql/mysql-access) and run the command below to view the cache:
-
-  ```sql
-  SELECT table_name FROM information_schema.tables WHERE table_name LIKE 'cache%' AND table_name != 'cache_form';
-  ```
-
- This returns a list of all the cache tables in the database. These are safe to empty, but don't remove the tables themselves in case Redis is disabled in the future.
-
-1. Run the command below on each table, replacing `<tablename>` with the name of the cache table, to empty the cache:
-
-  ```sql
-  TRUNCATE TABLE `<tablename>`;
-  ```
-
-</Accordion>
-
+</Alert>
 
 ## More Resources
 - [Performance Addons](/addons)


### PR DESCRIPTION
The DB cleanup portion of this doc is recommended and is relevant to both D7 and D9.3+ Redis implementations.

<!--
Pull requests should be opened in a branch off the `main` branch.

For more information on contributing to Pantheon documentation:
- [Contributor Guidelines](https://docs.pantheon.io/contribute)
- [Style Guide](https://docs.pantheon.io/style-guide)
- and the [Google developer documentation style guide](https://developers.google.com/style) for formatting recommendations when contributing to the docs.

**Note:** Please fill out the PR template to ensure proper processing and release timing. If you're not sure about a section, leave it empty.
-->

Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>

## Effect

<!-- Use this section to detail the changes summarized above, or remove if not needed -->

The following changes are already committed:

*
*

## Remaining Work and Prerequisites

<!-- Remove if not needed -->
The following changes still need to be completed:

- [ ] List any outstanding work here

### Dependencies and Timing

<!-- If this PR relies on other work before it should be merged or if it should be merged after a certain date, detail that here. -->

- [ ] Other prerequisites that must be completed before merging this PR

**Release**:
- [ ] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)