### PR TITLE
[Release note] New collection settings added to the Content Publisher dashboard

### DIFF
--- a/source/releasenotes/2025-12-12-new-collection-settings-content-publisher-dashboard.md
+++ b/source/releasenotes/2025-12-12-new-collection-settings-content-publisher-dashboard.md
@@ -1,8 +1,9 @@
 ---
-title: "New collection settings added to the Content Publisher dashboard"
+title: "New collection settings and other updates for Content Publisher"
 published_date: "2025-12-12"
 categories: [content-publisher]
 ---
+## Key changes
 Collection metadata and publishing configurations are now managed via the [Content Dashboard](https://content.pantheon.io):
 * Go to "**Collection Settings** > **Metadata**" in the Content Dashboard to manage custom metadata fields for a given collection. 
   * Previously, this was done from the Google Docs Add-on via "**About this collection** > **Page Metadata**". 


### PR DESCRIPTION
## Summary

Adds new release note: [multidev link
](https://pr-9814-documentation.appa.pantheon.site/release-notes/2025/12/new-collection-settings-content-publisher-dashboard)

- [x] Hold for release until submitted changes for [this doc page](https://docs.content.pantheon.io/collection-settings) have been approved and published by @rolandbenedetti73 
- [x] Hold for release until CVE link has been added @rolandbenedetti73 