### PR TITLE
[SITE-1553] WordPress 6.6.1

### DIFF
--- a/source/releasenotes/2024-07-23-wordpress-6-6-1.md
+++ b/source/releasenotes/2024-07-23-wordpress-6-6-1.md
@@ -1,6 +1,6 @@
 ---
-title: WordPress 6.6.1 
-published_date: "2024-07-23"
+title: WordPress 6.6.1 release
+published_date: "2024-07-24"
 categories: [wordpress, action-required]
 ---
 

--- a/source/releasenotes/2024-07-23-wordpress-6-6-1.md
+++ b/source/releasenotes/2024-07-23-wordpress-6-6-1.md
@@ -1,0 +1,15 @@
+---
+title: WordPress 6.6.1 
+published_date: "2024-07-23"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.6.1](https://wordpress.org/news/2024/07/wordpress-6-6-1-maintenance-release/), became available on Pantheon as of July 23, 2024.
+
+### Action required
+Upgrade to WordPress 6.6.1 right from your Pantheon dashboard or Terminus for the latest fixes. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+<h3>Highlights</h3>
+
+* [7 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!61692&milestone=6.6.1&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=priority)
+* [9 bug fixes in the Block Editor](https://core.trac.wordpress.org/ticket/61692#comment:4)


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Add release note for WordPress 6.6.1

**Release**:
- [x] When ready
- [ ] After date: $DATE

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)