### PR TITLE
Legacy dashboard site creation: Drupal 10 & Drupal 11

### DIFF
--- a/source/content/partials/dashboard-site-creation-1.md
+++ b/source/content/partials/dashboard-site-creation-1.md
@@ -20,6 +20,17 @@ reviewed: ""
 
    ![Select Drupal version](../../images/create-new-site-cms-drupal-11crop.png)
 
+   <Alert title="Note" type="info" >
+
+   The above options are available during site creation in the **new dashboard**. The legacy dashboard site creation experience does not match today, but it will be aligned in the future.
+
+   Upgrade today by clicking **Try the New Dashboard**, located in the top right of the legacy dashboard navigation. Or if you prefer not to upgrade, use the following site creation links:
+
+   * [Drupal 11](https://dashboard.pantheon.io/sites/create?upstream_machine_name=drupal-11-composer-managed)
+   * [Drupal 10](https://dashboard.pantheon.io/sites/create?upstream_machine_name=drupal-10-composer-managed)
+
+   </Alert>
+
 1. Enter the following information and click **Continue**:
    - Sitename
    - Select a region for this site.


### PR DESCRIPTION
Fixes: #9267 
## Summary 
[Create a New CMS Site](https://docs.pantheon.io/add-site-dashboard): Note workarounds for Drupal 10 and 11 site creation in the legacy dashboard 