### PR TITLE
BUG-9246 — Fix mobile menu

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,6 +1,10 @@
 import React from "react"
 import { location, globalHistory } from "@reach/router"
 
+// Import PDS Global wrapper for applying global context providers.
+import { GlobalWrapper } from "@pantheon-systems/pds-toolkit-react"
+import { MOBILE_MENU_BREAKPOINT } from './src/vars/responsive'
+
 // Import PDS core styles.
 import "./node_modules/@pantheon-systems/pds-toolkit-react/_dist/css/pds-core.css"
 import "./node_modules/@pantheon-systems/pds-toolkit-react/_dist/css/pds-layouts.css"
@@ -41,4 +45,9 @@ export const onRouteUpdate = () => {
 // Trigger resize event once rendered
 export const onInitialClientRender = () => {
   window.dispatchEvent(new Event("resize"))
+}
+
+// Global context providers
+export const wrapRootElement = ({ element }) => {
+  return <GlobalWrapper mobileMenuMaxWidth={MOBILE_MENU_BREAKPOINT}>{element}</GlobalWrapper>
 }

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -1,5 +1,9 @@
 import React from 'react'
 
+// Import PDS Global wrapper for applying global context providers.
+import { GlobalWrapper } from "@pantheon-systems/pds-toolkit-react"
+import { MOBILE_MENU_BREAKPOINT } from './src/vars/responsive'
+
 /*
  * Add global scripts to ensure Bootstrap and jQuery JS is included
  */
@@ -14,4 +18,9 @@ export const onRenderBody = ({ setPostBodyComponents }) => {
         window.dataLayer.push({'event':'OneTrustGroupsUpdated'})
       }
   ])
+}
+
+// Global context providers
+export const wrapRootElement = ({ element }) => {
+  return <GlobalWrapper mobileMenuMaxWidth={MOBILE_MENU_BREAKPOINT}>{element}</GlobalWrapper>
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -4128,22 +4128,23 @@
       }
     },
     "node_modules/@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.134",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.134.tgz",
-      "integrity": "sha512-3lnbRwnRTj2yZ/wpnpWAtcEDuXV9Be3mewM89xWIRoXNQ7srUyvFbj0NNNr/VegioT+Ftg1MMQWWfPJoGYbeuw==",
+      "version": "1.0.0-dev.140",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.140.tgz",
+      "integrity": "sha512-ZgB5H5ZYwNoO+e4kJVBF+s1sTjX9DswTFIAj9TXe3DwqGEv/c2XQMHeyjqaKRS6Cbe6Ts8gIBllIu4clIHxcDQ==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.138",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.138.tgz",
-      "integrity": "sha512-dGRT5tapGBggyvdk0fV6xbpI5V5PsIXlP5NLC1yGPyoImKA7FK8H6InhLNkGD/YmR/nIDl7uBsFkEOBTK20UrA==",
+      "version": "1.0.0-dev.168",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.168.tgz",
+      "integrity": "sha512-WVkvYbetfl+A8fB8qVx1NtUvszDRgAXDCWTe48NW76ynR+yc/JQX3EiP5C2BR5/yElpwJIt3FXsgRDuYGC7dcQ==",
       "dependencies": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
-        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.134",
+        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.140",
         "@reactuses/core": "^5.0.15",
         "focus-trap-react": "^10.2.1",
         "hash-sum": "^2.0.0",
+        "react-hotkeys-hook": "^4.5.1",
         "react-router-dom": "^6.13.0",
         "react-toastify": "^9.0.3"
       },
@@ -4204,6 +4205,16 @@
         "prop-types": "^15.8.1",
         "react": ">=16.3.0",
         "react-dom": ">=16.3.0"
+      }
+    },
+    "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/react-hotkeys-hook": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz",
+      "integrity": "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": ">=16.8.1",
+        "react-dom": ">=16.8.1"
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/react-router-dom": {
@@ -29193,21 +29204,22 @@
       }
     },
     "@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.134",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.134.tgz",
-      "integrity": "sha512-3lnbRwnRTj2yZ/wpnpWAtcEDuXV9Be3mewM89xWIRoXNQ7srUyvFbj0NNNr/VegioT+Ftg1MMQWWfPJoGYbeuw=="
+      "version": "1.0.0-dev.140",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.140.tgz",
+      "integrity": "sha512-ZgB5H5ZYwNoO+e4kJVBF+s1sTjX9DswTFIAj9TXe3DwqGEv/c2XQMHeyjqaKRS6Cbe6Ts8gIBllIu4clIHxcDQ=="
     },
     "@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.138",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.138.tgz",
-      "integrity": "sha512-dGRT5tapGBggyvdk0fV6xbpI5V5PsIXlP5NLC1yGPyoImKA7FK8H6InhLNkGD/YmR/nIDl7uBsFkEOBTK20UrA==",
+      "version": "1.0.0-dev.168",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.168.tgz",
+      "integrity": "sha512-WVkvYbetfl+A8fB8qVx1NtUvszDRgAXDCWTe48NW76ynR+yc/JQX3EiP5C2BR5/yElpwJIt3FXsgRDuYGC7dcQ==",
       "requires": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
-        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.134",
+        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.140",
         "@reactuses/core": "^5.0.15",
         "focus-trap-react": "^10.2.1",
         "hash-sum": "^2.0.0",
+        "react-hotkeys-hook": "^4.5.1",
         "react-router-dom": "^6.13.0",
         "react-toastify": "^9.0.3"
       },
@@ -29248,6 +29260,12 @@
             "focus-trap": "^7.5.4",
             "tabbable": "^6.2.0"
           }
+        },
+        "react-hotkeys-hook": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz",
+          "integrity": "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==",
+          "requires": {}
         },
         "react-router-dom": {
           "version": "6.22.3",

--- a/src/layout/SearchBar/index.js
+++ b/src/layout/SearchBar/index.js
@@ -2,7 +2,7 @@ import React from "react"
 import { Link } from "gatsby"
 
 import AddSearch from "../../components/addSearch"
-import { InputText } from "@pantheon-systems/pds-toolkit-react"
+import { TextInput } from "@pantheon-systems/pds-toolkit-react"
 
 import "./style.css"
 
@@ -16,13 +16,13 @@ const SearchBar = ({ page }) => (
     title="Search Pantheon Documentation"
     className="pds-spacing-pad-block-start-l pds-spacing-pad-block-end-2xl"
   >
-    <InputText
+    <TextInput
       id="search"
-      aria-label="Search Pantheon Documentation"
       placeholder="Search Pantheon Documentation"
       type="search"
       data-addsearch-id="search_widget"
-      label=" "
+      label="Search Pantheon Documentation"
+      showLabel={false}
     />
     {page == "default" ? <AddSearch /> : null}
   </form>

--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -6,6 +6,8 @@ import {
   NavMenu,
 } from "@pantheon-systems/pds-toolkit-react"
 
+import { MOBILE_MENU_BREAKPOINT } from '../../vars/responsive'
+
 import "./style.css"
 
 // Links for NavMenu component.
@@ -118,7 +120,6 @@ const mainNavigationLinks = [
   },
 ]
 
-const mobileMenuBreakpoint = 900
 
 const Header = ({ page }) => (
   <>
@@ -126,12 +127,12 @@ const Header = ({ page }) => (
       Skip to main content
     </a>
 
-    <Navbar mobileMenuMaxWidth={mobileMenuBreakpoint}>
+    <Navbar>
       <NavMenu
         slot="items-left"
         ariaLabel="Main Navigation"
         menuItems={mainNavigationLinks}
-        mobileMenuMaxWidth={mobileMenuBreakpoint}
+        mobileMenuMaxWidth={MOBILE_MENU_BREAKPOINT}
       />
       <div slot="items-right" className="pds-button-group">
         <a

--- a/src/vars/responsive.js
+++ b/src/vars/responsive.js
@@ -1,0 +1,1 @@
+export const MOBILE_MENU_BREAKPOINT = 900


### PR DESCRIPTION
## Summary
Fixes: #9246 
- Updates pds-toolkit-react to dev.168
- Adds PDS GlobalWrapper (which includes the PDS `ResponsiveContext` provider)
- Creates `MOBILE_MENU_BREAKPOINT` to apply to items not yet handled by `ResponsiveContext`


### Bonus update: 
- Update PDS `InputText` for `TextInput` — the former is deprecated and will be removed before PDS 1.0.0 release. 
