### PR TITLE
Fix enablement styles

### DIFF
--- a/src/components/enablement/index.js
+++ b/src/components/enablement/index.js
@@ -1,28 +1,25 @@
-import React from "react"
-import { Callout } from "@pantheon-systems/pds-toolkit-react"
+import React from 'react';
+import { Callout } from '@pantheon-systems/pds-toolkit-react';
 import './style.css';
 
 const Enablement = ({ title, link, campaign, children }) => {
-
   function _handleClick() {
-    if (window.analytics){
-      window.analytics.track("Docs Enablement Clicked", {
-          campaign: {campaign},
+    if (window.analytics) {
+      window.analytics.track('Docs Enablement Clicked', {
+        campaign: { campaign },
       });
     }
   }
   return (
-    <Callout
-          children={children}
-          type="info"
-          className="docs-alert"
-        >
+    <Callout children={children} type="info" className="docs-alert">
       <h4>
-        <a href={link} onClick={_handleClick}>{title}</a>
+        <a href={link} onClick={_handleClick}>
+          {title}
+        </a>
       </h4>
       {children}
     </Callout>
-  )
-}
+  );
+};
 
-export default Enablement
+export default Enablement;

--- a/src/components/enablement/index.js
+++ b/src/components/enablement/index.js
@@ -1,4 +1,5 @@
 import React from "react"
+import { Callout } from "@pantheon-systems/pds-toolkit-react"
 import './style.css';
 
 const Enablement = ({ title, link, campaign, children }) => {
@@ -11,12 +12,16 @@ const Enablement = ({ title, link, campaign, children }) => {
     }
   }
   return (
-    <div className="enablement">
-      <h4 className="info">
-        <a href={link} className="external" onClick={_handleClick}>{title}</a>
+    <Callout
+          children={children}
+          type="info"
+          className="docs-alert"
+        >
+      <h4>
+        <a href={link} onClick={_handleClick}>{title}</a>
       </h4>
       {children}
-    </div>
+    </Callout>
   )
 }
 

--- a/src/components/enablement/index.js
+++ b/src/components/enablement/index.js
@@ -13,11 +13,10 @@ const Enablement = ({ title, link, campaign, children }) => {
   return (
     <Callout children={children} type="info" className="docs-alert">
       <h4>
-        <a href={link} onClick={_handleClick}>
           {title}
-        </a>
       </h4>
-      {children}
+      {children} <a href={link} onClick={_handleClick}>Learn more</a>
+
     </Callout>
   );
 };

--- a/src/components/enablement/index.js
+++ b/src/components/enablement/index.js
@@ -12,11 +12,11 @@ const Enablement = ({ title, link, campaign, children }) => {
   }
   return (
     <Callout children={children} type="info" className="docs-alert">
-      <h4>
-          {title}
-      </h4>
-      {children} <a href={link} onClick={_handleClick}>Learn more</a>
-
+      <h4>{title}</h4>
+      {children}{' '}
+      <a href={link} onClick={_handleClick}>
+        Learn more
+      </a>
     </Callout>
   );
 };


### PR DESCRIPTION
Fixes #9019 

Updates the `Enablement` component to use the `Callout` component from `pds` and hard codes the type to `info`.

Examples: 
* Bypassing Cache with HTTP Headers:
  * See enablement for "Quicksilver Cloud Hooks Training"       
  * [Preview link](https://pr-9421-documentation.appa.pantheon.site/cache-control) | [Production](https://docs.pantheon.io/cache-control)
 

* Pantheon YAML Configuration Files:
  * See enablement for "Agency WebOps Training"   
  * [Preview link](https://pr-9421-documentation.appa.pantheon.site/pantheon-yml) | [Production](https://docs.pantheon.io/pantheon-yml) 