### PR TITLE
Debug broken anchor

### DIFF
--- a/source/content/guides/account-mgmt/traffic/01-introduction.md
+++ b/source/content/guides/account-mgmt/traffic/01-introduction.md
@@ -181,6 +181,7 @@ Load tests and other performance reviews of the Pantheon platform are generally 
 If you identify an underlying issue that may affect the platform, please let us know. If an issue is identified with your codebase, Pantheon can [recommend a Partner](https://directory.pantheon.io/agencies?docs) or connect you with our [Professional Services](/guides/professional-services) team to help you with remediation.
 
 ### What about Denial of Service and other attacks?
+
 Malicious actors can create unplanned events in traffic, and this is not a fair measure of value a customer receives from our platform. We ask that customers help us identify and support the investigation of these issues. On a case by case basis, Pantheon may choose to waive overages in its judgment weighing factors such as how many clients are affected, to what degree could this have been addressed by customers, and how uniquely Pantheon is positioned to help our customers resolve these issues.
 
 Malicious actors are different from unwanted traffic, which may be unique to a customer’s preferences for the targeted audience of their site. From a traffic measurement perspective, Pantheon is focused on omitting traffic that is objectively malicious.

--- a/source/content/guides/account-mgmt/traffic/01-introduction.md
+++ b/source/content/guides/account-mgmt/traffic/01-introduction.md
@@ -117,7 +117,6 @@ A visit does not count if it is one of the following:
 
 ## FAQs
 ### Why doesn't Pantheon's traffic metrics match my other analytics?
-
 Website traffic is an important indicator of a successful website. Analytics suites (e.g. Google Analytics, Similarweb, Mixpanel) each serve a different purpose from Pantheon’s Site Dashboard.
 
 <Alert title="Note"  type="info" >
@@ -182,7 +181,6 @@ Load tests and other performance reviews of the Pantheon platform are generally 
 If you identify an underlying issue that may affect the platform, please let us know. If an issue is identified with your codebase, Pantheon can [recommend a Partner](https://directory.pantheon.io/agencies?docs) or connect you with our [Professional Services](/guides/professional-services) team to help you with remediation.
 
 ### What about Denial of Service and other attacks?
-
 Malicious actors can create unplanned events in traffic, and this is not a fair measure of value a customer receives from our platform. We ask that customers help us identify and support the investigation of these issues. On a case by case basis, Pantheon may choose to waive overages in its judgment weighing factors such as how many clients are affected, to what degree could this have been addressed by customers, and how uniquely Pantheon is positioned to help our customers resolve these issues.
 
 Malicious actors are different from unwanted traffic, which may be unique to a customer’s preferences for the targeted audience of their site. From a traffic measurement perspective, Pantheon is focused on omitting traffic that is objectively malicious.

--- a/source/content/guides/account-mgmt/traffic/01-introduction.md
+++ b/source/content/guides/account-mgmt/traffic/01-introduction.md
@@ -117,6 +117,7 @@ A visit does not count if it is one of the following:
 
 ## FAQs
 ### Why doesn't Pantheon's traffic metrics match my other analytics?
+
 Website traffic is an important indicator of a successful website. Analytics suites (e.g. Google Analytics, Similarweb, Mixpanel) each serve a different purpose from Pantheon’s Site Dashboard.
 
 <Alert title="Note"  type="info" >

--- a/src/components/popover.js
+++ b/src/components/popover.js
@@ -1,9 +1,11 @@
-import React, { useState, useEffect} from "react"
+import React, { useState, useEffect } from 'react';
 
-import { Popover as PDSPopover } from "@pantheon-systems/pds-toolkit-react"
+import { Popover as PDSPopover } from '@pantheon-systems/pds-toolkit-react';
 
 const Popover = ({ icon, title, content }) => {
-  const processedContent = <div dangerouslySetInnerHTML={{ __html: content }} />
+  const processedContent = (
+    <div dangerouslySetInnerHTML={{ __html: content }} />
+  );
   const [isClient, setIsClient] = useState(false);
 
   useEffect(() => {
@@ -14,7 +16,7 @@ const Popover = ({ icon, title, content }) => {
     return null;
   }
 
-  return <PDSPopover content={processedContent} title={title} />
-}
+  return <PDSPopover content={processedContent} title={title} />;
+};
 
-export default Popover
+export default Popover;

--- a/src/components/popover.js
+++ b/src/components/popover.js
@@ -1,9 +1,18 @@
-import React from "react"
+import React, { useState, useEffect} from "react"
 
 import { Popover as PDSPopover } from "@pantheon-systems/pds-toolkit-react"
 
 const Popover = ({ icon, title, content }) => {
   const processedContent = <div dangerouslySetInnerHTML={{ __html: content }} />
+  const [isClient, setIsClient] = useState(false);
+
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
+
+  if (!isClient) {
+    return null;
+  }
 
   return <PDSPopover content={processedContent} title={title} />
 }


### PR DESCRIPTION
Fixes #9490 
Replaces #9502 

Debug broken anchors across traffic intro page, for example: 

https://docs.pantheon.io/guides/account-mgmt/traffic#what-about-denial-of-service-and-other-attacks 

---

### Bug
The presence of a `Popover` component caused other elements to render incorrectly, wrapping them inside a div with pds-popover classes.

### Fix
Ensured Popover only renders on the client side using `useState` and `useEffect`, preventing issues during server-side rendering (SSR).
