### PR TITLE
[SITE-4178] Drush 5/7 upcoming EOL release note

### DIFF
--- a/source/releasenotes/2025-04-08-drush-5-7-eol.md
+++ b/source/releasenotes/2025-04-08-drush-5-7-eol.md
@@ -1,25 +1,21 @@
 ---
 title: "Drush 5 and 7 no longer available starting May 13, 2025"
 published_date: "2025-04-08"
-categories: [infrastructure, action-required]
+categories: [infrastructure, action-required, drupal, security]
 ---
 
-As part of our ongoing platform maintenance and security improvements, Drush versions 5 and 7 will reach end-of-life (EOL) on May 13, 2025. After this date, these versions will no longer be available for sites to use on the platform.
+As part of our ongoing platform maintenance and security improvements, Drush versions 5 and 7 will no longer be available on Pantheon starting May 13, 2025. After this date, sites using these versions will automatically be upgraded to Drush 8.
 
-## Impact
+Drush 5 reached end-of-life (EOL) in May 2015 and Drush 7 in July 2017. EOL software does not receive security or feature updates, and could expose sites to attack if any vulnerabilities or exploits are discovered.
 
-Sites using Drush 5 or 7 will need to upgrade to a supported version to maintain functionality and security. Drush 8 and newer versions are recommended for all production sites.
-
-[Find out which version of Drush your site is running](https://docs.pantheon.io/guides/drush/drush-versions#verify-current-drush-version-interacting-with-your-drupal-site).
+[Find out which version of Drush your site is running](/guides/drush/drush-versions#verify-current-drush-version-interacting-with-your-drupal-site).
 
 ## Action Required
 
-If your site is using Drush 5 or 7, you should:
+Sites using Drush 5 or 7 will need to [upgrade to Drush 8](/guides/drush/drush-versions#drupal-7) to maintain functionality and security:
 
 1. Test your site with a newer version of Drush (8 or newer)
 2. Update your site's Drush version
 3. Review your deployment workflows and CI/CD pipelines to ensure compatibility with the new Drush version
 
 On May 13, 2025, all sites using Drush 5 or 7 will be auto-upgraded to Drush 8.
-
-For guidance on upgrading Drush, please refer to our [Drush documentation](/guides/drush/). 

--- a/source/releasenotes/2025-04-08-drush-5-7-eol.md
+++ b/source/releasenotes/2025-04-08-drush-5-7-eol.md
@@ -17,7 +17,9 @@ Sites using Drush 5 or 7 will need to upgrade to a supported version to maintain
 If your site is using Drush 5 or 7, you should:
 
 1. Test your site with a newer version of Drush (8 or newer)
-2. Update your site's Drush version before May 13, 2025
+2. Update your site's Drush version
 3. Review your deployment workflows and CI/CD pipelines to ensure compatibility with the new Drush version
+
+On May 13, 2025, all sites using Drush 5 or 7 will be auto-upgraded to Drush 8.
 
 For guidance on upgrading Drush, please refer to our [Drush documentation](/guides/drush/). 

--- a/source/releasenotes/2025-04-08-drush-5-7-eol.md
+++ b/source/releasenotes/2025-04-08-drush-5-7-eol.md
@@ -1,0 +1,23 @@
+---
+title: "Drush 5 and 7 no longer available starting May 13, 2025"
+published_date: "2025-04-08"
+categories: [infrastructure, action-required]
+---
+
+As part of our ongoing platform maintenance and security improvements, Drush versions 5 and 7 will reach end-of-life (EOL) on May 13, 2025. After this date, these versions will no longer be available for sites to use on the platform.
+
+## Impact
+
+Sites using Drush 5 or 7 will need to upgrade to a supported version to maintain functionality and security. Drush 8 and newer versions are recommended for all production sites.
+
+[Find out which version of Drush your site is running](https://docs.pantheon.io/guides/drush/drush-versions#verify-current-drush-version-interacting-with-your-drupal-site).
+
+## Action Required
+
+If your site is using Drush 5 or 7, you should:
+
+1. Test your site with a newer version of Drush (8 or newer)
+2. Update your site's Drush version before May 13, 2025
+3. Review your deployment workflows and CI/CD pipelines to ensure compatibility with the new Drush version
+
+For guidance on upgrading Drush, please refer to our [Drush documentation](/guides/drush/). 


### PR DESCRIPTION
## Summary

As of May 13, sites using Drush 5 and 7 will be auto-upgraded to Drush 8.

A follow-on PR will have:
1. A release note to be published on May 13
2. Changes to the docs where Drush 5 or 7 is referenced