### PR TITLE
Filename typo fix in 04-ddev.md

### DIFF
--- a/source/content/guides/local-development/04-ddev.md
+++ b/source/content/guides/local-development/04-ddev.md
@@ -60,7 +60,7 @@ Be sure that you have:
 
   In addition to starting local Docker containers for the site, this command will also install DDEV provider integration recipes to your site's codebase at `.ddev/providers`, which we will use in the next step.
 
-1. Copy your site's `.ddev/providers/example.pantheon.yaml` provider file to `.ddev/providers/pantheon.yaml`.
+1. Copy your site's `.ddev/providers/pantheon.yaml.example` provider file to `.ddev/providers/pantheon.yaml`.
 
   <Alert title="Note" type="info" >
 


### PR DESCRIPTION
The listed example config file doesn't match [DDEV's doco](https://ddev.readthedocs.io/en/latest/users/providers/pantheon/#pantheon-quickstart), and won't exist when users follow the instructions. This PR should fix this. 