### PR TITLE
Add vitest to GitHub actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,5 +19,5 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 'latest'
-      - run: npm install
+      - run: npm ci
       - run: npx vitest src/components

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,23 @@
+name: Test
+on:
+  pull_request:
+    paths:
+      - 'src/**'
+      - '.github/workflows/test.yml'
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - ready_for_review
+  workflow_dispatch:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 'latest'
+      - run: npm install
+      - run: npx vitest src/components

--- a/.github/workflows/vitest.yml
+++ b/.github/workflows/vitest.yml
@@ -1,9 +1,9 @@
-name: Test
+name: JavaScript Unit Tests
 on:
   pull_request:
     paths:
       - 'src/**'
-      - '.github/workflows/test.yml'
+      - '.github/workflows/vitest.yml'
     types:
       - opened
       - synchronize

--- a/src/components/omniSidebarNav/helpers.js
+++ b/src/components/omniSidebarNav/helpers.js
@@ -17,10 +17,12 @@ const turnItemsIntoLinks = (item, activePage) => {
   // If the link is external, add an icon to indicate that.
   // Internal links will start with a slash.
   if (item.link.startsWith('http')) {
-    linkText = (
-      <>
-        <Icon iconName="externalLink" /> {item.title}
-      </>
+    linkText = React.createElement(
+      React.Fragment,
+      null,
+      React.createElement(Icon, { iconName: "externalLink" }),
+      " ",
+      item.title
     );
   }
 


### PR DESCRIPTION
Fixes #9083
Replaces #9161 

## Summary
Adds a GitHub actions workflow to run `npx vitest src/components` on PRs that change files in `src/` (can be altered to limit that scope to `src/components/` or if the workflow itself is updated.

Also allows for manual triggering (`workflow_dispatch`) in the Actions tab.