### PR TITLE
Evaluate requests from the cli before setting SERVER_NAME

### DIFF
--- a/source/content/server_name-and-server_port.md
+++ b/source/content/server_name-and-server_port.md
@@ -23,7 +23,9 @@ In general, you don't want your code to rely on this, but some extensions (theme
 Adding the following code will pass the correct value when `'SERVER_NAME'` is used:
 
 ```php
-$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+if (php_sapi_name() != 'cli') {
+  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+}
 ```
 
 While this fix does correct symptoms such as undesirable URLs, we recommended replacing all instances of `'SERVER_NAME'` with `'HTTP_HOST'` directly (e.g. [`WP_HOME` and `WP_SITE`](https://github.com/pantheon-systems/WordPress/blob/default/wp-config-pantheon.php#L52) for WordPress).

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -307,7 +307,9 @@ ___
 **Solution:** Add the following to `wp-config.php`:
 
 ```php:title=wp-config.php
-$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+if (php_sapi_name() != 'cli') {
+  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+}
 
 if (isset($_ENV['PANTHEON_ENVIRONMENT'])) {
   if (isset($_SERVER['HTTP_USER_AGENT_HTTPS']) && $_SERVER['HTTP_USER_AGENT_HTTPS'] === 'ON') {
@@ -860,7 +862,9 @@ ___
   // server name and not the current hostname, as a
   // result, Redirection's "URL and server"-based
   // redirects never match.
-  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+  if (php_sapi_name() != 'cli') {
+    $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+  }
   ```
 
 Visit the [SERVER_NAME and SERVER_PORT on Pantheon](/server_name-and-server_port) doc for more information about how to use `HTTP_Host` on Pantheon.
@@ -930,7 +934,9 @@ The plugin generates the site's URL using `$_SERVER['SERVER_NAME']` instead of `
 **Solution:** Add the following line to `wp-config.php`:
 
 ```php:title=wp-config.php
-$_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+if (php_sapi_name() != 'cli') {
+  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
+}
 ```
 
 ___


### PR DESCRIPTION
Fixes #9424 
## Summary
[WordPress Plugins and Themes with Known Issues](https://docs.pantheon.io/wordpress-known-issues) - Check if the request is coming from the CLI before setting SERVER_NAME across all instances 

```
if (php_sapi_name() != 'cli') {
  $_SERVER['SERVER_NAME'] = $_SERVER['HTTP_HOST'];
}
```

