### PR TITLE
Release note for Plugin Pipeline Example 0.3.10-rc1

### DIFF
--- a/source/releasenotes/2024-11-21-plugin-pipeline-example-0-3-10-rc1.md
+++ b/source/releasenotes/2024-11-21-plugin-pipeline-example-0-3-10-rc1.md
@@ -1,0 +1,11 @@
+---
+title: "Plugin Pipeline Example 0.3.10-rc1 now available"
+published_date: "2024-11-21"
+categories: [wordpress,plugins]
+---
+
+The latest version of Plugin Pipeline Example, [0.3.10-rc1](https://github.com/pantheon-systems/plugin-pipeline-example/releases/tag/0.3.10-rc1), is available as of November, 21, 2024.
+
+
+
+


### PR DESCRIPTION
**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for [Plugin Pipeline Example 0.3.10-rc1](https://github.com/pantheon-systems/plugin-pipeline-example/releases/tag/0.3.10-rc1).