### PR TITLE
Update Tin Canny Reporting issue

### DIFF
--- a/source/content/wordpress-known-issues.md
+++ b/source/content/wordpress-known-issues.md
@@ -998,11 +998,11 @@ ___
 
 ### Tin Canny Reporting
 
-<ReviewDate date="2025-07-21" />
+<ReviewDate date="2025-08-06" />
 
 **Issue:** [Tin Canny Reporting for LearnDash](https://www.uncannyowl.com/downloads/tin-canny-reporting/) contains a `rename()` PHP function which is [not supported on Pantheon](/guides/filesystem/files-directories#renamemove-files-or-directories). As a result, this plugin will not work on Pantheon.
 
-**Solution:** While no fix for this issue exists, a workaround exists in which the `rename()` function is manually replaced with `copy()` and `unlink()`. However, this is not recommended as it may break the plugin in future updates. The file that contains the `rename()` function is the `finalize_module_upload()` function in `tin-canny-zip-uploader/tincanny-zip-uploader.php`.
+**Solution:** While a fix for this issue is expected in versions above 5.1.0.3, a temporary workaround exists in which the `rename()` function is manually replaced with `copy()` and `unlink()`. However, this is not recommended as it may break the plugin in future updates. The file that contains the `rename()` function is the `finalize_module_upload()` function in `tin-canny-zip-uploader/tincanny-zip-uploader.php`.
 
 ___
 


### PR DESCRIPTION
Update Tin Canny known issue to report a specific version

## Summary

**[WordPress Known Issues](https://docs.pantheon.io/wordpress-known-issues)** - Uncanny Owl has reported that the fix should be in versions above 5.1.0.3. This PR updates the note to say that a fix does not exist _yet_ and gives an (expected) version number for support. We can drop this or update again when the updated version is released to just say "update to the latest version".