### PR TITLE
php runtime gen2 next block rollout

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -94,7 +94,7 @@ Does your application require an OS package or PHP extension that is no longer a
 ## Known Issues
 
 - New Relic is not available for sites running PHP 5.6. Compatibility will be added soon.
-- Drupal 8+ sites using Solr 3 should not upgrade to PHP Runtime Generation 2. [Upgrading to Solr 8](https://docs.pantheon.io/release-notes/2025/08/solr-3-drupal-94-eol) or disabling Solr is required.
+- Drupal 8+ sites using Solr 3 are not compatible with PHP Runtime Generation 2.  [Upgrading to Solr 8](https://docs.pantheon.io/release-notes/2025/08/solr-3-drupal-94-eol) or disabling Solr is required. These sites will not be included in the initial automatic upgrade rollout, but will be upgraded after November 12, 2025.
 
 ## Reporting Issues
 

--- a/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
+++ b/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
@@ -15,6 +15,7 @@ The upgrade rollout will take place over the next 40 days. The table below shows
 | Start Date for Upgrades | Site Plans | Environments |
 |-----------|------------------|--------------|
 | September 24 | Sandbox | Dev/Multidevs |
+| October 6 | Sandbox | Test/Live |
 
 
 <Alert type="info" title="Deploying code will upgrade test/live environments">


### PR DESCRIPTION
## Summary

* Update the PHP Runtime Gen 2 rollout release note with the next "block" of sites that will be upgraded
* Clarify known issue with Solr 3 with Drupal 8+

This is ready for publishing