### PR TITLE
adds a check for missing .md file extension

### DIFF
--- a/.github/workflows/release-note-file.yml
+++ b/.github/workflows/release-note-file.yml
@@ -14,12 +14,19 @@ jobs:
 
       - name: Find invalid filenames in added/modified files
         run: |
-          git fetch origin ${{ github.base_ref }} --depth=1
-          git diff --name-only --diff-filter=A origin/${{ github.base_ref }} | grep '^source/releasenotes/' | while read -r file; do
+            git fetch origin ${{ github.base_ref }} --depth=1
+            git diff --name-only --diff-filter=A origin/${{ github.base_ref }} | grep '^source/releasenotes/' | while read -r file; do
             filename=$(basename "$file")
             name="${filename%.*}"  # Remove only the last extension
+            ext="${filename##*.}"
+            # Check for multiple dots in the filename (excluding extension)
             if [[ "$name" == *.* ]]; then
-              echo "Invalid file: $file"
+              echo "Invalid file: $file (multiple dots in filename)"
               exit 1
             fi
-          done
+            # Check for missing .md extension
+            if [[ "$ext" != "md" ]]; then
+              echo "Invalid file: $file (missing .md extension)"
+              exit 1
+            fi
+            done

--- a/source/releasenotes/2025-06-02-test-filename-no-extension
+++ b/source/releasenotes/2025-06-02-test-filename-no-extension
@@ -1,7 +1,0 @@
----
-title: Test releasenote filename without extension
-published_date: "2025-06-02"
-categories: [new-feature]
----
-
-This is a test release note without a file extension 

--- a/source/releasenotes/2025-06-02-test-filename-no-extension
+++ b/source/releasenotes/2025-06-02-test-filename-no-extension
@@ -1,0 +1,7 @@
+---
+title: Test releasenote filename without extension
+published_date: "2025-06-02"
+categories: [new-feature]
+---
+
+This is a test release note without a file extension 


### PR DESCRIPTION
Fixes #9531 

## Summary

**CI only**

This change updates the "invalid filenames in release notes" check that @pwtyler added to also check for missing `.md` file extensions in release notes.