### PR TITLE
SITE-3453 Update 2025-01-16-php-53-55-eol.md

### DIFF
--- a/source/releasenotes/2025-01-16-php-53-55-eol.md
+++ b/source/releasenotes/2025-01-16-php-53-55-eol.md
@@ -3,12 +3,13 @@ title: "PHP 5.3 and 5.5 no longer available starting February 25, 2025"
 published_date: "2025-01-16"
 categories: [infrastructure, security, action-required]
 ---
+_**Editorial note:** As of January 29, 2025, this release note has been edited to amend the action required. Where previously we required upgrading 5.3 and 5.5 to 7.2 we are now allowing upgrades to 5.6 as well. This can be helpful if you choose to upgrade PHP versions incrementally rather than making the jump to 7.x_
+<hr/>
 As part of our continued effort to protect and secure customer sites, the Pantheon platform will no longer offer PHP versions 5.3 and 5.5 as of February 25, 2025.
 
 PHP 5.5 was declared end-of-life (EOL) by [the PHP Foundation](https://www.php.net/supported-versions.php) on July 21, 2016, more than eight years ago. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
 
 We will soon provide long term support (LTS) security coverage for the remaining EOL versions of PHP on the platform.
-_Editorial note: As of January 29, 2025, this release note has been edited to amend the action required. Where previously we required upgrading 5.3 and 5.5 to 7.2 we are now allowing an upgrade to 5.6 as well. This can be helpful if you choose to upgrade PHP versions incrementally rather than making the jump to 7.x_
 ## Action required
 
 Customers with sites using PHP 5.3 and 5.5 should test and [upgrade the PHP version](/guides/php/php-versions) to at least PHP 5.6. If no action is taken, sites using PHP 5.3 and 5.5 will be auto-upgraded to PHP 5.6 on February 25, 2025. Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.

--- a/source/releasenotes/2025-01-16-php-53-55-eol.md
+++ b/source/releasenotes/2025-01-16-php-53-55-eol.md
@@ -11,6 +11,6 @@ We will soon provide long term support (LTS) security coverage for the remaining
 
 ## Action required
 
-Customers with sites using PHP 5.3 and 5.5 should test and [upgrade the PHP version](/guides/php/php-versions) to at least PHP 7.2. If no action is taken, sites using PHP 5.3 and 5.5 will be auto-upgraded to PHP 5.6 on February 25, 2025. Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.
+Customers with sites using PHP 5.3 and 5.5 should test and [upgrade the PHP version](/guides/php/php-versions) to at least PHP 5.6. If no action is taken, sites using PHP 5.3 and 5.5 will be auto-upgraded to PHP 5.6 on February 25, 2025. Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.
 
 Sites created with custom upstreams using EOL PHP versions may also have unexpected behavior upon site creation.

--- a/source/releasenotes/2025-01-16-php-53-55-eol.md
+++ b/source/releasenotes/2025-01-16-php-53-55-eol.md
@@ -8,7 +8,7 @@ As part of our continued effort to protect and secure customer sites, the Panthe
 PHP 5.5 was declared end-of-life (EOL) by [the PHP Foundation](https://www.php.net/supported-versions.php) on July 21, 2016, more than eight years ago. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
 
 We will soon provide long term support (LTS) security coverage for the remaining EOL versions of PHP on the platform.
-
+_Editorial note: As of January 29, 2025, this release note has been edited to amend the action required. Where previously we required upgrading 5.3 and 5.5 to 7.2 we are now allowing an upgrade to 5.6 as well. This can be helpful if you choose to upgrade PHP versions incrementally rather than making the jump to 7.x_
 ## Action required
 
 Customers with sites using PHP 5.3 and 5.5 should test and [upgrade the PHP version](/guides/php/php-versions) to at least PHP 5.6. If no action is taken, sites using PHP 5.3 and 5.5 will be auto-upgraded to PHP 5.6 on February 25, 2025. Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.


### PR DESCRIPTION
## Summary

**[PHP 5.3/5.5 EOL release note](https://docs.pantheon.io/release-notes/2025/01/php-53-55-eol)** - Note that PHP 5.6 can be tested now
