### PR TITLE
Fixing broken link

### DIFF
--- a/source/content/guides/wordpress-configurations/08-installing-updating-from-third-party-sources.md
+++ b/source/content/guides/wordpress-configurations/08-installing-updating-from-third-party-sources.md
@@ -20,7 +20,7 @@ This section provides guidance on how to manage plugins that use third-party sou
 
 <Alert title="Note" type="info" >
 
-All the guidance in this document is intended to be used in conjunction with Dev or Multidev environments on Pantheon where version-controlled files can be changed directly. [Pantheon's security practices lock down file permissions in the Test and Live environments]("guides/filesystem/files-directories#write-access-on-environments").
+All the guidance in this document is intended to be used in conjunction with Dev or Multidev environments on Pantheon where version-controlled files can be changed directly. [Pantheon's security practices lock down file permissions in the Test and Live environments](/guides/filesystem/files-directories#write-access-on-environments).
 
 </Alert>
 


### PR DESCRIPTION
The link at the top of https://docs.pantheon.io/guides/wordpress-configurations/installing-updating-from-third-party-sources goes to a 404.