### PR TITLE
Remove "known issue" about subdirectory multisite and WordPress (Composer Managed)

### DIFF
--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -123,10 +123,6 @@ composer update vendor/package
 
 Replace `vendor/package` with the package name you want to update. This will update only the named package to the latest version that matches the version constraints in your `composer.json` file.
 
-## Known Issues
-
-- There is currently a known issue with WordPress Composer Managed not supporting WordPress Multisite with subdirectories. [Alternative implementations](/guides/wordpress-composer/wordpress-ic) of WordPress with Composer may be used for this use case.
-
 ## Report an Issue
 
 Create an [issue in the Github repo](https://github.com/pantheon-systems/wordpress-composer-managed/issues) for the team to review and address if you discover an issue with the WordPress Composer Managed upstream.


### PR DESCRIPTION
Fixes #9145 

## Summary

**[Create a Composer-managed WordPress Site with Bedrock](https://docs.pantheon.io/guides/wordpress-composer/wordpress-composer-managed)** - Removes "known issue" about using WordPress (Composer Managed) with subdirectory multisite. Since https://github.com/pantheon-systems/wordpress-composer-managed/pull/140 subdirectory and subdomain multisites are being tested on PRs, so this should no longer be an issue. (Also, I've tested it manually.)
