### PR TITLE
[CMSP-954] New PHP Defaults

### DIFF
--- a/source/releasenotes/2024-07-17-php-defaults.md
+++ b/source/releasenotes/2024-07-17-php-defaults.md
@@ -7,6 +7,6 @@ Pantheon has pushed an update to the WordPress, Drupal 7, and Drupal Composer Ma
 
 PHP 8.1 currently only receives security support, and will reach End of Life in December 2025.
 
-If you maintain a [custom upstream](/guides/custom-upstream), this change will not be reflected in your `pantheon.upstream.yml` unless you [update your from from Pantheon's upstream](https://docs.pantheon.io/guides/custom-upstream/create-custom-upstream#pull-in-core-from-pantheons-upstream).
+If you maintain a [custom upstream](/guides/custom-upstream), this change will not be reflected in `pantheon.upstream.yml` unless you [update your fork from Pantheon's upstream](https://docs.pantheon.io/guides/custom-upstream/create-custom-upstream#pull-in-core-from-pantheons-upstream).
 
 Please test this core update thoroughly before deploying to the Live environment. If your site requires an older version of PHP, or if you'd like to upgrade to PHP 8.3, see [Pantheon’s documentation on how to manage PHP versions via the pantheon.yml configuration file](/guides/php/php-versions).

--- a/source/releasenotes/2024-07-17-php-defaults.md
+++ b/source/releasenotes/2024-07-17-php-defaults.md
@@ -1,0 +1,12 @@
+---
+title: New PHP Defaults
+published_date: "2024-07-17"
+categories: [infrastructure, wordpress, drupal, action-required]
+---
+Pantheon has pushed an update to the WordPress, Drupal 7, and Drupal Composer Managed upstreams which sets PHP 8.2 as the default PHP version, rather than 8.1.
+
+PHP 8.1 currently only receives security support, and will reach End of Life in December 2025.
+
+If you maintain a [custom upstream](/guides/custom-upstream), this change will not be reflected in your `pantheon.upstream.yml` unless you [update your from from Pantheon's upstream](https://docs.pantheon.io/guides/custom-upstream/create-custom-upstream#pull-in-core-from-pantheons-upstream).
+
+Please test this core update thoroughly before deploying to the Live environment. If your site requires an older version of PHP, or if you'd like to upgrade to PHP 8.3, see [Pantheon’s documentation on how to manage PHP versions via the pantheon.yml configuration file](/guides/php/php-versions).


### PR DESCRIPTION
## Summary


**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for PHP 8.2

### Dependencies and Timing

- [ ] https://github.com/pantheon-systems/drops-7/pull/204
- [ ] https://github.com/pantheon-systems/WordPress/pull/389
- [ ] https://github.com/pantheon-systems/drupal-composer-managed/pull/48

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)