### PR TITLE
Code block style bugfix

### DIFF
--- a/src/styles/codeBlocks.css
+++ b/src/styles/codeBlocks.css
@@ -108,6 +108,10 @@ pre > code {
   font-weight: var(--pds-typography-font-weight-regular);
 }
 
+.gatsby-highlight code {
+  padding: 0;
+}
+
 .gatsby-highlight {
   margin-block-end: var(--pds-spacing-2xl);
 }


### PR DESCRIPTION
## Summary

Fixes an issue where the first line of code in a gatsby code block is being indented. 

Before:
<img width="415" height="167" alt="image" src="https://github.com/user-attachments/assets/8237e8d4-7261-48a3-98f2-be776230f24a" />

After: 
<img width="437" height="169" alt="Screenshot 2025-07-17 at 1 31 08 PM" src="https://github.com/user-attachments/assets/58cbf04d-a972-4ae5-a602-b777a912b5fc" />
