### PR TITLE
Rsync and SFTP syntax fix

### DIFF
--- a/source/content/guides/sftp/04-rsync-and-sftp.md
+++ b/source/content/guides/sftp/04-rsync-and-sftp.md
@@ -156,7 +156,7 @@ If you need to upload the file directory from a local installation called *Foo* 
 
 <Alert title="Warning" type="danger">
 
-Always use the `temp-dir flag` when using rsync for uploads. Removing the flag will result in broken files after cloning from one environment to another.
+Always use the `temp-dir` flag when using rsync for uploads. Removing the flag will result in broken files after cloning from one environment to another.
 
 </Alert>
 


### PR DESCRIPTION
moving the Tickmark over to only encapsulate `temp-dir` and not the word "flag".

## Summary

**[Large File Transfers with rsync and SFTP](https://docs.pantheon.io/guides/sftp/rsync-and-sftp#empty-a-folder-recursively-using-rsync)** - We accidentally surrounded the word "Flag" as if it was code, when saying `temp-dir flag`. The word flag isn't part of the code, so we need to clarify that "`temp-dir` flag" is what we're trying to say.
- Current: `"temp-dir flag`"
-  Corrected: "`temp-dir` flag"
