### PR TITLE
Update Terminus installation docs

### DIFF
--- a/source/content/terminus/02-install.md
+++ b/source/content/terminus/02-install.md
@@ -71,15 +71,15 @@ While you can install Terminus using a PHAR as described in the [Windows and Lin
 
 1. Install OpenSSH via Homebrew by running the command below:
 
-```bash{promptUser: user}
-brew install openssh
-```
+  ```bash{promptUser: user}
+  brew install openssh
+  ```
 
 1. Install Terminus by running the command below:
 
-```bash{promptUser: user}
-brew install pantheon-systems/external/terminus
-```
+  ```bash{promptUser: user}
+  brew install pantheon-systems/external/terminus
+  ```
 
 <hr/>
 

--- a/source/content/terminus/02-install.md
+++ b/source/content/terminus/02-install.md
@@ -61,13 +61,21 @@ Terminus 4.x is compatible with PHP 8.2+.
 
 </Alert>
 
-
-
 ## Installation and Update Methods
 ### macOS
-[Homebrew](https://brew.sh/), a package manager for MacOS, is the recommended installation method for MacOS. However, the method [described below](#windows-and-linux) for Windows and Linux can also be used by MacOS users who are not using Homebrew.
+[Homebrew](https://brew.sh/), a package manager for MacOS, is the recommended installation method for MacOS. As of May 2025, the built-in MacOS version of OpenSSH can cause issues with Terminus if a site being accessed is frozen. For this reason, we recommend installing OpenSSH and Terminus via Homebrew, described below. 
 
-Install Terminus by running the command below:
+While you can install Terminus using a PHAR as described in the [Windows and Linux section](#windows-and-linux), we still recommend using Homebrew for installing OpenSSH.
+
+1. If you do not have Homebrew installed, follow the instructions on the [Homebrew website](https://brew.sh/).
+
+1. Install OpenSSH via Homebrew by running the command below:
+
+```bash{promptUser: user}
+brew install openssh
+```
+
+1. Install Terminus by running the command below:
 
 ```bash{promptUser: user}
 brew install pantheon-systems/external/terminus

--- a/source/content/terminus/02-install.md
+++ b/source/content/terminus/02-install.md
@@ -5,6 +5,7 @@ description:  Learn how to install and update Terminus to your local computer.
 terminuspage: true
 type: terminuspage
 layout: terminuspage
+contributors: [whitneymeredith,jazzsequence]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/terminus/install
 contenttype: [guide]
@@ -15,6 +16,7 @@ audience: [development]
 product: [terminus]
 integration: [--]
 showtoc: true
+reviewed: "2025-07-22"
 ---
 
 This page provides information on how to install, authenticate, and update Terminus.


### PR DESCRIPTION
## Summary

**[Install and Update Terminus](https://docs.pantheon.io/terminus/install)** - Update the installation docs for MacOS to advise against using built-in MacOS OpenSSH with Terminus. Refactor MacOS installation instructions with ordered list that includes using Homebrew to install OpenSSH

fixes #9616 