### PR TITLE
New Relic Permalink Location Changed

### DIFF
--- a/source/content/guides/new-relic/07-new-relic-faq.md
+++ b/source/content/guides/new-relic/07-new-relic-faq.md
@@ -23,7 +23,7 @@ A New Relic&reg; account can have only one owner at any given time. You must be 
 
 ### How can I share a link to a particular metric?
 
-Click **Permalink** at the bottom of any page. This will preserve the current time window and take the link recipient to the same page you are currently viewing.
+Click the chain link icon at the top right corner of any page. This will preserve the current time window and take the link recipient to the same page you are currently viewing.
 
 ### How much does New Relic&reg; Performance Monitoring cost?
 


### PR DESCRIPTION
## Summary

**[New Relic FAQ](https://docs.pantheon.io/guides/new-relic/new-relic-faq)** - Since New Relic's redesign a few years ago, the Permalink UI changed. Updating it to match the current setup.
