### PR TITLE
Content Publisher MCP Server release note

### DIFF
--- a/src/source/releasenotes/2026-02-10-content-publisher-mcp-server-beta.md
+++ b/src/source/releasenotes/2026-02-10-content-publisher-mcp-server-beta.md
@@ -17,7 +17,7 @@ The Model Context Protocol (MCP) is an open standard that allows AI assistants a
 ## Example workflows
 * "Create a Google Doc about our product launch and connect it to the Marketing collection, go through the preview, enrich and publish phase"
 * "Update the description metadata for the Q1 report and publish it"
-* "Add sarah@company.com as a collaborator on the Documentation collection"
+* "Add `sarah@company.com` as a collaborator on the Documentation collection"
 * “Find all documents with Author set at “John Doe” and replace with “Jane Doe”
 
 And really, any other content operation workflow you might think of!


### PR DESCRIPTION
Adds release note for Content Publisher MCP Server
Docs published to https://docs.content.pantheon.io/mcp

👀 https://pr-9869-pandocs.pantheonsite.io/release-notes/2026/02/content-publisher-mcp-server-beta