### PR TITLE
remove WPX Cron Manager Lite

### DIFF
--- a/source/content/guides/wordpress-developer/06-wordpress-cron.md
+++ b/source/content/guides/wordpress-developer/06-wordpress-cron.md
@@ -141,8 +141,6 @@ Pantheon's WordPress upstream disables WP-Cron by default in favor of Pantheon C
 
 There are several plugins you can use if you want to keep an eye on WP-Cron but don't like the command line. [WP Crontrol](https://wordpress.org/plugins/wp-crontrol/screenshots/ "WP Crontrol page on wordpress.org"), for example, shows all events scheduled for your site. You can create, edit, run, or delete jobs immediately from within your WordPress admin dashboard. You can also hook new actions into schedules or move existing actions to new schedules from within the Tools section.
 
-[WPX Cron Manager Lite](https://wordpress.org/plugins/wpx-cron-manager-light/ "WPX Cron Manager Lite") works similarly with a slightly different UI. This plugin requires you to do a one-time installation of the WPX framework, which you can do straight from the plugin manager page.
-
 ## Manage WP-Cron Externally
 
 You can use external crons if you want more control over your site's cron jobs, or if you don't want WP-Cron or Pantheon Cron to handle jobs internally. This will solve the problems with high traffic and low traffic sites discussed in the [Troubleshooting](#troubleshooting) section.


### PR DESCRIPTION
## Summary

**[WordPress Developer Guide - WordPress Cron](https://docs.pantheon.io/guides/wordpress-developer/wordpress-cron)** - Removes closed WPX Cron Manager Lite from plugins section.

fixes #9618 