### PR TITLE
php runtime gen 2 timeline updates, env:list release note

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -45,7 +45,7 @@ Since any `pantheon.yml` changes are part of your site repository and promoted i
 |-----------|------------------|--------------|
 | **Beta** | May - September 16, 2025 | Environments can be opted-in. All other environments will remain on the previous generation. |
 | **New Sites** | September 17, 2025 | New sites created on the platform will use PHP Runtime Generation 2. |
-| **Gen 2 Rollout** | September 24 - November 3, 2025 | A 40-day rollout will gradually upgrade sites to PHP Runtime Generation 2. [Sites may be opted-out](#q-how-do-i-opt-out-of-the-upcoming-platform-rollout). |
+| **Gen 2 Rollout** | September 24 - November 23, 2025 | A 60-day rollout will gradually upgrade sites to PHP Runtime Generation 2. [Sites may be opted-out](#q-how-do-i-opt-out-of-the-upcoming-platform-rollout). |
 | **Gen 1 Removal** | Early 2026 | PHP Runtime Generation 1 will no longer be available. All remaining sites will be auto-upgraded. |
 
 
@@ -93,7 +93,6 @@ Does your application require an OS package or PHP extension that is no longer a
 
 ## Known Issues
 
-- New Relic is not available for sites running PHP 5.6. Compatibility will be added soon.
 - Drupal 8+ sites using Solr 3 are not compatible with PHP Runtime Generation 2.  [Upgrading to Solr 8](https://docs.pantheon.io/release-notes/2025/08/solr-3-drupal-94-eol) or disabling Solr is required. These sites will not be included in the initial automatic upgrade rollout, but will be upgraded after November 12, 2025.
 
 ## Reporting Issues

--- a/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
+++ b/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
@@ -10,15 +10,12 @@ We continue to encourage customers to [upgrade to Generation 2 proactively](/php
 
 ## Rollout Timeline
 
-The upgrade rollout will take place over the next 40 days. The table below shows which upgrades are being processed. We will update this release note as we begin each phase.
+The upgrade rollout will take place over the next 60 days. The table below shows which upgrades are being processed. We will update this release note as we begin each phase.
 
 | Start Date for Upgrades | Site Plans | Environments |
 |-----------|------------------|--------------|
 | September 24 | Sandbox | Dev/Multidevs |
-| TBD* | Sandbox | Test/Live |
-
-_**Editorial note:**_
-* _* This date has been revised from October 6 to TBD._
+| October 14 | Sandbox | Test/Live |
 
 <Alert type="info" title="Deploying code will upgrade test/live environments">
 

--- a/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
+++ b/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
@@ -10,12 +10,18 @@ We continue to encourage customers to [upgrade to Generation 2 proactively](/php
 
 ## Rollout Timeline
 
-The upgrade rollout will take place over the next 60 days. The table below shows which upgrades are being processed. We will update this release note as we begin each phase.
+The upgrade rollout will take place over the next 60<sup>1</sup> days. The table below shows which upgrades are being processed. We will update this release note as we begin each phase.
 
 | Start Date for Upgrades | Site Plans | Environments |
 |-----------|------------------|--------------|
 | September 24 | Sandbox | Dev/Multidevs |
-| October 14 | Sandbox | Test/Live |
+| October 14<sup>2</sup> | Sandbox | Test/Live |
+
+_**Editorial note:**_
+
+_<sup>1</sup> This has been revised from 40 to 60 days_
+
+_<sup>2</sup> This date has been revised from October 6 to October 14_
 
 <Alert type="info" title="Deploying code will upgrade test/live environments">
 

--- a/source/releasenotes/2025-10-07-terminus-410.md
+++ b/source/releasenotes/2025-10-07-terminus-410.md
@@ -9,7 +9,8 @@ Terminus [4.1.0](https://github.com/pantheon-systems/terminus/releases/tag/4.1.0
 This release includes enhanced environment information visibility and improved error messaging.
 
 ### Added
-- PHP Runtime Generation and PHP Version fields are now displayed with the `env:list` command output, providing better visibility into your environment's PHP configuration
+- PHP Runtime Generation and PHP Version fields are now optional fields of the `env:list` command output, providing better visibility into your environment's PHP configuration
+    - Use `env:list <site> --fields=id,php_runtime_generation,php_version` to view these fields
 
 ### Fixed
 - Improved workflow timeout handling now displays warnings instead of confusing error messages when workflows take longer than expected


### PR DESCRIPTION
## Summary

Admittedly, this PR is stuffing in multiple changes in one.

* Updating the PHP Runtime Gen 2 rollout to announce the next phase for 10/24
* Updating the Terminus 4.1.0 release note to specify how to use `env:list` to output the new features
* Removing the 'known issue' of PHP 5.6 + New Relic + Gen 2
