### PR TITLE
Advise keeping ssh connections alive

### DIFF
--- a/source/content/guides/mariadb-mysql/04-database-workflow-tool.md
+++ b/source/content/guides/mariadb-mysql/04-database-workflow-tool.md
@@ -76,16 +76,7 @@ if (!function_exists('install_drupal')) {
 }
 ```
 
-### "Connection to server closed by remote host" notice when running search-replace
-
-Sites with large databases may encounter a timeout when trying to run `terminus wp search-replace` on all tables. This is due to the [idle timeout limit](/timeouts) on SSH connections.
-
-You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
-
-```ini
-Host *.drush.in
-  ServerAliveInterval 60
-```
+<Partial file="ssh-ServerAliveInterval.md" />
 
 ## More Resources
 - [MySQL Troubleshooting with New Relic&reg; Performance Monitoring](/guides/new-relic/debug-mysql-new-relic)

--- a/source/content/partials/ssh-ServerAliveInterval.md
+++ b/source/content/partials/ssh-ServerAliveInterval.md
@@ -1,0 +1,21 @@
+---
+contenttype: [partial]
+categories: [ssh]
+cms: [--]
+product: [--]
+integration: [--]
+tags: [--]
+reviewed: ""
+---
+
+### "Connection to server closed by remote host" notice when running search-replace
+ 
+Sites with large databases may encounter a timeout when trying to run `terminus wp search-replace` on all tables. This is due to the [idle timeout limit](/timeouts) on SSH connections.
+
+You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
+
+```ini
+Host *.drush.in
+  ServerAliveInterval 60
+```
+

--- a/source/content/partials/ssh-ServerAliveInterval.md
+++ b/source/content/partials/ssh-ServerAliveInterval.md
@@ -8,11 +8,8 @@ tags: [--]
 reviewed: ""
 ---
 
-### "Connection to server closed by remote host" notice when running search-replace
- 
-Sites with large databases may encounter a timeout when trying to run `terminus wp search-replace` on all tables. This is due to the [idle timeout limit](/timeouts) on SSH connections.
-
-You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
+### "Connection to server closed by remote host" returned by long-running CLI operations
+Long running Drush and/or WP-CLI commands may timeout due to the [idle timeout limit](/timeouts) on SSH connections. You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
 
 ```ini
 Host *.drush.in

--- a/source/content/partials/ssh-ServerAliveInterval.md
+++ b/source/content/partials/ssh-ServerAliveInterval.md
@@ -9,7 +9,7 @@ reviewed: ""
 ---
 
 ### "Connection to server closed by remote host" returned by long-running CLI operations
-Long running Drush and/or WP-CLI commands may timeout due to the [idle timeout limit](/timeouts) on SSH connections. You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
+Long-running Drush and/or WP-CLI commands may timeout due to the [idle timeout limit](/timeouts) on SSH connections. You can avoid this by configuring your local machine to send an SSH `keepalive` packet every 60 seconds. Add this to your `$HOME/.ssh/ssh_config` file:
 
 ```ini
 Host *.drush.in

--- a/source/content/ssh-keys.md
+++ b/source/content/ssh-keys.md
@@ -2,7 +2,7 @@
 title: Generate and Add SSH Keys
 description: Understand how to generate SSH keys to configure Git, SFTP, or Drupal Drush.
 tags: [security, dashboard, ssh]
-reviewed: "2025-06-02"
+reviewed: "2025-06-17"
 contenttype: [doc]
 innav: [true]
 categories: [security, git, config]
@@ -184,6 +184,8 @@ Removing SSH keys is separate from [revoking the machine tokens used by Terminus
 ## Troubleshooting
 
 <Partial file="host-keys.md" />
+
+<Partial file="ssh-ServerAliveInterval.md" />
 
 ### ECDSA Key Support
 


### PR DESCRIPTION
Fixes #9573 
## Summary

Convert [existing h3](https://docs.pantheon.io/guides/mariadb-mysql/database-workflow-tool#connection-to-server-closed-by-remote-host-notice-when-running-search-replace) to partial and reuse in [SSH troubleshooting](https://docs.pantheon.io/ssh-keys#troubleshooting)

[Preview link](https://pr-9580-documentation.appa.pantheon.site/ssh-keys#connection-to-server-closed-by-remote-host-notice-when-running-search-replace)
