### PR TITLE
dev basic php rollout begins soon

### DIFF
--- a/source/content/php-runtime-generation-2.md
+++ b/source/content/php-runtime-generation-2.md
@@ -48,6 +48,22 @@ Since any `pantheon.yml` changes are part of your site repository and promoted i
 | **Gen 2 Rollout** | September 24 - November 23, 2025 | A 60-day rollout will gradually upgrade sites to PHP Runtime Generation 2. [Sites may be opted-out](#q-how-do-i-opt-out-of-the-upcoming-platform-rollout). |
 | **Gen 1 Removal** | Early 2026 | PHP Runtime Generation 1 will no longer be available. All remaining sites will be auto-upgraded. |
 
+### Current Phase Details 
+Currently, we are in the **Gen 2 Rollout** phase. The upgrade rollout will take place over the next 60 days. The table below shows which upgrades are being processed. [Sites may be opted-out](#q-how-do-i-opt-out-of-the-upcoming-platform-rollout). We will revise this section of documentation as we begin each phase along with any updates to the timeline. 
+
+<Alert type="info" title="Deploying code will upgrade test/live environments">
+
+Once the Dev environment for a site has been upgraded to Generation 2, deploying commits from Dev to Test will automatically upgrade the Test environment to Generation 2 as well. Following this pattern, an upgrade to the Live environment takes place once commits are deployed from the Test to Live environment.
+
+</Alert>
+
+
+| Start Date for Upgrades | Site Plans | Environments |
+|-----------|------------------|--------------|
+| September 24 | Sandbox | Dev/Multidevs |
+| October 14 | Sandbox | Test/Live |
+| October 16 | Basic | Dev/Multidevs |
+
 
 ## Known Changes and Requirements
 

--- a/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
+++ b/source/releasenotes/2025-09-24-php-runtime-gen2-rollout-begins.md
@@ -10,21 +10,13 @@ We continue to encourage customers to [upgrade to Generation 2 proactively](/php
 
 ## Rollout Timeline
 
-The upgrade rollout will take place over the next 60<sup>1</sup> days. The table below shows which upgrades are being processed. We will update this release note as we begin each phase.
-
-| Start Date for Upgrades | Site Plans | Environments |
-|-----------|------------------|--------------|
-| September 24 | Sandbox | Dev/Multidevs |
-| October 14<sup>2</sup> | Sandbox | Test/Live |
-| October 16<sup>3</sup> | Basic | Dev/Multidevs |
+The upgrade rollout will take place over the next 60<sup>1</sup> days. For granular timeline details<sup>2</sup>, see [related documentation](/php-runtime-generation-2/#timeline).
 
 _**Editorial note:**_
 
 _<sup>1</sup> This has been revised from 40 to 60 days_
 
-_<sup>2</sup> This date has been revised from October 6 to October 14_
-
-_<sup>3</sup> Timeline has been updated to include rollout to Basic site plans._ 
+_<sup>2</sup> Timeline has been relocated out of release notes into related documentation_ 
 
 <Alert type="info" title="Deploying code will upgrade test/live environments">
 


### PR DESCRIPTION
## Summary

**[PHP Gen 2 rollout release note](https://docs.pantheon.io/release-notes/2025/09/php-runtime-gen2-rollout-begins)** - Include date for dev/multidev environments of basic sites