### PR TITLE
add Tin Canny Reporting to WP known issues page

### DIFF
--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -11,7 +11,7 @@ audience: [development]
 product: [--]
 integration: [--]
 tags: [plugins, themes, code]
-reviewed: "2025-02-14"
+reviewed: "2025-07-21"
 ---
 
 This page lists WordPress plugins, themes, and functions that may not function as expected or are currently problematic on the Pantheon platform. This is not a comprehensive list (see [other issues](#other-issues)). We continually update it as problems are reported and/or solved. If you are aware of any modules or plugins that do not work as expected, please [contact support](/guides/support/contact-support/).
@@ -993,6 +993,8 @@ ___
 ___
 
 ### Tin Canny Reporting
+
+<ReviewDate date="2025-07-21" />
 
 **Issue:** [Tin Canny Reporting for LearnDash](https://www.uncannyowl.com/downloads/tin-canny-reporting/) contains a `rename()` PHP function which is [not supported on Pantheon](/guides/filesystem/files-directories#renamemove-files-or-directories). As a result, this plugin will not work on Pantheon.
 

--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -992,6 +992,14 @@ ___
 
 ___
 
+### Tin Canny Reporting
+
+**Issue:** [Tin Canny Reporting for LearnDash](https://www.uncannyowl.com/downloads/tin-canny-reporting/) contains a `rename()` PHP function which is [not supported on Pantheon](/guides/filesystem/files-directories#renamemove-files-or-directories). As a result, this plugin will not work on Pantheon.
+
+**Solution:** While no fix for this issue exists, a workaround exists in which the `rename()` function is manually replaced with `copy()` and `unlink()`. However, this is not recommended as it may break the plugin in future updates. The file that contains the `rename()` function is the `finalize_module_upload()` function in `tin-canny-zip-uploader/tincanny-zip-uploader.php`.
+
+___
+
 ### TubePress Pro
 
 **Issue:** Sites running PHP version 5.3 produce a WSOD after activating the [TubePress Pro](https://tubepress.com/).


### PR DESCRIPTION
## Summary

**[WordPress Known Issues](https://docs.pantheon.io/wordpress-known-issues)** - Adds Tin Canny Reporting to WordPress Known Issues page.

fixes #9606 