### PR TITLE
Fix drush command syntax

### DIFF
--- a/source/content/guides/logs-pantheon/06-faq-logs.md
+++ b/source/content/guides/logs-pantheon/06-faq-logs.md
@@ -67,13 +67,13 @@ Drupal logs events with the Database Logging module (dblog) by default. PHP fata
 - Use [Terminus](/terminus):
 
  ```bash{promptUser: user}
- terminus drush <site>.<env> -- watchdog-show
+ terminus drush <site>.<env> -- watchdog:show
  ```
 
 - Terminus can invoke Drush commands to "watch" events in real-time; `--tail` can be used to continuously show new watchdog messages until interrupted (Control+C).
 
  ```bash{promptUser: user}
- terminus drush <site>.<env> -- watchdog-show --tail
+ terminus drush <site>.<env> -- watchdog:show --tail
  ```
 
 ### My Drupal database logs are huge. Should I disable dblog?


### PR DESCRIPTION
Fixes #9238 

## Summary

[Environment Log Files on Pantheon](https://docs.pantheon.io/guides/logs-pantheon/faq-logs) update syntax for `watchdog:show` command 