### PR TITLE
Update docs: ssh-keys.md

### DIFF
--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -44,7 +44,7 @@ Pantheon supports ECDSA and RSA SSH keys. Currently, we do not support `ed25519`
 1. Open your terminal and enter the following command to generate a key:
 
    ```bash{promptUser: user}
-   ssh-keygen -t rsa
+   ssh-keygen -t rsa -m PEM
    ```
 
   Do not edit the default location of `~/.ssh/id_rsa` unless you have a reason to change it. If the command says the key already exists, you can either overwrite it, or continue to the next step with your existing key.
@@ -79,7 +79,7 @@ Pantheon supports ECDSA and RSA SSH keys. Currently, we do not support `ed25519`
 1. Open your terminal and enter the following command to generate a key. This command works for Windows 10:
 
    ```bash{promptUser: winshell}
-   ssh-keygen -t rsa
+   ssh-keygen -t rsa -m PEM
    ```
 
   Do not edit the default location of `~/.ssh/id_rsa` unless you have a reason to change it. If the command says the key already exists, you can either overwrite it, or continue to the next step with your existing key.


### PR DESCRIPTION
## Summary

Doc: **[Generate and Add SSH Keys](https://docs.pantheon.io/ssh-keys)**

ㅤ
Add `-m PEM` to `ssh-keygen -t rsa`

Run `ssh-keygen -t rsa -m PEM` to generate a new RSA key pair, and the private key is saved in PEM format.

This format is sometimes required for compatibility with certain software or systems, and fix error `invalid privatekey: [B@12a3456b`

More: ["Invalid privatekey" when using JSch](https://stackoverflow.com/a/53783283/7598333)
