### PR TITLE
[SITE-5157] Release note for edge cache purge error handling

### DIFF
--- a/src/source/releasenotes/2026-03-25-edge-cache-purge-error-handling.md
+++ b/src/source/releasenotes/2026-03-25-edge-cache-purge-error-handling.md
@@ -1,0 +1,7 @@
+---
+title: "Improved error handling for edge cache purge failures"
+published_date: "2026-03-25"
+categories: [bugfix, infrastructure]
+---
+
+Edge cache purge failures could previously cause a **502 Bad Gateway** error. These failures are now handled gracefully across all CMS frameworks and PHP versions.

--- a/src/source/releasenotes/2026-03-25-edge-cache-purge-error-handling.md
+++ b/src/source/releasenotes/2026-03-25-edge-cache-purge-error-handling.md
@@ -1,7 +1,0 @@
----
-title: "Improved error handling for edge cache purge failures"
-published_date: "2026-03-25"
-categories: [bugfix, infrastructure]
----
-
-Edge cache purge failures could previously cause a **502 Bad Gateway** error. These failures are now handled gracefully across all CMS frameworks and PHP versions.

--- a/src/source/releasenotes/2026-03-26-edge-cache-purge-error-handling.md
+++ b/src/source/releasenotes/2026-03-26-edge-cache-purge-error-handling.md
@@ -1,0 +1,17 @@
+---
+title: "Improved error handling for edge cache purge failures"
+published_date: "2026-03-26"
+categories: [infrastructure]
+---
+
+Edge cache purge failures could previously cause a **502 Bad Gateway** error. These failures are now handled gracefully across all CMS frameworks and PHP versions. 
+
+Rather than throwing a 502, the improved error handling will log the following: 
+
+* The number of cache keys that failed to purge (useful for gauging impact)
+* The file and line number where the exception originated (useful for debugging without a full stack trace)
+  * Example log output:
+
+    ```
+    Failed to clear 1 edge cache keys: Unexpected result from Pantheon API when attempting to PURGE edge cache. in /srv/includes/pantheon.php:696
+    ```


### PR DESCRIPTION
## Summary

Adds a release note for the edge cache purge error handling fix (cos-runtime-php [PR #864](https://github.com/pantheon-systems/cos-runtime-php/pull/864)).