### PR TITLE
Release Note for WordPress 6.7.1

### DIFF
--- a/source/releasenotes/2024-11-21-wordpress-6-7-1.md
+++ b/source/releasenotes/2024-11-21-wordpress-6-7-1.md
@@ -1,0 +1,14 @@
+---
+title: WordPress 6.7.1 release is now available
+published_date: "2024-11-21"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.7.1](https://wordpress.org/news/2024/11/wordpress-6-7-1-maintenance-release/), became available on Pantheon as of November 21, 2024. 
+
+### Action required
+Upgrade to WordPress 6.7.1 right from your Pantheon dashboard or Terminus for the latest fixes. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+<h3>Highlights</h3>
+
+* 16 bug fixes [throughout Core](https://core.trac.wordpress.org/query?resolution=fixed&milestone=6.7.1&group=component&col=id&col=summary&col=milestone&col=owner&col=type&col=status&col=priority&order=priority) and [the block editor](https://github.com/WordPress/wordpress-develop/pull/7851)


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for yesterday's 6.7.1 update to WordPress (https://github.com/pantheon-systems/WordPress/pull/409)