### PR TITLE
Fix Terminus 4.2.0 release note - remove items already in 4.1.x

### DIFF
--- a/src/source/releasenotes/2026-04-13-terminus-4-2-0.md
+++ b/src/source/releasenotes/2026-04-13-terminus-4-2-0.md
@@ -2,10 +2,10 @@
 title: "Terminus 4.2.0 release now available"
 published_date: "2026-04-13"
 categories: [tools-apis]
-description: "Terminus 4.2.0 is now available. This release integrates three core plugins, adds unified search commands, and enhances Node.js site management."
+description: "Terminus 4.2.0 is now available. This release integrates three core plugins and enhances Node.js/STA site management."
 ---
 
-Terminus [4.2.0](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0) is now available. This minor release brings major improvements including three integrated plugins, unified search commands, and enhanced Node.js/STA site support.
+Terminus [4.2.0](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0) is now available. This minor release brings major improvements including three integrated plugins and enhanced Node.js/STA site support.
 
 ## Key improvements in this release
 
@@ -13,10 +13,6 @@ Terminus [4.2.0](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0
   - [terminus-secrets-manager-plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) for managing secrets ([#2764](https://github.com/pantheon-systems/terminus/pull/2764))
   - [terminus-repository-plugin](https://github.com/pantheon-systems/terminus-repository-plugin) for repository management ([#2792](https://github.com/pantheon-systems/terminus/pull/2792))
   - [terminus-node-logs-plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin) for Node.js build logs ([#2791](https://github.com/pantheon-systems/terminus/pull/2791))
-
-- **Unified search commands**: New `search:enable` and `search:disable` commands support both Solr and Elasticsearch, providing a consistent interface for managing search indexing across all sites. The legacy `solr:enable` and `solr:disable` commands are now deprecated. ([#2783](https://github.com/pantheon-systems/terminus/pull/2783), [#2784](https://github.com/pantheon-systems/terminus/pull/2784))
-
-- **Domain verification**: New `domain:verify` command allows you to verify domain ownership through DNS challenges, displaying challenge details when a domain is unverified. ([#2790](https://github.com/pantheon-systems/terminus/pull/2790), [#2797](https://github.com/pantheon-systems/terminus/pull/2797))
 
 - **Enhanced Node.js/STA site management**:
   - `node:builds:wait` command for tracking STA site deployment progress ([#2798](https://github.com/pantheon-systems/terminus/pull/2798))
@@ -27,9 +23,8 @@ Terminus [4.2.0](https://github.com/pantheon-systems/terminus/releases/tag/4.2.0
   - Node.js sites can now use the `metrics` command ([#2806](https://github.com/pantheon-systems/terminus/pull/2806))
 
 - **Bug fixes**:
-  - Fixed empty request body serialization ([#2780](https://github.com/pantheon-systems/terminus/pull/2780))
-  - Improved `env:wake` command reliability ([#2815](https://github.com/pantheon-systems/terminus/pull/2815), [#2816](https://github.com/pantheon-systems/terminus/pull/2816))
-  - Fixed SSH output formatting for better readability ([#2814](https://github.com/pantheon-systems/terminus/pull/2814))
+  - Update check in env:wake for node sites ([#2816](https://github.com/pantheon-systems/terminus/pull/2816))
+  - Update Node.js site creation notice to reflect actual build trigger ([#2819](https://github.com/pantheon-systems/terminus/pull/2819))
 
 ## How to upgrade to Terminus 4.2.0
 


### PR DESCRIPTION
## Problem

The 4.2.0 release note incorrectly included features that were already released in 4.1.6, 4.1.7, and 4.1.9:
- search:enable/disable commands (shipped in 4.1.6)
- domain:verify command (shipped in 4.1.6) 
- domain:verify fix (shipped in 4.1.7)
- SSH output and env:wake fixes (shipped in 4.1.9)

## Solution

Corrected the release note to only highlight what's actually new in 4.2.0:
- Plugin integrations (secrets-manager, repository, node-logs)
- Enhanced Node.js/STA site management
- Node.js-specific bug fixes

Related: https://github.com/pantheon-systems/terminus/pull/2823