### PR TITLE
CMSP-1022: WordPress 6.6 Release Notes

### DIFF
--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -6,10 +6,10 @@ categories: [wordpress, action-required]
 
 The latest version of WordPress, [6.6 (Dorsey)](https://wordpress.org/news/2024/07/dorsey/), became available on Pantheon as of July 16, 2024.
 
-<h3>Action required</h3>
-Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard). 
+### Action required
+Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
 
-<h3>Highlights</h3>
+### Highlights
 
 * New design options for the Block Editor, including color or font sets, as well as a new previous experience for pages in the site editor.
 * Maintenance and quality updates to the [Interactivity API](https://make.wordpress.org/core/2024/06/28/updates-to-the-interactivity-api-in-6-6/).
@@ -17,4 +17,3 @@ Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the 
 * [Support for PHP 7.0 and 7.1 was dropped](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).  The new minimum supported version of PHP will be 7.2.24. Pantheon recommends running PHP 8.2 or above.
 
 For full details about WordPress 6.6, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-6/) or the [WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/).
-

--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -7,7 +7,7 @@ categories: [wordpress, action-required]
 The latest version of WordPress, [6.6 (Dorsey)](https://wordpress.org/news/2024/07/dorsey/), became available on Pantheon as of July 16, 2024.
 
 <h3>Action required</h3>
-Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements.
+Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard). 
 
 <h3>Highlights</h3>
 

--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -1,18 +1,20 @@
 ---
-title: WordPress 6.6 (Dorsey) Release
+title: WordPress 6.6 (Dorsey) release
 published_date: "2024-07-16"
 categories: [wordpress, action-required]
 ---
 
 The latest version of WordPress, [6.6 (Dorsey)](https://wordpress.org/news/2024/07/dorsey/), became available on Pantheon as of July 16, 2024.
 
+<h3>Action required</h3>
+Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements.
+
 <h3>Highlights</h3>
 
 * New design options for the Block Editor, including color or font sets, as well as a new previous experience for pages in the site editor.
-* Maintenance and quality updates to the [Interactivity API](https://make.wordpress.org/core/2024/06/28/updates-to-the-interactivity-api-in-6-6/)
+* Maintenance and quality updates to the [Interactivity API](https://make.wordpress.org/core/2024/06/28/updates-to-the-interactivity-api-in-6-6/).
 * A number of updates to working with themes, including a new [Theme.json version](https://make.wordpress.org/core/2024/06/19/theme-json-version-3/) due to breaking changes.
-* Support for PHP 7.0 and 7.1 [was removed](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).  The new minimum supported version of PHP will be 7.2.24. Pantheon recommends running PHP 8.2 or above.
+* [Support for PHP 7.0 and 7.1 was dropped](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).  The new minimum supported version of PHP will be 7.2.24. Pantheon recommends running PHP 8.2 or above.
 
 For full details about WordPress 6.6, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-6/) or the [WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/).
 
-Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements.

--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -14,3 +14,5 @@ The latest version of WordPress, [6.6 (Dorsey)](https://wordpress.org/news/2024/
 * Support for PHP 7.0 and 7.1 [was removed](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).  The new minimum supported version of PHP will be 7.2.24. Pantheon recommends running PHP 8.2 or above.
 
 For full details about WordPress 6.6, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-6/) or the [WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/).
+
+Upgrade to WordPress 6.6 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements.

--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -1,6 +1,6 @@
 ---
 title: WordPress 6.6 (Dorsey) release
-published_date: "2024-07-16"
+published_date: "2024-07-17"
 categories: [wordpress, action-required]
 ---
 

--- a/source/releasenotes/2024-07-16-wordpress-6-6.md
+++ b/source/releasenotes/2024-07-16-wordpress-6-6.md
@@ -1,0 +1,16 @@
+---
+title: WordPress 6.6 (Dorsey) Release
+published_date: "2024-07-16"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.6 (Dorsey)](https://wordpress.org/news/2024/07/dorsey/), became available on Pantheon as of July 16, 2024.
+
+<h3>Highlights</h3>
+
+* New design options for the Block Editor, including color or font sets, as well as a new previous experience for pages in the site editor.
+* Maintenance and quality updates to the [Interactivity API](https://make.wordpress.org/core/2024/06/28/updates-to-the-interactivity-api-in-6-6/)
+* A number of updates to working with themes, including a new [Theme.json version](https://make.wordpress.org/core/2024/06/19/theme-json-version-3/) due to breaking changes.
+* Support for PHP 7.0 and 7.1 [was removed](https://make.wordpress.org/core/2024/04/08/dropping-support-for-php-7-1/).  The new minimum supported version of PHP will be 7.2.24. Pantheon recommends running PHP 8.2 or above.
+
+For full details about WordPress 6.6, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-6/) or the [WordPress 6.6 Field Guide](https://make.wordpress.org/core/2024/06/25/wordpress-6-6-field-guide/).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for WordPress 6.6
https://pr-9109-documentation.appa.pantheon.site/release-notes/2024/07/wordpress-6-6

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)