### PR TITLE
[CMSP-1364] Release note for WordPress 6.5.5

### DIFF
--- a/source/releasenotes/2024-06-24-wordpress-6-5-5.md
+++ b/source/releasenotes/2024-06-24-wordpress-6-5-5.md
@@ -1,0 +1,16 @@
+---
+title: WordPress 6.5.5 security update
+published_date: "2024-06-24"
+categories: [wordpress, security, action-required]
+---
+
+The latest version of WordPress, [6.5.5](https://wordpress.org/news/2024/06/wordpress-6-5-5/), became available on Pantheon as of June 24, 2024.
+
+<h3>Highlights</h3>
+
+* **Security updates:** Addressed three security vulnerabilities in the HTML API, template part block type and on Windows-hosted sites respectively.
+* [3 additional bug fixes in Core](https://core.trac.wordpress.org/query?component=!Build%2FTest+Tools&milestone=6.5.5&col=id&col=summary&col=owner&col=type&col=status&col=priority&col=component&order=priority)
+
+For more information about WordPress 6.5.5, visit the [HelpHub page for version 6.5.5](https://wordpress.org/documentation/wordpress-version/version-6-5-5/)
+
+Upgrade to WordPress 6.5.5 right from your Pantheon dashboard or Terminus for added security. 


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for WordPress 6.5.5 security release

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)