### PR TITLE
Add requirement for automated cert renewals

### DIFF
--- a/source/content/partials/https-requirements.md
+++ b/source/content/partials/https-requirements.md
@@ -13,5 +13,5 @@ reviewed: ""
  - AAAA records are not required, but if set must exclusively point to Pantheon.
  - Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.
  - CAA records must **either** not exist for the domain and its parent domains **or** authorize Let's Encrypt. Note that CAA records are inherited by subdomains.
- - Requests to the `/.well-known/acme-challenge/*` path must return a 200 response. For example, if the domain passes through a third-party WAF before routing to Pantheon and returns a 403 response for this path then automated certificate renewal would be blocked. 
+ - Requests to the `/.well-known/acme-challenge/*` path must return a 200 response. If the domain passes through a third-party WAF before routing to Pantheon and returns a 403 response for this path then automated certificate renewal would be blocked - to resolve, you must add a bypass rule to your WAF that exempts the `/.well-known/acme-challenge/*` path so that automated renewals can be served. 
 

--- a/source/content/partials/https-requirements.md
+++ b/source/content/partials/https-requirements.md
@@ -13,3 +13,5 @@ reviewed: ""
  - AAAA records are not required, but if set must exclusively point to Pantheon.
  - Authoritative Name Servers must serve mixed-case lookups, and must not fail CAA lookups.
  - CAA records must **either** not exist for the domain and its parent domains **or** authorize Let's Encrypt. Note that CAA records are inherited by subdomains.
+ - Requests to the `/.well-known/acme-challenge/*` path must return a 200 response. For example, if the domain passes through a third-party WAF before routing to Pantheon and returns a 403 response for this path then automated certificate renewal would be blocked. 
+


### PR DESCRIPTION
Fixes #9096 

## Summary

Add a requirement for automated cert renewals - path must return 200 response, WAFs blocking the path will break automated renewal: 
* Global CDN Guide - HTTPS: [Preview link](https://pr-9520-documentation.appa.pantheon.site/guides/global-cdn/https#requirements-for-automated-certificate-renewal) | [Production link](https://docs.pantheon.io/guides/global-cdn/https#requirements-for-automated-certificate-renewal)
* Launch Guide - Configure DNS: [Preview link](https://pr-9520-documentation.appa.pantheon.site/guides/launch/configure-dns/#requirements-for-automated-certificate-renewal) | [Production link](https://docs.pantheon.io/guides/launch/configure-dns/#requirements-for-automated-certificate-renewal)