### PR TITLE
Fix sidebar nav for Errors and Server Responses 

### DIFF
--- a/src/components/omniSidebarNav/submenus/support.js
+++ b/src/components/omniSidebarNav/submenus/support.js
@@ -36,9 +36,9 @@ const support = () => {
         ]),
         simpleLink('/timeouts', 'Timeouts and Errors', [
           simpleLink('/timeouts', 'Timeouts on Pantheon'),
-          getGuideDirectory('guides/errors-and-server-responses'),
           simpleLink('/debug-connections', 'Debugging Connectivity Issues'),
         ]),
+        getGuideDirectory('guides/errors-and-server-responses'),
         simpleLink('/mime-types', 'MIME Types'),
         simpleLink('/resetting-passwords', 'Resetting Passwords'),
         simpleLink('/local-dns-cache', 'Local DNS Cache'),

--- a/src/components/omniSidebarNav/submenus/support.js
+++ b/src/components/omniSidebarNav/submenus/support.js
@@ -34,10 +34,8 @@ const support = () => {
             'Symlinks and plugins that assume write access',
           ),
         ]),
-        simpleLink('/timeouts', 'Timeouts and Errors', [
-          simpleLink('/timeouts', 'Timeouts on Pantheon'),
-          simpleLink('/debug-connections', 'Debugging Connectivity Issues'),
-        ]),
+        simpleLink('/timeouts', 'Timeouts on Pantheon'),
+        simpleLink('/debug-connections', 'Debugging Connectivity Issues'),
         getGuideDirectory('guides/errors-and-server-responses'),
         simpleLink('/mime-types', 'MIME Types'),
         simpleLink('/resetting-passwords', 'Resetting Passwords'),


### PR DESCRIPTION
## Summary

Multipage guide, [Errors and Server Responses](https://docs.pantheon.io/guides/errors-and-server-responses) is nested too deep. This PR pulls the guide up a layer in the sidebar nav so we can see subpages too 

Instead of: 
Support > Troubleshooting > Timeouts and Errors > Errors and Server Responses

It's now: 
Support > Troubleshooting > Errors and Server Responses
