### PR TITLE
Validate release note file name

### DIFF
--- a/.github/workflows/release-note-file.yml
+++ b/.github/workflows/release-note-file.yml
@@ -9,10 +9,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # Ensures we have at least one previous commit for diffing
 
       - name: Find invalid filenames in added/modified files
         run: |
-          git diff --name-only --diff-filter=A origin/main | grep '^source/releasenotes/' | while read -r file; do
+          git fetch origin ${{ github.base_ref }} --depth=1
+          git diff --name-only --diff-filter=A origin/${{ github.base_ref }} | grep '^source/releasenotes/' | while read -r file; do
             filename=$(basename "$file")
             name="${filename%.*}"  # Remove only the last extension
             if [[ "$name" == *.* ]]; then

--- a/.github/workflows/release-note-file.yml
+++ b/.github/workflows/release-note-file.yml
@@ -1,0 +1,22 @@
+name: Check Release Notes Filenames
+
+on:
+  pull_request:
+
+jobs:
+  check-filenames:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Find invalid filenames in added/modified files
+        run: |
+          git diff --name-only --diff-filter=A origin/main | grep '^source/releasenotes/' | while read -r file; do
+            filename=$(basename "$file")
+            name="${filename%.*}"  # Remove only the last extension
+            if [[ "$name" == *.* ]]; then
+              echo "Invalid file: $file"
+              exit 1
+            fi
+          done


### PR DESCRIPTION
## Summary

Ensures PRs like #9453 don't happen again, where a `.` in the file name causes an 404 and breaks RSS reader.

