### PR TITLE
release note for native php sessions

### DIFF
--- a/source/releasenotes/2025-09-17-wp-native-php-sessions-1-4-4.md
+++ b/source/releasenotes/2025-09-17-wp-native-php-sessions-1-4-4.md
@@ -1,0 +1,12 @@
+---
+title: "Native PHP Sessions 1.4.4 update now available"
+published_date: "2025-09-17"
+categories: [action-required, wordpress, plugins]
+---
+
+Pantheon has released a new version of our [Native PHP Sessions plugin](https://wordpress.org/plugins/wp-native-php-sessions/). This release updates documentation and a number of minor dependencies under the hood. Most notably, this update tests the plugin against PHP 8.4, increases the minimum PHP version to 7.4 and bumps the minimum supported WordPress version to 5.3.
+
+## Action required
+You are encouraged to upgrade your version of Native PHP Sessions to the latest version as soon as you are able.
+
+If you have issues with the plugin, [please use the GitHub issue queue for the plugin](https://github.com/pantheon-systems/wp-native-php-sessions/issues). 

--- a/source/releasenotes/2025-09-17-wp-native-php-sessions-1-4-4.md
+++ b/source/releasenotes/2025-09-17-wp-native-php-sessions-1-4-4.md
@@ -4,7 +4,7 @@ published_date: "2025-09-17"
 categories: [action-required, wordpress, plugins]
 ---
 
-Pantheon has released a new version of our [Native PHP Sessions plugin](https://wordpress.org/plugins/wp-native-php-sessions/). This release updates documentation and a number of minor dependencies under the hood. Most notably, this update tests the plugin against PHP 8.4, increases the minimum PHP version to 7.4 and bumps the minimum supported WordPress version to 5.3.
+Pantheon has released a new version of our [Native PHP Sessions plugin](https://wordpress.org/plugins/wp-native-php-sessions/). This release updates documentation and a number of minor dependencies under the hood. Most notably, this update tests the plugin against PHP 8.4, increases the minimum PHP version to 7.4 and bumps the minimum supported WordPress version to 5.3. Additionally, to comply with WordPress plugin repository guidelines, we have removed "WordPress" from the plugin name.
 
 ## Action required
 You are encouraged to upgrade your version of Native PHP Sessions to the latest version as soon as you are able.


### PR DESCRIPTION
## Summary

**[Release Notes](https://docs.pantheon.io/release-notes)** - Adds a release note for Native PHP Sessions 1.4.4. This release is already live so this note can go out whenever.