### PR TITLE
fixing formatting for php 8.4 release note

### DIFF
--- a/source/releasenotes/2025-07-15-php-84-now-available.md
+++ b/source/releasenotes/2025-07-15-php-84-now-available.md
@@ -32,7 +32,7 @@ PHP 8.4 is not expected to bring new performance gains for sites. But for develo
 
 PHP 8.4 is only available with the new [PHP Runtime Generation 2](/php-runtime-generation-2). To upgrade your site, set the following in your `pantheon.yml` file:
 
-   ```yaml:title=pantheon.yml
-   php_runtime_generation: 2
-   php_version: 8.4 
-   ```
+```yaml:title=pantheon.yml
+php_runtime_generation: 2
+php_version: 8.4 
+```


### PR DESCRIPTION
## Summary

**[PHP 8.4 release note](https://docs.pantheon.io/release-notes/2025/07/php-84-now-available)** - Fixing the space before the `php_runtime_generation` line

<img width="415" height="167" alt="Screenshot 2025-07-15 at 11 55 16 AM" src="https://github.com/user-attachments/assets/7bc10431-34d3-43d8-9e7a-65c5b1df6e07" />
