### PR TITLE
[SITE-5508] Add release note for Drupal CMS 2 availability

### DIFF
--- a/src/source/releasenotes/2026-03-06-upstream-drupal-cms-2-available.md
+++ b/src/source/releasenotes/2026-03-06-upstream-drupal-cms-2-available.md
@@ -1,5 +1,5 @@
 ---
-title: "Drupal CMS 2 upstream update now available"
+title: "Upstream update for Drupal CMS 2 now available"
 published_date: "2026-03-06"
 categories: [drupal, upstream]
 ---


### PR DESCRIPTION
Add release note for Drupal CMS 2 availability

Pending on: https://github.com/pantheon-systems/drupal-composer-managed/pull/96