### PR TITLE
php runtime gen 2 known issue clarification

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -94,7 +94,7 @@ Does your application require an OS package or PHP extension that is no longer a
 ## Known Issues
 
 - New Relic is not available for sites running PHP 5.6. Compatibility will be added soon.
-- Drupal 8+ sites cannot access Solr 3. [Upgrading to Solr 8](https://docs.pantheon.io/release-notes/2025/08/solr-3-drupal-94-eol) is required.
+- Drupal 8+ sites using Solr 3 should not upgrade to PHP Runtime Generation 2. [Upgrading to Solr 8](https://docs.pantheon.io/release-notes/2025/08/solr-3-drupal-94-eol) or disabling Solr is required.
 
 ## Reporting Issues
 


### PR DESCRIPTION
## Summary

* Clarify Drupal 8+ Solr 3 sites should not use PHP Runtime Gen 2