### PR TITLE
interstitial page now applies to all sandboxes

### DIFF
--- a/source/content/guides/account-mgmt/plans/07-site-plans.md
+++ b/source/content/guides/account-mgmt/plans/07-site-plans.md
@@ -7,7 +7,7 @@ contributors: [wordsmither]
 showtoc: true
 permalink: docs/guides/account-mgmt/plans/site-plans
 editpath: docs/guides/account-mgmt/plans/07-site-plans.md
-reviewed: "2025-05-01"
+reviewed: "2025-05-08"
 contenttype: [guide]
 innav: [false]
 categories: [plans]
@@ -137,7 +137,7 @@ Sandbox sites are useful for trying out the Pantheon platform, creating sandboxe
 To downgrade to Sandbox, see [Cancel Current Plan](/guides/account-mgmt/plans/site-plans#cancel-your-plan).
 
 ### Interstitial Warning Pages
-In order to inform visitors they are accessing a non-production sandbox site, and to discourage abuse of sandbox sites (spam, phishing, or other malicious purposes) - Pantheon displays an interstitial warning page for all newly created sandbox sites. 
+In order to inform visitors they are accessing a non-production sandbox site, and to discourage abuse of sandbox sites (spam, phishing, or other malicious purposes) - Pantheon displays an interstitial warning page for all sandbox sites.
 
 ![screenshot of warning message](../../../../images/interstitial-warning-message.png)
 

--- a/source/releasenotes/2025-05-01-interstitial-pages.md
+++ b/source/releasenotes/2025-05-01-interstitial-pages.md
@@ -4,7 +4,9 @@ published_date: "2025-05-01"
 categories: [security]
 ---
 
-Beginning May 6, 2025, newly created [_sandbox_ sites](/guides/account-mgmt/plans/site-plans#sandbox-sites) will show an interstitial page when a visitor loads a page for the first time.
+_**Editorial note**: As of May 8, 2025, this release note has been edited to no longer specify "newly created" sandbox sites - as this change now applies to all sandbox sites regardless of when the site was created.
+
+Beginning May 6, 2025, [_sandbox_ sites](/guides/account-mgmt/plans/site-plans#sandbox-sites) will show an interstitial page when a visitor loads a page for the first time.
 
 ![screenshot of warning message](../images/interstitial-warning-message.png)
 
@@ -14,4 +16,4 @@ This change is being made to discourage abuse of the sandbox sites for spam, phi
 
 See [related documentation to learn more](/guides/account-mgmt/plans/site-plans#sandbox-sites) about this change, including how to bypass the interstitial page for automated testing.
 
-For questions or concerns, please reach out to [Pantheon Support](https://support.pantheon.io).
+For questions or concerns, please reach out to [Pantheon Support](https://pantheon.io/support).

--- a/source/releasenotes/2025-05-01-interstitial-pages.md
+++ b/source/releasenotes/2025-05-01-interstitial-pages.md
@@ -4,7 +4,7 @@ published_date: "2025-05-01"
 categories: [security]
 ---
 
-_**Editorial note**: As of May 8, 2025, this release note has been edited to no longer specify "newly created" sandbox sites - as this change now applies to all sandbox sites regardless of when the site was created.
+_**Editorial note**: As of May 8, 2025, this release note has been edited to no longer specify "newly created" sandbox sites - as this change now applies to all sandbox sites regardless of when the site was created._
 
 Beginning May 6, 2025, [_sandbox_ sites](/guides/account-mgmt/plans/site-plans#sandbox-sites) will show an interstitial page when a visitor loads a page for the first time.
 


### PR DESCRIPTION
## Summary

Re: https://docs.pantheon.io/release-notes/2025/05/interstitial-pages
* Do not specify newly created sandboxes, all sandboxes will see interstitial page 
* Add an editorial note for context on the revision
* Update support link 

Re: https://docs.pantheon.io/guides/account-mgmt/plans/site-plans#interstitial-warning-pages
* Do not specify newly created sandboxes, all sandboxes will see interstitial page 
