### PR TITLE
Git reset Dev to Live for Integrated Composer sites

### DIFF
--- a/source/content/guides/git/05-undo-commits.md
+++ b/source/content/guides/git/05-undo-commits.md
@@ -179,14 +179,12 @@ You can reset your Dev environment history to match the current state of your Li
 
 <Tab title="All others" id="all-others" active={true}>
 
-1. Identify the most recent commit deployed to Live.
+Run the commands below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
 
-1. Run the command below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
-
-    ```bash{promptUser: user}
-    git reset --hard `terminus env:code-log <site>.live --format=string | grep -m1 'live' | cut -f 4`
-    git push origin master -f
-    ```
+```bash{promptUser: user}
+git reset --hard `terminus env:code-log <site>.live --format=string | grep -m1 'live' | cut -f 4`
+git push origin master -f
+```
 
 </Tab>
 
@@ -194,18 +192,16 @@ You can reset your Dev environment history to match the current state of your Li
 
 <Alert title="Note" type="info">
 
-We've adjusted the following steps for [Integrated Composer sites](/guides/integrated-composer), so that you reset history to the **second** to last commit hash on the Live environment, rather than the first - to avoid resetting dev's history to a build artifact.
+We've adjusted the following for [Integrated Composer sites](/guides/integrated-composer), so that you reset history to the **second** to last commit hash on the Live environment, rather than the first - to avoid resetting dev's history to a build artifact.
 
 </Alert>
 
-1. Identify the **second** most recent commit deployed to Live.
+Run the commands below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
 
-1. Run the command below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
-
-    ```bash{promptUser: user}
-    git reset --hard `terminus env:code-log <site>.live --format=string | grep -m2 'live' | tail -n 1 | cut -f 4`
-    git push origin master -f
-    ```
+```bash{promptUser: user}
+git reset --hard `terminus env:code-log <site>.live --format=string | grep -m2 'live' | tail -n 1 | cut -f 4`
+git push origin master -f
+```
 
 </Tab>
 

--- a/source/content/guides/git/05-undo-commits.md
+++ b/source/content/guides/git/05-undo-commits.md
@@ -12,6 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [--]
 integration: [--]
+reviewed: "2025-01-23"
 ---
 
 Git makes it easy to reverse commits pushed to the Pantheon Dev environment.
@@ -174,6 +175,10 @@ You can revert a past commit that has been pushed to your Test or Live environme
 
 You can reset your Dev environment history to match the current state of your Live environment using [Terminus](/terminus). The method in this section is destructive and should be used with caution. It does not clone the Live environment's database or files down to Dev. However, it does reset the Dev environment's codebase.
 
+<TabList>
+
+<Tab title="All others" id="all-others" active={true}>
+
 1. Identify the most recent commit deployed to Live.
 
 1. Run the command below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
@@ -182,6 +187,30 @@ You can reset your Dev environment history to match the current state of your Li
     git reset --hard `terminus env:code-log <site>.live --format=string | grep -m1 'live' | cut -f 4`
     git push origin master -f
     ```
+
+</Tab>
+
+<Tab title="Integrated Composer" id="integrated-composer">
+
+<Alert title="Note" type="info">
+
+We've adjusted the following steps for [Integrated Composer sites](/guides/integrated-composer), so that you reset history to the **second** to last commit hash on the Live environment, rather than the first - to avoid resetting dev's history to a build artifact.
+
+</Alert>
+
+1. Identify the **second** most recent commit deployed to Live.
+
+1. Run the command below to overwrite the history on Dev's codebase to reflect Live (replace `<site>` with your site's name):
+
+    ```bash{promptUser: user}
+    git reset --hard `terminus env:code-log <site>.live --format=string | grep -m2 'live' | tail -n 1 | cut -f 4`
+    git push origin master -f
+    ```
+
+</Tab>
+
+</TabList>
+
 
 ## What if Dev Is Behind Test and Live?
 

--- a/source/content/terminus/03-examples.md
+++ b/source/content/terminus/03-examples.md
@@ -14,6 +14,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
+reviewed: "2025-01-23"
 ---
 
 This section provides information on how to apply updates, deploy code, switch upstreams, and install Drush and WP-CLI with Terminus, as well as information on command structure and automatic site and environment detection.
@@ -281,6 +282,11 @@ There are a few scenarios where it may be useful to reset your Dev environment (
 
 - The Dev environment has been seriously corrupted and you would like to cleanly reset it to Live.
 
+
+<TabList>
+
+<Tab title="All others" id="all-others" active={true}>
+
 Follow the steps below to reset Dev to Live.
 
 1. Clone the site's codebase to your local machine if you have not done so already (replace `awesome-site` with your site name):
@@ -329,6 +335,69 @@ Follow the steps below to reset Dev to Live.
   ```
 
 The Site Dashboard will open when the reset procedure completes.
+
+</Tab>
+
+<Tab title="Integrated Composer" id="integrated-composer">
+
+Follow the steps below to reset Dev to Live.
+
+<Alert title="Note" type="info">
+
+We've adjusted the following script for [Integrated Composer sites](/guides/integrated-composer), so that you reset history to the **second** to last commit hash on the Live environment, rather than the most recent - to avoid resetting history to a build artifact.
+
+</Alert>
+
+1. Clone the site's codebase to your local machine if you have not done so already (replace `awesome-site` with your site name):
+
+  ```bash{promptUser: user}
+  terminus connection:info awesome-site.dev --fields='Git Command' --format=string
+  ```
+
+1. Automate the procedure for resetting Dev to Live by downloading the following bash script:
+
+  <Download file="ic-reset-dev-to-live.sh" />
+
+  ```bash
+  #!/bin/bash
+
+  #Authenticate Terminus
+  terminus auth:login
+
+  #Provide the target site name (e.g. your-awesome-site)
+  echo 'Provide the site name (e.g. your-awesome-site), then press [ENTER] to reset the Dev environment to Live:';
+  read SITE;
+
+  #Set the Dev environment's connection mode to Git
+  echo "Making sure the environment's connection mode is set to Git...";
+  terminus connection:set $SITE.dev git
+
+  #Identify the second most recent commit deployed to Live and overwrite history on Dev's codebase to reflect Live
+  echo "Rewriting history on the Dev environment's codebase...";
+  git reset --hard `terminus env:code-log $SITE.live --format=string | grep -m2 'live' | tail -n 1 | cut -f 4`
+
+  #Force push to Pantheon to rewrite history on Dev and reset codebase to Live
+  git push origin master -f
+
+  #Clone database and files from Live into Dev
+  echo "Importing database and files from Live into Dev...";
+  terminus env:clone-content $SITE.live dev
+
+  #Open the Dev environment on the Site Dashboard
+  terminus dashboard:view $SITE.dev
+  ```
+
+1. Execute the script from the command line within the root directory of your site's codebase:
+
+  ```bash{promptUser: user}
+  sh /PATH/TO/SCRIPT/reset-dev-to-live.sh
+  ```
+
+The Site Dashboard will open when the reset procedure completes.
+
+</Tab>
+
+</TabList>
 
 ## Switch Upstreams
 

--- a/source/scripts/ic-reset-dev-to-live.sh.txt
+++ b/source/scripts/ic-reset-dev-to-live.sh.txt
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+#Authenticate Terminus
+terminus auth:login
+
+#Provide the target site name (e.g. your-awesome-site)
+echo 'Provide the site name (e.g. your-awesome-site), then press [ENTER] to reset the Dev environment to Live:';
+read SITE;
+
+#Set the Dev environment's connection mode to Git
+echo "Making sure the environment's connection mode is set to Git...";
+terminus connection:set $SITE.dev git
+
+#Identify the second most recent commit deployed to Live and overwrite history on Dev's codebase to reflect Live
+echo "Rewriting history on the Dev environment's codebase...";
+git reset --hard `terminus env:code-log $SITE.live --format=string | grep -m2 'live' | tail -n 1 | cut -f 4`
+
+#Force push to Pantheon to rewrite history on Dev and reset codebase to Live
+git push origin master -f
+
+#Clone database and files from Live into Dev
+echo "Importing database and files from Live into Dev...";
+terminus env:clone-content $SITE.live dev
+
+#Open the Dev environment on the Site Dashboard
+terminus dashboard:view $SITE.dev


### PR DESCRIPTION
Fixes #9382 

## Summary

**[Terminus > Examples](https://pr-9389-documentation.appa.pantheon.site/terminus/examples#reset-dev-environment-to-live)** 
**[Git > Undo Git Commits](https://pr-9389-documentation.appa.pantheon.site/guides/git/undo-commits#reset-dev-environment-to-live)** 

Add tabs recommending the appropriate procedure based on the given scenario: 
* Integrated Composer sites 
  * Updated procedure, resets dev to the second most recent commit from Live, avoiding build artifacts 
* All others 
  * No changes to the original procedure, still resets dev to the latest commit from Live, no build artifacts in play 