### PR TITLE
Drop (Changelog) from the Release Notes nav menu item 

### DIFF
--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -84,7 +84,7 @@ const mainNavigationLinks = [
       {
         linkContent: (
           <Link id="release-notes" to="/release-notes">
-            Release Notes (Changelog)
+            Release Notes
           </Link>
         ),
       },

--- a/src/layout/header/index.js
+++ b/src/layout/header/index.js
@@ -1,19 +1,16 @@
-import React from "react"
-import { Link } from "gatsby"
+import React from 'react';
+import { Link } from 'gatsby';
 
-import {
-  Navbar,
-  NavMenu,
-} from "@pantheon-systems/pds-toolkit-react"
+import { Navbar, NavMenu } from '@pantheon-systems/pds-toolkit-react';
 
-import { MOBILE_MENU_BREAKPOINT } from '../../vars/responsive'
+import { MOBILE_MENU_BREAKPOINT } from '../../vars/responsive';
 
-import "./style.css"
+import './style.css';
 
 // Links for NavMenu component.
 const mainNavigationLinks = [
   {
-    label: "Documentation",
+    label: 'Documentation',
     links: [
       {
         linkContent: (
@@ -118,8 +115,7 @@ const mainNavigationLinks = [
       </a>
     ),
   },
-]
-
+];
 
 const Header = ({ page }) => (
   <>
@@ -127,7 +123,13 @@ const Header = ({ page }) => (
       Skip to main content
     </a>
 
-    <Navbar logoLinkContent={<a href="https://pantheon.io" target="_blank" rel="nofollow">Pantheon Home</a>}>
+    <Navbar
+      logoLinkContent={
+        <a href="https://pantheon.io" target="_blank" rel="nofollow">
+          Pantheon Home
+        </a>
+      }
+    >
       <NavMenu
         slot="items-left"
         ariaLabel="Main Navigation"
@@ -152,6 +154,6 @@ const Header = ({ page }) => (
       </div>
     </Navbar>
   </>
-)
+);
 
-export default Header
+export default Header;


### PR DESCRIPTION
## Summary

Small copy edit to the main nav, instead of seeing **Release Notes (Changelog)** in the menu nav it will simply be **Release Notes** 

Requested by @IngridKwok 