### PR TITLE
Release note for WordPress 6.7.2

### DIFF
--- a/source/releasenotes/2025-02-11-wordpress-6-7-2.md
+++ b/source/releasenotes/2025-02-11-wordpress-6-7-2.md
@@ -1,0 +1,14 @@
+---
+title: WordPress 6.7.2 release now available
+published_date: "2025-02-11"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.7.2](https://wordpress.org/news/2025/02/wordpress-6-7-2-maintenance-release/), is available on Pantheon as of February 11, 2025. 
+
+### Action required
+Upgrade to WordPress 6.7.2 directly from your Pantheon dashboard or Terminus to get the latest fixes. For detailed instructions, see [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+<h3>Highlights</h3>
+
+* 35 bug fixes throughout [the block editor, HTML API and Customize](https://make.wordpress.org/core/tag/6-7-2/).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Release note for WordPress 6.7.2
