### PR TITLE
Terminus Release 4.1.2 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.1.1            | November 04, 2025  |                    |
+| 4.1.2            | January 27, 2026   |                    |
+| 4.1.1            | November 04, 2025  | January 27, 2027   |
 | 4.1.0            | September 29, 2025 | November 04, 2026  |
 | 4.0.3            | September 11, 2025 | September 29, 2026 |
 | 4.0.2            | September 05, 2025 | September 11, 2026 |

--- a/src/source/releasenotes/2026-01-27-terminus-412.md
+++ b/src/source/releasenotes/2026-01-27-terminus-412.md
@@ -1,0 +1,25 @@
+---
+title: "Terminus 4.1.2 release now available"
+published_date: "2026-01-27"
+categories: [tools-apis]
+---
+
+Terminus [4.1.2](https://github.com/pantheon-systems/terminus/releases/tag/4.1.2) is now available. This patch update contains the latest bug fixes and improvements for this tool.
+
+This release includes enhanced logging capabilities and improved session handling.
+
+### Added
+- Add timestamps to all logger output messages for better debugging and log analysis
+
+### Fixed
+- Consider a session active only if it's valid for more than 1 minute, improving session stability
+- Handle cases where is_initialized doesn't return a value, preventing potential errors
+- Do not rely on commit labels, instead compare commits between 2 environments for more accurate deployment detection
+
+## How to upgrade Terminus
+If you manage your installation via Homebrew on macOS, you can update Terminus with the following command:
+
+```shell{promptUser: user}
+brew upgrade pantheon-systems/external/terminus
+```
+For other systems, see additional upgrade instructions [here](/terminus/install).


### PR DESCRIPTION
## Summary

**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Terminus Release 4.1.2

## Changes

- Update supported versions table with 4.1.2 release date and EOL date for 4.1.1
- Add release note for Terminus 4.1.2

## Related Links

- Terminus Release PR: https://github.com/pantheon-systems/terminus/pull/2762
- DEVX Ticket: https://getpantheon.atlassian.net/browse/DEVX-6475
- CCB Ticket: https://getpantheon.atlassian.net/browse/CCB-2377