### PR TITLE
Fix formatting in 05-custom-domains.md

### DIFF
--- a/src/source/content/guides/domains/05-custom-domains.md
+++ b/src/source/content/guides/domains/05-custom-domains.md
@@ -65,13 +65,13 @@ Note that each custom domain is counted regardless of the environment to which i
 
   It might take 30 minutes or more for DNS records to propagate, depending on your DNS host and your domain's TTL values. If you encounter issues after 30 minutes, check some of the following:
 
-    - Ensure that there's no "parking page" or redirect configured in your DNS.
-    - The TXT record's Host value doesn't have a trailing `.`.
-    - That the [DNS value has propagated](https://www.whatsmydns.net/#TXT/).
+  - Ensure that there's no "parking page" or redirect configured in your DNS.
+  - The TXT record's Host value doesn't have a trailing `.`.
+  - That the [DNS value has propagated](https://www.whatsmydns.net/#TXT/).
 
-    You'll automatically be taken to the domain's **Details** page where you will see both the current DNS records detected (the **Detected Values**), as well as the values to be added at your DNS host (**Required Values**):
+  You'll automatically be taken to the domain's **Details** page where you will see both the current DNS records detected (the **Detected Values**), as well as the values to be added at your DNS host (**Required Values**):
 
-   ![Custom domain Details page](../../../images/dashboard/new-dashboard/2024/_domainadded.png)
+  ![Custom domain Details page](../../../images/dashboard/new-dashboard/2024/_domainadded.png)
 
   If you instead see:
 


### PR DESCRIPTION
Correct formatting issues in the custom domains guide.

https://docs.pantheon.io/guides/domains/custom-domains

The current formatting looks like this:
<img width="1120" height="410" alt="screenshot_451" src="https://github.com/user-attachments/assets/e48fef15-b4a7-446c-b090-b48549d2ee15" />
