### PR TITLE
Removed Solr v8.0 mention from WordPress Pantheon Search guide

### DIFF
--- a/source/content/guides/wordpress-developer/10-wordpress-solr.md
+++ b/source/content/guides/wordpress-developer/10-wordpress-solr.md
@@ -20,7 +20,6 @@ This section provides information on how to use Apache Solr with your WordPress 
 
 [Apache Solr](/solr) is a system for indexing and searching site content. All plans except for Basic can use Pantheon Solr.
 
-<!--<Partial file="solr-version.md" />-->
 Currently, Pantheon provides Apache Solr v3.6 for WordPress search for all plans except the Basic plan.
 
 <Enablement title="Get WebOps Training" link="https://pantheon.io/learn-pantheon?docs">

--- a/source/content/guides/wordpress-developer/10-wordpress-solr.md
+++ b/source/content/guides/wordpress-developer/10-wordpress-solr.md
@@ -10,17 +10,18 @@ audience: [development]
 product: [search]
 integration: [plugins]
 tags: [solr, plugins]
-contributors: [cityofoaksdesign]
+contributors: [cityofoaksdesign, ccharlton]
 showtoc: true
 permalink: docs/guides/wordpress-developer/wordpress-solr
-reviewed: "2022-12-13"
+reviewed: "2024-09-09"
 ---
 
 This section provides information on how to use Apache Solr with your WordPress Pantheon site.
 
 [Apache Solr](/solr) is a system for indexing and searching site content. All plans except for Basic can use Pantheon Solr.
 
-<Partial file="solr-version.md" />
+<!--<Partial file="solr-version.md" />-->
+Currently, Pantheon provides Apache Solr v3.6 for WordPress search for all plans except the Basic plan.
 
 <Enablement title="Get WebOps Training" link="https://pantheon.io/learn-pantheon?docs">
 


### PR DESCRIPTION
## Summary

**[Enable Solr for WordPress](https://docs.pantheon.io/guides/wordpress-developer/wordpress-solr)** - WordPress Solr Power plugin only support Solr v3.6, so the partial doc that mentioned we provide v8.0 as well did not apply to WP.