### PR TITLE
[DEVX-4421] Terminus Release 3.6.2

### DIFF
--- a/source/content/terminus/10-supported-terminus.md
+++ b/source/content/terminus/10-supported-terminus.md
@@ -23,18 +23,15 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 3.6.1            | December 05, 2024  |                    |
+| 3.6.2            | March 03, 2025     |                    |
+| 3.6.1            | December 05, 2024  | March 03, 2026     |
 | 3.6.0            | September 19, 2024 | December 05, 2025  |
 | 3.5.2            | August 19, 2024    | September 19, 2025 |
 | 3.5.1            | June 13, 2024      | August 19, 2025    |
 | 3.5.0            | June 6, 2024       | June 13, 2025      |
 | 3.4.0            | April 23, 2024     | June 6, 2025       |
 | 3.3.5            | February 28, 2024  | April 23, 2025     |
-| 3.3.4            | February 27, 2024  | February 28, 2025  |
-| 3.3.3            | January 11, 2024   | February 27, 2025  |
-| 3.3.2            | January 11, 2024   | January 11, 2025   |
-| 3.3.1            | November 30, 2023  | January 11, 2025   |
-| 3.3.0 or earlier | November 29, 2023  | November 30, 2024  |
+| 3.3.4 or earlier | February 27, 2024  | February 28, 2025  |
 
 
 ### PHP Version Compatibility Matrix

--- a/source/releasenotes/2025-03-03-terminus-362.md
+++ b/source/releasenotes/2025-03-03-terminus-362.md
@@ -4,7 +4,7 @@ published_date: "2025-03-03"
 categories: [tools-apis]
 ---
 
-Terminus [3.6.2](https://github.com/pantheon-systems/terminus/releases/tag/3.6.2) is now available as of March 03, 2025. This minor update contains the latest bug fixes and improvements for this tool.
+Terminus [3.6.2](https://github.com/pantheon-systems/terminus/releases/tag/3.6.2) is now available as of March 03, 2025. This small update contains the latest bug fixes and improvements for this tool.
 
 For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/3.6.2).
 

--- a/source/releasenotes/2025-03-03-terminus-362.md
+++ b/source/releasenotes/2025-03-03-terminus-362.md
@@ -1,0 +1,17 @@
+---
+title: "Terminus 3.6.2 release now available"
+published_date: "2025-03-03"
+categories: [tools-apis]
+---
+
+Terminus [3.6.2](https://github.com/pantheon-systems/terminus/releases/tag/3.6.2) is now available as of March 03, 2025. This minor update contains the latest bug fixes and improvements for this tool.
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/3.6.2).
+
+## How to upgrade Terminus
+If you manage your installation via Homebrew on macOS, you can update Terminus with the following command:
+
+```shell{promptUser: user}
+brew upgrade pantheon-systems/external/terminus
+```
+For other systems, see additional upgrade instructions [here](/terminus/install).


### PR DESCRIPTION
## Summary

**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Adds Terminus Release 3.6.2

Release note added to `source/releasenotes`
