### PR TITLE
Correct `actions/cache` version to v4

### DIFF
--- a/source/content/terminus/ci/github-actions.md
+++ b/source/content/terminus/ci/github-actions.md
@@ -60,7 +60,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: terminus-binary
         with:
           path: ~/terminus/terminus
@@ -106,14 +106,14 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           php-version: '8.1'
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: terminus-cache
         with:
           path: ~/.terminus
           key: ${{ runner.os }}-terminus-cache-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-terminus-cache-
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         id: terminus-binary
         with:
           path: ~/terminus/terminus


### PR DESCRIPTION
## Summary

**[Authenticate Terminus in a GitHub Actions Pipeline](https://docs.pantheon.io/terminus/ci/github-actions)** - Updates the source action version.

Fixes https://github.com/pantheon-systems/documentation/issues/9504