### PR TITLE
Every Drupal version >= 9 uses the same repo as upstream.

### DIFF
--- a/source/content/guides/git/06-resolve-merge-conflicts.md
+++ b/source/content/guides/git/06-resolve-merge-conflicts.md
@@ -52,7 +52,7 @@ This is safe to run if you don't have your own changes in any of the conflicting
 <Tab title="Drupal (Latest)" id="d#">
 
   ```bash{promptUser: user}
-  git pull -Xtheirs https://github.com/pantheon-upstreams/drupal-10-composer-managed.git main
+  git pull -Xtheirs https://github.com/pantheon-upstreams/drupal-composer-managed.git main
   # resolve conflicts
   git push origin master
   ```


### PR DESCRIPTION
## Summary

**[Resolving merge conflicts](https://docs.pantheon.io/guides/git/resolve-merge-conflicts)** - drupal-10-composer-managed is a start state, not the real upstream sites should reference once created.

Now that Drupal9 and Drupal Latest are the same, should we maybe get rid of Drupal 9?