### PR TITLE
Update 2026-02-04-wordpress-6-9-1.md

### DIFF
--- a/src/source/releasenotes/2026-02-04-wordpress-6-9-1.md
+++ b/src/source/releasenotes/2026-02-04-wordpress-6-9-1.md
@@ -1,6 +1,6 @@
 ---
 title: WordPress 6.9.1 maintenance release available
-published_date: "2025-09-30"
+published_date: "2026-02-04"
 categories: [wordpress, action-required]
 ---
 


### PR DESCRIPTION
Accidentally merged this directly to main. 
Original had the wrong date (though the file name was dated correctly). 
This PR fixes the date.