### PR TITLE
WordPress 6.8 release

### DIFF
--- a/source/releasenotes/2025-04-15-wordpress-6-8.md
+++ b/source/releasenotes/2025-04-15-wordpress-6-8.md
@@ -11,8 +11,8 @@ Upgrade to WordPress 6.8 right from your Pantheon dashboard or Terminus to acces
 
 ### Highlights
 
-* Speculative loading, preloading pages for a faster user experience.
-* Improved password security with bcrypt
+* [Speculative loading](https://make.wordpress.org/core/2025/03/06/speculative-loading-in-6-8/), preloading pages for a faster user experience.
+* [Improved password security](https://make.wordpress.org/core/2025/02/17/wordpress-6-8-will-use-bcrypt-for-password-hashing/) with bcrypt
 * Improvements to the style book, editor, and more than 100 accessibility improvements
 * [...and more](https://wordpress.org/download/releases/6-8/)
 

--- a/source/releasenotes/2025-04-15-wordpress-6-8.md
+++ b/source/releasenotes/2025-04-15-wordpress-6-8.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress 6.8 (Cecil) release now available
+title: WordPress 6.8 release now available
 published_date: "2025-04-15"
 categories: [wordpress, action-required]
 ---

--- a/source/releasenotes/2025-04-15-wordpress-6-8.md
+++ b/source/releasenotes/2025-04-15-wordpress-6-8.md
@@ -1,0 +1,19 @@
+---
+title: WordPress 6.8 (Cecil) release now available
+published_date: "2025-04-15"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.8 (Cecil)](https://wordpress.org/news/2025/04/cecil/), is available on Pantheon as of April 15, 2025.
+
+### Action required
+Upgrade to WordPress 6.8 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+* Speculative loading, preloading pages for a faster user experience.
+* Improved password security with bcrypt
+* Improvements to the style book, editor, and more than 100 accessibility improvements
+* [...and more](https://wordpress.org/download/releases/6-8/)
+
+For full details about WordPress 6.8, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-8/) or the [WordPress 6.8 Field Guide](https://make.wordpress.org/core/2025/03/28/wordpress-6-8-field-guide/).


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Add release note for WordPress 6.8 shipped today https://github.com/pantheon-systems/WordPress/pull/414
