### PR TITLE
[SITE-4575] Add release note for WP Saml Auth

### DIFF
--- a/source/releasenotes/2025-06-16-wp-saml-auth-2-2-0.md
+++ b/source/releasenotes/2025-06-16-wp-saml-auth-2-2-0.md
@@ -6,7 +6,7 @@ categories: [action-required, wordpress, security]
 
 Pantheon has released a new version of our [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/). This release adds a notification for a recently discovered vulnerability in the [SimpleSAMLphp library](https://github.com/advisories/GHSA-46r4-f8gj-xg56) that can expose sites to SSO (Single Sign-On) forgery or impersonation.
 
-**This vulnerability affects only a small minority of WP SAML Auth implementations because the plugin defaults to a more modern library, [OneLogin PHP SAML](https://github.com/SAML-Toolkits/php-saml). Only sites that opted in to SimpleSAMLphp and are behind on updates to that library are vulnerable.**
+**This vulnerability affects only a small minority of WP SAML Auth implementations because the plugin defaults to a more modern library, [OneLogin PHP SAML](https://github.com/SAML-Toolkits/php-saml). Only sites configured with an outdated version of the SimpleSAMLphp library are vulnerable.**
 
 The update to WP SAML Auth includes a warning message displayed in the WordPress admin if a vulnerable version of SimpleSAMLphp is detected with instructions to install SimpleSAMLphp 2.3.7 or higher. Since the migration from the previous and most vulnerable versions of SimpleSAMLphp (1.x) to a newer and more secure version (2.x or above) can be onerous, some teams may prefer to switch from SimpleSAMLphp to the default of the plugin, OneLogin PHP SAML than to upgrade SimpleSAMLphp.
 

--- a/source/releasenotes/2025-06-16-wp-saml-auth-2-2-0.md
+++ b/source/releasenotes/2025-06-16-wp-saml-auth-2-2-0.md
@@ -1,0 +1,18 @@
+---
+title: "WP SAML Auth 2.2.0 update now available"
+published_date: "2025-06-16"
+categories: [action-required, wordpress, security]
+---
+
+Pantheon has released a new version of our [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/). This release adds a notification for a recently discovered vulnerability in the [SimpleSAMLphp library](https://github.com/advisories/GHSA-46r4-f8gj-xg56) that can expose sites to SSO (Single Sign-On) forgery or impersonation.
+
+**This vulnerability affects only a small minority of WP SAML Auth implementations because the plugin defaults to a more modern library, [OneLogin PHP SAML](https://github.com/SAML-Toolkits/php-saml). Only sites that opted in to SimpleSAMLphp and are behind on updates to that library are vulnerable.**
+
+The update to WP SAML Auth includes a warning message displayed in the WordPress admin if a vulnerable version of SimpleSAMLphp is detected with instructions to install SimpleSAMLphp 2.3.7 or higher. Since the migration from the previous and most vulnerable versions of SimpleSAMLphp (1.x) to a newer and more secure version (2.x or above) can be onerous, some teams may prefer to switch from SimpleSAMLphp to the default of the plugin, OneLogin PHP SAML than to upgrade SimpleSAMLphp.
+
+When a version of SimpleSAMLphp older than 2.0.0 is detected, an error notice is displayed in the WordPress admin on every page. An option has been added that can be used to disable SAML-based authentication entirely if the version of the library is in this critical state. When a version of SimpleSAMLphp older than 2.3.7 is detected, that notice is downgraded to a warning, but is still visible across all admin pages until SimpleSAMLphp has been upgraded. If the version could not be detected, a warning message appears on the WP SAML Auth admin page.
+
+## Action required
+You are encouraged to upgrade your version of WP SAML Auth to the latest version as soon as possible so you know with certainty whether your site is vulnerable. If you see the notice in your dashboard, we recommend that you upgrade to the latest version of [SimpleSAMLphp](https://simplesamlphp.org/) immediately.
+
+If you have questions or concerns, [please open issues in the queue for the plugin](https://github.com/pantheon-systems/wp-saml-auth). 


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Release note for wp saml auth 2.2.0

> https://github.com/pantheon-systems/wp-saml-auth/releases/tag/2.2.0


https://pr-9577-documentation.appa.pantheon.site/release-notes/2025/06/wp-saml-auth-2-2-0