### PR TITLE
DELENG-435: Add catalog-info.yaml for service catalog onboarding

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: service
   lifecycle: mature
-  owner: developer-experience
+  owner: docs-admins

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: backstage.io/v1alpha1
+kind: Component
+metadata:
+  name: documentation
+  description: Pantheon Docs
+  annotations:
+    github.com/project-slug: pantheon-systems/documentation
+spec:
+  type: service
+  lifecycle: mature
+  owner: developer-experience


### PR DESCRIPTION
## Summary
Adds `catalog-info.yaml` to enable service catalog integration per [Onboarding to The Catalog](https://getpantheon.atlassian.net/wiki/spaces/Catalog/pages/3284434948/Onboarding+to+The+Catalog) documentation.

## Changes
- **Added `catalog-info.yaml`** with the following metadata:
  - **Owner:** `developer-experience`
  - **Lifecycle:** `mature`
  - **Type:** `service`

## How Owner Was Determined
- **CODEOWNERS teams:** `developer-experience, docs-admins, filesystem, platform-edge-routing, release-note-authors, site-experience`
- **Catalog owner:** `developer-experience`
- **Note:** CODEOWNERS lists multiple teams; selected first team (`developer-experience`) as owner

## How Lifecycle Was Determined
- Analyzed README.md for lifecycle indicators
- `mature` was selected based on content analysis
- Valid options: `experimental`, `mature`, `deprecated` (per catalog documentation)

## Testing
- [ ] Verify catalog-info.yaml syntax is valid
- [ ] Confirm owner team exists in GitHub
- [ ] Check that lifecycle value is one of the valid options

## Related
- Jira: [DELENG-435](https://getpantheon.atlassian.net/browse/DELENG-435)
- Part of Repository Ownership Initiative
- Follows [Catalog Onboarding Guide](https://getpantheon.atlassian.net/wiki/spaces/Catalog/pages/3284434948/Onboarding+to+The+Catalog)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[DELENG-435]: https://getpantheon.atlassian.net/browse/DELENG-435?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ