### PR TITLE
php runtime gen2: clamav known issue, only for non live

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -33,6 +33,8 @@ During the beta phase, you can opt in to test your sites on the new PHP runtime.
 - Identify any potential issues early
 - Provide valuable feedback to our team
 
+We currently recommend only using the PHP Runtime Generation 2 beta for testing with non-Live environments.
+
 ### How to Opt In
 
 To enable the second generation PHP runtime for an environment, add the following to your `pantheon.yml`:
@@ -113,6 +115,7 @@ To provide the most secure environment, sites running Drupal 7 or 8 may need upg
 
 - SFTP mode is currently unsupported. Git mode is available. 
 - Drupal 7 sites cannot access Solr services. An update to `drops-7` will be available soon.
+- ClamAV is currently unavailable.
 
 ## Reporting Issues
 

--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -11,6 +11,10 @@ product: [--]
 integration: [--]
 ---
 
+<Alert title="Warning" type="danger">
+We currently recommend only using the PHP Runtime Generation 2 beta for testing with non-Live environments.
+</Alert>
+
 ## Overview
 
 A new generation of our Serverless PHP Runtime is available in beta. This upgrade represents our commitment to providing a modern, secure, and efficient PHP runtime for your websites.
@@ -32,8 +36,6 @@ During the beta phase, you can opt in to test your sites on the new PHP runtime.
 - Test your deployment workflows
 - Identify any potential issues early
 - Provide valuable feedback to our team
-
-We currently recommend only using the PHP Runtime Generation 2 beta for testing with non-Live environments.
 
 ### How to Opt In
 


### PR DESCRIPTION
## Summary

** update PHP Runtime Generation 2 beta doc with a new known issue, and mark it as recommended only for non-live environments