### PR TITLE
Audit DDEV setup guide for accuracy and clarity

### DIFF
--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -2,7 +2,7 @@
 title: Local Development on Pantheon
 subtitle: Install and Configure DDEV for Drupal
 description: Install and configure DDEV for Drupal local development.
-contributors: [whitneymeredith]
+contributors: [whitneymeredith, rachelwhitton]
 contenttype: [guide]
 innav: [false]
 categories: [automate]
@@ -33,22 +33,32 @@ Be sure that you have:
 
 1. Follow the system prompts to install DDEV.
 
-1. Choose a [supported Docker provider](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/) to install and use with DDEV, then start Docker before proceeding. 
+1. Choose and install a [supported Docker provider](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/) for use with DDEV, then open the program on your machine before you proceed. 
 
 ## Use DDEV with Pantheon
 
 1. Navigate to your Pantheon Dashboard and [generate a machine token](/machine-tokens/) for use with your DDEV site.
 
-1. Open your global DDEV configuration file at `~/.ddev/global_config.yaml` and add the API token to the `web_environment` section:
+1. Open your global DDEV configuration file at `~/.ddev/global_config.yaml` and add your Pantheon machine token to the `web_environment` section, replace `insertyourtoken` with your token value:
 
-    ```bash{promptUser: user}
+    ```yaml
     web_environment:
-    - TERMINUS_MACHINE_TOKEN=insertyourtoken
+        - TERMINUS_MACHINE_TOKEN=insertyourtoken
     ```
 
-1. [Clone the site's codebase](/guides/git/git-config#clone-your-site-codebase), and from the site's root directory run the `ddev config` command.
+1. [Clone the site's codebase](/guides/git/git-config#clone-your-site-codebase), and from the site's root directory run: 
 
-1. Run the `ddev start` command. This starts the project in Docker and populates provider integrations in `.ddev/providers`.
+  ```bash{promptUser: user}
+  ddev config
+  ```
+
+1. Start your DDEV project locally by running the following command. 
+
+  ```bash{promptUser: user}
+  ddev start
+  ```
+
+  In addition to starting local Docker containers for the site, this command will also install DDEV provider integration recipes to your site's codebase at `.ddev/providers`, which we will use in the next step.
 
 1. Copy your site's `.ddev/providers/example.pantheon.yaml` provider file to `.ddev/providers/pantheon.yaml`.
 
@@ -58,29 +68,40 @@ Be sure that you have:
 
   </Alert>
 
-1. Update the project name and environment variable in your new `.ddev/providers/pantheon.yaml` file. In the example below, the project name is `de8` and the targeted environment is `live`. This example updates the local DDEV environment with database and content file backups from the Pantheon Live environment.
+1. Update the project name and environment variable in your new `.ddev/providers/pantheon.yaml` file. In the example below, the project name is `de8` and the targeted environment is `dev`.
 
-    ```bash{promptUser: user}
+    ```yaml
     environment_variables:
-      project: de8.live
+      project: de8.dev
     ```
 
-1. Now that you have the provider file created and edited, restart DDEV: 
+1. Now that you have the provider file created and edited, restart your DDEV containers with the following command: 
 
   ```bash{promptUser: user}
   ddev restart
   ```
 
-1. If you haven't already, generate a backup on the Pantheon environment you want to use as a starting point for your local development environment. You can do this from the site dashboard, or via Terminus: 
+1. If you haven't already, create a backup on the Pantheon environment you configured in step 6 above. You can [create a new backup from the site dashboard](/guides/backups/create-backups#create-a-backup-in-the-dashboard), or via Terminus: 
 
   ```bash{promptUser: user}
-  terminus backup:create de8.live
+  terminus backup:create <site>.<env>
   ```
 
-1. Run `ddev pull pantheon` to update your local database and content files. You can add the `--skip-files` parameter if you don't want to sync the content files to your local. Remember to specify the site and Pantheon environment you want to target when running the `ddev pull` command, and create a new backup when you need to refresh what you pull.
+1. Run the following command to pull your site's database and files from Pantheon into your local DDEV environment. You can add the `--skip-files` parameter if you don't want to sync the content files to your local. 
+
+  ```bash{promptUser: user}
+  ddev pull pantheon
+  ```
+
+1. Run the following command to open your local development URL in your browser: 
+
+  ```bash{promptUser: user}
+  ddev launch
+  ```
+
 
 ## More Resources
 
-- [DDEV's Pantheon Quickstart docs](https://ddev.readthedocs.io/en/latest/users/providers/pantheon/)
-- [Drupal Drush on Pantheon](/guides/drush)
-- [Using Drupal on Pantheon](/develop-drupal)
+- [DDEV's Pantheon Quickstart doc](https://ddev.readthedocs.io/en/latest/users/providers/pantheon/)
+- [DDEV command references](https://ddev.readthedocs.io/en/stable/users/usage/commands/)
+- [DDEV Provider Integrations doc](https://ddev.readthedocs.io/en/latest/users/providers/).

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -59,7 +59,6 @@ Be sure that you have:
 
   </Alert>
 
-
 1. Update the project name and environment variable. In the example below, the project name is `de8` and the targeted environment is `live`. This example updates the local DDEV environment with database and content file backups from the Pantheon Live environment.
 
     ```bash{promptUser: user}

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -68,7 +68,7 @@ Be sure that you have:
 
   </Alert>
 
-1. Update the project name and environment variable in your new `.ddev/providers/pantheon.yaml` file. In the example below, the project name is `de8` and the targeted environment is `dev`.
+1. Update the project name and environment variable in your new `.ddev/providers/pantheon.yaml` file. In the example below, the Pantheon project name is `de8` and the targeted Pantheon environment is `dev`.
 
     ```yaml
     environment_variables:

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -55,7 +55,7 @@ Be sure that you have:
 
   <Alert title="Note" type="info" >
 
-  Do this in your site's `.ddev` directory, not the global `.dev` directory.
+  Do this in your site's `.ddev` directory, not the global `.ddev` directory.
 
   </Alert>
 

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -49,7 +49,16 @@ Be sure that you have:
     - TERMINUS_MACHINE_TOKEN=insertyourtoken
     ```
 
-1. Copy the `example.pantheon.yaml` provider file to the `pantheon.yaml`.
+1. [Clone the site's codebase](/guides/git/git-config#clone-your-site-codebase), and from the site's root directory run the `ddev config` command.
+
+1. Copy your site's `.ddev/providers/example.pantheon.yaml` provider file to `.ddev/providers/pantheon.yaml`.
+
+  <Alert title="Note" type="info" >
+
+  Do this in your site's `.ddev` directory, not the global `.dev` directory.
+
+  </Alert>
+
 
 1. Update the project name and environment variable. In the example below, the project name is `de8` and the targeted environment is `live`. This example updates the local DDEV environment with database and content file backups from the Pantheon Live environment.
 
@@ -62,5 +71,6 @@ Be sure that you have:
 
 ## More Resources
 
+- [DDEV's Pantheon Quickstart docs](https://ddev.readthedocs.io/en/latest/users/providers/pantheon/)
 - [Drupal Drush on Pantheon](/guides/drush)
 - [Using Drupal on Pantheon](/develop-drupal)

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -27,7 +27,7 @@ Be sure that you have:
 - Installed Drush as part of your Drupal project. You can add this via your CLI:
 
     ```bash{promptUser: user}
-    $ ddev composer require drush/drush
+    ddev composer require drush/drush
     ```
 
 ## Download and Install DDEV

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -24,11 +24,6 @@ Be sure that you have:
 - An existing Drupal site on Pantheon, or [create](https://dashboard.pantheon.io/sites/create) a site.
 - Reviewed the [Get started with DDEV guide](https://ddev.readthedocs.io/en/latest/).
 - Verified that you meet DDEV's [system requirements](https://ddev.readthedocs.io/en/latest/).
-- Installed Drush as part of your Drupal project. You can add this via your CLI:
-
-    ```bash{promptUser: user}
-    ddev composer require drush/drush
-    ```
 
 ## Download and Install DDEV
 
@@ -37,6 +32,8 @@ Be sure that you have:
 1. Open the installer package and allow it to prepare.
 
 1. Follow the system prompts to install DDEV.
+
+1. Choose a [supported Docker provider](https://ddev.readthedocs.io/en/latest/users/install/docker-installation/) to install and use with DDEV, then start Docker before proceeding. 
 
 ## Use DDEV with Pantheon
 
@@ -51,20 +48,34 @@ Be sure that you have:
 
 1. [Clone the site's codebase](/guides/git/git-config#clone-your-site-codebase), and from the site's root directory run the `ddev config` command.
 
+1. Run the `ddev start` command. This starts the project in Docker and populates provider integrations in `.ddev/providers`.
+
 1. Copy your site's `.ddev/providers/example.pantheon.yaml` provider file to `.ddev/providers/pantheon.yaml`.
 
   <Alert title="Note" type="info" >
 
-  Do this in your site's `.ddev` directory, not the global `.ddev` directory.
+  Do this in your site's `.ddev` directory, not the global `.ddev` directory. The `.ddev/providers/pantheon.yaml` file is a DDEV recipe for integration with Pantheon. For more information on DDEV provider integrations, see [DDEV docs](https://ddev.readthedocs.io/en/latest/users/providers/).
 
   </Alert>
 
-1. Update the project name and environment variable. In the example below, the project name is `de8` and the targeted environment is `live`. This example updates the local DDEV environment with database and content file backups from the Pantheon Live environment.
+1. Update the project name and environment variable in your new `.ddev/providers/pantheon.yaml` file. In the example below, the project name is `de8` and the targeted environment is `live`. This example updates the local DDEV environment with database and content file backups from the Pantheon Live environment.
 
     ```bash{promptUser: user}
     environment_variables:
       project: de8.live
     ```
+
+1. Now that you have the provider file created and edited, restart DDEV: 
+
+  ```bash{promptUser: user}
+  ddev restart
+  ```
+
+1. If you haven't already, generate a backup on the Pantheon environment you want to use as a starting point for your local development environment. You can do this from the site dashboard, or via Terminus: 
+
+  ```bash{promptUser: user}
+  terminus backup:create de8.live
+  ```
 
 1. Run `ddev pull pantheon` to update your local database and content files. You can add the `--skip-files` parameter if you don't want to sync the content files to your local. Remember to specify the site and Pantheon environment you want to target when running the `ddev pull` command, and create a new backup when you need to refresh what you pull.
 

--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -104,4 +104,4 @@ Be sure that you have:
 
 - [DDEV's Pantheon Quickstart doc](https://ddev.readthedocs.io/en/latest/users/providers/pantheon/)
 - [DDEV command references](https://ddev.readthedocs.io/en/stable/users/usage/commands/)
-- [DDEV Provider Integrations doc](https://ddev.readthedocs.io/en/latest/users/providers/).
+- [DDEV Provider Integrations doc](https://ddev.readthedocs.io/en/latest/users/providers/)


### PR DESCRIPTION
Fixes #9227 
## Summary

**[Install and Configure DDEV for Drupal](https://pr-9279-documentation.appa.pantheon.site/guides/local-development/ddev)** - Reviewed and revised the entire guide based on my experience today getting ddev setup and running on macos 
