### PR TITLE
docs: Add Terminus 4.1.9 release notes

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.1.8            | March 30, 2026     |                    |
+| 4.1.9            | April 08, 2026     |                    |
+| 4.1.8            | March 30, 2026     | April 08, 2027     |
 | 4.1.7            | March 23, 2026     | March 30, 2027     |
 | 4.1.6            | March 18, 2026     | March 23, 2027     |
 | 4.1.4            | February 02, 2026  | March 18, 2027     |

--- a/src/source/releasenotes/2026-04-08-terminus-4-1-9.md
+++ b/src/source/releasenotes/2026-04-08-terminus-4-1-9.md
@@ -1,0 +1,31 @@
+---
+title: "Terminus 4.1.9 release now available"
+published_date: "2026-04-08"
+categories: [tools-apis]
+description: "Terminus 4.1.9 is now available. This patch release fixes SSH output formatting issues and resolves env:wake command failures."
+---
+
+Terminus [4.1.9](https://github.com/pantheon-systems/terminus/releases/tag/4.1.9) is now available. This patch release fixes SSH output formatting issues and resolves env:wake command failures.
+
+## Key improvements in this release
+
+- **SSH output formatting fix**: Resolved an issue where SSH command output would appear garbled when streaming, improving terminal display readability. ([#2814](https://github.com/pantheon-systems/terminus/pull/2814))
+- **env:wake command fix**: Fixed env:wake failures by removing the unnecessary X-Pantheon-Styx-Hostname header requirement, allowing environments to wake successfully. ([#2815](https://github.com/pantheon-systems/terminus/pull/2815))
+
+## How to upgrade to Terminus 4.1.9
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.1.9).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).

--- a/src/source/releasenotes/2026-04-09-terminus-4-1-9.md
+++ b/src/source/releasenotes/2026-04-09-terminus-4-1-9.md
@@ -1,11 +1,11 @@
 ---
 title: "Terminus 4.1.9 release now available"
-published_date: "2026-04-08"
+published_date: "2026-04-09"
 categories: [tools-apis]
 description: "Terminus 4.1.9 is now available. This patch release fixes SSH output formatting issues and resolves env:wake command failures."
 ---
 
-Terminus [4.1.9](https://github.com/pantheon-systems/terminus/releases/tag/4.1.9) is now available. This patch release fixes SSH output formatting issues and resolves env:wake command failures.
+Terminus [4.1.9](https://github.com/pantheon-systems/terminus/releases/tag/4.1.9) is now available. This patch release fixes SSH output formatting issues and resolves `env:wake` command failures.
 
 ## Key improvements in this release
 


### PR DESCRIPTION
## Summary

Add release notes for Terminus 4.1.9 stable release.

This release includes two bug fixes:
- SSH output formatting fix (#2814)
- env:wake command fix (#2815)

## Related

- Terminus PR: https://github.com/pantheon-systems/terminus/pull/2817
- Release tag: 4.1.9 (to be tagged after review)