### PR TITLE
SITE-4405 - Adds documentation for WordPress 6.8.1 release

### DIFF
--- a/source/releasenotes/2025-04-30-wordpress-6-8-1.md
+++ b/source/releasenotes/2025-04-30-wordpress-6-8-1.md
@@ -1,0 +1,16 @@
+---
+title: WordPress 6.8.1 release now available
+published_date: "2025-04-30"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [6.8.1](https://wordpress.org/news/2025/04/wordpress-6-8-1-maintenance-release/), is available on Pantheon as of April 30, 2025.
+
+### Action required
+Upgrade to WordPress 6.8.1 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+* 15 bugs throughout [Core and the Block Editor](https://make.wordpress.org/core/tag/6-8-1/).
+
+For full details about WordPress 6.8.1, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-6-8-1/)


### PR DESCRIPTION
Adds documentation for the WordPress 6.8.1 release on the platform

## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Add release note for WordPress 6.8.1 [pantheon-systems/WordPress/pull/415](https://github.com/pantheon-systems/WordPress/pull/415)