### PR TITLE
update rest api no-cache example code

### DIFF
--- a/source/content/cache-control.md
+++ b/source/content/cache-control.md
@@ -118,14 +118,14 @@ $regex_json_path_patterns = array(
 foreach ($regex_json_path_patterns as $regex_json_path_pattern) {
   if (preg_match($regex_json_path_pattern, $_SERVER['REQUEST_URI'])) {
       // re-use the rest_post_dispatch filter in the Pantheon page cache plugin
-      add_filter( 'rest_post_dispatch', 'filter_rest_post_dispatch_send_cache_control', 12, 2 );
+      add_filter( 'rest_post_dispatch', 'filter_rest_post_dispatch_send_cache_control', 12 );
       break;
   }
 }
 
 // Re-define the send_header value with any custom Cache-Control header
-function filter_rest_post_dispatch_send_cache_control( $response, $server ) {
-    $server->send_header( 'Cache-Control', 'no-cache, must-revalidate, max-age=0' );
+function filter_rest_post_dispatch_send_cache_control( $response ) {
+    $response->header( 'Cache-Control', 'no-cache, must-revalidate, max-age=0' );
     return $response;
 }
 ```


### PR DESCRIPTION
Fixes #8675

## Summary

**[Bypassing Cache with HTTP Headers](https://docs.pantheon.io/cache-control)** - Updates the code snippet example for bypassing cache headers for rest requests