### PR TITLE
Update configure-dns.md

### DIFF
--- a/source/content/partials/configure-dns.md
+++ b/source/content/partials/configure-dns.md
@@ -8,7 +8,7 @@ tags: [--]
 reviewed: ""
 ---
 
-The <Icon icon="triangleExclamation" /> icon within the Domains / HTTPS page indicates that the domain has not been correctly routed to Pantheon. Complete the steps below before you provision your HTTPS.
+The <Icon icon="triangleExclamation" /> icon within the Domains / HTTPS page indicates that the domain has not been correctly routed to Pantheon. Complete the steps below before you provision your HTTPS. The addition of a Custom Domain now requires Domain Validation via a TXT record, please follow [the steps outlined here](/guides/domains/custom-domains) before proceeding with the outlined steps below:
 
 1. Access the **<Icon icon="wavePulse" /> Live** environment in your Pantheon Site Dashboard.
 1. Navigate to the **<Icon icon="global" /> Domains / HTTPS** page.


### PR DESCRIPTION
Noting that TXT records must be added in order to add a domain, before being able to point A/AAAA records, reported in community slack.


Closes #

## Summary

<!-- Do not remove this section.

Example format: [Pantheon User Account Login Session Length](https://docs.pantheon.io/user-dashboard#pantheon-user-account-login-session-length)** - Adds action that Terminus users are also logged out after 24 hours of inactivity.
-->

**[Configure DNS and Provision HTTPS](https://docs.pantheon.io/guides/launch/configure-dns/#configure-dns)** - Small addition to this page to point out that TXT records are required before A/AAAA records can be added to DNS provider. 


## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)