### PR TITLE
add release note for mu-plugin 1.4.5

### DIFF
--- a/source/releasenotes/2024-07-19-pantheon-mu-plugin-1-4-5.md
+++ b/source/releasenotes/2024-07-19-pantheon-mu-plugin-1-4-5.md
@@ -4,14 +4,12 @@ published_date: "2024-07-19"
 categories: [wordpress, plugins]
 ---
 
-The latest [1.4.5 update](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) of the Pantheon MU Plugin is now available. 
-
-The MU plugin update will be included with the WordPress 6.6.1 release. 
+The latest update, [v1.4.5](https://github.com/pantheon-systems/pantheon-mu-plugin/releases), of the Pantheon MU Plugin is now available. This update will be included with the upcoming WordPress 6.6.1 release.
 
 ### What's new?
 
-This update adds a filter to the WordPress Multisite Network Setup page for subdirectory multisite installations that include a custom `wp-content` directory. Previously, WordPress would warn that a custom `wp-content` directory may not be supported by subdirectory multisites. However, this does not apply to our WordPress (Composer Managed) upstream (powered by [Bedrock](https://roots.io/bedrock/)). Our MU plugin uses a customized implementation of the WordPress core file that renders this page and, as such, we have added a new function and a filter (`pantheon.enable_subdirectory_networks_message`) that allows us (and you!) to disable that message in cases where it does not apply.
+This update introduces a filter to the WordPress Multisite Network Setup page for subdirectory multisite installations with a custom `wp-content` directory. Previously, WordPress showed a warning that a custom `wp-content` directory might not be supported by subdirectory multisites. However, this warning does not apply to our WordPress (Composer Managed) upstream, which is powered by [Bedrock](https://roots.io/bedrock/). Our MU plugin has a customized version of the WordPress core file that renders this page. To address this, we've added a new function and filter (`pantheon.enable_subdirectory_networks_message`) that lets us (and you!) disable the warning when it's irrelevant.
 
-The next update to the WordPress (Composer Managed) upstream will include the implementation of this filter added to the MU plugin.
+The next update to the WordPress (Composer Managed) upstream will include this filter from the MU plugin.
 
 For more information about WordPress (Composer Managed) refer to our [WordPress and Composer documentation](https://docs.pantheon.io/guides/wordpress-composer).

--- a/source/releasenotes/2024-07-19-pantheon-mu-plugin-1-4-5.md
+++ b/source/releasenotes/2024-07-19-pantheon-mu-plugin-1-4-5.md
@@ -1,0 +1,17 @@
+---
+title: Pantheon MU Plugin v1.4.5 release
+published_date: "2024-07-19"
+categories: [wordpress, plugins]
+---
+
+The latest [1.4.5 update](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) of the Pantheon MU Plugin is now available. 
+
+The MU plugin update will be included with the WordPress 6.6.1 release. 
+
+### What's new?
+
+This update adds a filter to the WordPress Multisite Network Setup page for subdirectory multisite installations that include a custom `wp-content` directory. Previously, WordPress would warn that a custom `wp-content` directory may not be supported by subdirectory multisites. However, this does not apply to our WordPress (Composer Managed) upstream (powered by [Bedrock](https://roots.io/bedrock/)). Our MU plugin uses a customized implementation of the WordPress core file that renders this page and, as such, we have added a new function and a filter (`pantheon.enable_subdirectory_networks_message`) that allows us (and you!) to disable that message in cases where it does not apply.
+
+The next update to the WordPress (Composer Managed) upstream will include the implementation of this filter added to the MU plugin.
+
+For more information about WordPress (Composer Managed) refer to our [WordPress and Composer documentation](https://docs.pantheon.io/guides/wordpress-composer).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for mu-plugin 1.4.5 (see https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.4.5)
[Pantheon MU Plugin v1.4.5 release](https://pr-9114-documentation.appa.pantheon.site/release-notes/2024/07/pantheon-mu-plugin-1-4-5)

### Dependencies and Timing

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)