### PR TITLE
Support terminus release 3.6.0

### DIFF
--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 3.5.2            | August 19, 2024    |                    |
+| 3.6.0            | September 19, 2024 |                    |
+| 3.5.2            | August 19, 2024    | September 19, 2025 |
 | 3.5.1            | June 13, 2024      | August 19, 2025    |
 | 3.5.0            | June 6, 2024       | June 13, 2025      |
 | 3.4.0            | April 23, 2024     | June 6, 2025       |


### PR DESCRIPTION
## Summary

**[Terminus v3.6.0](/terminus/supported-terminus)** - Add EOL date for Terminus 3.6.0

## Effect

The following changes are already committed:

* https://github.com/pantheon-systems/terminus/pull/2628

**Release**:
- [X] When ready

--------------------------------------------------

## Post Launch

**Do not remove** - To be completed by the docs team upon merge:

- [ ] Redirect `/old-path/` => `/new-path/` (if applicable)
- [ ] Include/exclude pages ^ respectively within docs search service provider (if applicable)
- [ ] For Heroes - add a props post to the [discussion board](https://discuss.pantheon.io/c/pantheon-platform/documentation/17).
- [ ] Remove from the [project board](https://github.com/pantheon-systems/documentation/projects/14)

