### PR TITLE
pantheon-mu-plugin 1.5.1 release note

### DIFF
--- a/source/releasenotes/2024-09-09-pantheon-mu-plugin-1-5-1.md
+++ b/source/releasenotes/2024-09-09-pantheon-mu-plugin-1-5-1.md
@@ -1,13 +1,13 @@
 ---
-title: Pantheon MU Plugin v1.5.1 release 
+title: Pantheon MU Plugin v1.5.1 release
 published_date: "2024-09-09"
 categories: [wordpress, plugins]
 ---
 
-The Pantheon MU Plugin [v1.5.1](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) update is now available. This latest update is included with next version of WordPress and can be installed on [WordPress (composer managed)](https://docs.pantheon.io/guides/wordpress-composer) installs using `composer update` or by checking for updates in the dashboard.
+The Pantheon MU Plugin [v1.5.1](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) update is now available for composer based WordPress sites. For non-composer based WordPress sites, this latest update will be bundled with the next WordPress core update. [WordPress (composer managed)](/guides/wordpress-composer) sites can upgrade today using `composer update` or by checking for updates in the dashboard.
 
 ### What's new?
 
-This update adds two new plugin additions to the compatibility layer feature warning of potential issues with [PhastPress](https://docs.pantheon.io/plugins-known-issues#phastpress) and [WP Cerber](https://docs.pantheon.io/plugins-known-issues#wp-cerber-security-antispam--malware-scan).
+This update adds two new plugin additions to the compatibility layer feature warning of potential issues with [PhastPress](/plugins-known-issues#phastpress) and [WP Cerber](/plugins-known-issues#wp-cerber-security-antispam--malware-scan).
 
 Additionally, this release updates some of the content in the WordPress multisite setup screens and adds filters to allow for the customization of the location of the WordPress configuration file and the "Happy publishing" comment typically found in `wp-config.php` files.

--- a/source/releasenotes/2024-09-09-pantheon-mu-plugin-1-5-1.md
+++ b/source/releasenotes/2024-09-09-pantheon-mu-plugin-1-5-1.md
@@ -1,0 +1,13 @@
+---
+title: Pantheon MU Plugin v1.5.1 release 
+published_date: "2024-09-09"
+categories: [wordpress, plugins]
+---
+
+The Pantheon MU Plugin [v1.5.1](https://github.com/pantheon-systems/pantheon-mu-plugin/releases) update is now available. This latest update is included with next version of WordPress and can be installed on [WordPress (composer managed)](https://docs.pantheon.io/guides/wordpress-composer) installs using `composer update` or by checking for updates in the dashboard.
+
+### What's new?
+
+This update adds two new plugin additions to the compatibility layer feature warning of potential issues with [PhastPress](https://docs.pantheon.io/plugins-known-issues#phastpress) and [WP Cerber](https://docs.pantheon.io/plugins-known-issues#wp-cerber-security-antispam--malware-scan).
+
+Additionally, this release updates some of the content in the WordPress multisite setup screens and adds filters to allow for the customization of the location of the WordPress configuration file and the "Happy publishing" comment typically found in `wp-config.php` files.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for the [1.5.1 release](https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.5.1) of the pantheon-mu-plugin.
