### PR TITLE
Add Claude local settings to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,7 @@ out
 /public/current-sha.txt
 
 pnpm-lock.yaml
+
+# Claude
+
+.claude/settings.local.json


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` to gitignore to prevent Claude Code local settings from being committed

## Test plan
- Verify `.claude/settings.local.json` is properly ignored by git
- Confirm no other files are affected by this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)