### PR TITLE
Removed known issue for ocp

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -104,9 +104,7 @@ Does your application require an OS package or PHP extension that is no longer a
 
 ## Known Issues
 
-- [Object Cache Pro installation via Terminus for standard WordPress configurations](/object-cache/wordpress#installation-and-configuration) is currently unavailable. 
-  - Workaround: [Downgrade to PHP Runtime Generation 1](/php-runtime-generation-2#q-can-i-switch-back-to-the-previous-php-runtime-if-i-encounter-issues), follow the installation procedure, then upgrade back to PHP Runtime Generation 2.
-
+- There are no known issues currently
 ## Reporting Issues
 
 If you encounter any issues while testing your site with PHP Runtime Generation 2:


### PR DESCRIPTION
## Summary

**[PHP Runtime Generation 2 (Beta)](https://docs.pantheon.io/php-runtime-generation-2)** - Bug fix for https://getpantheon.atlassian.net/browse/SITE-5187 fixed an issue with installing Object Cache Pro for PHP runtime generation 2. This PR removes the description of the issue under `Known Issues`
