### PR TITLE
Restore CODEOWNERS 

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -12,10 +12,10 @@ src/source/content/bots-and-indexing @pantheon-systems/platform-edge-routing
 # The FileSystem team is responsible for managing static files on Pantheon
 src/source/content/guides/filesystem/ @pantheon-systems/filesystem
 # The lifecycle-ops team is responsible for Integrated Composer
-src/source/content/guides/integrated-composer/ @pantheon-systems/lifecycle-ops
+src/source/content/guides/integrated-composer/ @pantheon-systems/developer-experience
 # The cms-platform team is responsible for WordPress Multisite
-src/source/content/guides/multisite/ @pantheon-systems/cms-platform
+src/source/content/guides/multisite/ @pantheon-systems/site-experience
 # The cms-platform team is responsible for External Libraries on Pantheon
-src/source/content/external-libraries @pantheon-systems/cms-platform
+src/source/content/external-libraries @pantheon-systems/site-experience
 # There is a team just for release note permissions
 src/source/releasenotes/ @pantheon-systems/release-note-authors


### PR DESCRIPTION
Restores the `CODEOWNERS` file which was removed in #9816 