### PR TITLE
SITE-1972: EoL PHP 5.3 & 5.5

### DIFF
--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -33,7 +33,7 @@ Click the links below to display complete PHP information for each version, incl
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.2](https://v72-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 
-Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. As of March 12, 2025, Pantheon [automatically upgraded sites running PHP 5.3 and 5.5 to PHP 5.6](/release-notes/2025/02/eol-php-53-55).
+Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. As of March 12, 2025, Pantheon [automatically upgraded sites running PHP 5.3 and 5.5 to PHP 5.6](/release-notes/2025/03/php-eol-53-55).
 
 ## Drush Compatibility
 

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -33,7 +33,7 @@ Click the links below to display complete PHP information for each version, incl
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.2](https://v72-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 
-Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. You can [upgrade your PHP version](/guides/php/php-versions) in the development environment to resume development on your site.
+Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. As of February 25, 2025, Pantheon [automatically upgraded sites running PHP 5.3 and 5.5 to PHP 5.6](/release-notes/2025/02/eol-php-53-55).
 
 ## Drush Compatibility
 

--- a/source/content/guides/php/01-introduction.md
+++ b/source/content/guides/php/01-introduction.md
@@ -33,7 +33,7 @@ Click the links below to display complete PHP information for each version, incl
 | [7.3](https://v73-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 | [7.2](https://v72-php-info.pantheonsite.io/)     | <span style="color:green">✔</span>         | ❌           |
 
-Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. As of February 25, 2025, Pantheon [automatically upgraded sites running PHP 5.3 and 5.5 to PHP 5.6](/release-notes/2025/02/eol-php-53-55).
+Sites that run older PHP versions not listed above will continue to serve pages. While older sites will still run unlisted and unsupported versions of PHP, new sites cannot change their PHP version to unsupported values. As of March 12, 2025, Pantheon [automatically upgraded sites running PHP 5.3 and 5.5 to PHP 5.6](/release-notes/2025/02/eol-php-53-55).
 
 ## Drush Compatibility
 

--- a/source/releasenotes/2025-02-25-eol-php-53-55.md
+++ b/source/releasenotes/2025-02-25-eol-php-53-55.md
@@ -1,0 +1,17 @@
+---
+title: "PHP 5.3 and 5.5 no longer available"
+published_date: "2025-02-25"
+categories: [infrastructure, security, action-required]
+---
+
+As part of our continued effort to protect and secure customer sites, the Pantheon platform no longer offers PHP versions 5.3 and 5.5. All sites currently configured to use PHP 5.3 or 5.6 are automatically switched to PHP 5.6.
+
+PHP 5.5 was declared end-of-life (EOL) by [the PHP Foundation](https://www.php.net/supported-versions.php) on July 21, 2016, more than eight years ago. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
+
+## Action required
+
+While all sites using PHP 5.3 or 5.5 have been auto-upgraded to PHP 5.6, sites' [`pantheon.yml`](/pantheon-yml) files have not been changed and may still contain the retired values. In the future, this will cause a `git push` to the platform to be rejected. Customers with sites configured for PHP 5.3 or 5.5 should [upgrade the PHP version](/guides/php/php-versions) in `pantheon.yml` to at least PHP 5.6.
+
+Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.
+
+Sites created with custom upstreams using EOL PHP versions may also have unexpected behavior upon site creation.

--- a/source/releasenotes/2025-02-25-eol-php-53-55.md
+++ b/source/releasenotes/2025-02-25-eol-php-53-55.md
@@ -1,6 +1,6 @@
 ---
 title: "PHP 5.3 and 5.5 no longer available"
-published_date: "2025-02-25"
+published_date: "2025-03-03"
 categories: [infrastructure, security, action-required]
 ---
 

--- a/source/releasenotes/2025-02-25-eol-php-53-55.md
+++ b/source/releasenotes/2025-02-25-eol-php-53-55.md
@@ -4,13 +4,13 @@ published_date: "2025-02-25"
 categories: [infrastructure, security, action-required]
 ---
 
-As part of our continued effort to protect and secure customer sites, the Pantheon platform no longer offers PHP versions 5.3 and 5.5. All sites currently configured to use PHP 5.3 or 5.6 are automatically switched to PHP 5.6.
+As part of our continued effort to protect and secure customer sites, the Pantheon platform no longer offers PHP versions 5.3 and 5.5. All sites currently configured to use PHP 5.3 or 5.5 have been automatically upgraded to PHP 5.6.
 
 PHP 5.5 was declared end-of-life (EOL) by [the PHP Foundation](https://www.php.net/supported-versions.php) on July 21, 2016, more than eight years ago. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
 
 ## Action required
 
-While all sites using PHP 5.3 or 5.5 have been auto-upgraded to PHP 5.6, sites' [`pantheon.yml`](/pantheon-yml) files have not been changed and may still contain the retired values. In the future, this will cause a `git push` to the platform to be rejected. Customers with sites configured for PHP 5.3 or 5.5 should [upgrade the PHP version](/guides/php/php-versions) in `pantheon.yml` to at least PHP 5.6.
+While all sites previously using PHP 5.3 or 5.5 have been auto-upgraded to PHP 5.6, the [`pantheon.yml`](/pantheon-yml) file for these sites have not been changed and will still contain the retired values. In the future, this will cause a `git push` to the platform to be rejected. Customers with sites configured for PHP 5.3 or 5.5 should [upgrade the PHP version](/guides/php/php-versions) in `pantheon.yml` to at least PHP 5.6.
 
 Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.
 

--- a/source/releasenotes/2025-03-12-php-eol-53-55.md
+++ b/source/releasenotes/2025-03-12-php-eol-53-55.md
@@ -1,6 +1,6 @@
 ---
 title: "PHP 5.3 and 5.5 no longer available"
-published_date: "2025-03-03"
+published_date: "2025-03-12"
 categories: [infrastructure, security, action-required]
 ---
 

--- a/source/releasenotes/2025-03-12-php-eol-53-55.md
+++ b/source/releasenotes/2025-03-12-php-eol-53-55.md
@@ -4,7 +4,7 @@ published_date: "2025-03-12"
 categories: [infrastructure, security, action-required]
 ---
 
-As part of our continued effort to protect and secure customer sites, the Pantheon platform no longer offers PHP versions 5.3 and 5.5. All sites currently configured to use PHP 5.3 or 5.5 have been automatically upgraded to PHP 5.6.
+As part of our continued effort to protect and secure customer sites, the Pantheon platform no longer offers PHP versions 5.3 and 5.5. Sites currently configured to use PHP 5.3 or 5.5 are being automatically upgraded to PHP 5.6 over the next few days.
 
 PHP 5.5 was declared end-of-life (EOL) by [the PHP Foundation](https://www.php.net/supported-versions.php) on July 21, 2016, more than eight years ago. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
 


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds release note for PHP EoL 
**[PHP](https://docs.pantheon.io/guides/php)** - Details on EoL handling (TBD)


- [x] ~Feb 25~ Mar 03 release date
- [x] Platform changes released
- [x] PHP guide page updated


https://pr-9453-documentation.appa.pantheon.site/release-notes/2025/02/eol-php-53-55
https://pr-9453-documentation.appa.pantheon.site/guides/php