### PR TITLE
Clarify what counts for known bots, incognito bots and load testing traffic limits

### DIFF
--- a/source/content/guides/account-mgmt/traffic/01-introduction.md
+++ b/source/content/guides/account-mgmt/traffic/01-introduction.md
@@ -132,7 +132,9 @@ This table shows some of the reasons why traffic in the Dashboard may differ fro
 |                                                 | Counts as Traffic | Counts for Analytics |
 |:------------------------------------------------|:-----------------:|:--------------------:|
 | **API Request**                                 |        Yes        |          No          |
-| **Automated traffic from bots or load testing** |        Yes        |       Sometimes      |
+| **Known and Self-identified Bots**              |        No         |       Sometimes      |
+| **Unknown and Incognito Bots**                  |        Yes        |       Sometimes      |
+| **Load Testing and Third-party Monitoring**     |        Yes        |       Sometimes      |
 | **Content pre-fetching**                        |        Yes        |       Sometimes      |
 | **Pages without a tracking asset**              |        Yes        |          No          |
 | **User closes browser before tracking loads**   |        Yes        |          No          |


### PR DESCRIPTION
## Summary

**[Measuring Site Traffic](https://docs.pantheon.io/guides/account-mgmt/traffic#why-doesnt-pantheons-traffic-metrics-match-my-other-analytics)** - Updates the table so that the following are distinguished, rather than grouped together in the existing row for "Automated traffic from bots or load testing": 

* Known and Self-identified Bots = No, Sometimes
* Unknown and Incognito Bots = Yes, Sometimes
* Load Testing and Third-party Monitoring = Yes, Sometimes
