### PR TITLE
Remove stale blog links

### DIFF
--- a/source/content/agency-tips.md
+++ b/source/content/agency-tips.md
@@ -89,10 +89,7 @@ Use the `pantheon.yml` file to set up platform hooks and advanced site configura
 
 ### New Relic APM Pro
 
-New Relic APM Pro is an advanced tool for application monitoring and troubleshooting, provided to all sites on Pantheon for free. For details, see [New Relic&reg; Performance Monitoring](/guides/new-relic). The following blog posts are also a great reference:
-
-- [New Relic & Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
-- [Troubleshooting WordPress Performance with New Relic&reg; Performance Monitoring](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)
+New Relic APM Pro is an advanced tool for application monitoring and troubleshooting, provided to all sites on Pantheon for free. For details, see [New Relic&reg; Performance Monitoring](/guides/new-relic).
 
 ## Cron
 Pantheon does not provide a way to set custom scheduling for cron jobs. For details, see [Cron for Drupal](/drupal-cron) and [Cron for WordPress](/guides/wordpress-developer/wordpress-cron).

--- a/source/content/guides/new-relic/01-introduction.md
+++ b/source/content/guides/new-relic/01-introduction.md
@@ -31,7 +31,3 @@ All plans except for a Basic plan can use New Relic&reg;. New Relic&reg; is avai
 ## More Resources
 
 - [Incident Management with New Relic&reg; and PagerDuty](/guides/pagerduty/)
-
-- [New Relic&reg; Performance Monitoring and Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
-
-- [Troubleshooting WordPress Performance with New Relic&reg;](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)

--- a/source/content/guides/new-relic/03-monitor-new-relic.md
+++ b/source/content/guides/new-relic/03-monitor-new-relic.md
@@ -37,13 +37,7 @@ Depending on which area you need to optimize, you will explore different areas o
 
 For more information on using New Relic&reg;'s features, we encourage you to review the [New Relic&reg; APM](https://docs.newrelic.com/docs/apm) docs, especially the pages on [transactions](https://docs.newrelic.com/docs/apm/transactions) and [slow query details](https://docs.newrelic.com/docs/apm/applications-menu/monitoring/viewing-slow-query-details). You can find more information on using New Relic&reg; to investigate specific areas of performance below:
 
-- [Measuring PHP7 Performance with New Relic&reg;](https://pantheon.io/blog/measuring-php-7-performance-new-relic-nobsbenchmarks)
-
 - [MySQL Troubleshooting With New Relic&reg; Performance Monitoring](/guides/new-relic/debug-mysql-new-relic)
-
-- [New Relic&reg; Performance Monitoring and Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
-
-- [Troubleshooting WordPress Performance with New Relic&reg; Performance Monitoring](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)
 
 ## Configure Ping Monitors (Synthetics) for Availability
 

--- a/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -111,6 +111,4 @@ Availability monitoring from APM is heavily outdated, and will not work with the
 ## More Resources
 
 - [MySQL Troubleshooting with New Relic Performance Monitoring](/guides/new-relic/debug-mysql-new-relic)
-- [Troubleshooting WordPress Performance with New Relic](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)
-- [New Relic Performance Monitoring and Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
 - [New Relic FAQ](/guides/new-relic/new-relic-faq)

--- a/source/content/guides/pagerduty/02-monitor.md
+++ b/source/content/guides/pagerduty/02-monitor.md
@@ -79,8 +79,4 @@ Now that you have a monitor setup in New Relic&reg; to periodically check your P
 
 - [MySQL Troubleshooting with New Relic&reg; Performance Monitoring](/guides/new-relic/debug-mysql-new-relic)
 
-- [New Relic&reg; Performance Monitoring and Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
-
-- [Troubleshooting WordPress Performance with New Relic&reg;](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)
-
 - [New Relic&reg; FAQ](/guides/new-relic/new-relic-faq)

--- a/source/content/guides/pagerduty/04-notify.md
+++ b/source/content/guides/pagerduty/04-notify.md
@@ -54,7 +54,3 @@ Now we'll hookup our PagerDuty service as a notification channel for our alert p
 ## More Resources
 
 - [Monitor and Improve Site Performance with New Relic&reg;](/guides/new-relic/monitor-new-relic)
-
-- [New Relic&reg; Performance Monitoring and Drupal: Find Your Site's Slow Spots](https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots)
-
-- [Troubleshooting WordPress Performance with New Relic&reg;](https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic)


### PR DESCRIPTION
## Summary

### Stale Blogs: 
* https://pantheon.io/blog/new-relic-drupal-find-site-slow-spots
* https://pantheon.io/blog/troubleshooting-wordpress-performance-new-relic
* https://pantheon.io/blog/measuring-php-7-performance-new-relic-nobsbenchmarks

### Removed from: 
* [New Relic: Introduction](https://docs.pantheon.io/guides/new-relic#more-resources)
* [New Relic: Monitor and Improve Site Performance](https://docs.pantheon.io/guides/new-relic/monitor-new-relic#monitor-and-improve-performance)
* [New Relic: Troubleshoot](https://docs.pantheon.io/guides/new-relic/troubleshoot-new-relic#more-resources)
* [Pantheon Agency Tips](https://docs.pantheon.io/agency-tips#new-relic-apm-pro)
* [Incident Management: New Relic Ping Monitors](https://docs.pantheon.io/guides/pagerduty/monitor/#more-resources)
* [Incident Management: Notifications](https://docs.pantheon.io/guides/pagerduty/notify/#more-resources)
