### PR TITLE
Update plugins-known-issues.md for Solid Security debugging

### DIFF
--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -630,7 +630,7 @@ ___
 
 **Solution 1**  Dynamically append the `itsec-hb-token` parameter to redirection URLs when it's present in the original request. Edit the `functions.php` file of your WordPress theme. If you're using a child theme, make the changes there to avoid overwriting during theme updates.
 
-```php
+```php:title=functions.php
 add_filter('wp_redirect', 'retain_itsec_hb_token', 10, 2);
 
 function retain_itsec_hb_token($location, $status) {
@@ -643,7 +643,7 @@ function retain_itsec_hb_token($location, $status) {
 
 **Solution 2** Ensure the `itsec-hb-token` parameter is retained during redirection to the `wp-login.php?checkemail=confirm` page. Locate the `wp-config.php` file in the root directory of your WordPress installation. Add the following code snippet at the top of the file, replacing "LOGIN_LOCATION" with your defined login slug (such as `log-me`):
 
-```php
+```php:title=wp-config.php
 if (($_SERVER['REQUEST_URI'] == '/wp-login.php?checkemail=confirm') && (php_sapi_name() != "cli")) {
     header('HTTP/1.0 301 Moved Permanently');
     header('Location: https://' . $_SERVER['HTTP_HOST'] . '/wp-login.php?checkemail=confirm&itsec-hb-token=LOGIN_LOCATION');

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -628,7 +628,7 @@ ___
 
 **Issue 3:** Unable to reset WordPress password or register new WordPress users when "Hide Backend" feature is enabled due to `itsec-hb-token` parameter being stripped from URL redirections.
 
-**Solution 1**  Dynamically append the `itsec-hb-token` parameter to redirection URLs when it's present in the original request. Edit the `functions.php` file of your WordPress theme. If you're using a child theme, make the changes there to avoid overwriting during theme updates.
+**Solution:** Two adjustments are needed to fully resolve this issue. First, dynamically append the `itsec-hb-token` parameter to redirection URLs when the parameter present in the original request. Edit the `functions.php` file of your WordPress theme. If you're using a child theme, make the changes there to avoid overwriting during theme updates.
 
 ```php:title=functions.php
 add_filter('wp_redirect', 'retain_itsec_hb_token', 10, 2);
@@ -641,7 +641,7 @@ function retain_itsec_hb_token($location, $status) {
 }
 ```
 
-**Solution 2** Ensure the `itsec-hb-token` parameter is retained during redirection to the `wp-login.php?checkemail=confirm` page. Locate the `wp-config.php` file in the root directory of your WordPress installation. Add the following code snippet at the top of the file, replacing "LOGIN_LOCATION" with your defined login slug (such as `log-me`):
+Second, ensure the `itsec-hb-token` parameter is retained when during login redirection to the `wp-login.php?checkemail=confirm` page. Locate the `wp-config.php` file in the root directory of your WordPress installation. Add the following code snippet at the top of the file, replacing "LOGIN_LOCATION" with your defined login slug (such as `log-me`):
 
 ```php:title=wp-config.php
 if (($_SERVER['REQUEST_URI'] == '/wp-login.php?checkemail=confirm') && (php_sapi_name() != "cli")) {


### PR DESCRIPTION
The CSE team is cleaning up some of our playbooks and found documentation about a WordPress Plugin issue that was not talked about publicly. After reviewing within our colleagues, we decided this would be best handled by moving to the public facing documentation, so customers can potentially self-resolve the problem.

## Summary

**[WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/plugins-known-issues#solid-security-previously-ithemes-security)** - adding documentation for a known plugin issue with [Solid Security (former iThemes)](https://docs.pantheon.io/plugins-known-issues#solid-security-previously-ithemes-security), and the two known solutions to address the problem. 

The source is [this internal Pantheon CSE Playbook](https://getpantheon.atlassian.net/wiki/spaces/CS/pages/2860974234/Solid+Security+former+iThemes+Hide+Backend+URL+Forgot+Password+-+Retaining+itsec-hb-token+Parameter), which did not contain any CSE-only information, and was deemed suitable to move into the public docs to help customers self-resolve issues. 
