### PR TITLE
fix: round totalColumns up to ensure all categories are displayed

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,12 +7,11 @@
     "": {
       "name": "pantheon-documentation",
       "version": "0.1.0",
-      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "@mdx-js/mdx": "^1.6.22",
         "@mdx-js/react": "^1.6.22",
-        "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.228",
+        "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.236",
         "dotenv": "^10.0.0",
         "focus-trap-react": "^10.3.1",
         "gatsby": "^4.25.4",
@@ -2054,15 +2053,20 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "dependencies": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
       },
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/runtime/node_modules/regenerator-runtime": {
+      "version": "0.14.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+      "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
     },
     "node_modules/@babel/template": {
       "version": "7.24.7",
@@ -3717,25 +3721,26 @@
       }
     },
     "node_modules/@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.156",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.156.tgz",
-      "integrity": "sha512-x11UDRzVDSTjb+hpPCUP0bUPROtnSph3QG1o3ETNtKes8VXm4tpTvJ16NcFubH7o39xKxK9OfbIXZAr136P1kg==",
-      "license": "GPL-3.0-or-later"
+      "version": "1.0.0-dev.157",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.157.tgz",
+      "integrity": "sha512-2+g8GrprrIyvV5Y2vXpLqn6+cywUxAN+wpzrbmWDGZ9MiCRHLi9lBxo6sLld1RCr6CjbSVXhLaZQXCkBpaaM8A=="
     },
     "node_modules/@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.228",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.228.tgz",
-      "integrity": "sha512-8tYfmdnqTNcYKTlXw1Q8NUJ9oerg0Acpbe7Iklnh2ffCrOD6fAqdw3tkxEHUzXPbL4y4NAqcZOvZ/wZGTLpGNg==",
+      "version": "1.0.0-dev.236",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.236.tgz",
+      "integrity": "sha512-3sVSuvqr8oZDQp7En/9mQgBapqnSuLUclRG4TxiECnFfHILoOHx9iV1z1noFfDzPivktSrhTRjCh9jtUOxQYJQ==",
       "dependencies": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
-        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.156",
+        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.157",
         "@reactuses/core": "^5.0.15",
+        "downshift": "^9.0.8",
         "focus-trap-react": "^10.2.1",
         "hash-sum": "^2.0.0",
         "prism-react-renderer": "^2.4.1",
         "prismjs": "^1.29.0",
         "react-code-block": "^1.1.1",
+        "react-device-detect": "^2.2.3",
         "react-hotkeys-hook": "^4.5.1",
         "react-router-dom": "^6.13.0",
         "react-toastify": "^9.0.3"
@@ -7885,6 +7890,11 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
+    "node_modules/compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -8972,6 +8982,31 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "node_modules/downshift": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.9.tgz",
+      "integrity": "sha512-ygOT8blgiz5liDuEFAIaPeU4dDEa+w9p6PHVUisPIjrkF5wfR59a52HpGWAVVMoWnoFO8po2mZSScKZueihS7g==",
+      "dependencies": {
+        "@babel/runtime": "^7.24.5",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "18.2.0",
+        "tslib": "^2.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.12.0"
+      }
+    },
+    "node_modules/downshift/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/downshift/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -19329,6 +19364,18 @@
         "node": ">= 8"
       }
     },
+    "node_modules/react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "dependencies": {
+        "ua-parser-js": "^1.0.33"
+      },
+      "peerDependencies": {
+        "react": ">= 0.14.0",
+        "react-dom": ">= 0.14.0"
+      }
+    },
     "node_modules/react-dom": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
@@ -25101,11 +25148,18 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "@babel/runtime": {
-      "version": "7.22.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
-      "integrity": "sha512-XsDuspWKLUsxwCp6r7EhsExHtYfbe5oAGQ19kqngTdCPUoPQzOPdUbD/pB9PJiwb2ptYKQDjSJT3R6dC+EPqfQ==",
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.0.tgz",
+      "integrity": "sha512-VtPOkrdPHZsKc/clNqyi9WUA8TINkZ4cGk63UUE3u4pmB2k+ZMQRDuIOagv8UVd6j7k0T3+RRIb7beKTebNbcw==",
       "requires": {
-        "regenerator-runtime": "^0.13.11"
+        "regenerator-runtime": "^0.14.0"
+      },
+      "dependencies": {
+        "regenerator-runtime": {
+          "version": "0.14.1",
+          "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.14.1.tgz",
+          "integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw=="
+        }
       }
     },
     "@babel/template": {
@@ -26329,24 +26383,26 @@
       }
     },
     "@pantheon-systems/pds-design-tokens": {
-      "version": "1.0.0-dev.156",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.156.tgz",
-      "integrity": "sha512-x11UDRzVDSTjb+hpPCUP0bUPROtnSph3QG1o3ETNtKes8VXm4tpTvJ16NcFubH7o39xKxK9OfbIXZAr136P1kg=="
+      "version": "1.0.0-dev.157",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-design-tokens/-/pds-design-tokens-1.0.0-dev.157.tgz",
+      "integrity": "sha512-2+g8GrprrIyvV5Y2vXpLqn6+cywUxAN+wpzrbmWDGZ9MiCRHLi9lBxo6sLld1RCr6CjbSVXhLaZQXCkBpaaM8A=="
     },
     "@pantheon-systems/pds-toolkit-react": {
-      "version": "1.0.0-dev.228",
-      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.228.tgz",
-      "integrity": "sha512-8tYfmdnqTNcYKTlXw1Q8NUJ9oerg0Acpbe7Iklnh2ffCrOD6fAqdw3tkxEHUzXPbL4y4NAqcZOvZ/wZGTLpGNg==",
+      "version": "1.0.0-dev.236",
+      "resolved": "https://registry.npmjs.org/@pantheon-systems/pds-toolkit-react/-/pds-toolkit-react-1.0.0-dev.236.tgz",
+      "integrity": "sha512-3sVSuvqr8oZDQp7En/9mQgBapqnSuLUclRG4TxiECnFfHILoOHx9iV1z1noFfDzPivktSrhTRjCh9jtUOxQYJQ==",
       "requires": {
         "@floating-ui/react": "^0.24.3",
         "@floating-ui/react-dom": "~1.3.0",
-        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.156",
+        "@pantheon-systems/pds-design-tokens": "^1.0.0-dev.157",
         "@reactuses/core": "^5.0.15",
+        "downshift": "^9.0.8",
         "focus-trap-react": "^10.2.1",
         "hash-sum": "^2.0.0",
         "prism-react-renderer": "^2.4.1",
         "prismjs": "^1.29.0",
         "react-code-block": "^1.1.1",
+        "react-device-detect": "^2.2.3",
         "react-hotkeys-hook": "^4.5.1",
         "react-router-dom": "^6.13.0",
         "react-toastify": "^9.0.3"
@@ -29356,6 +29412,11 @@
         }
       }
     },
+    "compute-scroll-into-view": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/compute-scroll-into-view/-/compute-scroll-into-view-3.1.1.tgz",
+      "integrity": "sha512-VRhuHOLoKYOy4UbilLbUzbYg93XLjv2PncJC50EuTWPA3gaja1UjBsUP/D/9/juV3vQFr6XBEzn9KCAHdUvOHw=="
+    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -30165,6 +30226,30 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/dotenv-expand/-/dotenv-expand-5.1.0.tgz",
       "integrity": "sha512-YXQl1DSa4/PQyRfgrv6aoNjhasp/p4qs9FjJ4q4cQk+8m4r6k4ZSiEyytKG8f8W9gi8WsQtIObNmKd+tMzNTmA=="
+    },
+    "downshift": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/downshift/-/downshift-9.0.9.tgz",
+      "integrity": "sha512-ygOT8blgiz5liDuEFAIaPeU4dDEa+w9p6PHVUisPIjrkF5wfR59a52HpGWAVVMoWnoFO8po2mZSScKZueihS7g==",
+      "requires": {
+        "@babel/runtime": "^7.24.5",
+        "compute-scroll-into-view": "^3.1.0",
+        "prop-types": "^15.8.1",
+        "react-is": "18.2.0",
+        "tslib": "^2.6.2"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        },
+        "tslib": {
+          "version": "2.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+          "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="
+        }
+      }
     },
     "dunder-proto": {
       "version": "1.0.1",
@@ -37743,6 +37828,14 @@
             "isexe": "^2.0.0"
           }
         }
+      }
+    },
+    "react-device-detect": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-device-detect/-/react-device-detect-2.2.3.tgz",
+      "integrity": "sha512-buYY3qrCnQVlIFHrC5UcUoAj7iANs/+srdkwsnNjI7anr3Tt7UY6MqNxtMLlr0tMBied0O49UZVK8XKs3ZIiPw==",
+      "requires": {
+        "ua-parser-js": "^1.0.33"
       }
     },
     "react-dom": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@mdx-js/mdx": "^1.6.22",
     "@mdx-js/react": "^1.6.22",
-    "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.228",
+    "@pantheon-systems/pds-toolkit-react": "^1.0.0-dev.236",
     "dotenv": "^10.0.0",
     "focus-trap-react": "^10.3.1",
     "gatsby": "^4.25.4",

--- a/src/components/releaseNotePopoverCategorySelector.js
+++ b/src/components/releaseNotePopoverCategorySelector.js
@@ -146,6 +146,7 @@ const ReleaseNotePopoverCategorySelector = ({
         content={popoverContent}
         hasCloseButton={true}
         className={'rn-popover-categories'}
+        classNameContainer={'rn-popover-categories'}
         placement="bottom-start"
         onClose={handlePopoverClose}
         offsetValue={18}

--- a/src/components/releaseNotePopoverCategorySelector.js
+++ b/src/components/releaseNotePopoverCategorySelector.js
@@ -61,9 +61,9 @@ const ReleaseNotePopoverCategorySelector = ({
   let popoverTriggerIcon = isPopoverOpen ? 'angleUp' : 'angleDown';
 
   // Popover columns config
-  const itemsPerColumn = 6;
+  const itemsPerColumn = 7;
   const totalItems = activeCategories.length;
-  const totalColumns = totalItems / itemsPerColumn;
+  const totalColumns = Math.ceil(totalItems / itemsPerColumn);
 
   const popoverContent = (
     <>

--- a/src/templates/releaseNotesListing/style.css
+++ b/src/templates/releaseNotesListing/style.css
@@ -21,7 +21,7 @@
   }
 }
 
-.rn-popover-categories .pds-popover__container {
+.pds-popover__container.rn-popover-categories  {
   max-width: 100%;
   padding: 40px;
   z-index: 100;


### PR DESCRIPTION
## Summary

Fix: Ensure All Categories Are Displayed by Rounding totalColumns Up
This PR ensures that totalColumns is always an integer by rounding it up with Math.ceil(). It also fixes the `Popover` container width issue that was causing columns to overflow on smaller resolutions.  

**Changes:**
- Applied Math.ceil() to totalColumns to avoid decimal values.
- Updated `itemsPerColumn` to 7 to avoid a single element in the last column (this change can be reversed if needed).
- Updated `pds-toolit-react` to version `1.0.0-dev.236` to have access to the `classNameContainer` prop in the ´Popover´ component.  
- Adjusted `Popover` styles and classes to fix the container width issue.


