### PR TITLE
Fix Terminus Changelog

### DIFF
--- a/source/content/terminus/11-updates.md
+++ b/source/content/terminus/11-updates.md
@@ -1,6 +1,6 @@
 ---
 title: Terminus Guide
-subtitle: Current Terminus Release, Changelog, and Updates
+subtitle: Terminus Changelog
 description: Stay up to date on the latest Terminus version.
 terminuspage: true
 type: terminuspage
@@ -15,8 +15,6 @@ audience: [development]
 product: [terminus]
 integration: [--]
 ---
-
-<TerminusVersion text="Update to the Current Release" />
 
 ## Changelog
 

--- a/src/components/releases.js
+++ b/src/components/releases.js
@@ -1,49 +1,55 @@
-import React from "react"
-import { StaticQuery, graphql } from "gatsby"
-import { MDXRenderer } from "gatsby-plugin-mdx"
-import { MDXProvider } from "@mdx-js/react"
+import React from 'react';
+import { StaticQuery, graphql } from 'gatsby';
+import { MDXRenderer } from 'gatsby-plugin-mdx';
+import { MDXProvider } from '@mdx-js/react';
+import { subYears, parseISO, isAfter } from 'date-fns';
 
-import { headline1, headline2, headline3 } from "./releaseHeadlines"
+import { headline1, headline2, headline3 } from './releaseHeadlines';
 
 const shortcodes = {
   h1: headline1,
   h2: headline2,
   h3: headline3,
-}
+};
 
-const Releases = ({ data }) => (
-  <>
-    {data.allTerminusReleasesJson.edges.map((release, i) => {
-      return (
+const Releases = ({ data }) => {
+  const oneYearAgo = subYears(new Date(), 1);
+
+  // Filter releases published within the last year
+  const filteredReleases = data.allTerminusReleasesJson.edges.filter(
+    (release) => {
+      const publishedDate = release.node.published_at;
+      return publishedDate && isAfter(parseISO(publishedDate), oneYearAgo);
+    }
+  );
+
+  return (
+    <>
+      {filteredReleases.map((release, i) => (
         <div key={i}>
           <h3 className="toc-ignore" id={release.node.tag_name}>
             {release.node.tag_name}
           </h3>
           <MDXProvider components={shortcodes}>
-            <MDXRenderer>
-              {release.node.fields.markdownBody.childMdx.body}
-            </MDXRenderer>
+            <MDXRenderer>{release.node.fields.markdownBody.childMdx.body}</MDXRenderer>
           </MDXProvider>
           <hr />
         </div>
-      )
-    })}
-  </>
-)
+      ))}
+    </>
+  );
+};
 
-export default props => (
+export default (props) => (
   <StaticQuery
     query={graphql`
       query {
-        allTerminusReleasesJson(
-          sort: { fields: [tag_name], order: DESC }
-          filter: { fields: { original_id: { gt: 5224487 } } }
-        ) {
+        allTerminusReleasesJson(sort: { fields: [published_at], order: DESC }) {
           edges {
             node {
               id
               tag_name
-              body
+              published_at
               fields {
                 markdownBody {
                   childMdx {
@@ -56,6 +62,6 @@ export default props => (
         }
       }
     `}
-    render={data => <Releases data={data} {...props} />}
+    render={(data) => <Releases data={data} {...props} />}
   />
-)
+);

--- a/src/components/releases.js
+++ b/src/components/releases.js
@@ -15,29 +15,31 @@ const shortcodes = {
 const Releases = ({ data }) => {
   const oneYearAgo = subYears(new Date(), 1);
 
-  // Filter releases published within the last year
+  // Safe Filtering: Ensure `published_at` exists before filtering
   const filteredReleases = data.allTerminusReleasesJson.edges.filter(
     (release) => {
       const publishedDate = release.node.published_at;
       return publishedDate && isAfter(parseISO(publishedDate), oneYearAgo);
-    },
+    }
   );
 
   return (
     <>
-      {filteredReleases.map((release, i) => (
-        <div key={i}>
-          <h3 className="toc-ignore" id={release.node.tag_name}>
-            {release.node.tag_name}
-          </h3>
-          <MDXProvider components={shortcodes}>
-            <MDXRenderer>
-              {release.node.fields.markdownBody.childMdx.body}
-            </MDXRenderer>
-          </MDXProvider>
-          <hr />
-        </div>
-      ))}
+      {filteredReleases.length > 0 ? (
+        filteredReleases.map((release, i) => (
+          <div key={i}>
+            <h3 className="toc-ignore" id={release.node.tag_name}>
+              {release.node.tag_name}
+            </h3>
+            <MDXProvider components={shortcodes}>
+              <MDXRenderer>{release.node.fields.markdownBody.childMdx.body}</MDXRenderer>
+            </MDXProvider>
+            <hr />
+          </div>
+        ))
+      ) : (
+        <p>No recent releases found.</p>
+      )}
     </>
   );
 };

--- a/src/components/releases.js
+++ b/src/components/releases.js
@@ -20,7 +20,7 @@ const Releases = ({ data }) => {
     (release) => {
       const publishedDate = release.node.published_at;
       return publishedDate && isAfter(parseISO(publishedDate), oneYearAgo);
-    }
+    },
   );
 
   return (
@@ -31,7 +31,9 @@ const Releases = ({ data }) => {
             {release.node.tag_name}
           </h3>
           <MDXProvider components={shortcodes}>
-            <MDXRenderer>{release.node.fields.markdownBody.childMdx.body}</MDXRenderer>
+            <MDXRenderer>
+              {release.node.fields.markdownBody.childMdx.body}
+            </MDXRenderer>
           </MDXProvider>
           <hr />
         </div>

--- a/src/components/releases.js
+++ b/src/components/releases.js
@@ -20,7 +20,7 @@ const Releases = ({ data }) => {
     (release) => {
       const publishedDate = release.node.published_at;
       return publishedDate && isAfter(parseISO(publishedDate), oneYearAgo);
-    }
+    },
   );
 
   return (
@@ -32,7 +32,9 @@ const Releases = ({ data }) => {
               {release.node.tag_name}
             </h3>
             <MDXProvider components={shortcodes}>
-              <MDXRenderer>{release.node.fields.markdownBody.childMdx.body}</MDXRenderer>
+              <MDXRenderer>
+                {release.node.fields.markdownBody.childMdx.body}
+              </MDXRenderer>
             </MDXProvider>
             <hr />
           </div>

--- a/src/components/terminusVersion.js
+++ b/src/components/terminusVersion.js
@@ -1,22 +1,26 @@
-import React from "react"
-import { useStaticQuery, graphql } from "gatsby"
+import React from 'react';
+import { useStaticQuery, graphql } from 'gatsby';
 
 function TerminusVersion({ text }) {
-  const { terminusReleasesJson } = useStaticQuery(
-    graphql`
-      query {
-        terminusReleasesJson {
-          tag_name
+  const { allTerminusReleasesJson } = useStaticQuery(graphql`
+    query {
+      allTerminusReleasesJson(sort: { fields: [published_at], order: DESC }) {
+        edges {
+          node {
+            tag_name
+          }
         }
       }
-    `
-  )
+    }
+  `);
+
+  const latestRelease = allTerminusReleasesJson.edges[0].node.tag_name;
 
   return (
     <h2>
-      {text} {terminusReleasesJson.tag_name}
+      {text} {latestRelease}
     </h2>
-  )
+  );
 }
 
-export default TerminusVersion
+export default TerminusVersion;

--- a/src/templates/terminusCommand.js
+++ b/src/templates/terminusCommand.js
@@ -70,7 +70,7 @@ const items = [
   {
     id: 'docs-terminus-updates',
     link: '/terminus/updates',
-    title: 'Current Terminus Release and Changelog',
+    title: 'Terminus Changelog',
   },
 
   {

--- a/src/templates/terminuspage.js
+++ b/src/templates/terminuspage.js
@@ -70,7 +70,7 @@ const items = [
   {
     id: 'docs-terminus-updates',
     link: '/terminus/updates',
-    title: 'Current Terminus Release and Changelog',
+    title: 'Terminus Changelog',
   },
 
   {


### PR DESCRIPTION
## Summary

**[Current Terminus Release, Changelog, and Updates](https://pr-9351-documentation.appa.pantheon.site/terminus/updates)** - Fixes the issue that was breaking the terminus changelog `<Releases>` component. Turns out it was related to how we were filtering the releases in the GraphQL query. I've removed the filter and then re-added a new filter that filters releases older than a year.
