### PR TITLE
[SITE-5350] Add release note for Tika 3.x default change

### DIFF
--- a/src/source/content/external-libraries.md
+++ b/src/source/content/external-libraries.md
@@ -9,7 +9,7 @@ audience: [development]
 product: [--]
 integration: [--]
 tags: [code, libraries, modules, plugins]
-reviewed: "2025-12-10"
+reviewed: "2026-01-21"
 ---
 
 There are some scenarios when an external library is required. The Pantheon platform includes a number of PHP extensions and common libraries that are available for use.
@@ -60,7 +60,7 @@ Existing sites may still be using Tika 1.18 or 1.21, which are available at:
 
 <Alert title="Tika 1.x End of Life" type="warning">
 
-Tika 1.x will be removed on January 19, 2026. Sites using Tika 1.x should migrate to Tika 3 before this date. See the [Tika 1.x EOL release note](/release-notes/2025/10/tika1x-eol) for details.
+Tika 1.x will be removed on January 26, 2026. Sites using Tika 1.x should migrate to Tika 3 before this date. See the [Tika 1.x EOL release note](/release-notes/2025/10/tika1x-eol) for details.
 
 </Alert>
 

--- a/src/source/releasenotes/2025-10-14-tika1x-eol.md
+++ b/src/source/releasenotes/2025-10-14-tika1x-eol.md
@@ -1,9 +1,12 @@
 ---
-title: "Tika 1.xx no longer available starting January 19, 2026"
+title: "Tika 1.xx no longer available starting January 26, 2026"
 published_date: "2025-10-14"
 categories: [infrastructure, action-required, drupal, security]
 ---
-Tika 1.18 and 1.21 will no longer be available starting January 19, 2026. Impacted sites must upgrade to [Tika 3.2](https://tika.apache.org/3.2.0/index.html) which is available via [PHP Runtime Generation 2](/php-runtime-generation-2/).
+
+_**Editorial note: The date has been moved from January 19 to January 26.**_
+
+Tika 1.18 and 1.21 will no longer be available starting January 26, 2026. Impacted sites must upgrade to [Tika 3.2](https://tika.apache.org/3.2.0/index.html) which is available via [PHP Runtime Generation 2](/php-runtime-generation-2/).
 
 The [Apache Tika](https://tika.apache.org/) toolkit detects and extracts metadata and structured text content from various documents using existing parser libraries. On the Pantheon platform, our customers tend to use Tika to parse PDF content for searching with [Solr](/solr).
 
@@ -11,4 +14,4 @@ The [Apache Tika](https://tika.apache.org/) toolkit detects and extracts metadat
 
 For most customers, we expect the upgrade to be seamless and not require any manual intervention. But if your site has a custom Tika integration, we recommend you follow [our documentation for upgrading to Tika 3](/external-libraries#apache-tika) as soon as possible to ensure your site continues to operate as expected.
 
-Sites which have not upgraded to Tika 3 as of January 19, 2026, will be automatically upgraded. Setting `tika_version: 1` in `pantheon.yml` will be ignored after that date. Symlinks from the 1.xx jar filepaths (`/srv/bin/tika-app-1.xx.jar`) will point to the new Tika 3 jar (`/opt/pantheon/tika/tika.jar`). These symlinks will be removed later in 2026.
+Sites which have not upgraded to Tika 3 as of January 26, 2026, will be automatically upgraded. Setting `tika_version: 1` in `pantheon.yml` will be ignored after that date. Symlinks from the 1.xx jar filepaths (`/srv/bin/tika-app-1.xx.jar`) will point to the new Tika 3 jar (`/opt/pantheon/tika/tika.jar`). These symlinks will be removed later in 2026.

--- a/src/source/releasenotes/2026-01-21-tika-3-now-default.md
+++ b/src/source/releasenotes/2026-01-21-tika-3-now-default.md
@@ -15,7 +15,7 @@ If you need to use Tika 1.x for a new site, you can explicitly set the version i
 tika_version: 1
 ```
 
-However, [Tika 1.x will be removed on January 19, 2026](/release-notes/2025/10/tika1x-eol). We recommend testing your site with Tika 3.x and migrating before this date.
+However, [Tika 1.x will be removed on January 26, 2026](/release-notes/2025/10/tika1x-eol). We recommend testing your site with Tika 3.x and migrating before this date.
 
 ## More information
 


### PR DESCRIPTION
## Summary
- Adds release note announcing that new sites now default to Tika 3.x
- Links to existing Tika documentation and related release notes
- Bumps date for Tika 1.x removal from Jan 19th to Jan 26th, adds editorial note to related release note 

https://pr-9826-pandocs.pantheonsite.io/release-notes/2026/01/tika-3-now-default

https://pr-9826-pandocs.pantheonsite.io/release-notes/2025/10/tika1x-eol

https://pr-9826-pandocs.pantheonsite.io/external-libraries#apache-tika

- [x] Hold for release (https://github.com/pantheon-systems/titan-mt/pull/21383)