### PR TITLE
update php 5.3 / 5.5 eol and auto-upgrade date

### DIFF
--- a/source/releasenotes/2025-01-16-php-53-55-eol.md
+++ b/source/releasenotes/2025-01-16-php-53-55-eol.md
@@ -4,9 +4,10 @@ published_date: "2025-01-16"
 categories: [infrastructure, security, action-required]
 ---
 
-_**Editorial note:** As of January 29, 2025, this release note has been edited to amend the action required. Where previously we required upgrading 5.3 and 5.5 to 7.2 we are now allowing upgrades to 5.6 as well. This can be helpful if you choose to upgrade PHP versions incrementally rather than making the jump to 7.x._
+_**Editorial notes:**_
+  * _The date of the auto-upgrades has been updated from February 25 to March 12._
+  * _As of January 29, 2025, this release note has been edited to amend the action required. Where previously we required upgrading 5.3 and 5.5 to 7.2 we are now allowing upgrades to 5.6 as well. This can be helpful if you choose to upgrade PHP versions incrementally rather than making the jump to 7.x._
 
-_**Editorial note:** The date of the auto-upgrades has been updated from February 25 to March 12._
 
 <hr/>
 As part of our continued effort to protect and secure customer sites, the Pantheon platform will no longer offer PHP versions 5.3 and 5.5 as of March 12, 2025.


### PR DESCRIPTION
## Summary

**[PHP 5.3/5.5 EOL](https://docs.pantheon.io/release-notes/2025/01/php-53-55-eol)** - Updated release note with new date for the auto-upgrade due to internal delays
