### PR TITLE
Terminus 4 Linux Install Goes To Old Version

### DIFF
--- a/src/source/content/terminus/02-install.md
+++ b/src/source/content/terminus/02-install.md
@@ -113,7 +113,6 @@ The commands below will:
 mkdir -p ~/terminus && cd ~/terminus
 curl -L https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar --output terminus
 chmod +x terminus
-./terminus self:update
 sudo ln -s ~/terminus/terminus /usr/local/bin/terminus
 ```
 

--- a/src/source/content/terminus/02-install.md
+++ b/src/source/content/terminus/02-install.md
@@ -111,7 +111,7 @@ The commands below will:
 
 ```bash{promptUser: user}
 mkdir -p ~/terminus && cd ~/terminus
-curl -L https://github.com/pantheon-systems/terminus/releases/download/4.1.1/terminus.phar --output terminus
+curl -L https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar --output terminus
 chmod +x terminus
 ./terminus self:update
 sudo ln -s ~/terminus/terminus /usr/local/bin/terminus


### PR DESCRIPTION
Update it to not use Terminus 4.1.1  and instead use the latest version of Terminus.