### PR TITLE
[CMSP-1448] PHP Release Note

### DIFF
--- a/source/releasenotes/2024-07-10-php-82-83.md
+++ b/source/releasenotes/2024-07-10-php-82-83.md
@@ -1,0 +1,10 @@
+---
+title: "PHP 8.2 and 8.3 updated to their latest patch releases"
+published_date: "2024-07-10"
+categories: [infrastructure]
+---
+PHP [8.2.21](https://www.php.net/ChangeLog-8.php#8.2.21) and [8.3.9](https://www.php.net/ChangeLog-8.php#8.3.9) were released on the platform. They contain the latest bug fixes for PHP.
+
+As a reminder, PHP 8.0 reached End-of-Life and PHP 8.1 was moved to security-only updates on 26 November 2023. PHP 8.1 will reach End-of-Life in December 2025. For the best performance and security, Pantheon recommends running PHP 8.2 and above.
+
+* [PHP Supported Versions](https://www.php.net/supported-versions.php)

--- a/source/releasenotes/2024-07-15-php-82-83.md
+++ b/source/releasenotes/2024-07-15-php-82-83.md
@@ -1,6 +1,6 @@
 ---
 title: "PHP 8.2 and 8.3 updated to their latest patch releases"
-published_date: "2024-07-10"
+published_date: "2024-07-15"
 categories: [infrastructure]
 ---
 PHP [8.2.21](https://www.php.net/ChangeLog-8.php#8.2.21) and [8.3.9](https://www.php.net/ChangeLog-8.php#8.3.9) were released on the platform. They contain the latest bug fixes for PHP.


### PR DESCRIPTION
## Summary
Adds a release note for the latest releases  of PHP https://www.php.net/ChangeLog-8.php#PHP_8_2

**[Release Notes](https://docs.pantheon.io/release-notes)** 
https://pr-9085-documentation.appa.pantheon.site/release-notes/2024/07/php-82-83
### Dependencies and Timing

- [x] Merge https://github.com/pantheon-systems/cos-runtime-php/pull/539

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)