### PR TITLE
86 GITHUB_EMBED

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,43 +67,13 @@ git clone git@github.com:pantheon-systems/documentation.git
 cd documentation
 ```
 
-### Create a GitHub API Token
-
-We use the [gatsby-remark-embed-snippet](https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-remark-embed-snippet) to use files from GitHub in our docs. Before you can build a local development site, you need to provide a GitHub token to the environment:
-
-1. Log in to GitHub and go to <https://github.com/settings/tokens>
-1. Click **Generate new token**.
-1. Give the token a name, expiration, and description.
-1. Select your GitHub user as the resource owner.
-1. For repository access, select **Only select repositories** and select your fork of this repository.
-1. Under Repository permissions, choose **Access: Read-only** from the **Access** dropdown button for **Contents**.
-1. Click **Generate token**.
-
-#### GitHub Tokens (classic)
-
-Alternatively, if you'd rather create a classic-style token:
-
-1. Log in to GitHub and go to <https://github.com/settings/tokens>
-1. Click **Generate new token (classic)**
-1. Give the token a name and click the **public_repo** checkbox, then the **Generate Token** button at the bottom
-1. Copy the token to your clipboard
-1. In the root `documentation` directory, create a new file called `.env.development` and add (replacing `$TOKENHASH` ):
-
-   ```bash
-   GITHUB_API=$TOKENHASH
-   ```
-
 ## Using GitHub Codespaces
 
 A [GitHub Codespace](https://github.com/features/codespaces) can be used to test the site as well. To set up a Codespace, navigate to the branch you want to use as the base (e.g. `main`) and click the Code dropdown.
 
 ![Codespaces screenshot](/source/images/assets/codespaces-setup.png)
 
-This will take you to a VSCode-like interface with a Terminal window. From here, export your GitHub API token you created in the previous step using the following command (replacing `$TOKENHASH` with your API token):
-
-```bash{promptUser: user}
-export GITHUB_API=$TOKENHASH
-```
+This will take you to a VSCode-like interface with a Terminal window.
 
 Now you can run `npm ci` and `npm start` in the Terminal panel at the bottom of the page. The docs site will build inside the Codespaces container and install Node dependencies just like it would on your local machine. When the Node server is running, a dialog box will appear at the bottom right corner asking if you want to open the Codespace in a browser and if you want to make the Codespace public.
 

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -155,18 +155,6 @@ module.exports = {
             resolve: "gatsby-remark-grid-tables", // https://www.gatsbyjs.com/plugins/gatsby-remark-grid-tables/
           },
           {
-            // Used to create code snippets from files on GitHub
-            resolve: "gatsby-remark-github", // https://www.gatsbyjs.com/plugins/gatsby-remark-github/
-            options: {
-              marker: "GITHUB-EMBED",
-              insertEllipsisComments: true,
-              ellipsisPhrase: "...",
-              useCache: true,
-              cacheKey: "gatsby-remark-github-v1",
-              token: process.env.GITHUB_API,
-            },
-          },
-          {
             // Required so the custom Youtube component can create iframes that work with Gatsby
             resolve: "gatsby-remark-responsive-iframe", // https://www.gatsbyjs.com/plugins/gatsby-remark-responsive-iframe/
           },

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,12 +1,12 @@
-const dotenv = require("dotenv")
+const dotenv = require('dotenv');
 
 // load environment specific configurations.
 dotenv.config({
   path: `.env.${process.env.NODE_ENV}`,
-})
-require("dotenv").config({
+});
+require('dotenv').config({
   path: `.env.${process.env.NODE_ENV}`,
-})
+});
 
 // Gatsby Configuration, Options, and Plugins
 module.exports = {
@@ -23,7 +23,7 @@ module.exports = {
   },
   // Creates a shorthand for Contributor data in GraphQL
   mapping: {
-    "Mdx.frontmatter.contributors": "ContributorYaml",
+    'Mdx.frontmatter.contributors': 'ContributorYaml',
   },
   plugins: [
     `gatsby-transformer-yaml`,
@@ -32,17 +32,17 @@ module.exports = {
       // Handles inserting the GTM js blob into the site
       resolve: `gatsby-plugin-google-tagmanager`,
       options: {
-        id: "GTM-MDF545G", // process.env.GTM_ID_NEW,
+        id: 'GTM-MDF545G', // process.env.GTM_ID_NEW,
         //testing includeInDevelopment: false,
         defaultDataLayer: {},
       },
     },
     {
       // Handles inserting the Segment js blob into the site
-      resolve: "gatsby-plugin-segment-js",
+      resolve: 'gatsby-plugin-segment-js',
       options: {
-        prodKey: "lEIpoQHx3G5Jqsy3GmjcPS357D4AlwlA",
-        devKey: "kDdX1dpmsAWuUn8zb1QDJR8YGbWJjKoj",
+        prodKey: 'lEIpoQHx3G5Jqsy3GmjcPS357D4AlwlA',
+        devKey: 'kDdX1dpmsAWuUn8zb1QDJR8YGbWJjKoj',
         trackPage: false,
         trackPageOnlyIfReady: true,
         customSnippet:
@@ -119,7 +119,7 @@ module.exports = {
       },
     },
     // When running Gatsby develop, creates reporting pages
-    ...(process.env.NODE_ENV === "development"
+    ...(process.env.NODE_ENV === 'development'
       ? [
           {
             resolve: `gatsby-plugin-page-creator`,
@@ -148,19 +148,19 @@ module.exports = {
       // Allows for React components within the Markdown files.
       resolve: `gatsby-plugin-mdx`, // https://www.gatsbyjs.com/plugins/gatsby-plugin-mdx/
       options: {
-        extensions: [".mdx", ".md"],
+        extensions: ['.mdx', '.md'],
         gatsbyRemarkPlugins: [
           {
             // Allows for more complex tables
-            resolve: "gatsby-remark-grid-tables", // https://www.gatsbyjs.com/plugins/gatsby-remark-grid-tables/
+            resolve: 'gatsby-remark-grid-tables', // https://www.gatsbyjs.com/plugins/gatsby-remark-grid-tables/
           },
           {
             // Required so the custom Youtube component can create iframes that work with Gatsby
-            resolve: "gatsby-remark-responsive-iframe", // https://www.gatsbyjs.com/plugins/gatsby-remark-responsive-iframe/
+            resolve: 'gatsby-remark-responsive-iframe', // https://www.gatsbyjs.com/plugins/gatsby-remark-responsive-iframe/
           },
           {
             // Self-explanatory
-            resolve: "gatsby-remark-images", // https://www.gatsbyjs.com/plugins/gatsby-remark-images/
+            resolve: 'gatsby-remark-images', // https://www.gatsbyjs.com/plugins/gatsby-remark-images/
             options: {
               maxWidth: 1035,
               // sizeByPixelDensity: true,
@@ -180,12 +180,12 @@ module.exports = {
           {
             resolve: `gatsby-remark-table-of-contents`,
             options: {
-              exclude: "Table of Contents",
+              exclude: 'Table of Contents',
               tight: true,
               ordered: false,
               fromHeading: 2,
               toHeading: 3,
-              className: "table-of-contents",
+              className: 'table-of-contents',
             },
           },
           {
@@ -201,21 +201,21 @@ module.exports = {
           {
             resolve: `gatsby-remark-prismjs`,
             options: {
-              classPrefix: "language-",
+              classPrefix: 'language-',
               inlineCodeMarker: null,
               noInlineHighlight: true,
               aliases: {},
               prompt: {
-                user: "user",
-                host: "localhost",
+                user: 'user',
+                host: 'localhost',
               },
             },
           },
           {
-            resolve: "gatsby-remark-external-links",
+            resolve: 'gatsby-remark-external-links',
             options: {
-              target: "_blank",
-              rel: "nofollow noopener external",
+              target: '_blank',
+              rel: 'nofollow noopener external',
             },
           },
         ],
@@ -225,7 +225,7 @@ module.exports = {
     `gatsby-plugin-sharp`,
     `gatsby-plugin-react-helmet`,
     {
-      resolve: "gatsby-plugin-sitemap",
+      resolve: 'gatsby-plugin-sitemap',
     },
     {
       resolve: 'gatsby-plugin-feed',
@@ -245,8 +245,11 @@ module.exports = {
         feeds: [
           {
             serialize: ({ query: { site, allMdx } }) => {
-              return allMdx.edges.map(edge => {
-                const url = new URL(edge.node.fields.slug, site.siteMetadata.siteUrl).toString();
+              return allMdx.edges.map((edge) => {
+                const url = new URL(
+                  edge.node.fields.slug,
+                  site.siteMetadata.siteUrl,
+                ).toString();
                 // Simple hash function to turn a string into a numeric value
                 // https://chatgpt.com/share/69aeb001-e00f-41b9-98a4-816aa6a0330d
                 function hashCode(str) {
@@ -265,7 +268,9 @@ module.exports = {
 
                   const hours = (hash % 24).toString().padStart(2, '0');
                   const minutes = (hash % 60).toString().padStart(2, '0');
-                  const seconds = ((hash >> 8) % 60).toString().padStart(2, '0'); // Shift for more variance
+                  const seconds = ((hash >> 8) % 60)
+                    .toString()
+                    .padStart(2, '0'); // Shift for more variance
 
                   return `${hours}:${minutes}:${seconds}`;
                 }
@@ -300,13 +305,14 @@ module.exports = {
                 }
               }
             `,
-            output: "/release-notes/rss.xml",
-            title: "Pantheon release notes RSS feed",
-            description: 'Stay updated with the latest releases and enhancements.',
-            site_url: 'docs.pantheon.io/release-notes'
+            output: '/release-notes/rss.xml',
+            title: 'Pantheon release notes RSS feed',
+            description:
+              'Stay updated with the latest releases and enhancements.',
+            site_url: 'docs.pantheon.io/release-notes',
           },
         ],
       },
     },
   ],
-}
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "gatsby-remark-code-titles": "^1.1.0",
         "gatsby-remark-copy-linked-files": "^5.25.0",
         "gatsby-remark-external-links": "0.0.4",
-        "gatsby-remark-github": "^2.0.0",
         "gatsby-remark-grid-tables": "^0.1.0",
         "gatsby-remark-images": "^6.25.0",
         "gatsby-remark-prismjs": "^6.25.0",
@@ -12511,14 +12510,6 @@
       "integrity": "sha512-DyN5vD4NE3aSeB+PXYNKxzGsfocxp6asDc2XXE3b0ekO2BaRUpBicbbUygfSvYfUz1IkmjFR1YF7dPklraMZ2g==",
       "dependencies": {
         "unist-util-is": "^3.0.0"
-      }
-    },
-    "node_modules/gatsby-remark-github": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-github/-/gatsby-remark-github-2.0.0.tgz",
-      "integrity": "sha512-z4ZYFTA6PWjVvUrD4UNF6pTIdWnv4ra8DNC0sv/M/HyxGLfd9QByL1ZyPPLow2RwMolsSilnszTdxVIeFeXUMw==",
-      "peerDependencies": {
-        "remark-github-plugin": "^1.1.0"
       }
     },
     "node_modules/gatsby-remark-grid-tables": {
@@ -32880,12 +32871,6 @@
           }
         }
       }
-    },
-    "gatsby-remark-github": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/gatsby-remark-github/-/gatsby-remark-github-2.0.0.tgz",
-      "integrity": "sha512-z4ZYFTA6PWjVvUrD4UNF6pTIdWnv4ra8DNC0sv/M/HyxGLfd9QByL1ZyPPLow2RwMolsSilnszTdxVIeFeXUMw==",
-      "requires": {}
     },
     "gatsby-remark-grid-tables": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
     "gatsby-remark-code-titles": "^1.1.0",
     "gatsby-remark-copy-linked-files": "^5.25.0",
     "gatsby-remark-external-links": "0.0.4",
-    "gatsby-remark-github": "^2.0.0",
     "gatsby-remark-grid-tables": "^0.1.0",
     "gatsby-remark-images": "^6.25.0",
     "gatsby-remark-prismjs": "^6.25.0",

--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -391,34 +391,9 @@ This issue happens when you attempt to update very outdated core files from the 
 1. Set the Site Connection Mode to SFTP
 
 1. Reupload the `pantheon.upstream.yml` file if missing:
-
- <TabList>
-
- <Tab title="Drupal (Latest Version)" id="d9-2conflict-merge" active={true}>
-
-  GITHUB-EMBED https://github.com/pantheon-upstreams/drupal-composer-managed/blob/main/pantheon.upstream.yml yaml:title=pantheon.yml GITHUB-EMBED
-
- [View on GitHub](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/main/pantheon.upstream.yml)
-
- </Tab>
-
- <Tab title="Drupal 7" id="d7-2conflict-merge">
-
- GITHUB-EMBED https://github.com/pantheon-systems/drops-7/blob/master/pantheon.upstream.yml yaml:title=pantheon.upstream.yml GITHUB-EMBED
-
-  [View on GitHub](https://github.com/pantheon-systems/drops-7/blob/default/pantheon.upstream.yml)
-
- </Tab>
-
- <Tab title="WordPress" id="wp-2conflict-merge">
-
- GITHUB-EMBED https://github.com/pantheon-systems/WordPress/blob/default/pantheon.upstream.yml yaml:title=pantheon.upstream.yml GITHUB-EMBED
-
-  [View on GitHub](https://github.com/pantheon-systems/WordPress/blob/default/pantheon.upstream.yml)
-
- </Tab>
-
- </TabList>
+   * [Drupal (Latest Version)](https://github.com/pantheon-upstreams/drupal-composer-managed/blob/main/pantheon.upstream.yml)
+   * [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/default/pantheon.upstream.yml)
+   * [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/pantheon.upstream.yml)
 
 1. Return to the Commit in dashboard, and note that `pantheon.upstream.yml` can now be committed
 

--- a/source/content/guides/backups/02-access-backups.md
+++ b/source/content/guides/backups/02-access-backups.md
@@ -23,7 +23,72 @@ Pantheon backups are stored offsite on Google Cloud Storage instances. We recomm
 
 <Download file="pantheon-backup-to-s3.sh" />
 
-GITHUB-EMBED https://github.com/pantheon-systems/documentation/blob/main/source/scripts/pantheon-backup-to-s3.sh.txt bash GITHUB-EMBED
+```bash
+#!/bin/bash
+
+# pantheon-backup-to-s3.sh
+# Script to backup Pantheon sites and copy to Amazon s3 bucket
+#
+# Requirements:
+#   - Pantheon terminus cli
+#   - Valid terminus machine token
+#   - Amazon aws cli
+#   - s3 cli access and user configured
+
+
+# The amazon S3 bucket to save the backups to (must already exist)
+S3BUCKET=""
+# Optionally specify bucket region
+S3BUCKETREGION=""
+# The Pantheon terminus user (email address)
+TERMINUSUSER=""
+# Site names to backup (e.g. 'site-one site-two')
+SITENAMES=""
+# Site environments to backup (any combination of dev, test and live)
+SITEENVS="dev live"
+# Elements of backup to be downloaded.
+ELEMENTS="code files db"
+# Local backup directory (must exist, requires trailing slash)
+BACKUPDIR="<local-path-to-folder>/"
+# Add a date and unique string to the filename
+BACKUPDATE=$(date +%Y%m%d%s)
+# This sets the proper file extension
+EXTENSION="tar.gz"
+DBEXTENSION="sql.gz"
+# Hide Terminus update messages
+TERMINUS_HIDE_UPDATE_MESSAGES=1
+
+# connect to terminus
+terminus auth:login --email $TERMINUSUSER
+
+# iterate through sites to backup
+for thissite in $SITENAMES; do
+  # iterate through current site environments
+  for thisenv in $SITEENVS; do
+    # create backup
+    terminus backup:create $thissite.$thisenv
+
+    # iterate through backup elements
+    for element in $ELEMENTS; do
+      # download current site backups
+      if [[ $element == "db" ]]; then
+        terminus backup:get --element=$element --to=$BACKUPDIR$thissite.$thisenv.$element.$BACKUPDATE.$DBEXTENSION $thissite.$thisenv
+      else
+        terminus backup:get --element=$element --to=$BACKUPDIR$thissite.$thisenv.$element.$BACKUPDATE.$EXTENSION $thissite.$thisenv
+      fi
+    done
+  done
+done
+echo $BACKUPDIR
+
+# sync the local backup directory to aws s3
+if [ -z "${S3BUCKETREGION}" ]; then
+    aws s3 sync $BACKUPDIR s3://$S3BUCKET
+else
+  aws s3 sync $BACKUPDIR s3://$S3BUCKET --region $S3BUCKETREGION
+
+fi
+```
 
 ## Access Backups Via the Dashboard
 

--- a/source/content/guides/local-development/02-configuration.md
+++ b/source/content/guides/local-development/02-configuration.md
@@ -214,13 +214,7 @@ This file is ignored by the `.gitignore` file in [WordPress](https://github.com/
 
 Pantheon sites that install WordPress 5.5 include a `wp-config-local-sample.php` file. Older sites can copy the [wp-config-local-sample.php](https://github.com/pantheon-systems/WordPress/blob/default/wp-config-local-sample.php) file on GitHub to the same directory as the site's `wp-config.php`, or create one in that location as shown here.
 
-The following can be used as a starting point for `wp-config-local.php`. Replace the database values with the values from your local environment, and the key/salt values with your unique phrase (generated from [WordPress.org](https://api.wordpress.org/secret-key/1.1/salt/)).
-
-<Accordion title={"Full text of wp-config-local-sample.php"} id={"full-wp-config-local-sample"}>
-
-GITHUB-EMBED https://github.com/pantheon-systems/WordPress/blob/default/wp-config-local-sample.php php GITHUB-EMBED
-
-</Accordion>
+This can be used as a starting point for `wp-config-local.php`. Replace the database values with the values from your local environment, and the key/salt values with your unique phrase (generated from [WordPress.org](https://api.wordpress.org/secret-key/1.1/salt/)).
 
 ### Drupal settings.local.php
 

--- a/source/content/guides/logs-pantheon/04-automate-log-downloads.md
+++ b/source/content/guides/logs-pantheon/04-automate-log-downloads.md
@@ -47,9 +47,76 @@ Read the comments in the scripts carefully to ensure that you modify variables c
 
   <Download file="collect-logs-rsync.sh" />
 
-  GITHUB-EMBED https://github.com/pantheon-systems/documentation/blob/main/source/scripts/collect-logs-rsync.sh.txt shell:title=collect-logs-rsync.sh GITHUB-EMBED
+  ```bash
+  #!/bin/bash
+  # Site UUID is REQUIRED: Site UUID from Dashboard URL, e.g. 12345678-1234-1234-abcd-0123456789ab
+  SITE_UUID=xxxxxxx
+  # Environment is REQUIRED: dev/test/live/or a Multidev
+  ENV=xxxxxxx
 
-  [View on GitHub](https://github.com/pantheon-systems/documentation/blob/main/source/scripts/collect-logs-rsync.sh.txt)
+  ########### Additional settings you don't have to change unless you want to ###########
+  # OPTIONAL: Set AGGREGATE_NGINX to true if you want to aggregate nginx logs.
+  #  WARNING: If set to true, this will potentially create a large file
+  AGGREGATE_NGINX=false
+  # if you just want to aggregate the files already collected, set COLLECT_LOGS to FALSE
+  COLLECT_LOGS=true
+  # CLEANUP_AGGREGATE_DIR removes all logs except combined.logs from aggregate-logs directory.
+  CLEANUP_AGGREGATE_DIR=false
+
+
+  if [ $COLLECT_LOGS == true ]; then
+  echo "COLLECT_LOGS set to $COLLECT_LOGS. Beginning the process..."
+  for app_server in $(dig +short -4 appserver.$ENV.$SITE_UUID.drush.in);
+  do
+      rsync -rlvz --size-only --ipv4 --progress -e "ssh -p 2222" "$ENV.$SITE_UUID@$app_server:logs" "app_server_$app_server"
+  done
+
+  # Include MySQL logs
+  for db_server in $(dig +short -4 dbserver.$ENV.$SITE_UUID.drush.in);
+  do
+      rsync -rlvz --size-only --ipv4 --progress -e "ssh -p 2222" "$ENV.$SITE_UUID@$db_server:logs" "db_server_$db_server"
+  done
+  else
+  echo 'skipping the collection of logs..'
+  fi
+
+  if [ $AGGREGATE_NGINX == true ]; then
+  echo "AGGREGATE_NGINX set to $AGGREGATE_NGINX. Starting the process of combining nginx-access logs..."
+  mkdir aggregate-logs
+
+  for d in $(ls -d app*/logs/nginx); do
+      for f in $(ls -f "$d"); do
+      if [[ $f == "nginx-access.log" ]]; then
+          cat "$d/$f" >> aggregate-logs/nginx-access.log
+          cat "" >> aggregate-logs/nginx-access.log
+      fi
+      if [[ $f =~ \.gz ]]; then
+          cp -v "$d/$f" aggregate-logs/
+      fi
+      done
+  done
+
+  echo "unzipping nginx-access logs in aggregate-logs directory..."
+  for f in $(ls -f aggregate-logs); do
+      if [[ $f =~ \.gz ]]; then
+      gunzip aggregate-logs/"$f"
+      fi
+  done
+
+  echo "combining all nginx access logs..."
+  for f in $(ls -f aggregate-logs); do
+      cat aggregate-logs/"$f" >> aggregate-logs/combined.logs
+  done
+  echo 'the combined logs file can be found in aggregate-logs/combined.logs'
+  else
+  echo "AGGREGATE_NGINX set to $AGGREGATE_NGINX. So we're done."
+  fi
+
+  if [ $CLEANUP_AGGREGATE_DIR == true ]; then
+  echo "CLEANUP_AGGREGATE_DIR set to $CLEANUP_AGGREGATE_DIR. Cleaning up the aggregate-logs directory"
+  find ./aggregate-logs/ -name 'nginx-access*' -print -exec rm {} \;
+  fi  
+  ```
 
   </Tab>
 
@@ -57,9 +124,76 @@ Read the comments in the scripts carefully to ensure that you modify variables c
   
   <Download file="collect-logs-sftp.sh" />
 
-  GITHUB-EMBED https://github.com/pantheon-systems/documentation/blob/main/source/scripts/collect-logs-sftp.sh.txt shell:title=collect-logs-sftp.sh GITHUB-EMBED
+  ```bash
+  #!/bin/bash
+  # Site UUID is REQUIRED: Site UUID from Dashboard URL, e.g. 12345678-1234-1234-abcd-0123456789ab
+  SITE_UUID=xxxxxxx
+  # Environment is REQUIRED: dev/test/live/or a Multidev
+  ENV=xxxxxxx
 
-  [View on GitHub](https://github.com/pantheon-systems/documentation/blob/main/source/scripts/collect-logs-sftp.sh.txt)
+  ########### Additional settings you don't have to change unless you want to ###########
+  # OPTIONAL: Set AGGREGATE_NGINX to true if you want to aggregate nginx logs.
+  #  WARNING: If set to true, this will potentially create a large file
+  AGGREGATE_NGINX=false
+  # if you just want to aggregate the files already collected, set COLLECT_LOGS to FALSE
+  COLLECT_LOGS=true
+  # CLEANUP_AGGREGATE_DIR removes all logs except combined.logs from aggregate-logs directory.
+  CLEANUP_AGGREGATE_DIR=false
+
+
+  if [ $COLLECT_LOGS == true ]; then
+  echo 'COLLECT_LOGS set to $COLLECT_LOGS. Beginning the process...'
+  for app_server in $(dig +short -4 appserver.$ENV.$SITE_UUID.drush.in);
+  do
+      echo "get -R logs \"app_server_$app_server\"" | sftp -o StrictHostKeyChecking=no -o Port=2222 "$ENV.$SITE_UUID@$app_server"
+  done
+
+  # Include MySQL logs
+  for db_server in $(dig +short -4 dbserver.$ENV.$SITE_UUID.drush.in);
+  do
+      echo "get -R logs \"db_server_$db_server\"" | sftp -o StrictHostKeyChecking=no -o Port=2222 "$ENV.$SITE_UUID@$db_server"
+  done
+  else
+  echo 'skipping the collection of logs..'
+  fi
+
+  if [ $AGGREGATE_NGINX == true ]; then
+  echo 'AGGREGATE_NGINX set to $AGGREGATE_NGINX. Starting the process of combining nginx-access logs...'
+  mkdir aggregate-logs
+
+  for d in $(ls -d app*/nginx); do
+      for f in $(ls -f "$d"); do
+      if [[ $f == "nginx-access.log" ]]; then
+          cat "$d/$f" >> aggregate-logs/nginx-access.log
+          cat "" >> aggregate-logs/nginx-access.log
+      fi
+      if [[ $f =~ \.gz ]]; then
+          cp -v "$d/$f" aggregate-logs/
+      fi
+      done
+  done
+
+  echo "unzipping nginx-access logs in aggregate-logs directory..."
+  for f in $(ls -f aggregate-logs); do
+      if [[ $f =~ \.gz ]]; then
+      gunzip aggregate-logs/"$f"
+      fi
+  done
+
+  echo "combining all nginx access logs..."
+  for f in $(ls -f aggregate-logs); do
+      cat aggregate-logs/"$f" >> aggregate-logs/combined.logs
+  done
+  echo 'the combined logs file can be found in aggregate-logs/combined.logs'
+  else
+  echo "AGGREGATE_NGINX set to $AGGREGATE_NGINX. So we're done."
+  fi
+
+  if [ $CLEANUP_AGGREGATE_DIR == true ]; then
+  echo 'CLEANUP_AGGREGATE_DIR set to $CLEANUP_AGGREGATE_DIR. Cleaning up the aggregate-logs directory'
+  find ./aggregate-logs/ -name 'nginx-access*' -print -exec rm {} \;
+  fi
+  ```
 
   </Tab>
 
@@ -71,7 +205,7 @@ You can run the script with parameters for reusability.
 
 1. Edit the 'collect-logs-rsync.sh' (you can choose to disable the AGGREGATE_NGINX):
   
-  ```bash{promptUser:user}
+  ```bash
   # Site UUID is REQUIRED: Site UUID from Dashboard URL, e.g. 12345678-1234-1234-abcd-0123456789ab
   SITE_UUID=$2
   # Environment is REQUIRED: dev/test/live/or a Multidev

--- a/source/content/guides/php/04-wp-config-php.md
+++ b/source/content/guides/php/04-wp-config-php.md
@@ -39,13 +39,7 @@ Ensure that you are running the latest version of [WordPress core](/core-updates
 
 ## Pantheon's WordPress Config
 
-<Accordion title="View Pantheon's WordPress Configuration" id="pantheon-wp-config-php" icon="wrench">
-
-You can also find this file on [GitHub](https://github.com/pantheon-systems/WordPress/blob/default/wp-config.php).
-
-GITHUB-EMBED https://github.com/pantheon-systems/WordPress/blob/default/wp-config.php php GITHUB-EMBED
-
-</Accordion>
+You can find this file on [GitHub](https://github.com/pantheon-systems/WordPress/blob/default/wp-config.php).
 
 <Alert title="Note" type="info">
 

--- a/source/content/partials/migrate/drupal-addfiles.md
+++ b/source/content/partials/migrate/drupal-addfiles.md
@@ -9,6 +9,7 @@ reviewed: ""
 ---
 
 <Partial file="drupal/migrate-add-files-part1.md" />
+
 1. Export a `tar.gz` or `.zip` file of your files directory:
 
   Navigate to your Drupal site's root directory to run this command, which will create an archive file in your user's home directory:
@@ -68,7 +69,33 @@ reviewed: ""
 
   <Download file="manual-rsync-script.sh" />
 
-  GITHUB-EMBED https://github.com/pantheon-systems/documentation/blob/main/source/scripts/manual-rsync-script.sh.txt bash GITHUB-EMBED
+  ```bash
+  #!/bin/bash
+
+  # manual-rsync-script.sh
+  # runs Rsync and waits two minutes if it doesn't work
+
+  ENV='dev'
+  SITE='SITEID'
+
+  read -sp "Your Pantheon Password: " PASSWORD
+  if [[ -z "$PASSWORD" ]]; then
+  echo "Whoops, need password"
+  exit
+  fi
+
+  while [ 1 ]
+  do
+      sshpass -p "$PASSWORD" rsync --partial -rlvz --size-only --ipv4 --progress -e 'ssh -p 2222' ./files/* --temp-dir=../tmp/ $ENV$SITE@appserver.$ENV.$SITE.drush.in:files/
+  if [ "$?" = "0" ] ; then
+      echo "rsync completed normally"
+  exit
+  else
+      echo "Rsync failure. Backing off and retrying..."
+      sleep 180
+  fi
+  done
+  ```
 
   </Tab>
 

--- a/source/content/terminus/03-examples.md
+++ b/source/content/terminus/03-examples.md
@@ -293,7 +293,34 @@ Follow the steps below to reset Dev to Live.
 
   <Download file="reset-dev-to-live.sh" />
 
-  GITHUB-EMBED https://github.com/pantheon-systems/documentation/blob/main/source/scripts/reset-dev-to-live.sh.txt bash GITHUB-EMBED
+  ```bash
+  #!/bin/bash
+
+  #Authenticate Terminus
+  terminus auth:login
+
+  #Provide the target site name (e.g. your-awesome-site)
+  echo 'Provide the site name (e.g. your-awesome-site), then press [ENTER] to reset the Dev environment to Live:';
+  read SITE;
+
+  #Set the Dev environment's connection mode to Git
+  echo "Making sure the environment's connection mode is set to Git...";
+  terminus connection:set $SITE.dev git
+
+  #Identify the most recent commit deployed to Live and overwrite history on Dev's codebase to reflect Live
+  echo "Rewriting history on the Dev environment's codebase...";
+  git reset --hard `terminus env:code-log $SITE.live --format=string | grep -m1 'live' | cut -f 4`
+
+  #Force push to Pantheon to rewrite history on Dev and reset codebase to Live
+  git push origin master -f
+
+  #Clone database and files from Live into Dev
+  echo "Importing database and files from Live into Dev...";
+  terminus env:clone-content $SITE.live dev
+
+  #Open the Dev environment on the Site Dashboard
+  terminus dashboard:view $SITE.dev
+  ```
 
 1. Execute the script from the command line within the root directory of your site's codebase:
 


### PR DESCRIPTION
## Summary

Removes `gatsby-remark-github` npm package, removes related config from `gatsby-config.js`, removes setup instructions from the `README.md` file, and replaces instances of usage across the docs with either a crosslink or a manual copy of the code snippets instead of using GITHUB_EMBED: 

* [Core Updates](https://pr-9295-documentation.appa.pantheon.site/core-updates#error-updating-conflict-modifydelete-pantheonupstreamyml-deleted-in-head-and-modified-in-upstreammaster-version-upstreammaster-of-pantheonupstreamyml-left-in-tree)
* [Access Backups](https://pr-9295-documentation.appa.pantheon.site/guides/backups/access-backups)
* [Local Development Configuration](https://pr-9295-documentation.appa.pantheon.site/guides/local-development/configuration#wordpress-wp-config-localphp)
* [Automate Log Downloads](https://pr-9295-documentation.appa.pantheon.site/guides/logs-pantheon/automate-log-downloads#create-a-script)
* [Configure Your wp-config.php File](https://pr-9295-documentation.appa.pantheon.site/guides/php/wp-config-php#pantheons-wordpress-config)
* [Debug Local DNS Cache](https://pr-9295-documentation.appa.pantheon.site/local-dns-cache)
* [Upload Your Files](https://pr-9295-documentation.appa.pantheon.site/guides/manual-d8-composer-to-d8/files)
* [Terminus: Get Started](https://pr-9295-documentation.appa.pantheon.site/terminus/examples#reset-dev-environment-to-live)
