### PR TITLE
D7 Long-Term Support

### DIFF
--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -43,7 +43,7 @@ Refer to [Create a New CMS Site](/add-site-dashboard) for how to create a new Dr
 Drupal 7 will reach it's end of life on January 5, 2025. Pantheon has partnered with Tag1 Consulting to offer Long-Term Support for Drupal 7 through January 5, 2027.
 
 #### What's included
-* Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](https://github.com/pantheon-systems/drops-7) via [the Pantheon Dashboard or Terminus command line tool](/core-updates).
+* Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](https://github.com/pantheon-systems/drops-7) via [the Pantheon Dashboard](core-updates#apply-upstream-updates-via-the-site-dashboard) or [Terminus command line tool](/core-updates#apply-upstream-updates-via-terminus).
 * Security patches and compatibility updates to community-contributed modules that power their site via Tag1’s D7ES module, which will be included in the Upstream.
 * Continued support for Drupal 7-compatible runtime environments on the Pantheon Platform, including PHP, MySQL and other prerequisites.
 

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -21,7 +21,7 @@ The following table indicates availability of the specified Drupal version, as w
 | 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
 | 9           |<span style="color:green">✔</span> <Popover title="Drupal 9 Availability" content="Drupal 9 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
 | 8           |<span style="color:green">✔</span> <Popover title="Drupal 8 Availability" content="Drupal 8 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
-| 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span>          |
+| 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span> <Popover title="Drupal 7 LTS" content="Pantheon offers Long-Term Support for Drupal 7 sites on the platform at no extra cost. For more information, see the <a href='#drupal-7-long-term-support'>section below.</a>" />        |
 | 6           | ❌          | ❌           | ❌          |
 
 ## Drupal 10 and 11 on Pantheon
@@ -35,6 +35,21 @@ Drupal 8 and 9 are not available as an option during site creation in the Panthe
 ```bash{promptUser: user}
 terminus site:create <site> <label> drupal8
 ```
+
+## Drupal 7 on Pantheon
+Refer to [Create a New CMS Site](/add-site-dashboard) for how to create a new Drupal 7 site from the Pantheon dashboard.
+
+### Drupal 7 Long-Term Support
+Drupal 7 will reach it's end of life on January 5, 2025. Pantheon has partnered with Tag1 Consulting to offer Long-Term Support for Drupal 7 through January 5, 2027.
+
+#### What's included
+* Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](/core-updates) via the Pantheon Dashboard or Terminus command line tool.
+* Security patches and compatibility updates to community-contributed modules that power their site via Tag1’s D7ES module, which will be included in the Upstream.
+* Continued support for Drupal 7-compatible runtime environments on the Pantheon Platform, including PHP, MySQL and other prerequisites.
+
+To learn more about this partnership, see related blog post: [Pantheon and Tag1 Consulting Partner to Provide Long-Term Support for Drupal 7 Websites ](https://pantheon.io/blog/pantheon-and-tag1-support-drupal-7-websites).
+
+To learn more about migrating from Drupal 7 to the latest version of Drupal, see [this guide](https://pantheon.io/resources/guide/drupal-7-end-life-why-you-should-start-your-migration-drupal-10-today).
 
 ## Drush Version Support
 

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -10,7 +10,7 @@ cms: [drupal]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2024-10-04"
+reviewed: "2024-10-09"
 ---
 
 The following table indicates availability of the specified Drupal versions, as well as our usage recommendations and our support scope.

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -10,7 +10,7 @@ cms: [drupal]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2024-10-09"
+reviewed: "2024-10-08"
 ---
 
 The following table indicates availability of the specified Drupal versions, as well as our usage recommendations and our support scope.

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -43,7 +43,7 @@ Refer to [Create a New CMS Site](/add-site-dashboard) for how to create a new Dr
 Drupal 7 will reach it's end of life on January 5, 2025. Pantheon has partnered with Tag1 Consulting to offer Long-Term Support for Drupal 7 through January 5, 2027.
 
 #### What's included
-* Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](/core-updates) via the Pantheon Dashboard or Terminus command line tool.
+* Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](https://github.com/pantheon-systems/drops-7) via [the Pantheon Dashboard or Terminus command line tool](/core-updates).
 * Security patches and compatibility updates to community-contributed modules that power their site via Tag1’s D7ES module, which will be included in the Upstream.
 * Continued support for Drupal 7-compatible runtime environments on the Pantheon Platform, including PHP, MySQL and other prerequisites.
 

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -44,7 +44,7 @@ Drupal 7 will reach it's end of life on January 5, 2025. Pantheon has partnered 
 
 #### What's included
 * Security and compatibility updates to Drupal core and core dependencies from Tag1 Consulting by updating their site running on the [Pantheon Drupal 7 Upstream](https://github.com/pantheon-systems/drops-7) via [the Pantheon Dashboard](core-updates#apply-upstream-updates-via-the-site-dashboard) or [Terminus command line tool](/core-updates#apply-upstream-updates-via-terminus).
-* Security patches and compatibility updates to community-contributed modules that power their site via Tag1’s D7ES module, which will be included in the Upstream.
+* Security patches and compatibility updates to community-contributed modules that power their site via Tag1’s D7 Extended Support (D7ES) module, which will be included in the Upstream.
 * Continued support for Drupal 7-compatible runtime environments on the Pantheon Platform, including PHP, MySQL and other prerequisites.
 
 To learn more about this partnership, see related blog post: [Pantheon and Tag1 Consulting Partner to Provide Long-Term Support for Drupal 7 Websites ](https://pantheon.io/blog/pantheon-and-tag1-support-drupal-7-websites).

--- a/source/content/supported-drupal.md
+++ b/source/content/supported-drupal.md
@@ -13,9 +13,9 @@ integration: [--]
 reviewed: "2024-10-04"
 ---
 
-The following table indicates availability of the specified Drupal version, as well as our usage recommendations and our support scope.
+The following table indicates availability of the specified Drupal versions, as well as our usage recommendations and our support scope.
 
-| Drupal Version | Available | Recommended | Supported |
+| Drupal version | Available | Recommended | Supported |
 | ----------- | :---------: | :---------: | :---------: |
 | 11          | <span style="color:green">✔</span> | <span style="color:green">✔</span>           | <span style="color:green">✔</span>
 | 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
@@ -30,7 +30,7 @@ Refer to [Create a New CMS Site](/add-site-dashboard) for how to create a new Dr
 If you already have a Drupal 10 site on Pantheon, you can upgrade your existing site to [Drupal 11 via Composer](https://www.drupal.org/docs/upgrading-drupal/upgrading-from-drupal-8-or-later/how-to-upgrade-from-drupal-10-to-drupal-11).
 
 ## Drupal 8 and 9 on Pantheon
-Drupal 8 and 9 are not available as an option during site creation in the Pantheon dashboard, however they can still be created on the platform using [Terminus](/terminus). For example:
+Drupal 8 and 9 are not available as an option during site creation in the Pantheon dashboard. However, they can still be created on the platform using [Terminus](/terminus). For example:
 
 ```bash{promptUser: user}
 terminus site:create <site> <label> drupal8
@@ -39,7 +39,7 @@ terminus site:create <site> <label> drupal8
 ## Drupal 7 on Pantheon
 Refer to [Create a New CMS Site](/add-site-dashboard) for how to create a new Drupal 7 site from the Pantheon dashboard.
 
-### Drupal 7 Long-Term Support
+### Drupal 7 long-term support
 Drupal 7 will reach it's end of life on January 5, 2025. Pantheon has partnered with Tag1 Consulting to offer Long-Term Support for Drupal 7 through January 5, 2027.
 
 #### What's included
@@ -51,7 +51,7 @@ To learn more about this partnership, see related blog post: [Pantheon and Tag1 
 
 To learn more about migrating from Drupal 7 to the latest version of Drupal, see [this guide](https://pantheon.io/resources/guide/drupal-7-end-life-why-you-should-start-your-migration-drupal-10-today).
 
-## Drush Version Support
+## Drush version support
 
 Refer to [Manage Drush Versions on Pantheon](/guides/drush/drush-versions/) for information on Drush versions that are compatible with each Drupal version.
 

--- a/source/releasenotes/2024-10-08-drupal-7-lts.md
+++ b/source/releasenotes/2024-10-08-drupal-7-lts.md
@@ -1,6 +1,6 @@
 ---
 title: "Drupal 7 Long-Term Support through 2027"
-published_date: "2024-10-09"
+published_date: "2024-10-08"
 categories: [drupal, security]
 ---
 Pantheon has committed to provide security updates to Drupal 7 sites for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.

--- a/source/releasenotes/2024-10-08-drupal-7-lts.md
+++ b/source/releasenotes/2024-10-08-drupal-7-lts.md
@@ -1,6 +1,6 @@
 ---
 title: "Drupal 7 Long-Term Support through 2027"
-published_date: "2024-10-04"
+published_date: "2024-10-08"
 categories: [drupal, security]
 ---
 Drupal 7 sites on Pantheon will continue to receive security updates for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.

--- a/source/releasenotes/2024-10-08-drupal-7-lts.md
+++ b/source/releasenotes/2024-10-08-drupal-7-lts.md
@@ -1,0 +1,8 @@
+---
+title: "Drupal 7 Long-Term Support through 2027"
+published_date: "2024-10-04"
+categories: [drupal, security]
+---
+Drupal 7 sites on Pantheon will continue to receive security updates for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.
+
+To learn more about whats included in this offering, see [related documentation](/supported-drupal/#drupal-7-long-term-support).

--- a/source/releasenotes/2024-10-09-drupal-7-lts.md
+++ b/source/releasenotes/2024-10-09-drupal-7-lts.md
@@ -3,6 +3,6 @@ title: "Drupal 7 Long-Term Support through 2027"
 published_date: "2024-10-09"
 categories: [drupal, security]
 ---
-Drupal 7 sites on Pantheon will continue to receive security updates for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.
+Pantheon has committed to provide security updates to Drupal 7 sites for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.
 
 To learn more about whats included in this offering, see [related documentation](/supported-drupal/#drupal-7-long-term-support).

--- a/source/releasenotes/2024-10-09-drupal-7-lts.md
+++ b/source/releasenotes/2024-10-09-drupal-7-lts.md
@@ -1,6 +1,6 @@
 ---
 title: "Drupal 7 Long-Term Support through 2027"
-published_date: "2024-10-08"
+published_date: "2024-10-09"
 categories: [drupal, security]
 ---
 Drupal 7 sites on Pantheon will continue to receive security updates for at least 2 additional years beyond it's upcoming end of life date on January 5, 2025. Pantheon is partnering with Tag1 Consulting to offer Long-Term Support (LTS) for Drupal 7 at no additional cost through at least January 5, 2027.


### PR DESCRIPTION
Closes #9224 
## Summary

* [Supported Drupal Versions](https://pr-9244-documentation.appa.pantheon.site/supported-drupal#drupal-7-long-term-support) 
  * Added tooltip next to ✅ for D7 Support for crosslink to the new D7 header below 
  * Added new subsection for D7 which includes LTS specs and crosslinks to marketing migration guide 

* New release note:
  * [Drupal 7 Long-Term Support through 2027](https://pr-9244-documentation.appa.pantheon.site/release-notes/2024/10/drupal-7-lts)