### PR TITLE
Updated column Counts for Analytics

### DIFF
--- a/source/content/guides/account-mgmt/traffic/01-introduction.md
+++ b/source/content/guides/account-mgmt/traffic/01-introduction.md
@@ -132,9 +132,9 @@ This table shows some of the reasons why traffic in the Dashboard may differ fro
 |                                                 | Counts as Traffic | Counts for Analytics |
 |:------------------------------------------------|:-----------------:|:--------------------:|
 | **API Request**                                 |        Yes        |          No          |
-| **Known and Self-identified Bots**              |        No         |       Sometimes      |
-| **Unknown and Incognito Bots**                  |        Yes        |       Sometimes      |
-| **Load Testing and Third-party Monitoring**     |        Yes        |       Sometimes      |
+| **Known and Self-identified Bots**              |        No         |          No          |
+| **Unknown and Incognito Bots**                  |        Yes        |          No          |
+| **Load Testing and Third-party Monitoring**     |        Yes        |          No          |
 | **Content pre-fetching**                        |        Yes        |       Sometimes      |
 | **Pages without a tracking asset**              |        Yes        |          No          |
 | **User closes browser before tracking loads**   |        Yes        |          No          |


### PR DESCRIPTION
Fixed a few rows in the 'Counts for Analytics' column.

## Summary

[Measuring Site Traffic](https://docs.pantheon.io/guides/account-mgmt/traffic#why-doesnt-pantheons-traffic-metrics-match-my-other-analytics) - Updates the table with which rows would not appear in a site's analytics suite since those bots and services do not process/run the JavaScript and therefore are counted in Pantheon's CDN metrics but the customer GA for example does not have that ability.

Follow up to PR https://github.com/pantheon-systems/documentation/pull/9299.