### PR TITLE
Release note: Content Publisher WP plugin 1.3.5

### DIFF
--- a/src/source/releasenotes/2026-03-05-content-publisher-wp-plugin-135.md
+++ b/src/source/releasenotes/2026-03-05-content-publisher-wp-plugin-135.md
@@ -1,5 +1,5 @@
 ---
-title: "Content Publisher WordPress plugin 1.3.5 released"
+title: "Pantheon Content Publisher 1.3.5 for WordPress now available"
 published_date: "2026-03-05"
 categories: [wordpress, content-publisher, plugins, new-feature]
 ---
@@ -10,6 +10,7 @@ Version 1.3.5 of the [Pantheon Content Publisher](https://wordpress.org/plugins/
 
 * **ACF integration** — Sync Content Publisher metadata fields to [Advanced Custom Fields](https://www.advancedcustomfields.com/). Define field mappings per post type in the plugin's Integration tab and metadata values are automatically applied on every publish.
 * **Custom post type support** — Publish content to any public post type registered on your WordPress site. Administrators can set the target post type per collection, or select "Chosen by the author" to let document authors control it via the `wp-post-type` metadata field.
+
 Update to 1.3.5 from the WordPress dashboard under **Plugins > Installed Plugins**, or download it from the [WordPress Plugin Repository](https://wordpress.org/plugins/pantheon-content-publisher/).
 
 For more details, see the [plugin changelog](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/releases).


### PR DESCRIPTION
Adds release note for Content Publisher WordPress plugin version 1.3.5.

New features in this release:
- ACF integration with per-post-type field mappings
- Custom post type support with author-choice mode


Pending on: https://github.com/pantheon-systems/pantheon-content-publisher-wordpress/pull/185