### PR TITLE
Add alert about site naming restrictions

### DIFF
--- a/source/content/guides/getstarted/06-addsite.md
+++ b/source/content/guides/getstarted/06-addsite.md
@@ -41,6 +41,8 @@ To create a CMS site:
 
    Site names are limited to 51 characters and can contain only numbers, letters, and dashes. Site names cannot start or end with a dash.
 
+Site names cannot be changed after site creation.
+
    </Alert>
 
    ![Enter site information](../../../images/create-new-site-info.png)

--- a/source/content/guides/getstarted/06-addsite.md
+++ b/source/content/guides/getstarted/06-addsite.md
@@ -41,7 +41,7 @@ To create a CMS site:
 
    Site names are limited to 51 characters and can contain only numbers, letters, and dashes. Site names cannot start or end with a dash.
 
-Site names cannot be changed after site creation.
+   Site names cannot be changed after site creation.
 
    </Alert>
 

--- a/source/content/guides/getstarted/06-addsite.md
+++ b/source/content/guides/getstarted/06-addsite.md
@@ -37,13 +37,13 @@ To create a CMS site:
 
 1. Enter the name and select a region for this site. If this site is to be part of a Professional Workspace, select a Workspace from **Choose a Workspace for the Site**. Click **Continue**. It can take several minutes to create a new site on Pantheon.
 
-   ![Enter site information](../../../images/create-new-site-info.png)
-
    <Alert title="Note" type="info">
 
-   Site names are limited to 51 characters.
+   Site names are limited to 51 characters and can contain only numbers, letters, and dashes. Site names cannot start or end with a dash.
 
    </Alert>
+
+   ![Enter site information](../../../images/create-new-site-info.png)
 
    <Alert title="Note" type="info" >
 


### PR DESCRIPTION
This PR is a modification to https://github.com/pantheon-systems/documentation/pull/9046.

When [describing site creation](https://docs.pantheon.io/guides/getstarted/addsite) we should specify the limits placed on names.