### PR TITLE
Update PDS to 1.0.0-dev.188

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
-        "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.173",
+        "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.188",
         "dotenv": "^10.0.0",
         "gatsby": "^4.25.4",
         "gatsby-cli": "^4.25.0",
@@ -2526,26 +2526,29 @@
       }
     },
     "node_modules/@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
+      "license": "MIT"
     },
     "node_modules/@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "1.10.0",
@@ -3232,6 +3235,12 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA==",
+      "license": "MIT"
+    },
     "node_modules/@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -3706,15 +3715,15 @@
       }
     },
     "node_modules/@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.140",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.140.tgz",
-      "integrity": "sha512-ZgB5H5ZYwNoO+e4kJVBF+s1sTjX9DswTFIAj9TXe3DwqGEv/c2XQMHeyjqaKRS6Cbe6Ts8gIBllIu4clIHxcDQ==",
+      "version": "1.0.0-dev.155",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.155.tgz",
+      "integrity": "sha512-AQiHgKbmES28YCU/6xuwbizZcuDfgPgDF5o5GPPMg5iYSwKLDvb9O125IIzOviXPfcUrrzbxnLGEngHiiaFGmA==",
       "license": "GPL-3.0-or-later"
     },
     "node_modules/@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.173",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.173.tgz",
-      "integrity": "sha512-5L/rGQflqM3/ml3WQazDvb+8Wg9gJnHdv2k3a88fZuwzIErZCFtx5wa4IujXVRSyh7EeVbaBFPxBwTrpvVd+KQ==",
+      "version": "1.0.0-dev.188",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.188.tgz",
+      "integrity": "sha512-sHHOjoEMG/78Ze4Syhi4V5lDqgx9O4BPNbW4hPb/YGeDr3XWs5kbcIZT+SnNGRu42qqmxyL+X6kh42lSPWzZQA==",
       "dependencies": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
@@ -3727,7 +3736,7 @@
         "react-toastify": "^9.0.3"
       },
       "engines": {
-        "node": ">=18.0.0 <=20.x"
+        "node": ">=18.0.0 <=22.x"
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0 || ^18.0.0"
@@ -3737,6 +3746,7 @@
       "version": "0.24.8",
       "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.24.8.tgz",
       "integrity": "sha512-AuYeDoaR8jtUlUXtZ1IJ/6jtBkGnSpJXbGNzokBL87VDJ8opMq1Bgrc0szhK482ReQY6KZsMoZCVSb4xwalkBA==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/react-dom": "^2.0.1",
         "aria-hidden": "^1.2.3",
@@ -3751,6 +3761,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-1.3.0.tgz",
       "integrity": "sha512-htwHm67Ji5E/pROEAr7f8IKFShuiCKHwUC/UY4vC3I5jiSvGFAYnSYiZO5MlGmads+QqvUkR9ANHEguGrDv72g==",
+      "license": "MIT",
       "dependencies": {
         "@floating-ui/dom": "^1.2.1"
       },
@@ -3760,11 +3771,12 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/@floating-ui/react/node_modules/@floating-ui/react-dom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-      "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
+      "license": "MIT",
       "dependencies": {
-        "@floating-ui/dom": "^1.6.1"
+        "@floating-ui/dom": "^1.0.0"
       },
       "peerDependencies": {
         "react": ">=16.8.0",
@@ -3772,11 +3784,12 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/focus-trap-react": {
-      "version": "10.2.3",
-      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.3.tgz",
-      "integrity": "sha512-YXBpFu/hIeSu6NnmV2xlXzOYxuWkoOtar9jzgp3lOmjWLWY59C/b8DtDHEAV4SPU07Nd/t+nS/SBNGkhUBFmEw==",
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
+      "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
+      "license": "MIT",
       "dependencies": {
-        "focus-trap": "^7.5.4",
+        "focus-trap": "^7.6.1",
         "tabbable": "^6.2.0"
       },
       "peerDependencies": {
@@ -3786,9 +3799,9 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/react-hotkeys-hook": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz",
-      "integrity": "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
+      "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
       "license": "MIT",
       "peerDependencies": {
         "react": ">=16.8.1",
@@ -3796,12 +3809,13 @@
       }
     },
     "node_modules/@pantheon-systems/pds-toolkit-react/node_modules/react-router-dom": {
-      "version": "6.22.3",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
-      "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
+      "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.15.3",
-        "react-router": "6.22.3"
+        "@remix-run/router": "1.22.0",
+        "react-router": "6.29.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -3815,6 +3829,7 @@
       "version": "9.1.3",
       "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-9.1.3.tgz",
       "integrity": "sha512-fPfb8ghtn/XMxw3LkxQBk3IyagNpF/LIKjOBflbexr2AWxAH1MJgvnESwEwBn9liLFXgTKWgBSdZpw9m4OTHTg==",
+      "license": "MIT",
       "dependencies": {
         "clsx": "^1.1.1"
       },
@@ -4748,28 +4763,38 @@
       }
     },
     "node_modules/@reactuses/core": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@reactuses/core/-/core-5.0.15.tgz",
-      "integrity": "sha512-54Y+pW30hKAFrxnMUPX22rtxXifVdjy659m3G7Yxx++xpToixPTAXxGT4uN9m8oDMCB2qLNKgZuKLCIoaKKP4A==",
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/@reactuses/core/-/core-5.0.23.tgz",
+      "integrity": "sha512-FsaCxZLjU5LbzNdNJc/l7U45kWwimWwkCGqq2ZKx5m3Yw8S6jdzfhvtcdQPhp6RjNao4o5UrtuF0DxhWTOKGyA==",
+      "license": "Unlicense",
       "dependencies": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "js-cookie": "^3.0.5",
         "lodash-es": "^4.17.21",
         "screenfull": "^5.0.0",
         "use-sync-external-store": "^1.2.0"
       },
       "peerDependencies": {
+        "qrcode": "^1.5",
         "react": "^16.8.0  || ^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "qrcode": {
+          "optional": true
+        }
       }
     },
     "node_modules/@reactuses/core/node_modules/lodash-es": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.21.tgz",
-      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw=="
+      "integrity": "sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==",
+      "license": "MIT"
     },
     "node_modules/@remix-run/router": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
-      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w==",
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
+      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -6072,6 +6097,7 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.4.tgz",
       "integrity": "sha512-y+CcFFwelSXpLZk/7fMB2mUbGtX9lKycf1MWJ7CaTIERyitVlyQx6C+sxcROU2BAJ24OiZyK+8wj2i8AlBoS3A==",
+      "license": "MIT",
       "dependencies": {
         "tslib": "^2.0.0"
       },
@@ -7688,6 +7714,7 @@
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
       "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -10781,9 +10808,10 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "node_modules/focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
+      "license": "MIT",
       "dependencies": {
         "tabbable": "^6.2.0"
       }
@@ -14082,7 +14110,8 @@
     "node_modules/hash-sum": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hash-sum/-/hash-sum-2.0.0.tgz",
-      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg=="
+      "integrity": "sha512-WdZTbAByD+pHfl/g9QSsBIIwy8IT+EsPiKDs0KNX+zSHhdDLFKdZu0BQHljvO+0QI/BasbMSUa8wYNCZTvhslg==",
+      "license": "MIT"
     },
     "node_modules/hasha": {
       "version": "5.2.2",
@@ -15462,6 +15491,7 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/js-cookie/-/js-cookie-3.0.5.tgz",
       "integrity": "sha512-cEiJEAEoIbWfCZYKWhVwFuvPX1gETRYPw6LlaTKoxD3s2AkXzkCjnp6h0V77ozyqj0jakteJ4YqDJT830+lVGw==",
+      "license": "MIT",
       "engines": {
         "node": ">=14"
       }
@@ -19330,11 +19360,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.22.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
-      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
+      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.15.3"
+        "@remix-run/router": "1.22.0"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -20431,6 +20462,7 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/screenfull/-/screenfull-5.2.0.tgz",
       "integrity": "sha512-9BakfsO2aUQN2K9Fdbj87RJIEZ82Q9IGim7FqM5OsebfoFC6ZHXgDq/KvniuLTPdeM8wY2o6Dj3WQ7KeQCj3cA==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
       },
@@ -21592,7 +21624,8 @@
     "node_modules/tabbable": {
       "version": "6.2.0",
       "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
+      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
+      "license": "MIT"
     },
     "node_modules/table": {
       "version": "6.8.1",
@@ -22711,11 +22744,12 @@
       "integrity": "sha512-RofWgt/7fL5wP1Y7fxE7/EmTLzQVnB0ycyibJ0OOHIlJqTNzglYFxVwETOcIoJqJmpDXJ9xImDv+Fq34F/d4Dw=="
     },
     "node_modules/use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
+      "license": "MIT",
       "peerDependencies": {
-        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/username-sync": {
@@ -25178,26 +25212,26 @@
       }
     },
     "@floating-ui/core": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.0.tgz",
-      "integrity": "sha512-PcF++MykgmTj3CIyOQbKA/hDzOAiqI3mhuoN44WRCopIs1sgoDoU4oty4Jtqaj/y3oDU6fnVSm4QG0a3t5i0+g==",
+      "version": "1.6.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
+      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
       "requires": {
-        "@floating-ui/utils": "^0.2.1"
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "@floating-ui/dom": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.3.tgz",
-      "integrity": "sha512-RnDthu3mzPlQ31Ss/BTwQ1zjzIhr3lk1gZB1OC56h/1vEtaXkESrOqL5fQVMfXpwGtRwX+YsZBdyHtJMQnkArw==",
+      "version": "1.6.13",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
+      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
       "requires": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.0"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.9"
       }
     },
     "@floating-ui/utils": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.1.tgz",
-      "integrity": "sha512-9TANp6GPoMtYzQdt54kfAyMmz1+osLlXdg2ENroU7zzrtflTLrrC/lgrIfaSe+Wu0b89GKccT7vxXA0MoAIO+Q=="
+      "version": "0.2.9",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
+      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
     },
     "@gatsbyjs/parcel-namer-relative-to-cwd": {
       "version": "1.10.0",
@@ -25748,6 +25782,11 @@
       "resolved": "https://registry.npmjs.org/@mdx-js/util/-/util-1.6.22.tgz",
       "integrity": "sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA=="
     },
+    "@microsoft/fetch-event-source": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@microsoft/fetch-event-source/-/fetch-event-source-2.0.1.tgz",
+      "integrity": "sha512-W6CLUJ2eBMw3Rec70qrsEW0jOm/3twwJv21mrmj2yORiaVmVYGS4sSS5yUwvQc1ZlDLYGPnClVWmUUMagKNsfA=="
+    },
     "@mischnic/json-sourcemap": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mischnic/json-sourcemap/-/json-sourcemap-0.1.0.tgz",
@@ -26159,14 +26198,14 @@
       }
     },
     "@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.140",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.140.tgz",
-      "integrity": "sha512-ZgB5H5ZYwNoO+e4kJVBF+s1sTjX9DswTFIAj9TXe3DwqGEv/c2XQMHeyjqaKRS6Cbe6Ts8gIBllIu4clIHxcDQ=="
+      "version": "1.0.0-dev.155",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.155.tgz",
+      "integrity": "sha512-AQiHgKbmES28YCU/6xuwbizZcuDfgPgDF5o5GPPMg5iYSwKLDvb9O125IIzOviXPfcUrrzbxnLGEngHiiaFGmA=="
     },
     "@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.173",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.173.tgz",
-      "integrity": "sha512-5L/rGQflqM3/ml3WQazDvb+8Wg9gJnHdv2k3a88fZuwzIErZCFtx5wa4IujXVRSyh7EeVbaBFPxBwTrpvVd+KQ==",
+      "version": "1.0.0-dev.188",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.188.tgz",
+      "integrity": "sha512-sHHOjoEMG/78Ze4Syhi4V5lDqgx9O4BPNbW4hPb/YGeDr3XWs5kbcIZT+SnNGRu42qqmxyL+X6kh42lSPWzZQA==",
       "requires": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
@@ -26190,11 +26229,11 @@
           },
           "dependencies": {
             "@floating-ui/react-dom": {
-              "version": "2.0.8",
-              "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.0.8.tgz",
-              "integrity": "sha512-HOdqOt3R3OGeTKidaLvJKcgg75S6tibQ3Tif4eyd91QnIJWr0NLvoXFpJA/j8HqkFSL68GDca9AuyWEHlhyClw==",
+              "version": "2.1.2",
+              "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
+              "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
               "requires": {
-                "@floating-ui/dom": "^1.6.1"
+                "@floating-ui/dom": "^1.0.0"
               }
             }
           }
@@ -26208,27 +26247,27 @@
           }
         },
         "focus-trap-react": {
-          "version": "10.2.3",
-          "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.2.3.tgz",
-          "integrity": "sha512-YXBpFu/hIeSu6NnmV2xlXzOYxuWkoOtar9jzgp3lOmjWLWY59C/b8DtDHEAV4SPU07Nd/t+nS/SBNGkhUBFmEw==",
+          "version": "10.3.1",
+          "resolved": "https://registry.npmjs.org/focus-trap-react/-/focus-trap-react-10.3.1.tgz",
+          "integrity": "sha512-PN4Ya9xf9nyj/Nd9VxBNMuD7IrlRbmaG6POAQ8VLqgtc6IY/Ln1tYakow+UIq4fihYYYFM70/2oyidE6bbiPgw==",
           "requires": {
-            "focus-trap": "^7.5.4",
+            "focus-trap": "^7.6.1",
             "tabbable": "^6.2.0"
           }
         },
         "react-hotkeys-hook": {
-          "version": "4.5.1",
-          "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.5.1.tgz",
-          "integrity": "sha512-scAEJOh3Irm0g95NIn6+tQVf/OICCjsQsC9NBHfQws/Vxw4sfq1tDQut5fhTEvPraXhu/sHxRd9lOtxzyYuNAg==",
+          "version": "4.6.1",
+          "resolved": "https://registry.npmjs.org/react-hotkeys-hook/-/react-hotkeys-hook-4.6.1.tgz",
+          "integrity": "sha512-XlZpbKUj9tkfgPgT9gA+1p7Ey6vFIZHttUjPqpTdyT5nqQ8mHL7elxvSbaC+dpSiHUSmr21Ya1mDxBZG3aje4Q==",
           "requires": {}
         },
         "react-router-dom": {
-          "version": "6.22.3",
-          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.22.3.tgz",
-          "integrity": "sha512-7ZILI7HjcE+p31oQvwbokjk6OA/bnFxrhJ19n82Ex9Ph8fNAq+Hm/7KchpMGlTgWhUxRHMMCut+vEtNpWpowKw==",
+          "version": "6.29.0",
+          "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.29.0.tgz",
+          "integrity": "sha512-pkEbJPATRJ2iotK+wUwHfy0xs2T59YPEN8BQxVCPeBZvK7kfPESRc/nyxzdcxR17hXgUPYx2whMwl+eo9cUdnQ==",
           "requires": {
-            "@remix-run/router": "1.15.3",
-            "react-router": "6.22.3"
+            "@remix-run/router": "1.22.0",
+            "react-router": "6.29.0"
           }
         },
         "react-toastify": {
@@ -26815,10 +26854,11 @@
       }
     },
     "@reactuses/core": {
-      "version": "5.0.15",
-      "resolved": "https://registry.npmjs.org/@reactuses/core/-/core-5.0.15.tgz",
-      "integrity": "sha512-54Y+pW30hKAFrxnMUPX22rtxXifVdjy659m3G7Yxx++xpToixPTAXxGT4uN9m8oDMCB2qLNKgZuKLCIoaKKP4A==",
+      "version": "5.0.23",
+      "resolved": "https://registry.npmjs.org/@reactuses/core/-/core-5.0.23.tgz",
+      "integrity": "sha512-FsaCxZLjU5LbzNdNJc/l7U45kWwimWwkCGqq2ZKx5m3Yw8S6jdzfhvtcdQPhp6RjNao4o5UrtuF0DxhWTOKGyA==",
       "requires": {
+        "@microsoft/fetch-event-source": "^2.0.1",
         "js-cookie": "^3.0.5",
         "lodash-es": "^4.17.21",
         "screenfull": "^5.0.0",
@@ -26833,9 +26873,9 @@
       }
     },
     "@remix-run/router": {
-      "version": "1.15.3",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.15.3.tgz",
-      "integrity": "sha512-Oy8rmScVrVxWZVOpEF57ovlnhpZ8CCPlnIIumVcV9nFdiSIrus99+Lw78ekXyGvVDlIsFJbSfmSovJUhCWYV3w=="
+      "version": "1.22.0",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.22.0.tgz",
+      "integrity": "sha512-MBOl8MeOzpK0HQQQshKB7pABXbmyHizdTpqnrIseTbsv0nAepwC2ENZa1aaBExNQcpLoXmWthhak8SABLzvGPw=="
     },
     "@rollup/rollup-android-arm-eabi": {
       "version": "4.24.0",
@@ -31391,9 +31431,9 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ=="
     },
     "focus-trap": {
-      "version": "7.5.4",
-      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.5.4.tgz",
-      "integrity": "sha512-N7kHdlgsO/v+iD/dMoJKtsSqs5Dz/dXZVebRgJw23LDk+jMi/974zyiOYDziY2JPp8xivq9BmUGwIJMiuSBi7w==",
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/focus-trap/-/focus-trap-7.6.4.tgz",
+      "integrity": "sha512-xx560wGBk7seZ6y933idtjJQc1l+ck+pI3sKvhKozdBV1dRZoKhkW5xoCaFv9tQiX5RH1xfSxjuNu6g+lmN/gw==",
       "requires": {
         "tabbable": "^6.2.0"
       }
@@ -37611,11 +37651,11 @@
       "integrity": "sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ=="
     },
     "react-router": {
-      "version": "6.22.3",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.22.3.tgz",
-      "integrity": "sha512-dr2eb3Mj5zK2YISHK++foM9w4eBnO23eKnZEDs7c880P6oKbrjz/Svg9+nxqtHQK+oMW4OtjZca0RqPglXxguQ==",
+      "version": "6.29.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.29.0.tgz",
+      "integrity": "sha512-DXZJoE0q+KyeVw75Ck6GkPxFak63C4fGqZGNijnWgzB/HzSP1ZfTlBj5COaGWwhrMQ/R8bXiq5Ooy4KG+ReyjQ==",
       "requires": {
-        "@remix-run/router": "1.15.3"
+        "@remix-run/router": "1.22.0"
       }
     },
     "react-server-dom-webpack": {
@@ -40183,9 +40223,9 @@
       }
     },
     "use-sync-external-store": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
-      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.4.0.tgz",
+      "integrity": "sha512-9WXSPC5fMv61vaupRkCKCxsPxBocVnwakBEkMIHHpkTTg6icbJtg6jzgtLDm4bl3cSHAca52rYWih0k4K3PfHw==",
       "requires": {}
     },
     "username-sync": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.173",
+    "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.188",
     "dotenv": "^10.0.0",
     "gatsby": "^4.25.4",
     "gatsby-cli": "^4.25.0",

--- a/src/components/ReleaseNoteTeaser/index.js
+++ b/src/components/ReleaseNoteTeaser/index.js
@@ -25,7 +25,7 @@ const ReleaseNoteTeaser = ({ ReleaseNoteData, className }) => {
 
   return (
     <React.Fragment key={ReleaseNoteData.id}>
-      <div
+      <article
         className={["docs-release-note-teaser", className]
           .join(" ")
           .trim()
@@ -50,7 +50,7 @@ const ReleaseNoteTeaser = ({ ReleaseNoteData, className }) => {
           className="pds-spacing-mar-block-end-m"
         />
         <MdxWrapper mdx={ReleaseNoteData.body} customShortcodes={customShortcodes} />
-      </div>
+      </article>
     </React.Fragment>
   )
 }

--- a/src/components/ReleaseNoteTeaser/index.js
+++ b/src/components/ReleaseNoteTeaser/index.js
@@ -1,35 +1,31 @@
-import React from "react"
-import { Link } from "gatsby"
-import ReleaseNoteCategories from "../ReleaseNoteCategories/index.js"
-import MdxWrapper from "../mdxWrapper.js"
-import PublishedDate from "../PublishedDate/index.js"
-import {
-  headline2,
-  headline3,
-  headline4,
-} from "../releaseHeadlines"
+import React from 'react';
+import { Link } from 'gatsby';
+import ReleaseNoteCategories from '../ReleaseNoteCategories/index.js';
+import MdxWrapper from '../mdxWrapper.js';
+import PublishedDate from '../PublishedDate/index.js';
+import { headline2, headline3, headline4 } from '../releaseHeadlines';
 
-import "./style.css"
+import './style.css';
 
 // Change the heading levels when release notes are displayed as a list so that the the headings don't conflict with the release note headings.
 const customShortcodes = {
   h1: headline2,
   h2: headline3,
   h3: headline4,
-}
+};
 
 const ReleaseNoteTeaser = ({ ReleaseNoteData, className }) => {
   if (!ReleaseNoteData) {
-    return null
+    return null;
   }
 
   return (
     <React.Fragment key={ReleaseNoteData.id}>
       <article
-        className={["docs-release-note-teaser", className]
-          .join(" ")
+        className={['docs-release-note-teaser', className]
+          .join(' ')
           .trim()
-          .replace(/\s+/g, " ")}
+          .replace(/\s+/g, ' ')}
       >
         <div className="docs-release-note-teaser__header pds-spacing-mar-block-end-xs">
           <Link
@@ -49,10 +45,13 @@ const ReleaseNoteTeaser = ({ ReleaseNoteData, className }) => {
           dateString={ReleaseNoteData.frontmatter.published_date}
           className="pds-spacing-mar-block-end-m"
         />
-        <MdxWrapper mdx={ReleaseNoteData.body} customShortcodes={customShortcodes} />
+        <MdxWrapper
+          mdx={ReleaseNoteData.body}
+          customShortcodes={customShortcodes}
+        />
       </article>
     </React.Fragment>
-  )
-}
+  );
+};
 
-export default ReleaseNoteTeaser
+export default ReleaseNoteTeaser;

--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -229,3 +229,14 @@ a.individual-changelog-link:hover {
 .mktoForm .mktoLogicalField.mktoInvalid {
   border: 1px solid var(--pds-color-input-border-critical);
 }
+
+article {
+  ul {
+    margin-block-start: var(--pds-spacing-3xs);
+    margin-block-end: var(--pds-spacing-m);
+  }
+
+  *:has(+ ul) {
+    margin-bottom: 0;
+  }
+}

--- a/src/templates/releaseNotesListing/index.js
+++ b/src/templates/releaseNotesListing/index.js
@@ -285,7 +285,7 @@ const ReleaseNotesListingTemplate = ({ data }) => {
             }}
           >
             <div
-              className="pds-input-field pds-input-field--text pds-spacing-mar-block-end-xl"
+              className="pds-text-input__input-wrapper pds-spacing-mar-block-end-xl"
               style={{
                 flexGrow: '2',
               }}


### PR DESCRIPTION
## Summary
- Update PDS to 1.0.0-dev.188 (Highest version that doesn't break the mobile experience)
- Update spacing for lists.
- Update release note teasers to use the `<article>` tag.
