### PR TITLE
WIP - remove dead code for popovers

### DIFF
--- a/src/templates/certificationpage.js
+++ b/src/templates/certificationpage.js
@@ -12,7 +12,6 @@ import TOC from '../components/toc';
 import MdxWrapper from '../components/mdxWrapper';
 
 class CertificationTemplate extends React.Component {
-
   render() {
     const node = this.props.data.mdx;
     const isoDate = this.props.data.date;

--- a/src/templates/certificationpage.js
+++ b/src/templates/certificationpage.js
@@ -12,31 +12,6 @@ import TOC from '../components/toc';
 import MdxWrapper from '../components/mdxWrapper';
 
 class CertificationTemplate extends React.Component {
-  componentDidMount() {
-    $('[data-toggle=popover]').popover({
-      trigger: 'click',
-    });
-
-    $('body').on('click', function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $('.popover').has(e.target).length === 0
-        ) {
-          $(this).popover('hide');
-        }
-      });
-    });
-
-    $('body').keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover('hide');
-        }
-      });
-    });
-  }
 
   render() {
     const node = this.props.data.mdx;

--- a/src/templates/doc.js
+++ b/src/templates/doc.js
@@ -1,51 +1,23 @@
-import React from "react"
-import { graphql } from "gatsby"
+import React from 'react';
+import { graphql } from 'gatsby';
 
-import Layout from "../layout/layout"
-import SEO from "../layout/seo"
-import HeaderBody from "../components/headerBody"
-import TOC from "../components/toc"
-import GetFeedback from "../components/getFeedback"
+import Layout from '../layout/layout';
+import SEO from '../layout/seo';
+import HeaderBody from '../components/headerBody';
+import TOC from '../components/toc';
+import GetFeedback from '../components/getFeedback';
 
-import { Container, SidebarLayout } from "@pantheon-systems/pds-toolkit-react"
+import { Container, SidebarLayout } from '@pantheon-systems/pds-toolkit-react';
 
-import MdxWrapper from "../components/mdxWrapper"
-
+import MdxWrapper from '../components/mdxWrapper';
 
 // Set container width for search and main content.
-const containerWidth = "standard"
+const containerWidth = 'standard';
 
 class DocTemplate extends React.Component {
-  componentDidMount() {
-    $("[data-toggle=popover]").popover({
-      trigger: "click",
-      placement: "right",
-    })
-
-    $("body").on("click", function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $(".popover").has(e.target).length === 0
-        ) {
-          $(this).popover("hide")
-        }
-      })
-    })
-
-    $("body").keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover("hide")
-        }
-      })
-    })
-  }
-
   render() {
-    const node = this.props.data.doc
-    const isoDate = this.props.data.date
+    const node = this.props.data.doc;
+    const isoDate = this.props.data.date;
 
     return (
       <Layout footerBorder>
@@ -53,7 +25,7 @@ class DocTemplate extends React.Component {
           title={node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
-          image={"/images/assets/default-thumb-doc.png"}
+          image={'/images/assets/default-thumb-doc.png'}
           categories={node.frontmatter.categories}
           keywords={node.frontmatter.tags}
           reviewed={isoDate.frontmatter.reviewed}
@@ -78,9 +50,8 @@ class DocTemplate extends React.Component {
                   isoDate={isoDate.frontmatter.reviewed}
                   cms={node.frontmatter.cms}
                 />
-                <div style={{ marginTop: "15px", marginBottom: "45px" }}>
+                <div style={{ marginTop: '15px', marginBottom: '45px' }}>
                   <MdxWrapper mdx={node.body} />
-
                 </div>
               </article>
               <TOC slot="sidebar" title="Contents" />
@@ -97,11 +68,11 @@ class DocTemplate extends React.Component {
           </Container>
         </main>
       </Layout>
-    )
+    );
   }
 }
 
-export default DocTemplate
+export default DocTemplate;
 
 export const pageQuery = graphql`
   query DocBySlug($slug: String!) {
@@ -139,4 +110,4 @@ export const pageQuery = graphql`
       }
     }
   }
-`
+`;

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -11,31 +11,6 @@ import TOC from '../components/toc';
 import MdxWrapper from '../components/mdxWrapper';
 
 class GuideTemplate extends React.Component {
-  componentDidMount() {
-    $('[data-toggle=popover]').popover({
-      trigger: 'click',
-    });
-
-    $('body').on('click', function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $('.popover').has(e.target).length === 0
-        ) {
-          $(this).popover('hide');
-        }
-      });
-    });
-
-    $('body').keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover('hide');
-        }
-      });
-    });
-  }
 
   render() {
     const node = this.props.data.mdx;

--- a/src/templates/guide.js
+++ b/src/templates/guide.js
@@ -11,7 +11,6 @@ import TOC from '../components/toc';
 import MdxWrapper from '../components/mdxWrapper';
 
 class GuideTemplate extends React.Component {
-
   render() {
     const node = this.props.data.mdx;
     const isoDate = this.props.data.date;

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -7,10 +7,10 @@ import HeaderBody from "../components/headerBody"
 import GetFeedback from "../components/getFeedback"
 import Navbar from "../components/navbar"
 import Partial from "../components/partial"
+import { Container } from "@pantheon-systems/pds-toolkit-react"
 
 let commandsJson = require("../../source/data/commands.json")
 
-import { Container } from "@pantheon-systems/pds-toolkit-react"
 
 // @TODO relocate this list
 // - To a YAML file and use GraphQL to pull data.
@@ -82,31 +82,6 @@ const items = [
 ]
 
 class CommandsTemplate extends React.Component {
-  componentDidMount() {
-    $("[data-toggle=popover]").popover({
-      trigger: "click",
-    })
-
-    $("body").on("click", function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $(".popover").has(e.target).length === 0
-        ) {
-          $(this).popover("hide")
-        }
-      })
-    })
-
-    $("body").keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover("hide")
-        }
-      })
-    })
-  }
 
   render() {
     const slug = this.props.pageContext.slug

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -1,131 +1,129 @@
-import React from "react"
-import { graphql, Link } from "gatsby"
-import GuideLayout from "../layout/GuideLayout"
-import SEO from "../layout/seo"
-import SearchBar from "../layout/SearchBar"
-import HeaderBody from "../components/headerBody"
-import GetFeedback from "../components/getFeedback"
-import Navbar from "../components/navbar"
-import Partial from "../components/partial"
-import { Container } from "@pantheon-systems/pds-toolkit-react"
+import React from 'react';
+import { graphql, Link } from 'gatsby';
+import GuideLayout from '../layout/GuideLayout';
+import SEO from '../layout/seo';
+import SearchBar from '../layout/SearchBar';
+import HeaderBody from '../components/headerBody';
+import GetFeedback from '../components/getFeedback';
+import Navbar from '../components/navbar';
+import Partial from '../components/partial';
+import { Container } from '@pantheon-systems/pds-toolkit-react';
 
-let commandsJson = require("../../source/data/commands.json")
-
+let commandsJson = require('../../source/data/commands.json');
 
 // @TODO relocate this list
 // - To a YAML file and use GraphQL to pull data.
 // - To a GraphQL query order by frontmatter weight/order/index field.
 const items = [
   {
-    id: "docs-terminus",
-    link: "/terminus",
-    title: "Introduction",
+    id: 'docs-terminus',
+    link: '/terminus',
+    title: 'Introduction',
   },
   {
-    id: "docs-terminus-install",
-    link: "/terminus/install",
-    title: "Install Terminus",
+    id: 'docs-terminus-install',
+    link: '/terminus/install',
+    title: 'Install Terminus',
   },
   {
-    id: "docs-terminus-examples",
-    link: "/terminus/examples",
-    title: "Get Started",
+    id: 'docs-terminus-examples',
+    link: '/terminus/examples',
+    title: 'Get Started',
   },
   {
-    id: "docs-terminus-commands",
-    link: "/terminus/commands",
-    title: "Command Directory",
+    id: 'docs-terminus-commands',
+    link: '/terminus/commands',
+    title: 'Command Directory',
   },
   {
-    id: "docs-terminus-scripting",
-    link: "/terminus/scripting",
-    title: "Scripting with Terminus",
+    id: 'docs-terminus-scripting',
+    link: '/terminus/scripting',
+    title: 'Scripting with Terminus',
   },
   {
-    id: "docs-terminus-plugins",
-    link: "/terminus/plugins",
-    title: "Install Plugins",
+    id: 'docs-terminus-plugins',
+    link: '/terminus/plugins',
+    title: 'Install Plugins',
   },
   {
-    id: "docs-terminus-directory",
-    link: "/terminus/directory",
-    title: "Plugin Directory",
+    id: 'docs-terminus-directory',
+    link: '/terminus/directory',
+    title: 'Plugin Directory',
   },
   {
-    id: "docs-terminus-create",
-    link: "/terminus/create",
-    title: "Create Terminus Plugins",
+    id: 'docs-terminus-create',
+    link: '/terminus/create',
+    title: 'Create Terminus Plugins',
   },
   {
-    id: "docs-terminus-configuration",
-    link: "/terminus/configuration",
-    title: "Terminus Configuration File",
+    id: 'docs-terminus-configuration',
+    link: '/terminus/configuration',
+    title: 'Terminus Configuration File',
   },
 
   {
-    id: "docs-supported-terminus",
-    link: "/terminus/supported-terminus",
-    title: "Supported Terminus and PHP Versions",
+    id: 'docs-supported-terminus',
+    link: '/terminus/supported-terminus',
+    title: 'Supported Terminus and PHP Versions',
   },
 
   {
-    id: "docs-terminus-updates",
-    link: "/terminus/updates",
-    title: "Current Terminus Release and Changelog",
+    id: 'docs-terminus-updates',
+    link: '/terminus/updates',
+    title: 'Current Terminus Release and Changelog',
   },
 
   {
-    id: "docs-terminus-terminus-3-0",
-    link: "/terminus/terminus-3-0",
-    title: "Terminus 3",
+    id: 'docs-terminus-terminus-3-0',
+    link: '/terminus/terminus-3-0',
+    title: 'Terminus 3',
   },
-]
+];
 
 class CommandsTemplate extends React.Component {
-
   render() {
-    const slug = this.props.pageContext.slug
+    const slug = this.props.pageContext.slug;
     //console.log("slug: ", slug) // For Debugging
 
-    const name = this.props.pageContext.name
+    const name = this.props.pageContext.name;
     //console.log("name: ", name) //For Debugging
 
-    const commands = this.props.data.dataJson.commands
+    const commands = this.props.data.dataJson.commands;
     //console.log("commands: ", commands) //For Debugging
 
     const getCommandBySlug = (slug) =>
-      commands.find(({ name }) => name === slug)
+      commands.find(({ name }) => name === slug);
     const getCommandJSONBySlug = (slug) =>
-      commandsJson.commands.find(({ name }) => name === slug)
+      commandsJson.commands.find(({ name }) => name === slug);
 
-    const command = getCommandBySlug(name)
+    const command = getCommandBySlug(name);
     //console.log("command: ", command) //For Debugging
 
-    const thisCommandJson = getCommandJSONBySlug(name)
+    const thisCommandJson = getCommandJSONBySlug(name);
     //console.log("thisCommandJson: ", thisCommandJson) //For Debugging
 
-    var options = Object.keys(thisCommandJson.definition.options).map(function (
-      key
-    ) {
-      return [String(key), thisCommandJson.definition.options[key]]
-    })
+    var options = Object.keys(thisCommandJson.definition.options).map(
+      function (key) {
+        return [String(key), thisCommandJson.definition.options[key]];
+      },
+    );
     options.forEach((option) => {
-      option.shift()
-    })
+      option.shift();
+    });
 
-    options.sort((a, b) => (a[0].name > b[0].name ? 1 : -1))
+    options.sort((a, b) => (a[0].name > b[0].name ? 1 : -1));
     options.sort(function (a, b) {
-      return a[0].name.localeCompare(b[0].name)
-    })
+      return a[0].name.localeCompare(b[0].name);
+    });
     //console.log("Options: ", options) //For Debugging
 
     return (
       <GuideLayout>
         <SEO
           slot="seo"
-          title={command.name + " | Terminus Commands"}
+          title={command.name + ' | Terminus Commands'}
           description={command.description}
-          image={"/images/assets/terminus-thumbLarge.png"}
+          image={'/images/assets/terminus-thumbLarge.png'}
         />
         <Navbar
           slot="guide-menu"
@@ -154,7 +152,7 @@ class CommandsTemplate extends React.Component {
               <div className="pds-spacing-mar-block-start-l pds-spacing-mar-block-end-4xl">
                 <pre className="language-bash">
                   <code className="language=bash">
-                    terminus {command.usage[0].replace(/\[|\]/g, "")}
+                    terminus {command.usage[0].replace(/\[|\]/g, '')}
                   </code>
                 </pre>
               </div>
@@ -170,16 +168,16 @@ class CommandsTemplate extends React.Component {
                             className="pds-spacing-mar-inline-end-2xs"
                           >
                             {usage
-                              .replace(/\[|\]/g, "")
-                              .replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, "")}
-                          </code>{" "}
+                              .replace(/\[|\]/g, '')
+                              .replace(/(?!^)\s\b[A-Z][a-z]\w*.+/g, '')}
+                          </code>{' '}
                           {usage
-                            .replace(/\[|\]/g, "")
+                            .replace(/\[|\]/g, '')
                             .match(/(?!^)\b[A-Z][a-z]*\b.+/)}
                         </p>
                         <hr className="commandHr" />
                       </>
-                    )
+                    );
                   }
                 })}
               </div>
@@ -204,7 +202,7 @@ class CommandsTemplate extends React.Component {
                             </td>
                           </tr>
                         </>
-                      )
+                      );
                     })}
                   </tbody>
                 </table>
@@ -214,13 +212,13 @@ class CommandsTemplate extends React.Component {
             </article>
           </main>
         </Container>
-        <GetFeedback page={"/" + slug} />
+        <GetFeedback page={'/' + slug} />
       </GuideLayout>
-    )
+    );
   }
 }
 
-export default CommandsTemplate
+export default CommandsTemplate;
 
 export const pageQuery = graphql`
   query CommandsData {
@@ -232,4 +230,4 @@ export const pageQuery = graphql`
       }
     }
   }
-`
+`;

--- a/src/templates/terminuspage.js
+++ b/src/templates/terminuspage.js
@@ -81,31 +81,6 @@ const items = [
 ]
 
 class TerminusTemplate extends React.Component {
-  componentDidMount() {
-    $("[data-toggle=popover]").popover({
-      trigger: "click",
-    })
-
-    $("body").on("click", function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $(".popover").has(e.target).length === 0
-        ) {
-          $(this).popover("hide")
-        }
-      })
-    })
-
-    $("body").keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover("hide")
-        }
-      })
-    })
-  }
 
   render() {
     const node = this.props.data.mdx

--- a/src/templates/terminuspage.js
+++ b/src/templates/terminuspage.js
@@ -1,114 +1,113 @@
-import React from "react"
-import { graphql } from "gatsby"
-import GuideLayout from "../layout/GuideLayout"
-import SEO from "../layout/seo"
-import SearchBar from "../layout/SearchBar"
-import HeaderBody from "../components/headerBody"
-import Navbar from "../components/navbar"
-import TOC from "../components/toc"
-import GetFeedback from "../components/getFeedback"
+import React from 'react';
+import { graphql } from 'gatsby';
+import GuideLayout from '../layout/GuideLayout';
+import SEO from '../layout/seo';
+import SearchBar from '../layout/SearchBar';
+import HeaderBody from '../components/headerBody';
+import Navbar from '../components/navbar';
+import TOC from '../components/toc';
+import GetFeedback from '../components/getFeedback';
 
-import MdxWrapper from "../components/mdxWrapper"
-import { SidebarLayout } from "@pantheon-systems/pds-toolkit-react"
+import MdxWrapper from '../components/mdxWrapper';
+import { SidebarLayout } from '@pantheon-systems/pds-toolkit-react';
 
 // @TODO relocate this list
 // - To a YAML file and use GraphQL to pull data.
 // - To a GraphQL query order by frontmatter weight/order/index field.
 const items = [
   {
-    id: "docs-terminus",
-    link: "/terminus",
-    title: "Introduction",
+    id: 'docs-terminus',
+    link: '/terminus',
+    title: 'Introduction',
   },
   {
-    id: "docs-terminus-install",
-    link: "/terminus/install",
-    title: "Install and Update Terminus",
+    id: 'docs-terminus-install',
+    link: '/terminus/install',
+    title: 'Install and Update Terminus',
   },
   {
-    id: "docs-terminus-examples",
-    link: "/terminus/examples",
-    title: "Get Started",
+    id: 'docs-terminus-examples',
+    link: '/terminus/examples',
+    title: 'Get Started',
   },
   {
-    id: "docs-terminus-commands",
-    link: "/terminus/commands",
-    title: "Command Directory",
+    id: 'docs-terminus-commands',
+    link: '/terminus/commands',
+    title: 'Command Directory',
   },
   {
-    id: "docs-terminus-scripting",
-    link: "/terminus/scripting",
-    title: "Scripting with Terminus",
+    id: 'docs-terminus-scripting',
+    link: '/terminus/scripting',
+    title: 'Scripting with Terminus',
   },
   {
-    id: "docs-terminus-plugins",
-    link: "/terminus/plugins",
-    title: "Install Plugins",
+    id: 'docs-terminus-plugins',
+    link: '/terminus/plugins',
+    title: 'Install Plugins',
   },
   {
-    id: "docs-terminus-directory",
-    link: "/terminus/directory",
-    title: "Plugin Directory",
+    id: 'docs-terminus-directory',
+    link: '/terminus/directory',
+    title: 'Plugin Directory',
   },
   {
-    id: "docs-terminus-create",
-    link: "/terminus/create",
-    title: "Create Terminus Plugins",
+    id: 'docs-terminus-create',
+    link: '/terminus/create',
+    title: 'Create Terminus Plugins',
   },
   {
-    id: "docs-terminus-configuration",
-    link: "/terminus/configuration",
-    title: "Terminus Configuration File",
+    id: 'docs-terminus-configuration',
+    link: '/terminus/configuration',
+    title: 'Terminus Configuration File',
   },
 
   {
-    id: "docs-supported-terminus",
-    link: "/terminus/supported-terminus",
-    title: "Supported Terminus and PHP Versions",
+    id: 'docs-supported-terminus',
+    link: '/terminus/supported-terminus',
+    title: 'Supported Terminus and PHP Versions',
   },
 
   {
-    id: "docs-terminus-updates",
-    link: "/terminus/updates",
-    title: "Current Terminus Release and Changelog",
+    id: 'docs-terminus-updates',
+    link: '/terminus/updates',
+    title: 'Current Terminus Release and Changelog',
   },
 
   {
-    id: "docs-terminus-terminus-3-0",
-    link: "/terminus/terminus-3-0",
-    title: "Terminus 3",
+    id: 'docs-terminus-terminus-3-0',
+    link: '/terminus/terminus-3-0',
+    title: 'Terminus 3',
   },
-]
+];
 
 class TerminusTemplate extends React.Component {
-
   render() {
-    const node = this.props.data.mdx
-    const isoDate = this.props.data.date
+    const node = this.props.data.mdx;
+    const isoDate = this.props.data.date;
     const ifCommandsDate =
-      node.fields.slug == "/terminus/commands"
+      node.fields.slug == '/terminus/commands'
         ? this.props.data.terminusReleasesJson.published_at
-        : node.frontmatter.reviewed
+        : node.frontmatter.reviewed;
     const ifCommandsISO =
-      node.fields.slug == "/terminus/commands"
+      node.fields.slug == '/terminus/commands'
         ? this.props.data.jsonISO.published_at
-        : isoDate.frontmatter.reviewed
+        : isoDate.frontmatter.reviewed;
 
     // Preprocess content region layout if has TOC or not.
-    const hasTOC = node.frontmatter.showtoc
+    const hasTOC = node.frontmatter.showtoc;
     const ContainerDiv = ({ children }) => (
       <div className="content-wrapper">{children}</div>
-    )
-    const ContentLayoutType = hasTOC ? SidebarLayout : ContainerDiv
+    );
+    const ContentLayoutType = hasTOC ? SidebarLayout : ContainerDiv;
 
     return (
       <GuideLayout>
         <SEO
           slot="seo"
-          title={node.frontmatter.subtitle + " | " + node.frontmatter.title}
+          title={node.frontmatter.subtitle + ' | ' + node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
-          image={"/images/assets/terminus-thumbLarge.png"}
+          image={'/images/assets/terminus-thumbLarge.png'}
           reviewed={ifCommandsISO}
           type={node.frontmatter.type}
         />
@@ -143,13 +142,13 @@ class TerminusTemplate extends React.Component {
           </main>
           {hasTOC && <TOC slot="sidebar" title="Contents" />}
         </ContentLayoutType>
-        <GetFeedback formId="tfYOGoE7" page={"/" + node.fields.slug} />
+        <GetFeedback formId="tfYOGoE7" page={'/' + node.fields.slug} />
       </GuideLayout>
-    )
+    );
   }
 }
 
-export default TerminusTemplate
+export default TerminusTemplate;
 
 export const pageQuery = graphql`
   query TerminusPageBySlug($slug: String!) {
@@ -187,4 +186,4 @@ export const pageQuery = graphql`
       published_at(formatString: "YYYY-MM-DD")
     }
   }
-`
+`;

--- a/src/templates/video.js
+++ b/src/templates/video.js
@@ -1,19 +1,17 @@
-import React from "react"
-import { graphql } from "gatsby"
-import Layout from "../layout/layout"
-import HeaderBody from "../components/headerBody"
-import SEO from "../layout/seo"
-import { Container } from "@pantheon-systems/pds-toolkit-react"
-import MdxWrapper from "../components/mdxWrapper"
-
+import React from 'react';
+import { graphql } from 'gatsby';
+import Layout from '../layout/layout';
+import HeaderBody from '../components/headerBody';
+import SEO from '../layout/seo';
+import { Container } from '@pantheon-systems/pds-toolkit-react';
+import MdxWrapper from '../components/mdxWrapper';
 
 // Set container width for search and main content.
-const containerWidth = "standard"
+const containerWidth = 'standard';
 
 class VideoTemplate extends React.Component {
-
   render() {
-    const node = this.props.data.mdx
+    const node = this.props.data.mdx;
 
     return (
       <Layout containerWidth={containerWidth}>
@@ -21,7 +19,7 @@ class VideoTemplate extends React.Component {
           title={node.frontmatter.title}
           description={node.frontmatter.description || node.excerpt}
           authors={node.frontmatter.contributors}
-          image={"/images/assets/default-thumb-doc.png"}
+          image={'/images/assets/default-thumb-doc.png'}
           type={node.frontmatter.type}
         />
         <main id="docs-main" tabIndex="-1">
@@ -40,11 +38,11 @@ class VideoTemplate extends React.Component {
           </Container>
         </main>
       </Layout>
-    )
+    );
   }
 }
 
-export default VideoTemplate
+export default VideoTemplate;
 
 export const pageQuery = graphql`
   query VideoBySlug($slug: String!) {
@@ -71,4 +69,4 @@ export const pageQuery = graphql`
       fileAbsolutePath
     }
   }
-`
+`;

--- a/src/templates/video.js
+++ b/src/templates/video.js
@@ -11,31 +11,6 @@ import MdxWrapper from "../components/mdxWrapper"
 const containerWidth = "standard"
 
 class VideoTemplate extends React.Component {
-  componentDidMount() {
-    $("[data-toggle=popover]").popover({
-      trigger: "click",
-    })
-
-    $("body").on("click", function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (
-          !$(this).is(e.target) &&
-          $(this).has(e.target).length === 0 &&
-          $(".popover").has(e.target).length === 0
-        ) {
-          $(this).popover("hide")
-        }
-      })
-    })
-
-    $("body").keyup(function (e) {
-      $('[data-toggle="popover"]').each(function () {
-        if (event.which === 27) {
-          $(this).popover("hide")
-        }
-      })
-    })
-  }
 
   render() {
     const node = this.props.data.mdx


### PR DESCRIPTION
@rachelwhitton @jazzsequence I think the sporadic errors we've been seeing in `npm run develop` relate to this code (that's present in a few templates). I think it might be safe to delete because popover is now coming from the design system instead of from custom code. I'll need to test more. But I'm getting a foothold on the PR so that I can reference it in the nav PR.