### PR TITLE
Deprecate Edge Integrations docs

### DIFF
--- a/source/content/guides/edge-integrations/01-introduction.md
+++ b/source/content/guides/edge-integrations/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Introduction [Deprecated]
+subtitle: Introduction [Archived]
 description: A modern approach to audience-based content personalization.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -20,7 +20,7 @@ reviewed: "2024-10-09"
 
 <Alert title="Warning" type="danger">
 
-This page is considered deprecated.
+This page has been archived. The content is no longer maintained and may be outdated.
 
 The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived.
 

--- a/source/content/guides/edge-integrations/01-introduction.md
+++ b/source/content/guides/edge-integrations/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Introduction
+subtitle: Introduction [Deprecated]
 description: A modern approach to audience-based content personalization.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -15,8 +15,18 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2022-03-23"
+reviewed: "2024-10-09"
 ---
+
+<Alert title="Warning" type="danger">
+
+This page is considered deprecated.
+
+The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived.
+
+While the integrations are still available with Pantheon Advanced Global CDN, and the code remains available, the SDKs are no longer actively developed or supported.
+
+</Alert>
 
 This guide is made to facilitate the onboarding process for developers who are implementing content personalization via Pantheon's [Advanced Global CDN](/guides/professional-services/advanced-global-cdn) into their own Drupal or WordPress website. 
 

--- a/source/content/guides/edge-integrations/02-configuration-overview.md
+++ b/source/content/guides/edge-integrations/02-configuration-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Configuration Overview
+subtitle: Configuration Overview [Deprecated]
 description: An overview of how to configure the pieces of Edge Integrations.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -8,7 +8,6 @@ type: guide
 showtoc: true
 permalink: docs/guides/edge-integrations/configuration-overview/
 editpath: edge-integrations/02-configuration-overview.md
-reviewed: "2022-03-23"
 contenttype: [guide]
 innav: [false]
 categories: [personalization]
@@ -16,8 +15,18 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-
+reviewed: "2024-10-09"
 ---
+
+<Alert title="Warning" type="danger">
+
+This page is considered deprecated.
+
+The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived.
+
+While the integrations are still available with Pantheon Advanced Global CDN, and the code remains available, the SDKs are no longer actively developed or supported.
+
+</Alert>
 
 ## Prerequisites
 

--- a/source/content/guides/edge-integrations/02-configuration-overview.md
+++ b/source/content/guides/edge-integrations/02-configuration-overview.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Configuration Overview [Deprecated]
+subtitle: Configuration Overview [Archived]
 description: An overview of how to configure the pieces of Edge Integrations.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -20,7 +20,7 @@ reviewed: "2024-10-09"
 
 <Alert title="Warning" type="danger">
 
-This page is considered deprecated.
+This page has been archived. The content is no longer maintained and may be outdated.
 
 The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived.
 

--- a/source/content/guides/edge-integrations/03-drupal-sdk.md
+++ b/source/content/guides/edge-integrations/03-drupal-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Drupal SDK
+subtitle: Drupal SDK [Deprecated]
 description: Install, configure, and use Edge Integrations with Drupal.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814, robloach, enotick]
@@ -15,8 +15,18 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2021-03-23"
+reviewed: "2024-10-09"
 ---
+
+<Alert title="Warning" type="danger">
+
+This page is considered deprecated.
+
+The Pantheon Edge Integrations SDK [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) is no longer maintained and those repositories have been archived.
+
+While the integrations are still available with Pantheon Advanced Global CDN, and the code remains available, the SDKs are no longer actively developed or supported.
+
+</Alert>
 
 The Edge Integrations personalization system for Drupal consists of two main parts:
 

--- a/source/content/guides/edge-integrations/03-drupal-sdk.md
+++ b/source/content/guides/edge-integrations/03-drupal-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Drupal SDK [Deprecated]
+subtitle: Drupal SDK [Archived]
 description: Install, configure, and use Edge Integrations with Drupal.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814, robloach, enotick]
@@ -20,7 +20,7 @@ reviewed: "2024-10-09"
 
 <Alert title="Warning" type="danger">
 
-This page is considered deprecated.
+This page has been archived. The content is no longer maintained and may be outdated.
 
 The Pantheon Edge Integrations SDK [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) is no longer maintained and those repositories have been archived.
 

--- a/source/content/guides/edge-integrations/04-wordpress-sdk.md
+++ b/source/content/guides/edge-integrations/04-wordpress-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: WordPress SDK
+subtitle: WordPress SDK [Deprecated]
 description: Install, configure, and use the Edge Integrations with WordPress.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -15,8 +15,18 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2022-03-09"
+reviewed: "2024-10-09"
 ---
+
+<Alert title="Warning" type="danger">
+
+This page is considered deprecated.
+
+The Pantheon Edge Integrations SDK for [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) is no longer maintained and those repositories have been archived.
+
+While the integrations are still available with Pantheon Advanced Global CDN, and the code remains available, the SDKs are no longer actively developed or supported.
+
+</Alert>
 
 This doc will help you personalize and provide custom experiences for visitors to your website, based on Geotargeting and Interest targeting.
 

--- a/source/content/guides/edge-integrations/04-wordpress-sdk.md
+++ b/source/content/guides/edge-integrations/04-wordpress-sdk.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: WordPress SDK [Deprecated]
+subtitle: WordPress SDK [Archived]
 description: Install, configure, and use the Edge Integrations with WordPress.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -20,7 +20,7 @@ reviewed: "2024-10-09"
 
 <Alert title="Warning" type="danger">
 
-This page is considered deprecated.
+This page has been archived. The content is no longer maintained and may be outdated.
 
 The Pantheon Edge Integrations SDK for [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) is no longer maintained and those repositories have been archived.
 

--- a/source/content/guides/edge-integrations/05-analytics.md
+++ b/source/content/guides/edge-integrations/05-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Analytics [Deprecated]
+subtitle: Analytics [Archived]
 description: Integrate Edge Integrations with Google Tag Manager and Google Analytics.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -20,7 +20,7 @@ reviewed: "2024-10-09"
 
 <Alert title="Warning" type="danger">
 
-This page is considered deprecated.
+This page has been archived. The content is no longer maintained and may be outdated.
 
 The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived. Additionally, this guide is written for a version of Google Analytics that may no longer be supported.
 

--- a/source/content/guides/edge-integrations/05-analytics.md
+++ b/source/content/guides/edge-integrations/05-analytics.md
@@ -1,6 +1,6 @@
 ---
 title: Edge Integrations
-subtitle: Analytics
+subtitle: Analytics [Deprecated]
 description: Integrate Edge Integrations with Google Tag Manager and Google Analytics.
 tags: [collaborate, composer, continuous-integrations, webops, workflow]
 contributors: [michellecolon-pantheon, jazzsequence, jspellman814]
@@ -15,8 +15,18 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2022-03-09"
+reviewed: "2024-10-09"
 ---
+
+<Alert title="Warning" type="danger">
+
+This page is considered deprecated.
+
+The Pantheon Edge Integrations SDKs [for Drupal](https://github.com/pantheon-systems/edge-integrations-drupal-sdk) and [WordPress](https://github.com/pantheon-systems/edge-integrations-wordpress-sdk) are no longer maintained and those repositories have been archived. Additionally, this guide is written for a version of Google Analytics that may no longer be supported.
+
+While the integrations are still available with Pantheon Advanced Global CDN, and the code remains available, the SDKs are no longer actively developed or supported.
+
+</Alert>
 
 Pantheon’s Edge Integrations offers advanced and powerful features for content personalization. At this time, two key primary features are supported: Geo and Interest. These features allow us to serve different content to each user at given URLs. Google Analytics won’t differentiate between the personalized versions of a page unless you instruct it otherwise. This section aims to help you enhance your configuration to track personalization experiences via Google Tag Manager.
 

--- a/source/content/guides/fastly-pantheon/01-introduction.md
+++ b/source/content/guides/fastly-pantheon/01-introduction.md
@@ -53,11 +53,7 @@ You can refer to the following docs for common caching issues:
 - [Debug Common Cache Busters](/guides/frontend-performance/caching#troubleshoot-caching-issues)
 - [Traffic Limits and Overages](/guides/account-mgmt/traffic)
 
-You should consult the [Edge Integrations Guide](/guides/edge-integrations/) and complete the appropriate configuration for your WordPress or Drupal site if you plan on using content personalization in addition to Fastly.
-
 ## More Resources
-
-- [Edge Integrations](/guides/edge-integrations/)
 
 - [New Relic Performance Monitoring on Pantheon](/guides/new-relic)
 

--- a/source/content/guides/fastly-pantheon/01-introduction.md
+++ b/source/content/guides/fastly-pantheon/01-introduction.md
@@ -53,6 +53,8 @@ You can refer to the following docs for common caching issues:
 - [Debug Common Cache Busters](/guides/frontend-performance/caching#troubleshoot-caching-issues)
 - [Traffic Limits and Overages](/guides/account-mgmt/traffic)
 
+You should consult the [Edge Integrations Guide](/guides/edge-integrations/) and complete the appropriate configuration for your WordPress or Drupal site if you plan on using content personalization in addition to Fastly.
+
 ## More Resources
 
 - [New Relic Performance Monitoring on Pantheon](/guides/new-relic)

--- a/source/content/modules.md
+++ b/source/content/modules.md
@@ -24,10 +24,6 @@ WordPress users should review [Pantheon Plugins](/guides/wordpress-configuration
 
 The Advanced Page Cache module attaches [Drupal's cache metadata](https://www.drupal.org/docs/8/api/cache-api/cache-api) to a response so that Pantheon's [Global CDN](/guides/global-cdn) edge service can granularly clear new content as it is saved. The Global CDN can detect when underlying data changes, such as nodes and taxonomy terms, then clear pages containing that entity. For details, see [this blog post](https://pantheon.io/blog/pantheon-advanced-page-cache-drupal-cache-metadata-global-cdn).
 
-## Edge Personalization
-
-The [Edge Integrations Drupal module](/guides/edge-integrations/drupal-sdk/) is a Software Development Kit (SDK) that allows users to personalize Drupal. This module uses configuration at the "edge" or the CDN to enable personalization options for Geolocation or Interests. This is done by using HTTP vary headers that tell the CDN to return cached variations of content based on values identified by the user browsing the site.
-
 ## [Generate Errors (Drupal 7)](https://www.drupal.org/project/generate_errors)
 
 Interface which allows you to generate various errors to test system behaviors like custom errors and server responses.

--- a/source/content/products.md
+++ b/source/content/products.md
@@ -102,9 +102,9 @@ Pantheon offers a wide array of products and features to simplify building and m
 
   </Product>
 
-  <Product title={"Personalization"} link={"/guides/edge-integrations/"}>
+  <Product title={"Pantheon Secrets"} link={"/guides/secrets/"}>
 
-  Edge Integrations is a Software Development Kit (SDK) that allows users to personalize WordPress and Drupal. 
+  Pantheon Secrets is key to maintaining industry best practices for secrets management, secure builds, and application implementation to provide an additional layer of security to your site.
 
   </Product>
 

--- a/source/data/landings.yaml
+++ b/source/data/landings.yaml
@@ -1066,8 +1066,6 @@
           url: "/guides/local-development/drupal-phpstorm"
         - text: "Drupal Commerce"
           url: "/guides/drupal-commerce"
-        - text: "Drupal SDK"
-          url: "/guides/edge-integrations/drupal-sdk/"
         - text: "Using Terminus to Create and Update Drupal Sites on Pantheon"
           url: "/guides/terminus-drupal-site-management/"
           icon: "book"


### PR DESCRIPTION
## Summary

**[Edge Integrations](https://docs.pantheon.io/guides/edge-integrations)** - Adds a deprecation notice to all the pages of the Edge Integrations guide

fixes #9213