### PR TITLE
IC guide incorrectly references WordPress

### DIFF
--- a/source/content/guides/integrated-composer/02-create.md
+++ b/source/content/guides/integrated-composer/02-create.md
@@ -23,7 +23,7 @@ This section provides information on how to use Drupal with Integrated Composer.
 
 ### Create Your Site
 
-There are two ways you can spin up a site using WordPress Composer Managed:
+There are two ways you can spin up a site using Drupal Composer Managed:
 
 - Running the following terminus command:
 


### PR DESCRIPTION
## Summary

**[Drupal with Integrated Composer](https://docs.pantheon.io/guides/integrated-composer/create)** 
- A line in this (Drupal-specific) section refers to WordPress instead of Drupal. PR fixes that.
