### PR TITLE
clarify instructions for adding upstream dependencies

### DIFF
--- a/source/content/guides/custom-upstream/02-create-custom-upstream.md
+++ b/source/content/guides/custom-upstream/02-create-custom-upstream.md
@@ -250,7 +250,7 @@ You must track Pantheon's corresponding upstream repository within the Custom Up
 
         - The latest version of Drupal on Pantheon includes [Integrated Composer](/guides/integrated-composer) to manage dependencies. This adds a separate `composer.json` file in the `upstream-configuration` directory.
 
-    1. Change to the `composer.json` file in the `upstream-configuration` directory and use `composer require` to add packages to the Upstream, then set the `config version` to a number that makes sense for you:
+    1. Change to the `upstream-configuration` directory and use `composer require` to add packages to the Upstream `composer.json` file:
 
      ```bash{promptUser: user}
      cd upstream-configuration


### PR DESCRIPTION
## Summary

**[Create a Custom Upstream](https://docs.pantheon.io/guides/custom-upstream/create-custom-upstream#pull-in-core-from-pantheons-upstream)**  

Tweaked the wording slightly to make it clear that you're switching to a directory, and affecting a file via commands. 

Removed mention of setting a "version" as it's very confusing and after asking internally, Pantheon devs confirmed: "After a conversation with the team about this I would say the docs are at best confusing, and at worst not entirely accurate on this point. In practice you can just pin packages to specific versions in the usual way, if necessary." -- mentioning this version refers to composer package version.
