### PR TITLE
removing outdated tika text

### DIFF
--- a/source/content/external-libraries.md
+++ b/source/content/external-libraries.md
@@ -80,18 +80,6 @@ Sites that are using these older versions of Tika should be upgraded to a newer 
 </Tab>
 </TabList>
 
-See the [Solr for Drupal](/guides/solr-drupal) guide for instructions on using Apache Tika with Pantheon Drupal sites. Currently Tika 1.21 is available.
-
-There are no known plugins in the WordPress.org repository that will enable the use of Tika.
-
-### Older Versions
-
-Pantheon also supplies the following older version of Tika:
-
-- `/srv/bin/tika-app-1.18.jar`
-
-Sites that are using an old version of Tika should be upgraded to the supported path as soon as possible.
-
 ## ImageMagick
 
 [ImageMagick](https://www.imagemagick.org/script/index.php) is a software suite to create, edit, compose, or convert bitmap images. It can read and write images in a variety of  [formats](https://www.imagemagick.org/script/formats.php) (over 100) including  [DPX](https://www.imagemagick.org/script/motion-picture.php), [EXR](https://www.imagemagick.org/script/high-dynamic-range.php), GIF, JPEG, JPEG-2000, PDF, PNG, Postscript, SVG, and TIFF. Use ImageMagick to resize, flip, mirror, rotate, distort, shear and transform images, adjust image colors, apply various special effects, or draw text, lines, polygons, ellipses and Bézier curves.


### PR DESCRIPTION
## Summary

**[external libraries](https://docs.pantheon.io/external-libraries#apache-tika)** - removing link to drupal solr docs that no longer mention tika, and removing extra copy about older versions