### PR TITLE
[Release Note] New releases and bug fixes across Content Publisher stack

### DIFF
--- a/source/releasenotes/2025-10-23-content-publisher-stack-updates.md
+++ b/source/releasenotes/2025-10-23-content-publisher-stack-updates.md
@@ -6,7 +6,7 @@ categories: [content-publisher, user-interface, drupal, modules]
 The following updates are now available for Content Publisher:
 
 * New release of the [Pantheon Content Publisher v1.0.3](https://www.drupal.org/project/pantheon_content_publisher/releases/1.0.3) Drupal module now availabe.
-* With [Approval Workflows](https://docs.content.pantheon.io/approval-workflows) enabled, Administrators now have the option to Approve submissions direclty from the **Pending approval** tab of a Collection in the Content Dashboard. Previously, opening each subission in Preview mode was required. 
+* With [Approval Workflows](https://docs.content.pantheon.io/approval-workflows) enabled, Administrators now have the option to Approve submissions direclty from the **Pending approval** tab of a Collection in the Content Dashboard. Previously, opening each submission in Preview mode was required.
 * The experience for [Smart Components](https://docs.content.pantheon.io/components) has been improved for first time users. 
 * Upgrade [Content Publisher AI metadata suggestion](https://docs.content.pantheon.io/metadata#h.mqduipr8a3w5) to use Gemini 2.5 flash instead of Gemini 2.0.
 * Bug fix for our [Next.js starter kit](https://docs.content.pantheon.io/nextjs-tutorial) and [SDK](https://github.com/pantheon-systems/content-publisher-sdk) to properly support Next.js 15.5 and the use of App Router. Improve the build process by using pinned versions of dependencies.


### PR DESCRIPTION
## Summary

* Pantheon Content Publisher for Drupal 1.0.3 release note

+ including other Content Publisher updates 