### PR TITLE
Fix broken links - report doc issue template

### DIFF
--- a/src/components/github/index.js
+++ b/src/components/github/index.js
@@ -15,7 +15,7 @@ const Github = ({ pageTitle, path, editPath }) => {
         <Icon iconName="github" /> Edit this page on GitHub
       </a>
       <a
-        href={`https://github.com/pantheon-systems/documentation/issues/new?title=${pageTitle}%20Doc%20Update%20&body=Re%3A%20%5B${pageTitle}%5D(https%3A%2F%2Fdocs.pantheon.io${path})%0A%0APriority%3A%20Low%2FMedium%2FHigh%20(choose%20one%2C%20remove%20the%20other%20options)%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution`}
+        href={`https://github.com/pantheon-systems/documentation/issues/new?title=${pageTitle}%20Doc%20Update%20&body=Re%3A%20%5B${pageTitle}%5D(https%3A%2F%2Fdocs.pantheon.io%2F${path})%0A%0APriority%3A%20Low%2FMedium%2FHigh%20(choose%20one%2C%20remove%20the%20other%20options)%0A%0A%23%23%20Issue%20Description%3A%0A%0A%23%23%20Suggested%20Resolution`}
         target="_blank"
         className="github-link"
       >

--- a/src/components/github/index.js
+++ b/src/components/github/index.js
@@ -1,8 +1,8 @@
-import React from "react"
+import React from 'react';
 
-import { Icon } from "@pantheon-systems/pds-toolkit-react"
+import { Icon } from '@pantheon-systems/pds-toolkit-react';
 
-import "./style.css"
+import './style.css';
 
 const Github = ({ pageTitle, path, editPath }) => {
   return editPath ? (
@@ -22,7 +22,7 @@ const Github = ({ pageTitle, path, editPath }) => {
         <Icon iconName="github" /> Report an issue with this doc
       </a>
     </div>
-  ) : null
-}
+  ) : null;
+};
 
-export default Github
+export default Github;


### PR DESCRIPTION
## Summary

Adds the missing `/` character so that links work again when using the "Report an issue with this doc" button on any given page 

<img width="991" alt="Screenshot 2024-10-30 at 11 30 46 AM" src="https://github.com/user-attachments/assets/284d3c4f-4fcc-4b0f-9edb-b992a3ef2880">
