### PR TITLE
[SITE-988] Remove Early Access notes from WP Composer documentation

### DIFF
--- a/source/content/certification/study-guide-cms/09-automate.md
+++ b/source/content/certification/study-guide-cms/09-automate.md
@@ -79,7 +79,7 @@ Pantheon offers several paths to help you launch a Drupal site that leverages In
 * If you are using a deprecated Pantheon Drupal Upstream and would like to convert your site from one of the deprecated upstreams to the supported `drupal-composer-managed` upstream, you can use the [Terminus Conversion Tools Plugin](https://github.com/pantheon-systems/terminus-conversion-tools-plugin).
 
 ### WordPress with Integrated Composer
-Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create an Integrated Composer WordPress site with Bedrock. This upstream is currently in EA.
+Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create an Integrated Composer WordPress site with Bedrock.
 
 #### Adding and Removing Dependencies with Integrated Composer
 

--- a/source/content/guides/integrated-composer/01-introduction.md
+++ b/source/content/guides/integrated-composer/01-introduction.md
@@ -44,7 +44,7 @@ You can use the [Terminus Conversion Tools Plugin](https://github.com/pantheon-s
 
 <Alert title="Note" type="info">
 
-Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create an Integrated Composer WordPress site with **Bedrock**. This upstream is currently in EA.
+Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create an Integrated Composer WordPress site with **Bedrock**.
 
 </Alert>
 

--- a/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
+++ b/source/content/guides/wordpress-composer/02-wordpress-composer-managed.md
@@ -17,12 +17,6 @@ permalink: docs/guides/wordpress-composer/wordpress-composer-managed
 anchorid: wordpress-composer-managed
 ---
 
-<Alert title="Early Access" type="info" icon="leaf">
-
-The WordPress Composer Managed upstream is available for [Early Access](/oss-support-levels#early-access) participants. Features for WordPress Composer Managed are in active development. Pantheon's development team is rolling out new functionality often while this product is in Early Access. Visit [our community Slack](https://pantheon-community.slack.com/) if you don't already have an account) to connect with other Pantheon users also using the upstream (you can sign up for the [Pantheon Slack channel here](https://slackin.pantheon.io/)). Please review Pantheon's [Software Evaluation Licensing Terms](https://legal.pantheon.io/#contract-hkqlbwpxo) for more information about access to our software.
-
-</Alert>
-
 This section provides information on how to use Bedrock with Integrated Composer on a WordPress site.
 
 WordPress does not natively support [Composer](https://getcomposer.org/), however, [Bedrock](https://roots.io/bedrock/) is a WordPress-specific framework for using Composer on WordPress sites.

--- a/source/content/guides/wordpress-composer/03-create-wp-site-composer-ci-auto-test.md
+++ b/source/content/guides/wordpress-composer/03-create-wp-site-composer-ci-auto-test.md
@@ -19,7 +19,7 @@ This section provides steps to create a new Pantheon WordPress site that will us
 
 <Alert title="Note" type="info">
 
-Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create a Composer-managed WordPress site with **Bedrock**. This upstream is currently in EA and **Terminus Build Tools** does not currently support the Bedrock-based WordPress (Composer Managed) upstream.
+Pantheon has a [WordPress (Composer Managed)](/guides/wordpress-composer/wordpress-composer-managed) upstream. You can use this upstream to create a Composer-managed WordPress site with **Bedrock**. **Terminus Build Tools** does not currently support the Bedrock-based WordPress (Composer Managed) upstream.
 
 </Alert >
 


### PR DESCRIPTION
## Summary

**[Create a Composer-managed WordPress Site with Bedrock](https://docs.pantheon.io/guides/wordpress-composer/wordpress-composer-managed)** - Removes the early access note at the top of the article

**[Create a Composer-managed WordPress Site with Terminus Build Tools](https://docs.pantheon.io/guides/wordpress-composer/create-wp-site-composer-ci-auto-test)** - Removes reference to WP (Composer Managed) upstream being in EA

**Note:** Release note about General Availability to follow in subsequent separate PR.
