### PR TITLE
Add YAML resource for Pantheon YAML configuration file

### DIFF
--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -373,3 +373,4 @@ Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](
 
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/guides/quicksilver)
 - [Upgrade PHP Versions](/guides/php/php-versions)
+- [YAML linter and comparator)](https://yamline.com/)

--- a/source/content/pantheon-yml.md
+++ b/source/content/pantheon-yml.md
@@ -373,4 +373,4 @@ Changes made to `pantheon.yml` **are not** detected when deployed as a [hotfix](
 
 - [Automating and Integrating your Pantheon Workflow with Quicksilver Platform Hooks](/guides/quicksilver)
 - [Upgrade PHP Versions](/guides/php/php-versions)
-- [YAML linter and comparator)](https://yamline.com/)
+- [YAML linter and comparator](https://yamline.com/)


### PR DESCRIPTION
## Summary

Add resource https://yamline.com/ (my website), it provides YAML tools such as a linter and comparator, which are useful for configuring Pantheon YAML files.