### PR TITLE
Small copy edit for Next.js Content Publisher tutorial

### DIFF
--- a/source/content/nextjs/content-publisher-tutorial.md
+++ b/source/content/nextjs/content-publisher-tutorial.md
@@ -135,7 +135,7 @@ You _can_ reuse an existing Content Publisher collection if you have one, but fo
 
 1. Enter something simple for **Collection name** like "Next.js tutorial content".
 
-1. For the **URL** field, enter the URL of your new Pantheon site's Dev environment, like `https://dev-my-site-name.pantheonsite.io/articles`.
+1. For the **URL** field, enter the URL of your new Pantheon site's Dev environment, like `https://dev-my-site-name.pantheonsite.io`.
 
   <Alert title="Tutorial vs. production usage" type="info" >
 


### PR DESCRIPTION
Based on [internal review and discussion in slack](https://pantheon.slack.com/archives/C09LX4DKH0E/p1761933382107799?thread_ts=1761770589.270539&cid=C09LX4DKH0E), the collection URL should not include `/articles`