### PR TITLE
SITE-2013: EoL PHP in pantheon.yml

### DIFF
--- a/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
+++ b/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
@@ -1,12 +1,16 @@
 ---
-title: "PHP 5.3 and 5.5 no allowed in pantheon.yml"
-published_date: "2025-03-12"
+title: "PHP 5.3 and 5.5 no longer allowed in pantheon.yml"
+published_date: "2025-06-03"
 categories: [infrastructure, action-required]
 ---
 
-Earlier this year, PHP versions 5.3 and 5.5 [reached end-of-life on the platform](/2025/03/php-eol-53-55). While sites configured to use these PHP versions have already been auto-upgraded to use PHP 5.6, the old values have still been allowed in the [`pantheon.yml`](/pantheon-yml) file. Starting today, PHP versions less than 5.6 will be rejected by the platform on git push.
+ Starting today, PHP versions less than 5.6 in `pantheon.yml` will be rejected by the platform on git push.
 
-Applying upstream updates on a site configured with an EoL PHP version may fail unexpectedly. The workflow logs will report if this is due to the PHP version being rejected. Sites created with custom upstreams using EoL PHP versions may also have unexpected behavior upon site creation.
+Earlier this year, PHP versions 5.3 and 5.5 [reached end-of-life on the platform](/2025/03/php-eol-53-55). While sites configured to use these PHP versions have already been auto-upgraded to use PHP 5.6, the old values have still been allowed in the [`pantheon.yml`](/pantheon-yml) file.
+
+Applying upstream updates on a site configured with an EoL PHP version may fail too.
+The workflow logs will report when that failure is due to the PHP version being rejected.
+Sites created with custom upstreams using EoL PHP versions may also see failed workflows.
 
 ## Action Required
 

--- a/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
+++ b/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
@@ -1,0 +1,15 @@
+---
+title: "PHP 5.3 and 5.5 no allowed in pantheon.yml"
+published_date: "2025-03-12"
+categories: [infrastructure, action-required]
+---
+
+Earlier this year, PHP versions 5.3 and 5.5 [reached end-of-life on the platform](/2025/03/php-eol-53-55). While sites configured to use these PHP versions have already been auto-upgraded to use PHP 5.6, the old values have still been allowed in the [`pantheon.yml`](/pantheon-yml) file. Starting today, PHP versions less than 5.6 will be rejected by the platform on git push.
+
+Applying upstream updates on a site configured with an EoL PHP version may fail unexpectedly. The workflow logs will report if this is due to the PHP version being rejected. Sites created with custom upstreams using EoL PHP versions may also have unexpected behavior upon site creation.
+
+## Action Required
+
+Customers with sites configured for PHP 5.3 or 5.5 should [upgrade the PHP version](/guides/php/php-versions) in `pantheon.yml` to at least PHP 5.6.
+
+Pantheon [currently recommends](/guides/php#supported-php-versions) at least PHP 8.1 for all production sites.

--- a/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
+++ b/source/releasenotes/2025-06-03-php-53-55-pantheon-yml.md
@@ -4,9 +4,9 @@ published_date: "2025-06-03"
 categories: [infrastructure, action-required]
 ---
 
- Starting today, PHP versions less than 5.6 in `pantheon.yml` will be rejected by the platform on git push.
+Starting today, PHP versions less than 5.6 in `pantheon.yml` will be rejected by the platform on git push.
 
-Earlier this year, PHP versions 5.3 and 5.5 [reached end-of-life on the platform](/2025/03/php-eol-53-55). While sites configured to use these PHP versions have already been auto-upgraded to use PHP 5.6, the old values have still been allowed in the [`pantheon.yml`](/pantheon-yml) file.
+Earlier this year, PHP versions 5.3 and 5.5 [reached end-of-life on the platform](/release-notes/2025/03/php-eol-53-55). While sites configured to use these PHP versions have already been auto-upgraded to use PHP 5.6, the old values have still been allowed in the [`pantheon.yml`](/pantheon-yml) file.
 
 Applying upstream updates on a site configured with an EoL PHP version may fail too.
 The workflow logs will report when that failure is due to the PHP version being rejected.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - PHP 5.3/5.5 now rejected by pantheon.yml

https://getpantheon.atlassian.net/browse/SITE-2013