### PR TITLE
Add Prettier pre-push hook

### DIFF
--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -1,0 +1,14 @@
+#!/bin/sh
+git fetch origin main
+# Check for changed JavaScript files.
+CHANGED_FILES=$(git diff --name-only origin/main...HEAD | grep -E '\.js$|\.jsx$|\.ts$|\.tsx$' || echo "")
+# If JavaScript files have changed, run Prettier.
+if [ -n "$CHANGED_FILES" ]; then
+	echo "Fixing the following files:"
+	echo "$CHANGED_FILES"
+
+	# Run Prettier on the changed files.
+	echo "$CHANGED_FILES" | xargs npx prettier --write
+else
+	echo "No files to format"
+fi

--- a/.github/hooks/pre-push
+++ b/.github/hooks/pre-push
@@ -9,6 +9,9 @@ if [ -n "$CHANGED_FILES" ]; then
 
 	# Run Prettier on the changed files.
 	echo "$CHANGED_FILES" | xargs npx prettier --write
+	echo "Adding Prettier changes to commit"
+	git add .
+	git commit -m "Apply Prettier formatting"
 else
 	echo "No files to format"
 fi

--- a/README.md
+++ b/README.md
@@ -45,6 +45,19 @@ nvm install 18
 npm install -g gatsby-cli
 ```
 
+### Using Git Hooks
+Git hooks have been added to `[.github/hooks](.github/hooks)` to help automate some of the tasks that make it easier to work locally with the repository. The following hooks are available:
+
+- `pre-commit`: Runs Prettier to check for code styling issues on updated/changed javascript files. If Prettier made any changes, those changes are automatically committed back to the PR. This mirrors the functionality of the [Prettier GitHub Action](.github/workflows/prettier.yml).
+
+To use the git hooks, you must configure your local environment to use `.github/hooks` as the hooks path (normally `.git/hooks`, but this folder is ignored by Git). This can be done by running the following command from the root of the repository:
+
+```bash
+git config core.hooksPath .github/hooks
+```
+
+It's recommended (but not required) to use the provided git hooks if you are working with any javascript files in the repository. This will help ensure that your changes are formatted correctly before being committed and ensure that your local environment and the remote branch are the same.
+
 ### Get the Code
 
 Fork and clone this repository:

--- a/src/components/omniSidebarNav/submenus/certification.js
+++ b/src/components/omniSidebarNav/submenus/certification.js
@@ -65,6 +65,6 @@ const CertificationItems = [
     link: 'https://certification.pantheon.io/',
     title: 'Certification Directory',
   },
-];
+]
 
 export default CertificationItems;

--- a/src/components/omniSidebarNav/submenus/certification.js
+++ b/src/components/omniSidebarNav/submenus/certification.js
@@ -65,6 +65,6 @@ const CertificationItems = [
     link: 'https://certification.pantheon.io/',
     title: 'Certification Directory',
   },
-]
+];
 
 export default CertificationItems;


### PR DESCRIPTION
This pull request adds a Prettier pre-push hook to automatically format JavaScript files before pushing. It also adds a new section to the readme file explaining how to use the git hooks that have been added to the `.github/hooks` folder. 

The `.github/hooks` folder includes a pre-push hook that runs Prettier to check for code styling issues and automatically adds the changes back to the branch if any are found. 

The documentation explains how to use this pre-push hook since it is not possible to commit git hooks stored in the normal `.git/hooks` directory to a repository.