### PR TITLE
Update 07-site-plans.md, small change for interstitial header value

### DIFF
--- a/source/content/guides/account-mgmt/plans/07-site-plans.md
+++ b/source/content/guides/account-mgmt/plans/07-site-plans.md
@@ -154,7 +154,7 @@ For example, if you are testing a site with Playwright, you can add the followin
 
 ```javascript
 await page.setExtraHTTPHeaders({
-  'Deterrence-Bypass': 'true',
+  'Deterrence-Bypass': '1',
 });
 ```
 


### PR DESCRIPTION
Updating the header value to 1 instead of true to match what GCDNs VCL is looking for

## Summary

**[Site Hosting Plans and Addons](https://docs.pantheon.io/guides/account-mgmt/plans/site-plans#interstitial-warning-pages)** - Updating the header value to 1 instead of true to match what GCDNs VCL is looking for
