### PR TITLE
moving hotfix page

### DIFF
--- a/source/content/guides/git/08-troubleshooting.md
+++ b/source/content/guides/git/08-troubleshooting.md
@@ -19,8 +19,6 @@ This section provides solutions to common Git troubleshooting scenarios.
 
 ### Reduce Large Repositories
 
-
-
 Repositories that exceed 2GB may experience failures or degraded performance when interacting with code via Git on Pantheon. We recommend that you reduce the repository size by removing objects that are no longer referenced. You can output the size of your repository by running [`git count-objects -vH`](https://git-scm.com/docs/git-count-objects) or `du -sh .git/` from within the root directory of your site's codebase.
 
 We recommend that you use [git filter-repo](https://github.com/newren/git-filter-repo/) to reduce the size of your repository.

--- a/source/content/guides/git/08-troubleshooting.md
+++ b/source/content/guides/git/08-troubleshooting.md
@@ -19,6 +19,8 @@ This section provides solutions to common Git troubleshooting scenarios.
 
 ### Reduce Large Repositories
 
+
+
 Repositories that exceed 2GB may experience failures or degraded performance when interacting with code via Git on Pantheon. We recommend that you reduce the repository size by removing objects that are no longer referenced. You can output the size of your repository by running [`git count-objects -vH`](https://git-scm.com/docs/git-count-objects) or `du -sh .git/` from within the root directory of your site's codebase.
 
 We recommend that you use [git filter-repo](https://github.com/newren/git-filter-repo/) to reduce the size of your repository.

--- a/source/content/guides/git/09-hotfixes.md
+++ b/source/content/guides/git/09-hotfixes.md
@@ -1,16 +1,22 @@
 ---
-title: Hotfixes
-description: Learn how to deploy and test hot fixes and preserve orphan commits on your Pantheon Drupal or WordPress site.
+title: Git on Pantheon Guide
+subtitle: Hotfixing with Git Tags
+description: Get solutions to common Git troubleshooting scenarios.
 tags: [code, collaborate, git, webops, workflow]
-contenttype: [doc]
-innav: [true]
+
+showtoc: true
+permalink: docs/guides/git/hotfixes
+contenttype: [guide]
+innav: [false]
 categories: [git]
 cms: [drupal, wordpress]
 audience: [development]
 product: [--]
-integration: [--]
+integration: [git]
 ---
 For Experts only. You should not need to attempt this if you use [Multidev](/guides/multidev) and keep commits from reaching Dev that you do not intend on deploying.
+
+
 
 <Alert title="Warning" type="danger">
 

--- a/source/content/guides/git/09-hotfixes.md
+++ b/source/content/guides/git/09-hotfixes.md
@@ -16,8 +16,6 @@ integration: [git]
 ---
 For Experts only. You should not need to attempt this if you use [Multidev](/guides/multidev) and keep commits from reaching Dev that you do not intend on deploying.
 
-
-
 <Alert title="Warning" type="danger">
 
 We do not recommend hotfixing. Hotfixes should be the exception, not the norm. Pushing a hotfix via Git is the only way to push code directly to Live without having to go through Dev and Test. Hotfixing is not a best practice and any damage to the source code will be the responsibility of the user, and should be avoided whenever possible.

--- a/source/content/guides/git/09-hotfixes.md
+++ b/source/content/guides/git/09-hotfixes.md
@@ -3,7 +3,6 @@ title: Git on Pantheon Guide
 subtitle: Hotfixing with Git Tags
 description: Get solutions to common Git troubleshooting scenarios.
 tags: [code, collaborate, git, webops, workflow]
-
 showtoc: true
 permalink: docs/guides/git/hotfixes
 contenttype: [guide]

--- a/source/content/guides/integrated-composer/07-ic-support.md
+++ b/source/content/guides/integrated-composer/07-ic-support.md
@@ -85,4 +85,4 @@ All modules will be overwritten by Integrated Composer if you don't add the exce
 
 ### Can I hotfix an Integrated Composer site?
 
-No. Integrated Composer is not compatible with the [hotfix](/hotfixes) workflow.
+No. Integrated Composer is not compatible with the [hotfix](/guides/git/hotfixes) workflow.

--- a/source/content/pantheon-workflow.md
+++ b/source/content/pantheon-workflow.md
@@ -239,7 +239,7 @@ By design, code changes via SFTP are prevented in Test and Live. All code change
 
 1. **Use the Workflow** (Recommended): Deploy code from Dev to Test to Live via the Site Dashboard or Terminus as outlined above, beginning in the [Combine Code from Dev and Content from Live in Test](#combine-code-from-dev-and-content-from-live-in-test) section.
 
-2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm. Pushing a [hotfix via Git tags](/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
+2. **Hotfixes**: Hotfixes is not a best practice and should be the exception, not the norm. Pushing a [hotfix via Git tags](/guides/git/hotfixes) is the only way to push code changes directly to Live without deploying through Dev and Test.
 
 ### Managing Database and Files: Clone, Import, Export, Wipe
 

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -362,7 +362,7 @@ You must do _one_ of the following to ensure that your newly created Multidev ha
 
 ### Deploying Hotfixes
 
-Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/hotfixes). Git tags created manually and pushed on the platform do not invoke all the processes that an actual deployment does. Pantheon standard workflow is done via the dashboard deploy or `terminus env:deploy`. As a workaround for hotfixes:
+Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](/guides/git/hotfixes). Git tags created manually and pushed on the platform do not invoke all the processes that an actual deployment does. Pantheon standard workflow is done via the dashboard deploy or `terminus env:deploy`. As a workaround for hotfixes:
 
 1. Modify your `pantheon.yml` file in a development environment (for example add a code comment).
 

--- a/src/components/omniSidebarNav/submenus/workflows.js
+++ b/src/components/omniSidebarNav/submenus/workflows.js
@@ -14,9 +14,7 @@ const workflows = () => {
         getGuideDirectory('guides/environment-configuration'),
         simpleLink('/connection-modes', 'Connection Modes'),
         getGuideDirectory('guides/sftp', 'SFTP'),
-        //Todo: relocate hotfixes into git guide
         getGuideDirectory('guides/git', 'Git'),
-        simpleLink('/hotfixes', 'Hotfixes'),
         simpleLink('/core-updates', 'Core Updates'),
         simpleLink('/workflow-logs', 'Workflow Logs'),
         simpleLink('/content-staging', 'Content Staging'),


### PR DESCRIPTION
Closes #9357

We'll need a redirect created from `/hotfixes` to `/guides/git/hotfixes`

- [x] Add redirect in agcdn: https://docs.pantheon.io/hotfixes => https://docs.pantheon.io/guides/git/hotfixes