### PR TITLE
[SITE-5441] Add release note for PHP security updates

### DIFF
--- a/src/source/releasenotes/2026-01-05-php-81-82-83-84-security-updates.md
+++ b/src/source/releasenotes/2026-01-05-php-81-82-83-84-security-updates.md
@@ -1,8 +1,10 @@
 ---
 title: "PHP 8.1, 8.2, 8.3 and 8.4 updated to their latest security patch releases"
-published_date: "2025-12-23"
+published_date: "2026-01-05"
 categories: [infrastructure]
 ---
+_**Editorial note**: These updates were completed and deployed to the platform on December 23rd 2025._
+
 PHP versions [8.1.34](https://www.php.net/ChangeLog-8.php#8.1.34), [8.2.30](https://www.php.net/ChangeLog-8.php#8.2.30), [8.3.29](https://www.php.net/ChangeLog-8.php#8.3.29), and [8.4.16](https://www.php.net/ChangeLog-8.php#8.4.16) are now available on the platform. These updates include important security fixes, along with bug fixes and enhancements that improve performance and stability. Updates will be applied automatically over the next few days, so no manual action is required.
 
 PHP 8.4 is only available with the new [PHP Runtime Generation 2](/php-runtime-generation-2).


### PR DESCRIPTION
PHP security patches available for PHP 8.1 - 8.4
https://getpantheon.atlassian.net/browse/SITE-5441

- [ ] Deployed via https://github.com/pantheon-systems/documentation-in-nextjs/pull/233