### PR TITLE
[SITE-5372] Apply php 8.3.28 patch and 8.4.15 doc

### DIFF
--- a/source/releasenotes/2025-12-08-php-83-84-patch-updates.md
+++ b/source/releasenotes/2025-12-08-php-83-84-patch-updates.md
@@ -1,6 +1,6 @@
 ---
 title: "PHP 8.3 and 8.4 updated to their latest patch releases"
-published_date: "2025-12-05"
+published_date: "2025-12-08"
 categories: [infrastructure]
 ---
 PHP versions [8.3.28](https://www.php.net/ChangeLog-8.php#8.3.28) and [8.4.15](https://www.php.net/ChangeLog-8.php#8.4.15), are now available on the platform. These updates bring the latest bug fixes, improving performance and security for your sites. The latest versions have already rolled out to all sites.


### PR DESCRIPTION
## Summary

This change releases php [8.3.28](https://www.php.net/ChangeLog-8.php#PHP_8_3) patch and [8.4.15](https://www.php.net/ChangeLog-8.php#PHP_8_4) patch on gen 2

**[Doc Page Title](https://docs.pantheon.io/doc-title)** - <Enter a one sentence summation of the pertinent changes (including not-yet-completed work) provided by this PR.>
