### PR TITLE
Update 06-wordpress-cron.md

### DIFF
--- a/source/content/guides/wordpress-developer/06-wordpress-cron.md
+++ b/source/content/guides/wordpress-developer/06-wordpress-cron.md
@@ -62,7 +62,7 @@ Pantheon Cron will not execute jobs on inactive environments, including [sleepin
 </Alert>
 
 ### WordPress Multisite
-By default, Pantheon Cron is disabled for WordPress Multisite installations, and the normal WP Cron will be used instead. This is because WordPress Multisite installations often have unpredictable customizations to domains or subdirectories and their mapping to subsites. 
+By default, Pantheon Cron is disabled for WordPress Multisite installations, and the normal WP Cron will be used instead.  
 
 ### Security
 

--- a/source/content/guides/wordpress-developer/06-wordpress-cron.md
+++ b/source/content/guides/wordpress-developer/06-wordpress-cron.md
@@ -62,8 +62,7 @@ Pantheon Cron will not execute jobs on inactive environments, including [sleepin
 </Alert>
 
 ### WordPress Multisite
-
-Pantheon Cron does not support WordPress Multisite installations due to the unpredictable customizations to domains or subdirectories and their mapping to subsites. Use WP-Cron if you have WordPress Multisite installations.
+By default, Pantheon Cron is disabled for WordPress Multisite installations, and the normal WP Cron will be used instead. This is because WordPress Multisite installations often have unpredictable customizations to domains or subdirectories and their mapping to subsites. 
 
 ### Security
 


### PR DESCRIPTION
## Summary

**[Cron for WordPress
](https://docs.pantheon.io/guides/wordpress-developer/wordpress-cron#wordpress-multisite)** - Updating docs for improved clarity on default behaviors. CSE continues to see confusion around this section, especially with what the assumed default will be, so we're leading with the expected behavior, and following with rationale afterwards.

