### PR TITLE
Fix code block on Object Cache Pro page

### DIFF
--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -327,15 +327,15 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 	define( 'WP_REDIS_CONFIG', $ocp_settings );
 	```
 	
-	<Alert title="Note" type="info">
-		If you don't want to bother with changing the configuration for local environments, you can simply disable Object Cache Pro for Lando and leave the existing configuration:
-	
-		```php
-		if ( isset( $_ENV['LANDO'] ) && 'ON' === $_ENV['LANDO'] ) {
-			define( 'WP_REDIS_DISABLED', true );
-		}
-		```
-	</Alert>
+<Alert title="Note" type="info">
+	If you don't want to bother with changing the configuration for local environments, you can simply disable Object Cache Pro for Lando and leave the existing configuration:
+
+	```php
+	if ( isset( $_ENV['LANDO'] ) && 'ON' === $_ENV['LANDO'] ) {
+		define( 'WP_REDIS_DISABLED', true );
+	}
+	```
+</Alert>
 	
 Make sure to commit your code back to your environment when you have made the appropriate changes.
 

--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -327,7 +327,7 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 	define( 'WP_REDIS_CONFIG', $ocp_settings );
 	```
 	
-<Alert title="Note" type="info">
+	<Alert title="Note" type="info">
 	If you don't want to bother with changing the configuration for local environments, you can simply disable Object Cache Pro for Lando and leave the existing configuration:
 
 	```php
@@ -335,7 +335,7 @@ Lando's [Pantheon recipe](https://docs.lando.dev/plugins/pantheon/) includes Red
 		define( 'WP_REDIS_DISABLED', true );
 	}
 	```
-</Alert>
+	</Alert>
 	
 Make sure to commit your code back to your environment when you have made the appropriate changes.
 


### PR DESCRIPTION
I noticed that there was an issue with the code block inside the Note about Lando configuration with OCP. This PR fixes that.

## Summary

**[Enable Object Cache Pro for WordPress](https://docs.pantheon.io/object-cache/wordpress#local-configuration-with-lando)** - Local configuration with Lando section, specifically

[Preview](https://pr-9405-documentation.appa.pantheon.site/object-cache/wordpress#local-configuration-with-lando)