### PR TITLE
simplifying PHP redirects section

### DIFF
--- a/source/content/guides/redirect/07-php.md
+++ b/source/content/guides/redirect/07-php.md
@@ -18,49 +18,9 @@ permalink: docs/guides/redirect/php
 
 If your site configuration prevents you from setting the primary domain from the platform level, you can use PHP redirects. However, redirecting the platform domain will break the screenshot of your site in the Personal Workspace, and might complicate troubleshooting for our [Support](/guides/support/contact-support/) team.
 
-AGCDN only works with custom domains. This means that `.pantheonsite.io` domains are not covered. With AGCDN, a site will not be fully protected under WAF if it is using the platform domain. A platform domain redirect to the main domain is recommended. 
+AGCDN only works with custom domains. This means that `.pantheonsite.io` domains are not covered. With AGCDN, a site will not be fully protected under WAF if it is using the platform domain. A platform domain redirect to the main domain is recommended.
 
 <Partial file="_redirects.md" />
 
 ## Convert Multiple `.htaccess` Redirects and Rewrites to PHP
-If you need to convert a large number of `.htaccess` redirects or rewrites to PHP, feel free to utilize our [free script](https://github.com/Pantheon-SE/pantheon-htaccess-rewrites) for both WordPress and Drupal.
-
-## Redirect Traffic to Your Live Site/Domain from `$site.pantheon.io`
-
-There are several ways you can use PHP to redirect traffic to your live site or domain from `$site.pantheon.io`:
-
-### Basic Use Case
-
-```php:title=wp-config.php%20or%20settings.php
- if($_SERVER['HTTP_HOST'] == 'old.domain.com') {
-    header('HTTP/1.0 301 Moved Permanently');
-    header('Location: https://new.domain.com/');
-  }
-```
-
-### Using RegEx
-
-```php:title=wp-config.php%20or%20settings.php
-if (preg_match('/^live-(.+)\.pantheonsite\.io$/', $_SERVER["HTTP_HOST"], $matches)) {
-		$redirect_url = 'https://www.' . $matches[1] . '.com';
-    $response_code = 301;
-	}
-```
-
-### Without Regex
-
-```php:title=wp-config.php%20or%20settings.php
-if ($_SERVER["HTTP_HOST"] == "live-mysite.pantheonsite.io") {
-    header('HTTP/1.0 301 Moved Permanently');
-    header('Location: https://www.' . $matches[1] . '.com/');
-}
-```
-
-### Redirect a `/requested/path`
-
-```php:title=wp-config.php%20or%20settings.php
-if($_SERVER["REQUEST_URI"] == '/old/path') {
-  header('HTTP/1.0 301 Moved Permanently');
-  header('Location: /new/path/');
-}
-```
+If you need to convert a large number of `.htaccess` redirects or rewrites to PHP, feel free to utilize our [free script](https://github.com/Pantheon-SE/pantheon-htaccess-rewrites) for both WordPress and Drupal. You can also do more [advanced redirects with PHP](/guides/redirect/advanced).

--- a/source/content/guides/redirect/07-php.md
+++ b/source/content/guides/redirect/07-php.md
@@ -23,7 +23,7 @@ AGCDN only works with custom domains. This means that `.pantheonsite.io` domains
 <Partial file="_redirects.md" />
 
 ## Redirect Platform Domains (`.pantheonsite.io`)
-We do not recommend redirecting [platform domains](/guides/domains/platform-domains), especially on Live production environments, as it restricts our ability to provide support for scenarios where 3rd party services are utilized prior to the domain resolving to Pantheon (e.g., you're stacking your own custom CDN service on top of Pantheon's infrastructure). 
+We do not recommend redirecting away from [platform domains](/guides/domains/platform-domains), especially on Live production environments, as it restricts our ability to provide support for scenarios where 3rd party services are utilized prior to the domain resolving to Pantheon (e.g., you're stacking your own custom CDN service on top of Pantheon's infrastructure). 
 
 ## Convert Multiple `.htaccess` Redirects and Rewrites to PHP
 If you need to convert a large number of `.htaccess` redirects or rewrites to PHP, feel free to utilize our [free script](https://github.com/Pantheon-SE/pantheon-htaccess-rewrites) for both WordPress and Drupal. You can also do more [advanced redirects with PHP](/guides/redirect/advanced).

--- a/source/content/guides/redirect/07-php.md
+++ b/source/content/guides/redirect/07-php.md
@@ -22,5 +22,8 @@ AGCDN only works with custom domains. This means that `.pantheonsite.io` domains
 
 <Partial file="_redirects.md" />
 
+## Redirect Platform Domains (`.pantheonsite.io`)
+We do not recommend redirecting [platform domains](/guides/domains/platform-domains), especially on Live production environments, as it restricts our ability to provide support for scenarios where 3rd party services are utilized prior to the domain resolving to Pantheon (e.g., you're stacking your own custom CDN service on top of Pantheon's infrastructure). 
+
 ## Convert Multiple `.htaccess` Redirects and Rewrites to PHP
 If you need to convert a large number of `.htaccess` redirects or rewrites to PHP, feel free to utilize our [free script](https://github.com/Pantheon-SE/pantheon-htaccess-rewrites) for both WordPress and Drupal. You can also do more [advanced redirects with PHP](/guides/redirect/advanced).


### PR DESCRIPTION
Closing #8636. The short examples on https://docs.pantheon.io/guides/redirect/php feel duplicative of the CMS-specific examples higher on the page and the more detailed examples on the next page. I think we should just remove them.