### PR TITLE
Specify support for phpMyAdmin usage on Pantheon

### DIFF
--- a/source/content/guides/mariadb-mysql/02-mysql-access.md
+++ b/source/content/guides/mariadb-mysql/02-mysql-access.md
@@ -52,9 +52,10 @@ There's a wide array of MySQL clients that you can use, including:
 - [TablePlus](https://tableplus.com/)
 - [Sequel Ace (formerly Sequel Pro)](https://sequel-ace.com/)
 - [Navicat](https://www.navicat.com/download)
-- [PHPMyAdmin](https://www.phpmyadmin.net/)
 
 Refer to the documentation or issue queue of your software to learn more about how to configure a connection.
+
+See our [platform considerations for phpMyAdmin usage](/guides/platform-considerations/platform-site-info#database-administration).
 
 #### Open Sequel Ace Database Connection
 

--- a/source/content/guides/mariadb-mysql/10-mariadb-mysql-faq.md
+++ b/source/content/guides/mariadb-mysql/10-mariadb-mysql-faq.md
@@ -79,6 +79,9 @@ mysql> SHOW VARIABLES LIKE "max_connections";
 
 There are many other factors that you should consider if you have concerns about maximum database connections. Contact your [CSM](/guides/professional-services#customer-success-management) or [Sales](https://pantheon.io/contact-sales?docs) for more information.
 
+### Can I use phpMyAdmin on Pantheon environments?
+No, Pantheon does not support running [phpMyAdmin](https://www.phpmyadmin.net/) on our application containers for database administration. See [platform considerations](/guides/platform-considerations/platform-site-info#database-administration) for more details.
+
 ## More Resources
 
 - [Accessing MariaDB and MySQL Databases](/guides/mariadb-mysql/mysql-access)

--- a/source/content/guides/platform-considerations/02-platform-site-info.md
+++ b/source/content/guides/platform-considerations/02-platform-site-info.md
@@ -78,6 +78,14 @@ Sample `services.yml` file:
 
 Pantheon does not currently support LESS or Sass/Compass CSS preprocessor languages. LESS and Sass will need to be pre-compiled to make traditional CSS stylesheets before being pushed to the platform.
 
+## Database Administration
+
+Pantheon does not provide a user interface for administering MySQL.
+
+You may use applications like [phpMyAdmin](https://www.phpmyadmin.net/) to administer MySQL in your local development environment. However, we do not support running the phpMyAdmin application on Pantheon's remote environments, as only [one application per site is allowed](#one-application-per-site). More critically, it would be a dangerous security risk to do so on Pantheon as it's primary purpose is to provide direct read/write access to the database.
+
+Instead, we recommend using the command-line interface or a MySQL client like [Sequel Ace](https://sequel-ace.com/) to [acccess MySQL directly](/guides/mariadb-mysql/mysql-access/).
+
 ## Database Stored Procedures
 
 <Partial file="platform-considerations-connections.md" />

--- a/source/content/plugins-known-issues.md
+++ b/source/content/plugins-known-issues.md
@@ -1649,11 +1649,11 @@ ___
 
 ## WP phpMyAdmin
 
-<ReviewDate date="2024-01-30" />
+<ReviewDate date="2025-02-14" />
 
-The [WP phpMyAdmin](https://puvox.software/software/wordpress-plugins/?plugin=wp-phpmyadmin-extension) plugin is not supported on Pantheon and will not work correctly.
+The [WP phpMyAdmin](https://wordpress.org/plugins/wp-phpmyadmin-extension/) plugin is not supported on Pantheon and will not work correctly.
 
-**Alternative:** Please see https://docs.pantheon.io/guides/mariadb-mysql/mysql-access for more information on accessing your database directly.
+**Alternative:** See our related documentation for more information on [accessing your database directly](/guides/mariadb-mysql/mysql-access).
 
 ___
 


### PR DESCRIPTION
## Summary

* **Platform Considerations**: Add new section "Database Administration" 
* **Access MariaDB and MySQL Databases**: Remove phpMyAdmin from the list of MySQL clients we recommend, mention it below the list and crosslink to platform considerations
* **MariaDB and MySQL FAQ**: Add new FAQ for phpMyAdmin and crosslink to platform considerations 