### PR TITLE
Fix branch name

### DIFF
--- a/source/content/core-updates.md
+++ b/source/content/core-updates.md
@@ -259,7 +259,7 @@ This process lets you manually resolve the conflict using the command line and a
 
   ```bash{promptUser: user}
   git fetch pantheon-drupal
-  git rebase pantheon-drupal/master
+  git rebase pantheon-drupal/main
   ```
 
   </Tab>


### PR DESCRIPTION
## Summary

**[WordPress and Drupal Core Updates](https://docs.pantheon.io/core-updates#merge-conflict-resolution)** 

Fixes the branch name for [https://github.com/pantheon-upstreams/drupal-composer-managed](https://github.com/pantheon-upstreams/drupal-composer-managed). This repo uses `main`, not `master`.
