### PR TITLE
Release Note: [BUGS-8984] Terminus 3.6.1

### DIFF
--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,8 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 3.6.1            | December 04, 2024  |                    |
-| 3.6.0            | September 19, 2024 | December 04, 2025  |
+| 3.6.1            | December 05, 2024  |                    |
+| 3.6.0            | September 19, 2024 | December 05, 2025  |
 | 3.5.2            | August 19, 2024    | September 19, 2025 |
 | 3.5.1            | June 13, 2024      | August 19, 2025    |
 | 3.5.0            | June 6, 2024       | June 13, 2025      |

--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 3.6.0            | September 19, 2024 |                    |
+| 3.6.1            | December 04, 2024  |                    |
+| 3.6.0            | September 19, 2024 | December 04, 2025  |
 | 3.5.2            | August 19, 2024    | September 19, 2025 |
 | 3.5.1            | June 13, 2024      | August 19, 2025    |
 | 3.5.0            | June 6, 2024       | June 13, 2025      |
@@ -33,10 +34,7 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 | 3.3.3            | January 11, 2024   | February 27, 2025  |
 | 3.3.2            | January 11, 2024   | January 11, 2025   |
 | 3.3.1            | November 30, 2023  | January 11, 2025   |
-| 3.3.0            | November 29, 2023  | November 30, 2024  |
-| 3.2.2            | September 28, 2023 | November 29, 2024  |
-| 3.2.1            | June 1, 2023       | September 28, 2024 |
-| 3.2.0 or earlier | May 22 , 2023      | June 1, 2024       |
+| 3.3.0 or earlier | November 29, 2023  | November 30, 2024  |
 
 
 ### PHP Version Compatibility Matrix

--- a/source/releasenotes/2024-12-04-terminus-361.md
+++ b/source/releasenotes/2024-12-04-terminus-361.md
@@ -1,12 +1,12 @@
 ---
-title: "Terminus 3.6.1 released"
+title: "Terminus 3.6.1 release now available"
 published_date: "2024-12-04"
 categories: [tools-apis, new-feature]
 ---
 
-Terminus [3.6.1](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1) was released. It contains the latest bug fixes and improvements for this tool.
+Terminus [3.6.1](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1) is now available as of December 04, 2024. This minor update contains the latest bug fixes and improvements for this tool.
 
-You can get the full details about this version in the release page linked above.
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1).
 
 ## How to upgrade Terminus
 If you manage your installation via Homebrew on macOS, you can update Terminus with the following command:

--- a/source/releasenotes/2024-12-04-terminus-361.md
+++ b/source/releasenotes/2024-12-04-terminus-361.md
@@ -1,0 +1,17 @@
+---
+title: "Terminus 3.6.1 released"
+published_date: "2024-12-04"
+categories: [tools-apis, new-feature]
+---
+
+Terminus [3.6.1](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1) was released. It contains the latest bug fixes and improvements for this tool.
+
+You can get the full details about this version in the release page linked above.
+
+## How to upgrade Terminus
+If you manage your installation via Homebrew on macOS, you can update Terminus with the following command:
+
+```shell{promptUser: user}
+brew upgrade pantheon-systems/external/terminus
+```
+For other systems, see additional upgrade instructions [here](/terminus/install).

--- a/source/releasenotes/2024-12-05-terminus-361.md
+++ b/source/releasenotes/2024-12-05-terminus-361.md
@@ -1,10 +1,10 @@
 ---
 title: "Terminus 3.6.1 release now available"
-published_date: "2024-12-04"
-categories: [tools-apis, new-feature]
+published_date: "2024-12-05"
+categories: [tools-apis]
 ---
 
-Terminus [3.6.1](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1) is now available as of December 04, 2024. This minor update contains the latest bug fixes and improvements for this tool.
+Terminus [3.6.1](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1) is now available as of December 05, 2024. This minor update contains the latest bug fixes and improvements for this tool.
 
 For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/3.6.1).
 


### PR DESCRIPTION
## Summary

**[Supported Terminus and PHP Versions](https://docs.pantheon.io/terminus/supported-terminus)** - Include Terminus 3.6.1

Also, include new release note.

Depends on https://github.com/pantheon-systems/terminus/releases/tag/3.6.1 actually existing before merging.