### PR TITLE
Update WP Best Practices to include guidance on blocking `/wp-json/wp/v2/users` to anonymous users

### DIFF
--- a/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
+++ b/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
@@ -66,7 +66,9 @@ There are many plugins and themes in WordPress that require license keys. It is 
 
 - Follow our [Frontend Performance](/guides/frontend-performance) guide to tune your WordPress site.
 
-## Disable Anonymous Access to WordPress Rest API
+## Disable Anonymous Access to the WordPress REST API
+
+### Option 1: Block the entire WordPress REST API
 
 The WordPress REST API is enabled for all users by default. You can disable the WordPress REST API for anonymous requests to improve security and avoid exposing admin users. This action improves site safety and reduces unexpected errors that can result in compromised WordPress core functionalities.
 
@@ -91,7 +93,7 @@ add_filter( 'rest_authentication_errors', function( $result ) {
 });
 ```
 
-## Block Anonymous Access to the `/users` WordPress Rest endpoint
+### Option 2: Block only the `/users` WordPress REST endpoint
 
 If blocking the entire REST API is not feasible for your site, you can choose a more selective approach. The WordPress REST API exposes the complete users list at the `/wp-json/wp/v2/users` endpoint. This is by design -- the `/users` endpoint contains data that is public elsewhere on your site and availalbe in other public places in WordPress, notably the HTML output and RSS feeds including name, avatar, etc. These endpoints are public so that the data to view and render content from elsewhere in the REST API is available. For example, since a post links to the author user, making user information easily accessible makes it simpler to access from API tools and integrations.
 

--- a/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
+++ b/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
@@ -10,7 +10,7 @@ audience: [development]
 product: [--]
 integration: [--]
 tags: [workflow, security, composer]
-reviewed: "2022-05-16"
+reviewed: "2024-08-12"
 showtoc: true
 permalink: docs/guides/wordpress-developer/wordpress-best-practices
 ---

--- a/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
+++ b/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
@@ -71,13 +71,10 @@ SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) to he
 
 The WordPress REST API endpoint at `/wp-json/wp/v2/users` shows a full list of all usernames on a WordPress site and associated metadata for users who have at least one published post in a public post type. While this information is available elsewhere, it can occasionally be prudent to disallow access to this list of users to unauthenticated users. Note: this should not _replace_ any of the other methods of avoiding attacks described above. Good site security should involve more than simply hiding the list of users on a site (especially when that information is already available, for example, in the site's HTML markup).
 
-Refer to the [WordPress Best Practices](/guides/wordpress-developer/wordpress-best-practices#block-anonymous-access-to-the-users-wordpress-rest-endpoint) doc for a code snippet that you can use to block anonymous access to `/users`.
+Refer to the [WordPress Best Practices](/guides/wordpress-developer/wordpress-best-practices#option-2-block-only-the-users-wordpress-rest-endpoint) doc for a code snippet that you can use to block anonymous access to `/users`.
 
 ## More Resources
 
 - [Using WP SAML Auth with Google Apps](/guides/wordpress-google-sso/)
 - [WordPress Security](/guides/wordpress-pantheon/wp-security)
 - [Secure Development on Pantheon](/guides/secure-development)
-
-
-

--- a/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
+++ b/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
@@ -71,7 +71,7 @@ SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) to he
 
 The WordPress REST API endpoint at `/wp-json/wp/v2/users` shows a full list of all usernames on a WordPress site and associated metadata for users who have at least one published post in a public post type. While this information is available elsewhere, it can occasionally be prudent to disallow access to this list of users to unauthenticated users. Note: this should not _replace_ any of the other methods of avoiding attacks described above. Good site security should involve more than simply hiding the list of users on a site (especially when that information is already available, for example, in the site's HTML markup).
 
-Refer to the [WordPress Best Practices](/guids/wordpress-developer/wordpress-best-practices#block-anonymous-access-to-the-users-wordpress-rest-endpoint) doc for a code snippet that you can use to block anonymous access to `/users`.
+Refer to the [WordPress Best Practices](/guides/wordpress-developer/wordpress-best-practices#block-anonymous-access-to-the-users-wordpress-rest-endpoint) doc for a code snippet that you can use to block anonymous access to `/users`.
 
 ## More Resources
 

--- a/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
+++ b/source/content/guides/wordpress-developer/05-wordpress-login-attacks.md
@@ -67,6 +67,12 @@ SSO often includes or requires [MFA](#add-multi-factor-authentication-mfa) to he
 
 1. Optional. Use plugins, such as [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) or [MiniOrange](https://plugins.miniorange.com/wordpress), to simplify the SSO integration with your IdP.
 
+### Block the `/users` REST Endpoint for Unauthenticated Users
+
+The WordPress REST API endpoint at `/wp-json/wp/v2/users` shows a full list of all usernames on a WordPress site and associated metadata for users who have at least one published post in a public post type. While this information is available elsewhere, it can occasionally be prudent to disallow access to this list of users to unauthenticated users. Note: this should not _replace_ any of the other methods of avoiding attacks described above. Good site security should involve more than simply hiding the list of users on a site (especially when that information is already available, for example, in the site's HTML markup).
+
+Refer to the [WordPress Best Practices](/guids/wordpress-developer/wordpress-best-practices#block-anonymous-access-to-the-users-wordpress-rest-endpoint) doc for a code snippet that you can use to block anonymous access to `/users`.
+
 ## More Resources
 
 - [Using WP SAML Auth with Google Apps](/guides/wordpress-google-sso/)


### PR DESCRIPTION
Fixes #8314 

## Summary

* **[WordPress Best Practices](https://docs.pantheon.io/guides/wordpress-developer/wordpress-best-practices)** - Adds a section on how to add a filter which blocks access to the `/users` endpoint for unauthenticated users.
* **[Avoid WordPress Login Attacks](https://docs.pantheon.io/guides/wordpress-developer/wordpress-login-attacks)** - Adds a section about blocking anonymous access to the `/users` endpoint, and why you might want to do it, which links back to the above section in the Best Practices doc.
