### PR TITLE
ocp config prefix variable

### DIFF
--- a/source/content/addons/object-cache/howto/wordpress.md
+++ b/source/content/addons/object-cache/howto/wordpress.md
@@ -381,6 +381,8 @@ The latest recommended version of the constant is below:
 * Pantheon OCP Config Version: 2.0
 */
 
+$ocp_redis_prefix = "ocppantheon";
+
 define( 'WP_REDIS_CONFIG', [
 	'token' => getenv('OCP_LICENSE') ?: null,
 	'host' => getenv('CACHE_HOST') ?: '127.0.0.1',


### PR DESCRIPTION
## Summary

The OCP config constant didn't have the prefix variable at the top. This would result in a `null` prefix.

The snippet being provided by the `install:run` workflow isn't changing.