### PR TITLE
Remove "account tier" from Autopilot screenshot limit

### DIFF
--- a/source/content/guides/autopilot/08-autopilot-faq.md
+++ b/source/content/guides/autopilot/08-autopilot-faq.md
@@ -85,7 +85,7 @@ Autopilot only checks for changes and updates to modules, themes, and core. You 
 
 ## Is there a limit to the number screenshots Autopilot will take?
 
-Yes. Depending on your [Account](/guides/support#support-features-and-response-times), Autopilot can be set for up to 25 pages on each site. It will check for updates once a week, and can also be run on demand.
+Yes. Autopilot can be set for up to 25 pages on each site. It will check for updates once a week, and can also be run on demand.
 
 ## Is Autopilot compatible with premium and paid WordPress plugins?
 


### PR DESCRIPTION
## Summary

**[Autopilot FAQs](https://docs.pantheon.io/guides/autopilot/autopilot-faq/#is-there-a-limit-to-the-number-screenshots-autopilot-will-take)** - Removing reference to account tier, since it has no impact on screenshot limits. For validation, see [this internal discussion Slack thread](https://pantheon.slack.com/archives/C01MZT20TDM/p1763563938611629?thread_ts=1763503360.828419&cid=C01MZT20TDM).