### PR TITLE
Terminus Release 4.2.0 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.1.9            | April 08, 2026     |                    |
+| 4.2.0            | April 13, 2026     |                    |
+| 4.1.9            | April 08, 2026     | April 13, 2027     |
 | 4.1.8            | March 30, 2026     | April 08, 2027     |
 | 4.1.7            | March 23, 2026     | March 30, 2027     |
 | 4.1.6            | March 18, 2026     | March 23, 2027     |

--- a/src/source/releasenotes/2026-04-13-terminus-4-2-0.md
+++ b/src/source/releasenotes/2026-04-13-terminus-4-2-0.md
@@ -1,0 +1,50 @@
+---
+title: "Terminus 4.2.0 release now available"
+published_date: "2026-04-13"
+categories: [tools-apis]
+description: "Terminus 4.2.0 is now available. This release integrates three core plugins, adds unified search commands, and enhances Node.js site management."
+---
+
+Terminus [4.2.0](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0) is now available. This minor release brings major improvements including three integrated plugins, unified search commands, and enhanced Node.js/STA site support.
+
+## Key improvements in this release
+
+- **Integrated core plugins**: Three popular plugins are now built directly into Terminus, eliminating the need for separate installation:
+  - [terminus-secrets-manager-plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) for managing secrets ([#2764](https://github.com/pantheon-systems/terminus/pull/2764))
+  - [terminus-repository-plugin](https://github.com/pantheon-systems/terminus-repository-plugin) for repository management ([#2792](https://github.com/pantheon-systems/terminus/pull/2792))
+  - [terminus-node-logs-plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin) for Node.js build logs ([#2791](https://github.com/pantheon-systems/terminus/pull/2791))
+
+- **Unified search commands**: New `search:enable` and `search:disable` commands support both Solr and Elasticsearch, providing a consistent interface for managing search indexing across all sites. The legacy `solr:enable` and `solr:disable` commands are now deprecated. ([#2783](https://github.com/pantheon-systems/terminus/pull/2783), [#2784](https://github.com/pantheon-systems/terminus/pull/2784))
+
+- **Domain verification**: New `domain:verify` command allows you to verify domain ownership through DNS challenges, displaying challenge details when a domain is unverified. ([#2790](https://github.com/pantheon-systems/terminus/pull/2790), [#2797](https://github.com/pantheon-systems/terminus/pull/2797))
+
+- **Enhanced Node.js/STA site management**:
+  - `node:builds:wait` command for tracking STA site deployment progress ([#2798](https://github.com/pantheon-systems/terminus/pull/2798))
+  - `node:builds:rollback` command for easy build rollbacks ([#2803](https://github.com/pantheon-systems/terminus/pull/2803))
+  - Enhanced `builds:list` with active build status ([#2807](https://github.com/pantheon-systems/terminus/pull/2807))
+  - Added deployment status to builds command ([#2801](https://github.com/pantheon-systems/terminus/pull/2801))
+  - Improved site creation workflow by skipping dev environment wait ([#2810](https://github.com/pantheon-systems/terminus/pull/2810))
+  - Node.js sites can now use the `metrics` command ([#2806](https://github.com/pantheon-systems/terminus/pull/2806))
+
+- **Bug fixes**:
+  - Fixed empty request body serialization ([#2780](https://github.com/pantheon-systems/terminus/pull/2780))
+  - Improved `env:wake` command reliability ([#2815](https://github.com/pantheon-systems/terminus/pull/2815), [#2816](https://github.com/pantheon-systems/terminus/pull/2816))
+  - Fixed SSH output formatting for better readability ([#2814](https://github.com/pantheon-systems/terminus/pull/2814))
+
+## How to upgrade to Terminus 4.2.0
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).


### PR DESCRIPTION
**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Terminus Release 4.2.0

## Changes

- Added Terminus 4.2.0 to supported versions table (released 2026-04-13)
- Updated 4.1.9 EOL date to 2027-04-13 (one year from 4.2.0 release)
- Added comprehensive release note covering all major features and improvements

## Links

- Terminus Release PR: https://github.com/pantheon-systems/terminus/pull/2821
- CCB ticket: https://getpantheon.atlassian.net/browse/CCB-2740

This PR is in draft until the release is tagged and published.