### PR TITLE
Update 05-advanced-curls.md - missing `Pantheon-Debug` header value

### DIFF
--- a/source/content/guides/launch/05-advanced-curls.md
+++ b/source/content/guides/launch/05-advanced-curls.md
@@ -50,7 +50,7 @@ This command shows line-by-line differences between the two sites while only res
 You can use the cURL `-I -H` option with Pantheon's Debug header to get additional information about a request.
 
  ```bash
- curl -I -H “Pantheon-Debug” https://myexamplesite.com
+ curl -I -H “Pantheon-Debug:1” https://myexamplesite.com
  ```
 
 This command shows the following header information:
@@ -81,6 +81,7 @@ This command shows the following header information:
  pcontext-pdocclustering: on
  pcontext-enforce-https: full
  pcontext-request-restarts: 1
+ pcontext-backend: agcdn
  vary: Accept-Encoding, Cookie, Cookie, Cookie
  age: 1959
  accept-ranges: bytes

--- a/source/content/guides/launch/05-advanced-curls.md
+++ b/source/content/guides/launch/05-advanced-curls.md
@@ -50,7 +50,7 @@ This command shows line-by-line differences between the two sites while only res
 You can use the cURL `-I -H` option with Pantheon's Debug header to get additional information about a request.
 
  ```bash
- curl -I -H “Pantheon-Debug:1” https://myexamplesite.com
+ curl -I -H "Pantheon-Debug:1" https://myexamplesite.com
  ```
 
 This command shows the following header information:


### PR DESCRIPTION
## Summary

Added missing value for `Pantheon-Debug` header. Also added the `pcontext` header AGCDN sites use.

[Advanced cURLs...](https://docs.pantheon.io/guides/launch/advanced-curls/#use-the-pantheon-debugger)

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)