### PR TITLE
fixing "the the" typo in composer-convert.md

### DIFF
--- a/source/content/composer-convert.md
+++ b/source/content/composer-convert.md
@@ -357,7 +357,7 @@ If you receive the error message "The provided host name is not valid for this s
 
 ## Change Upstreams
 
-Your Pantheon site is now set up to use the the latest version of Drupal Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
+Your Pantheon site is now set up to use the latest version of Drupal Integrated Composer upstream. To continue tracking additional changes to the Pantheon upstream, change the upstream your site is tracking with Composer:
 
 ```bash{promptUser:user}
 terminus site:upstream:set $SITE drupal-composer-managed


### PR DESCRIPTION
Fixing a typo on this page: https://docs.pantheon.io/composer-convert