### PR TITLE
Update 02-wordpress-best-practices.md

### DIFF
--- a/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
+++ b/source/content/guides/wordpress-developer/02-wordpress-best-practices.md
@@ -133,7 +133,7 @@ function additional_securityheaders( $headers ) {
     $headers['Referrer-Policy']             = 'no-referrer-when-downgrade'; //This is the default value, the same as if it were not set.
     $headers['X-Content-Type-Options']      = 'nosniff';
     $headers['X-XSS-Protection']            = '1; mode=block';
-    $headers['Permissions-Policy']          = 'geolocation=(self "https://example.com") microphone=() camera=()';
+    $headers['Permissions-Policy']          = 'geolocation=(self "https://example.com"), microphone=(), camera=()';
     $headers['Content-Security-Policy']     = "script-src 'self'";
     $headers['X-Frame-Options']             = 'SAMEORIGIN';
   }


### PR DESCRIPTION
## Summary

**[WordPress Best Practices](https://docs.pantheon.io/guides/wordpress-developer/wordpress-best-practices#security-headers)** - Permissions-Policy requires a comma between listed features that need permission. See [MDN](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Permissions-Policy#examples). The current implementation of this doc leaves off the comma.
