### PR TITLE
Removing "dedicated" messaging from the Support Guide page.

### DIFF
--- a/source/content/guides/account-mgmt/plans/09-workspace-plans.md
+++ b/source/content/guides/account-mgmt/plans/09-workspace-plans.md
@@ -49,7 +49,7 @@ Now that you have a Professional Workspace with a Gold Account Plan, you can [ad
 
 ## Platinum & Diamond Account Plan
 
- Platinum and Diamond Account Plans offer all the tools and features of the Gold Account Plan, and include features that benefit large teams and enterprise organizations such as direct access to experts, dedicated support, and more. [Contact Sales](https://pantheon.io/contact-sales) for more information about upgrading to a Platinum or Diamond Account Plan.
+Platinum and Diamond Account Plans offer all the tools and features of the Gold Account Plan, and include features that benefit large teams and enterprise organizations such as direct access to experts, advanced support, and more. [Contact Sales](https://pantheon.io/contact-sales) for more information about upgrading to a Platinum or Diamond Account Plan.
 
 ## Partner Program
 

--- a/source/content/guides/disaster-recovery/03-site-goes-down.md
+++ b/source/content/guides/disaster-recovery/03-site-goes-down.md
@@ -69,7 +69,7 @@ Filing an emergency ticket will escalate your downtime incident within the Suppo
 
 Depending on the account tier, your escalation path may differ. Escalation paths include the following:
 
-* Dedicated Support Team: All Diamond tier accounts have a dedicated support team, and tickets and issues are routed preferentially to them. This escalation is an automatic part of the intake process once a ticket is opened.
+* Diamond Support Team: All Diamond tier accounts have the Diamond support team, and tickets and issues are routed preferentially to them. This escalation is an automatic part of the intake process once a ticket is opened.
 
 * Customer Success Manager (CSM): Included for all Enterprise (contract) customers, CSMs serve as a coordinator when support involves multiple teams, or when additional subject matter experts need to be brought into the process. The CSM is also responsible for any post-incident Customer Incident Analysis or performance reviews.
 

--- a/source/content/guides/support/01-scope.md
+++ b/source/content/guides/support/01-scope.md
@@ -25,7 +25,7 @@ Pantheon offers a range of support options for mission-critical sites, such as 2
 
 | Account Tier                                           | Silver                            | Gold                              | Platinum               | Diamond            |
 |-----------------------------------------------------------|-----------------------------------|-----------------------------------|------------------------|--------------------|
-| **Scope**                                                 | Platform <Popover title="Scope of Support" content="<ul><li>Dashboard</li><li>Dev/Test/Live Workflow</li><li>Git/SFTP Mode</li><li>Self-service documentation</li></ul>" /> | Technical <Popover title="Scope of Support" content="<ul><li>Autopilot</li><li>Drupal & WordPress</li><li>Identifying problematic modules and plugins</li><li>Identifying application or site issues</li><li>DNS</li><li>Multidev</li><li>Basic CDN</li><li>Basic Terminus</li><li>Basic Localdev</li><li>Basic Custom Upstreams</li></ul>" /> | Performance <Popover title="Scope of Support" content="<ul><li>New Relic</li><li>Caching</li><li>Cloud Integrations</li><li>Custom Upstreams</li><li>Advanced Workflows</li><li>Advanced CDN</li><li>Advanced Terminus" /> | Dedicated Team <Popover title="Scope of Support" content="Bespoke site debugging" /> |
+| **Scope**                                                 | Platform <Popover title="Scope of Support" content="<ul><li>Dashboard</li><li>Dev/Test/Live Workflow</li><li>Git/SFTP Mode</li><li>Self-service documentation</li></ul>" /> | Technical <Popover title="Scope of Support" content="<ul><li>Autopilot</li><li>Drupal & WordPress</li><li>Identifying problematic modules and plugins</li><li>Identifying application or site issues</li><li>DNS</li><li>Multidev</li><li>Basic CDN</li><li>Basic Terminus</li><li>Basic Localdev</li><li>Basic Custom Upstreams</li></ul>" /> | Performance <Popover title="Scope of Support" content="<ul><li>New Relic</li><li>Caching</li><li>Cloud Integrations</li><li>Custom Upstreams</li><li>Advanced Workflows</li><li>Advanced CDN</li><li>Advanced Terminus" /> | Diamond Support <Popover title="Scope of Support" content="Bespoke site debugging" /> |
 | [**Live chat**](/guides/support/contact-support/#live-chat)                       | 24x5                              | 24x7                              | 24x7: Priority         | 24x7: Top Priority |
 | [**General support ticket**](/guides/support/contact-support/#general-support-ticket)                            | ❌ | 24x5: 8 Hours                     | 24x7: 2 Hours          | 24x7: 1 Hour       |
 | [**Emergency ticket**](/guides/support/contact-support/#emergency-ticket)                | ❌ | ❌ | 24x7: 1 Hour           | 24x7: 15 Minutes   |
@@ -52,8 +52,8 @@ Pantheon's [Sales](https://pantheon.io/contact-sales?docs) and Billing teams are
    - Advanced Workflows
    - Complex Caching Use Cases
    - Terminus
-- **Dedicated Team**:
-   - A dedicated Diamond team for bespoke site debugging
+- **Diamond Support**:
+   - Access for bespoke site debugging
 
 ## Range of Support
 
@@ -121,7 +121,7 @@ We provide technical support for all user interfaces of the Pantheon product, as
 
 We are also happy to help developers learn the ins and outs of making their sites work great on Pantheon, and we have a large number of tutorials for common development scenarios. We also do our best to answer most questions about development practices or techniques.
 
-### Dedicated Support Team
+### Diamond Support Team
 
 Diamond Account customers get an extra level of assistance for their dev teams. Pantheon's Diamond team can investigate misbehaving sites slowness, or error logs to help identify a root cause. This includes everything from database queries to front end performance.
 

--- a/source/content/guides/support/01-scope.md
+++ b/source/content/guides/support/01-scope.md
@@ -53,7 +53,7 @@ Pantheon's [Sales](https://pantheon.io/contact-sales?docs) and Billing teams are
    - Complex Caching Use Cases
    - Terminus
 - **Diamond Support**:
-   - Access for bespoke site debugging
+   - Access to bespoke site debugging
 
 ## Range of Support
 


### PR DESCRIPTION
Support Leaders have requested the removal of the term "dedicated" when referring to the Diamond Team, which has caused customer confusion around what our support offerings actually are. This update removes the confusion. More clarity on what Diamond provides will come in a future update.

## Summary

**[Scope of Support](https://docs.pantheon.io/guides/support/)** - Removes the phrase "dedicated" from the scope of our support.
**[Disaster Recovery](https://docs.pantheon.io/guides/disaster-recovery/site-goes-down#escalation-paths)** - Removes the phrase "dedicated" in reference to escalation paths when contacting support.
**[Workspace Plans](https://docs.pantheon.io/guides/account-mgmt/plans/workspace-plans#platinum--diamond-account-plan)** - Removes the phrase "dedicated" from our our workspace plan offerings.
