### PR TITLE
checking for search js before adding it

### DIFF
--- a/src/components/addSearch.js
+++ b/src/components/addSearch.js
@@ -21,15 +21,17 @@ class AddSearch extends React.Component {
       }
     }
     const script = document.createElement("script")
-    script.setAttribute(
-      "src",
-      `https://cdn.addsearch.com/v5/addsearch-ui.min.js?key=a7b957b7a8f57f4cc544c54f289611c6&id=search_widget${
-        resultPage.includes("search") ? "&type=resultpage" : ""
-      }`
-    )
-    script.setAttribute("defer", true)
 
-    document.body.appendChild(script)
+    if (!document.querySelector('script[src*="addsearch-ui.min.js"]')) {
+      script.setAttribute(
+        "src",
+        `https://cdn.addsearch.com/v5/addsearch-ui.min.js?key=a7b957b7a8f57f4cc544c54f289611c6&id=search_widget${resultPage.includes("search") ? "&type=resultpage" : ""
+        }`
+      )
+      script.setAttribute("defer", true)
+
+      document.body.appendChild(script)
+    }
   }
   render() {
     return <div className="addsearch-container" />


### PR DESCRIPTION
While working locally with `npm run develop` I regularly get this error while clicking around within guides.

<img width="770" alt="Screenshot 2024-07-09 at 9 09 25 PM" src="https://github.com/pantheon-systems/documentation/assets/211029/d86d2006-6b1c-49ba-b624-7db0ddf9bd96">

As far as I can tell, the error is resulting from running `document.body.appendChild(script)` repeatedly with the same value. While there might be a more elegant or systematic fix, this PR just checks to see if there already is a script tag adding the external JS file before trying to add it.

@rachelwhitton can you confirm that you also have seen this error while working locally and confirm that this the error disappears with this PR? If so, we should ask Mel to review/approve.