### PR TITLE
add push to pantheon 0.8.0 & 0.9.0  release note

### DIFF
--- a/src/source/releasenotes/2026-02-17-push-to-pantheon-0-8-0-0-9-0.md
+++ b/src/source/releasenotes/2026-02-17-push-to-pantheon-0-8-0-0-9-0.md
@@ -1,0 +1,31 @@
+---
+title: "0.8.0 and 0.9.0 Release of the 'Push to Pantheon' GitHub Action"
+published_date: "2026-02-17"
+categories: [tools-apis]
+---
+
+We have released [version 0.8.0](https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.8.0) and [version 0.9.0](https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.9.0) of the ['Push to Pantheon' GitHub Action](https://github.com/pantheon-systems/push-to-pantheon). 
+
+## What's new in 0.8.0?
+
+Version 0.8.0 adds several new features and improvements to the GitHub Action.
+
+* **Git-only deployment** - You can now deploy directly to Pantheon using Git push without requiring Terminus Build Tools. Set `skip_build_tools: true` to use this lightweight deployment option, which is ideal for brand-new sites or workflows that don't need database or file syncing.
+* **Automatic Build Tools fallback** - The action now automatically falls back to Git-only mode when Build Tools operations fail, ensuring deployments succeed even when the Build Tools plugin encounters issues. This fixes a failure mode where deploys would fail if a site did not yet have a Live environment initialized.
+* **Multidev limit checking** - The action now checks if you've reached Pantheon's multidev limit before attempting to create environments, providing clear error messages when limits are reached instead of cryptic failures.
+* **GitHub permission validation** - New pre-flight permission checks validate that your GITHUB_TOKEN has the required scopes before starting deployments, with helpful error messages explaining how to fix missing permissions.
+* **Build Tools version selection** - You can now choose which version of the Terminus Build Tools plugin to install using the `build_tools_version` input parameter. This gives you control over plugin compatibility and allows testing development versions if a particular Build Tools version or branch is required.
+
+## What's new in 0.9.0?
+
+Version 0.9.0 adds a number of under-the-hood improvements and moves much of the scripting logic out of the `action.yml` file and into a new `main.sh` file. This makes the action easier to maintain and test, and also allows for more complex logic that would be difficult to implement directly in the `action.yml` file. 
+
+Additionally, version 0.9.0 adds comprehensive unit and integration tests for the actions logic and deployment workflows, improving the reliability and stability of the action. The new testing framework also allows for easier debugging and faster development of new features in the future.
+
+For more details and a full list of changes in these releases, please refer to the [0.8.0 release notes](https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.8.0) and [0.9.0 release notes](https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.9.0). 
+
+To update to the latest version, modify your workflow file to use `0.9.0`:
+
+```yaml
+uses: pantheon-systems/push-to-pantheon@0.9.0
+```


### PR DESCRIPTION
Adds new release note for 0.8.0 (which never got a release note) and 0.9.0 of the Push to Pantheon action

https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.9.0
https://github.com/pantheon-systems/push-to-pantheon/releases/tag/0.8.0