### PR TITLE
Add Local Lando config for OCP and suggest Secrets for license storage

### DIFF
--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -123,16 +123,8 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	composer config --auth http-basic.objectcache.pro token $(terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")
 	```
 	
-	This will pull the Object Cache Pro license token directly into the `auth.json` file.
+	This will pull the Object Cache Pro license token directly into the `auth.json` file. You can open the `auth.json` file locally to ensure that it has a structure that looks like this:
 	
-	**Manually:**
-
-	1. Create an `auth.json` file in your directory.
-	
-	1. Run `terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")` to output the token to your terminal, then copy it into the `password` field in the next step.
-
-	1. Add the following code to the `auth.json` file.
-
 		```json
 		{
 			"http-basic": {

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -142,7 +142,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	
 	</Alert>
 
-1. Open your `composer.json` file and locate the `repositories` section. If it doesn't exist, add it as shown below:
+1. Open your `composer.json` file and locate the `repositories` section. If it doesn't exist, add it in the "repositories" section as shown below:
 
 	```json
 		repositories: [

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -302,7 +302,7 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 			type: redis:6.0
 	```
 
-	- This ensures that the Redis version in your Lando environment matches the 6.x environment on Pantheon.
+	- This ensures that the Redis version in your Lando environment matches the 6.x environment on Pantheon. Object Cache Pro will still work with the default version of Redis that is included in the Pantheon Lando recipe, so this step is optional.
 
 1. Next, in your `wp-config.php` (or `config/application.php` for Bedrock-based WordPress Composer sites), find the `WP_REDIS_CONFIG` settings. Lando does not support `igbinary` serialization or `zstd` compression, so you will need to modify these settings for Lando locally. The simplest solution is to store the configuration values to a variable and then modify the variable for Lando environments. For example:
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -192,42 +192,76 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	```bash{promptUser: user}
 	git add composer.* && git commit -m "Require Object Cache Pro"
 	```
-
-1. Add the license token your `config/application.php` file. Note that in the future, the license key will be provided by the platform. Currently, you are responsible for adding it to your repository.
-
+	
+1. Add the license token your `config/application.php` file. Note that in the future, the license key will be provided by the platform. Currently, you are responsible for adding it to your repository. However, you can take advantage of [Pantheon Secrets](/guides/secrets) to store the token as a secret. 
+	
 1. Open your `config/application.php` file to add configuration values to Object Cache Pro for your site.
 
-1. Locate the `Config::apply()` line at the bottom of the file and add the following code above the line:
+1. Locate the `Config::apply()` line at the bottom of the file and add the following code above that line.
 
-	```php
+	<Tablist>
+	
+	<Tab title="Using Pantheon Secrets" id="ocp-auth-secrets" active={true}>
+	
+	<Alert title="Secrets Usage Note" type="info">
+	You will need to have the Terminus Secrets Manager Plugin installed to perform any steps relating to Pantheon Secrets. For more information about how to install the Secrets Manager Plugin [refer to our documentation](/guides/secrets#installation). For more information about how Secrets work, refer to our [guide](/guides/secrets).
+	</Alert>
 
-		/**
-		 * Object Cache Pro config
-		 */
-		Config::define( 'WP_REDIS_CONFIG', [
-			'token' => '<LICENSE-TOKEN>',
-		] );
+	1. Before updating the `WP_REDIS_CONFIG` constant, store the license token as a secret:
+	
+		```bash{promptUser: user}
+		terminus secret:site:set <site> ocp_token $(terminus wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');") --scope=user,web
+		```
+		
+		This grabs the Object Cache Pro license key from Pantheon and stores it directly as a Pantheon Site Secret. You can verify that the secret has been stored by running `terminus secret:site:list <site>`
+		
+	1. Use the `pantheon_get_secret` function in your `config/application.php` file:
+	
+		```php
+			/**
+			 * Object Cache Pro config
+			 */
+			Config::define( 'WP_REDIS_CONFIG', [
+				'token' => pantheon_get_secret( 'ocp_token' ),
+			] );		
+		```
+	
+	</Tab>
 
-	```
-	You can put this directly under the `WP_DEBUG` rules so it looks like this:
-	```php
+	<Tab title="Manually" id="ocp-auth-manual">
+	
+	- Use the `OCP_LICENSE` fetched earlier from `terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")` and copy this into your `config/application.php` file:
 
-  	/**
-  	 * Debugging Settings
-  	 */
-  	Config::define('WP_DEBUG_DISPLAY', false);
-  	Config::define('WP_DEBUG_LOG', false);
-  	Config::define('SCRIPT_DEBUG', false);
-  	ini_set('display_errors', '0');
+		```php
+			/**
+			 * Object Cache Pro config
+			 */
+			Config::define( 'WP_REDIS_CONFIG', [
+				'token' => '<LICENSE-TOKEN>',
+			] );
+		```
+	
+		You can put this directly under the `WP_DEBUG` rules so it looks like this:
 
-  	/**
-  	 * Object Cache Pro config
-  	 */
-  	Config::define( 'WP_REDIS_CONFIG', [
-  		'token' => '<LICENSE-TOKEN>',
-  	] );
+		```php
+			/**
+			 * Debugging Settings
+			 */
+			Config::define('WP_DEBUG_DISPLAY', false);
+			Config::define('WP_DEBUG_LOG', false);
+			Config::define('SCRIPT_DEBUG', false);
+			ini_set('display_errors', '0');
 
-  ```
+			/**
+			 * Object Cache Pro config
+			 */
+			Config::define( 'WP_REDIS_CONFIG', [
+				'token' => '<LICENSE-TOKEN>',
+			] );
+		```
+	</Tab>
+	
+	</Tablist>
 
 1. Add Object Cache Pro configuration options after `Config::define( 'WP_REDIS_CONFIG', [` in `config/application.php` for **WordPress (Composer Managed)** sites. The full, recommended contents of the WP_REDIS_CONFIG constant are:
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -251,7 +251,10 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
  		'async_flush' => true,
  		'strict' => true,
 	```
-1. Make sure you `git push` your changes up to your repository before you activate the plugin.
+	
+	Refer to the [Object Cache Pro documentation](https://objectcache.pro/docs/) for detailed explanations of all the configuration settings.
+	
+1. Make sure you add and `git push` your changes up to your repository before you activate the plugin.
 
 1. Activate the plugin and enable Redis in the plugin. You can activate the Object Cache Pro plugin from the WordPress Admin, locally with WP-CLI, or via Terminus.
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -185,8 +185,8 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	git add composer.* && git commit -m "Require Object Cache Pro"
 	```
 	
-1. Add the license token your `config/application.php` file. Note that in the future, the license key will be provided by the platform. Currently, you are responsible for adding it to your repository. However, you can take advantage of [Pantheon Secrets](/guides/secrets) to store the token as a secret. 
-	
+1. Add the license token your `config/application.php` file. Normally, the license key is provided by the platform. However, when you are working locally, Lando (or your local development environment) does not have access to the platform environment variable. However, you can extract it from the `auth.json` created in the previous steps.
+
 1. Open your `config/application.php` file to add configuration values to Object Cache Pro for your site.
 
 1. Locate the `Config::apply()` line at the bottom of the file and add the following code above that line.

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -117,21 +117,19 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
         ```
 	1. Commit and push this file to your site.
 
-1. Obtain a license token to use in the following authentication steps.
-
-	```bash
-	terminus remote:wp "<site>.<env>" -- eval "echo getenv('OCP_LICENSE');"
-    ```
-
-1. Create the authentication token and add your license token to Composer. You can do this automatically with the following command or create it manually with the steps below.
-
+1. Obtain the license token and apply it directly to the Composer `auth.json` to be able to authenticate against Object Cache Pro's Composer repository.
+	
 	```bash{promptUser: user}
-	composer config --auth http-basic.objectcache.pro token <LICENSE-TOKEN>
+	composer config --auth http-basic.objectcache.pro token $(terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")
 	```
-
+	
+	This will pull the Object Cache Pro license token directly into the `auth.json` file. 
+	
 	**Manually:**
 
 	1. Create an `auth.json` file in your directory.
+	
+	1. Run `terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")` to output the token to your terminal, then copy it into the `password` field in the next step.
 
 	1. Add the following code to the `auth.json` file.
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -298,7 +298,7 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 
 	```yaml
 	services:
-		<your-service-name>:
+		cache:
 			type: redis:6.0
 	```
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -123,7 +123,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	composer config --auth http-basic.objectcache.pro token $(terminus remote:wp <site>.<env> -- eval "echo getenv('OCP_LICENSE');")
 	```
 	
-	This will pull the Object Cache Pro license token directly into the `auth.json` file. 
+	This will pull the Object Cache Pro license token directly into the `auth.json` file.
 	
 	**Manually:**
 
@@ -144,11 +144,11 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 		}
 		```
 
-1. Commit the `auth.json` to your repository:
-
-	 ```bash{promptUser: user}
-	git add auth.json && git commit -m "Add Object Cache Pro auth token."
-	```
+	<Alert title="Note" type="info">
+	
+	The `auth.json` file is only necessary for authenticating against the Object Cache Pro Composer repository. For this reason, we recommend adding it to your `.gitignore` so you are not committing secrets to your Git repository. However, excluding it from version control means that anyone else who may want to update Object Cache Pro locally will need to repeat the steps above to generate their own `auth.json` file.
+	
+	</Alert>
 
 1. Open your `composer.json` file and locate the `repositories` section. If it doesn't exist, add it as shown below:
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -390,6 +390,18 @@ Make sure to commit your code back to your environment when you have made the ap
   - Subsites do not get their own configuration or graphs.
   - If installed on a WordPress Multisite, the Flush cache button in the subsite dashboard widget flushes the cache of the entire network, not just the subsite cache. The default behavior can be modified by [adjusting the `WP_REDIS_CONFIG` settings](https://objectcache.pro/docs/configuration-options/#flushing-networks). Alternatively, you can flush a single site's cache by using the [WP-CLI command](https://objectcache.pro/docs/wp-cli/#multisite-flushing).
   - You must manually click the **Enable Cache** button in the Network Admin Object Cache Pro settings page while in SFTP mode to enable Object Cache Pro. Alternatively, you can use the Terminus commands above and commit the `object-cache.php` drop-in to your repository.
+- When working locally with Lando, it's possible that Lando's self-signed SSL certificate will cause issues connecting to the Object Cache Pro license API resulting in a license error. To resolve this, add the following code to a mu-plugin:
+	
+	```php
+	if ( isset( $_ENV['LANDO'] ) && 'ON' === $_ENV['LANDO'] ) {
+		add_filter( 'http_request_args', function ( $args ) {
+			$args['sslverify'] = false;
+			return $args;
+		} );	
+	}
+	```
+	
+	- You may wish to make this file local-only by adding it to your `.gitignore` file. This error will not cause any issues with the functioning of Object Cache Pro or the behavior of the plugin on Pantheon but it might prevent you from being able to make updates to the plugin locally.
 
   	<Alert title="Note" type="info">
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -222,7 +222,8 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 			 * Object Cache Pro config
 			 */
 			Config::define( 'WP_REDIS_CONFIG', [
-				'token' => pantheon_get_secret( 'ocp_token' ),
+				// Check for `pantheon_get_secret` then check for the OCP_LICENSE environment variable.
+				'token' => function_exists( 'pantheon_get_secret' ) ? pantheon_get_secret( 'ocp_token' ) : ( isset( getenv( 'OCP_LICENSE' ) ? getenv( 'OCP_LICENSE' ) : '' ),
 			] );		
 		```
 	

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -150,7 +150,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 	git add auth.json && git commit -m "Add Object Cache Pro auth token."
 	```
 
-1. Add the Object Cache Pro repository to your `composer.json` file's `repositories` section.
+1. Open your `composer.json` file and locate the `repositories` section. If it doesn't exist, add it as shown below:
 
 	```json
 		repositories: [

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -227,7 +227,7 @@ Refer to the [official Object Cache Pro documentation](https://objectcache.pro/d
 1. Add Object Cache Pro configuration options after `Config::define( 'WP_REDIS_CONFIG', [` in `config/application.php` for **WordPress (Composer Managed)** sites. The full, recommended contents of the WP_REDIS_CONFIG constant are:
 
 	```php
-		'token' => '<LICENSE-TOKEN>',
+		'token' => $token,
 		'host' => getenv('CACHE_HOST') ?: '127.0.0.1',
 		'port' => getenv('CACHE_PORT') ?: 6379,
 		'database' => getenv('CACHE_DB') ?: 0,
@@ -305,7 +305,7 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 
 	```php
 	$ocp_settings = [
-		'token' isset( getenv( 'OCP_LICENSE' ) ) ? getenv( 'OCP_LICENSE' ) : '',
+		'token' => $token, // The dynamically fetched token from above.
 		'host' => getenv('CACHE_HOST') ?: '127.0.0.1',
 		'port' => getenv('CACHE_PORT') ?: 6379,
 		'database' => getenv('CACHE_DB') ?: 0,


### PR DESCRIPTION
## Summary

**[Enable Object Cache Pro for WordPress](https://docs.pantheon.io/object-cache/wordpress)** - Updates Lando configuration to configure OCP locally for Lando (alternative to #9309 which recommends disabling OCP). Additionally, this PR suggests using Pantheon Secrets for storing the license key for Composer-based installs.
