### PR TITLE
[SITE-2088] WordPress 6.6.2 Release Note

### DIFF
--- a/source/releasenotes/2024-09-10-wordpress-662.md
+++ b/source/releasenotes/2024-09-10-wordpress-662.md
@@ -10,7 +10,7 @@ The latest version of WordPress, [6.6.2](https://wordpress.org/news/2024/09/word
 Upgrade to WordPress 6.6.2 right from your Pantheon dashboard or Terminus for the latest fixes. For details, see [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
 
 ## New compatibility layer in Pantheon MU plugin
-This release also includes an update to the Pantheon MU plugin, introducing a new "comptibility layer" designed to enhance the compatibility of your site’s plugins. For more information, see [this release note for the MU plugin](/release-notes/2024/07/pantheon-mu-plugin-1-5-0).
+This release also includes an update to the Pantheon MU plugin, introducing a new "compatibility layer" designed to enhance the compatibility of your site’s plugins. For more information, see [this release note for the MU plugin](/release-notes/2024/07/pantheon-mu-plugin-1-5-0).
 
 ### Release highlights
 * [15 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!61982&milestone=6.6.2&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=id)

--- a/source/releasenotes/2024-09-10-wordpress-662.md
+++ b/source/releasenotes/2024-09-10-wordpress-662.md
@@ -1,0 +1,17 @@
+---
+title: WordPress 6.6.2 release
+published_date: "2024-09-10"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.6.2](https://wordpress.org/news/2024/09/wordpress-6-6-2-maintenance-release/), became available on Pantheon as of September 10, 2024.
+
+### Action required
+Upgrade to WordPress 6.6.2 right from your Pantheon dashboard or Terminus for the latest fixes. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+## New Compatibility Layer in Pantheon MU Plugin
+This release also includes an update to the Pantheon MU plugin introducing a new "comptibility layer" feature designed to enhance the compatibility of your site’s plugins. For details, see [this release note for the MU plugin](/release-notes/2024/07/pantheon-mu-plugin-1-5-0).
+
+### Release Highlights
+* [15 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!61982&milestone=6.6.2&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=id)
+* [11 bug fixes in the Block Editor](https://core.trac.wordpress.org/ticket/61982#comment:5)

--- a/source/releasenotes/2024-09-10-wordpress-662.md
+++ b/source/releasenotes/2024-09-10-wordpress-662.md
@@ -7,11 +7,11 @@ categories: [wordpress, action-required]
 The latest version of WordPress, [6.6.2](https://wordpress.org/news/2024/09/wordpress-6-6-2-maintenance-release/), became available on Pantheon as of September 10, 2024.
 
 ### Action required
-Upgrade to WordPress 6.6.2 right from your Pantheon dashboard or Terminus for the latest fixes. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+Upgrade to WordPress 6.6.2 right from your Pantheon dashboard or Terminus for the latest fixes. For details, see [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
 
-## New Compatibility Layer in Pantheon MU Plugin
-This release also includes an update to the Pantheon MU plugin introducing a new "comptibility layer" feature designed to enhance the compatibility of your site’s plugins. For details, see [this release note for the MU plugin](/release-notes/2024/07/pantheon-mu-plugin-1-5-0).
+## New compatibility layer in Pantheon MU plugin
+This release also includes an update to the Pantheon MU plugin, introducing a new "comptibility layer" designed to enhance the compatibility of your site’s plugins. For more information, see [this release note for the MU plugin](/release-notes/2024/07/pantheon-mu-plugin-1-5-0).
 
-### Release Highlights
+### Release highlights
 * [15 bug fixes in Core](https://core.trac.wordpress.org/query?status=closed&id=!61982&milestone=6.6.2&group=status&col=id&col=summary&col=owner&col=type&col=priority&col=component&col=version&col=keywords&order=id)
 * [11 bug fixes in the Block Editor](https://core.trac.wordpress.org/ticket/61982#comment:5)


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for WordPress 6.6.2

https://pr-9216-documentation.appa.pantheon.site/release-notes/2024/09/wordpress-662

- [x] https://github.com/pantheon-systems/WordPress/pull/405