### PR TITLE
[SITE-1224] add release note for mu-plugin v1.5.0

### DIFF
--- a/source/releasenotes/2024-07-29-pantheon-mu-plugin-1-5-0.md
+++ b/source/releasenotes/2024-07-29-pantheon-mu-plugin-1-5-0.md
@@ -1,11 +1,19 @@
 ---
-title: Pantheon MU Plugin v1.5.0 release
+title: Pantheon MU Plugin v1.5.0 release 
 published_date: "2024-07-29"
 categories: [wordpress, plugins]
 ---
 
-The latest update, [v1.5.0](https://github.com/pantheon-systems/pantheon-mu-plugin/releases), of the Pantheon MU Plugin is now available. This update will be included with next version of WordPress and can be installed on [WordPress (composer managed)](https://docs.pantheon.io/guides/wordpress-composer) installs using `composer update` or by checking for updates in the dashboard.
+The Pantheon MU Plugin [v1.5.0](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) update is now available. This latest update is included with next version of WordPress and can be installed on [WordPress (composer managed)](https://docs.pantheon.io/guides/wordpress-composer) installs using composer update or by checking for updates in the dashboard.
 
 ### What's new?
 
-This update adds a new "compatibility layer" feature that automatically fixes and/or reports on the compatibility status of many of the plugins we have documentation for on our [WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/plugins-known-issues) guide. Where possible, if any of the plugins are detected, the compatibility layer will automatically apply the relevant fixes for you. If a plugin is detected but no fix is available, the compatibility layer will report the issue to you. These reports are added in a new section of the Site Health page under the Tools menu of your WordPress administration dashboard.
+This update introduces a new "comptibility layer" feature designed to enhance the compatibility of your site’s plugins. Here are the key highlights:
+
+* **Automatic compatibility fixes:** The compatibility layer automatically detects many plugins listed in our [WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/plugins-known-issues) guide. If a plugin is detected, relevant fixes are applied automatically.
+
+* **Compatibility reports:** If a plugin is detected but no fix is available, the compatibility layer generates a report for you.
+
+* **Site health integration:** Compatibility reports are added to a new section of the Site Health page, accessible under the Tools menu in your WordPress administration dashboard.
+
+Upgrade now to take advantage of these enhancements and ensure your plugins work seamlessly with your WordPress site.

--- a/source/releasenotes/2024-07-29-pantheon-mu-plugin-1-5-0.md
+++ b/source/releasenotes/2024-07-29-pantheon-mu-plugin-1-5-0.md
@@ -1,0 +1,11 @@
+---
+title: Pantheon MU Plugin v1.5.0 release
+published_date: "2024-07-29"
+categories: [wordpress, plugins]
+---
+
+The latest update, [v1.5.0](https://github.com/pantheon-systems/pantheon-mu-plugin/releases), of the Pantheon MU Plugin is now available. This update will be included with next version of WordPress and can be installed on [WordPress (composer managed)](https://docs.pantheon.io/guides/wordpress-composer) installs using `composer update` or by checking for updates in the dashboard.
+
+### What's new?
+
+This update adds a new "compatibility layer" feature that automatically fixes and/or reports on the compatibility status of many of the plugins we have documentation for on our [WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/plugins-known-issues) guide. Where possible, if any of the plugins are detected, the compatibility layer will automatically apply the relevant fixes for you. If a plugin is detected but no fix is available, the compatibility layer will report the issue to you. These reports are added in a new section of the Site Health page under the Tools menu of your WordPress administration dashboard.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for the new update of Pantheon MU Plugin.

This doc is pending the actual release in https://github.com/pantheon-systems/pantheon-mu-plugin/releases but is expected to be created today.