### PR TITLE
WordPress 6.7 release note

### DIFF
--- a/source/releasenotes/2024-11-12-wordpress-6.7.md
+++ b/source/releasenotes/2024-11-12-wordpress-6.7.md
@@ -17,4 +17,8 @@ Upgrade to WordPress 6.7 right from your Pantheon dashboard or Terminus for the 
 * [...and more](https://wordpress.org/download/releases/6-7/)
 * Check out the [6.7 preview](https://www.youtube.com/watch?v=mH3BIm8AP70) we recorded with [XWP](https://xwp.co/) on our [YouTube channel](https://www.youtube.com/getpantheon).
 
+### Notes
+
+* [Support for HEIC images](https://make.wordpress.org/core/2024/08/15/automatic-conversion-of-heic-images-to-jpeg-in-wordpress-6-7/) -- added in this version of WordPress -- will not be supported at release time on Pantheon due to a conflict with our version of ImageMagick. We are working on a solution that will include support for HEIC images in a future platform update.
+
 For full details about WordPress 6.7, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-7/) or the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/).

--- a/source/releasenotes/2024-11-12-wordpress-6.7.md
+++ b/source/releasenotes/2024-11-12-wordpress-6.7.md
@@ -1,10 +1,10 @@
 ---
-title: WordPress 6.7 (Rollins) release
+title: WordPress 6.7 (Rollins) release now available
 published_date: "2024-11-12"
 categories: [wordpress, action-required]
 ---
 
-The latest version of WordPress, [6.7 (Rollins)](https://wordpress.org/news/2024/11/rollins/), became available on Pantheon as of November 12, 2024.
+The latest version of WordPress, [6.7 (Rollins)](https://wordpress.org/news/2024/11/rollins/), is available on Pantheon as of November 12, 2024.
 
 ### Action required
 Upgrade to WordPress 6.7 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).

--- a/source/releasenotes/2024-11-12-wordpress-6.7.md
+++ b/source/releasenotes/2024-11-12-wordpress-6.7.md
@@ -7,15 +7,16 @@ categories: [wordpress, action-required]
 The latest version of WordPress, [6.7 (Rollins)](https://wordpress.org/news/2024/11/rollins/), is available on Pantheon as of November 12, 2024.
 
 ### Action required
-Upgrade to WordPress 6.7 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+Upgrade to WordPress 6.7 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
 
 ### Highlights
 
-* A new default theme, Twenty Twenty-Five, with dozens of customization options, templates and patters built into the Site Editor.
+* A new default theme, Twenty Twenty-Five, with dozens of customization options, templates, and patters built into the Site Editor.
 * A new Zoom Out view to see more of your page layout at once.
 * Updated style sections in the Site Editor to make it easier to customize your site design.
 * [...and more](https://wordpress.org/download/releases/6-7/)
-* Check out the [6.7 preview](https://www.youtube.com/watch?v=mH3BIm8AP70) we recorded with [XWP](https://xwp.co/) on our [YouTube channel](https://www.youtube.com/getpantheon).
+
+Check out the [6.7 preview](https://www.youtube.com/watch?v=mH3BIm8AP70) we recorded with [XWP](https://xwp.co/) on our [YouTube channel](https://www.youtube.com/getpantheon).
 
 ### Notes
 

--- a/source/releasenotes/2024-11-12-wordpress-6.7.md
+++ b/source/releasenotes/2024-11-12-wordpress-6.7.md
@@ -1,0 +1,20 @@
+---
+title: WordPress 6.7 (Rollins) release
+published_date: "2024-11-12"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.7 (Rollins)](https://wordpress.org/news/2024/11/rollins/), became available on Pantheon as of November 12, 2024.
+
+### Action required
+Upgrade to WordPress 6.7 right from your Pantheon dashboard or Terminus for the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+* A new default theme, Twenty Twenty-Five, with dozens of customization options, templates and patters built into the Site Editor.
+* A new Zoom Out view to see more of your page layout at once.
+* Updated style sections in the Site Editor to make it easier to customize your site design.
+* [...and more](https://wordpress.org/download/releases/6-7/)
+* Check out the [6.7 preview](https://www.youtube.com/watch?v=mH3BIm8AP70) we recorded with [XWP](https://xwp.co/) on our [YouTube channel](https://www.youtube.com/getpantheon).
+
+For full details about WordPress 6.7, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-7/) or the [WordPress 6.7 Field Guide](https://make.wordpress.org/core/2024/10/23/wordpress-6-7-field-guide/).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Release note for WordPress 6.7