### PR TITLE
Change "site" to "environment" in cache-clearing script

### DIFF
--- a/source/content/addons/object-cache/howto/drupal.md
+++ b/source/content/addons/object-cache/howto/drupal.md
@@ -148,7 +148,7 @@ Use the following script to cleanup cache tables in the database:
 echo 'Provide the site name (e.g. your-awesome-site), then press [ENTER]:';
 read SITE;
 
-echo 'Provide the site name (multidev, dev, test, or live), then press [ENTER]:';
+echo 'Provide the environment name (multidev, dev, test, or live), then press [ENTER]:';
 read ENV;
 
 # Get a list of all cache tables


### PR DESCRIPTION
## Summary

**[Database Cleanup (Required)](https://docs.pantheon.io/object-cache/drupal#database-cleanup-required)** 
- The detailed shell script was incorrectly asking for "site name" when it should be asking for "environment name."
