### PR TITLE
Fix install steps for t3

### DIFF
--- a/source/content/terminus/02-install.md
+++ b/source/content/terminus/02-install.md
@@ -113,9 +113,8 @@ sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 
 ```bash{promptUser: user}
 mkdir -p ~/terminus && cd ~/terminus
-curl -L https://github.com/pantheon-systems/terminus/releases/download/3.6.2/terminus.phar --output terminus
-chmod +x terminus
-./terminus self:update
+curl -L https://github.com/pantheon-systems/terminus/releases/download/3.6.2/terminus.phar --output terminus3
+chmod +x terminus3
 sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 ```
 


### PR DESCRIPTION
Fixes #9586 

Remove `self:update` step from the Terminus 3 install steps since it results in a Terminus 4 upgrade, which is incompatible with PHP <= 8.1 versions  