### PR TITLE
Terminus Release 4.1.3 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.1.1            | November 04, 2025  |                    |
+| 4.1.3            | January 29, 2026   |                    |
+| 4.1.1            | November 04, 2025  | January 29, 2027   |
 | 4.1.0            | September 29, 2025 | November 04, 2026  |
 | 4.0.3            | September 11, 2025 | September 29, 2026 |
 | 4.0.2            | September 05, 2025 | September 11, 2026 |

--- a/src/source/releasenotes/2026-01-29-terminus-4-1-3.md
+++ b/src/source/releasenotes/2026-01-29-terminus-4-1-3.md
@@ -1,0 +1,33 @@
+---
+title: "Terminus 4.1.3 release now available"
+published_date: "2026-01-29"
+categories: [tools-apis]
+---
+
+Terminus [4.1.3](https://github.com/pantheon-systems/terminus/releases/tag/4.1.3) is now available. This release includes critical fixes for plugin installation issues affecting customer GitHub Actions workflows.
+
+## Key improvements in this release
+
+- **Fixed Composer security warnings blocking plugin installation**: Resolved issues where Composer security audit was preventing Terminus from installing plugins in GitHub Actions environments ([#2766](https://github.com/pantheon-systems/terminus/pull/2766))
+- **Enhanced environment comparison**: Fixed logic to not rely on commit labels when comparing environments ([#2761](https://github.com/pantheon-systems/terminus/pull/2761))
+- **Improved session validation**: Sessions are now considered active only if they're valid for more than 1 minute ([#2758](https://github.com/pantheon-systems/terminus/pull/2758))
+- **Better error handling**: Added proper handling for cases where initialization status isn't returned ([#2760](https://github.com/pantheon-systems/terminus/pull/2760))
+- **Enhanced logging**: All logger output messages now include timestamps for better debugging ([#2745](https://github.com/pantheon-systems/terminus/pull/2745))
+
+## How to upgrade to Terminus 4.1.3
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.1.3).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).


### PR DESCRIPTION
**Version Updates** - Terminus Release 4.1.3

This PR updates documentation for the Terminus 4.1.3 release.

## Changes
- Add Terminus 4.1.3 to supported versions table with January 29, 2026 release date
- Set EOL date for Terminus 4.1.1 (January 29, 2027)
- Add release notes highlighting key fixes including Composer security warnings resolution

## Related Links
- Terminus Release PR: https://github.com/pantheon-systems/terminus/pull/2767
- CCB Ticket: CCB-2399
- BUGS Ticket: BUGS-10860