### PR TITLE
wrapping cookie in check for development mode

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -8,8 +8,11 @@ require("dotenv").config({
   path: `.env.${process.env.NODE_ENV}`,
 })
 
+
+
+
 // Gatsby Configuration, Options, and Plugins
-module.exports = {
+const allConfig = {
   // Puts build artifacts in a subdirectory, and updates all local links
   pathPrefix: `/`,
   // Reusable global information
@@ -37,18 +40,7 @@ module.exports = {
         defaultDataLayer: {},
       },
     },
-    {
-      // Handles inserting the Segment js blob into the site
-      resolve: "gatsby-plugin-segment-js",
-      options: {
-        prodKey: "lEIpoQHx3G5Jqsy3GmjcPS357D4AlwlA",
-        devKey: "kDdX1dpmsAWuUn8zb1QDJR8YGbWJjKoj",
-        trackPage: false,
-        trackPageOnlyIfReady: true,
-        customSnippet:
-          '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${writeKey}";;analytics.SNIPPET_VERSION="4.15.3";analytics.load("${writeKey}");analytics.ready(function() {window.dataLayer.push({"event": "segment_analytics_loaded"});});analytics.page();}}();',
-      },
-    },
+
     // Each instance of `gatsby-source-filesystem` tells Gatsby to look in a different directory for source files.
     {
       resolve: `gatsby-source-filesystem`,
@@ -308,3 +300,21 @@ module.exports = {
     },
   ],
 }
+
+if (process.env.NODE_ENV !== "development") {
+// add segment plugin
+  allConfig.plugins.push({
+    // Handles inserting the Segment js blob into the site
+    resolve: "gatsby-plugin-segment-js",
+    options: {
+      prodKey: "lEIpoQHx3G5Jqsy3GmjcPS357D4AlwlA",
+      devKey: "kDdX1dpmsAWuUn8zb1QDJR8YGbWJjKoj",
+      trackPage: false,
+      trackPageOnlyIfReady: true,
+      customSnippet:
+        '!function(){var analytics=window.analytics=window.analytics||[];if(!analytics.initialize)if(analytics.invoked)window.console&&console.error&&console.error("Segment snippet included twice.");else{analytics.invoked=!0;analytics.methods=["trackSubmit","trackClick","trackLink","trackForm","pageview","identify","reset","group","track","ready","alias","debug","page","once","off","on","addSourceMiddleware","addIntegrationMiddleware","setAnonymousId","addDestinationMiddleware"];analytics.factory=function(e){return function(){var t=Array.prototype.slice.call(arguments);t.unshift(e);analytics.push(t);return analytics}};for(var e=0;e<analytics.methods.length;e++){var key=analytics.methods[e];analytics[key]=analytics.factory(key)}analytics.load=function(key,e){var t=document.createElement("script");t.type="text/javascript";t.async=!0;t.src="https://cdn.segment.com/analytics.js/v1/" + key + "/analytics.min.js";var n=document.getElementsByTagName("script")[0];n.parentNode.insertBefore(t,n);analytics._loadOptions=e};analytics._writeKey="${writeKey}";;analytics.SNIPPET_VERSION="4.15.3";analytics.load("${writeKey}");analytics.ready(function() {window.dataLayer.push({"event": "segment_analytics_loaded"});});analytics.page();}}();',
+    },
+  });
+}
+
+module.exports = allConfig;

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,14 +4,24 @@ import React from 'react'
  * Add global scripts to ensure Bootstrap and jQuery JS is included
  */
 export const onRenderBody = ({ setPostBodyComponents }) => {
-  setPostBodyComponents([
+
+  const components = [
     <script key="jquery" src="https://cdnjs.cloudflare.com/ajax/libs/jquery/1.12.1/jquery.min.js" />,
     <script key="bootstrap" src="https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/js/bootstrap.min.js" />,
     <script key="twitter" src="https://platform.twitter.com/widgets.js" />,
-    // OneTrust Banner
-    <script src="https://cdn.cookielaw.org/scripttemplates/otSDKStub.js" type="text/javascript" charset="UTF-8" data-domain-script="fba5027b-04c0-4165-8778-4e10fb9f5fa3" />,
+  ];
+
+  // // add the cookie banner script only when doing a full build, not in development
+  if (process.env.NODE_ENV !== 'development') {
+    components.push(
+      <script key="cookie-banner" src="https://pantheon.io/cookie-banner.js" />
+    );
+    components.push(
       function OptanonWrapper() {
         window.dataLayer.push({'event':'OneTrustGroupsUpdated'})
       }
-  ])
+    );
+  }
+
+  setPostBodyComponents(components);
 }


### PR DESCRIPTION
closes #9098, but I'm really not sure if I should bother mucking with this type of code in Gatsby vs spending time exploring an eventual replacement.