### PR TITLE
Change PHP Runtime Gen 2 timeline

### DIFF
--- a/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
+++ b/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
@@ -15,8 +15,10 @@ The upgrade rollout will take place over the next 40 days. The table below shows
 | Start Date for Upgrades | Site Plans | Environments |
 |-----------|------------------|--------------|
 | September 24 | Sandbox | Dev/Multidevs |
-| October 6 | Sandbox | Test/Live |
+| TBD* | Sandbox | Test/Live |
 
+_**Editorial note:**_
+* _* This date has been revised from October 6 to TBD._
 
 <Alert type="info" title="Deploying code will upgrade test/live environments">
 


### PR DESCRIPTION
## Summary

* https://docs.pantheon.io/release-notes/2025/09/php-runtime-gen2-rollout-begins - removing mention of October 6 rollout