### PR TITLE
Update Local Object Cache Pro config for Lando

### DIFF
--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -97,11 +97,11 @@ terminus redis:enable <site>
 	<Alert title="Note" type="info">
 	**Note for Lando users:**
 
-	If you are using Lando for your local development, add the following to your `wp-config.php` file to deactivate Redis to prevent it from disabling your Lando server:
+	If you are using Lando for your local development, add the following to your `wp-config.php` file to deactivate Object Cache Pro to prevent it from disabling your Lando server:
 
-	```
-	if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
-	  define('FS_METHOD', 'direct');
+	``` php
+	if ( isset( $_ENV['LANDO'] ) && 'ON' === $_ENV['LANDO'] ) {
+	  define('WP_REDIS_DISABLED', true);
 	}
  	```
  	Make sure to git push it back to your dev environment once you are finished.

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -94,6 +94,19 @@ terminus redis:enable <site>
 
 	**Note:** WordPress Multisite users will need to append the `--network` flag to network activate the plugin.
 
+	<Alert title="Note" type="info">
+	**Note for Lando users:**
+
+	If you are using Lando for your local development, add the following to your `wp-config.php` file to deactivate Redis to prevent it from disabling your Lando server:
+
+	```
+	if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
+	  define('FS_METHOD', 'direct');
+	}
+ 	```
+ 	Make sure to git push it back to your dev environment once you are finished.
+	</alert>
+
 1. Navigate to `/wp-admin/options-general.php?page=objectcache` to see the current status of Object Cache Pro on your site as well as live graphs of requests, memory usage, and more.
 
 	<Alert title="Note" type="info">


### PR DESCRIPTION
## Summary

**[Enable Object Cache Pro for WordPress](https://docs.pantheon.io/object-cache/wordpress)** - Added note after 6c advising Lando users to disable Redis to prevent it from deactivating their server. Suggested by @pwtyler and tested by myself.
