### PR TITLE
Clarifying traffic metrics limitation

### DIFF
--- a/src/source/content/guides/global-cdn/07-global-cdn-beta.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-beta.md
@@ -208,7 +208,7 @@ terminus gcdn:verify my-site.live www.example.com
 
 ### Traffic Metrics Unavailable
 
-The traffic metrics page in the Pantheon dashboard will not contain any traffic data during the initial Beta period. This includes historical data before GCDN Beta was enabled. Traffic data for migrated sites will be restored in a future update.
+The traffic metrics page in the Pantheon dashboard will not contain any traffic data during the initial Beta period, including historical traffic data. In a future update, sites using GCDN Beta will regain access to traffic data, along with up to 3 months of traffic data from before Beta was activated. 
 
 
 ## FAQ

--- a/src/source/content/guides/global-cdn/07-global-cdn-beta.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-beta.md
@@ -208,7 +208,7 @@ terminus gcdn:verify my-site.live www.example.com
 
 ### Traffic Metrics Unavailable
 
-The traffic metrics page in the Pantheon dashboard will not reflect GCDN Beta traffic during the initial Beta period. Traffic data for migrated sites will be restored in a future update.
+The traffic metrics page in the Pantheon dashboard will not contain any traffic data during the initial Beta period. This includes historical data before GCDN Beta was enabled. Traffic data for migrated sites will be restored in a future update.
 
 
 ## FAQ


### PR DESCRIPTION
Doc: [Global CDN Beta](https://docs.pantheon.io/guides/global-cdn/global-cdn-beta)
Section: [Traffic Metrics Unavailable](https://docs.pantheon.io/guides/global-cdn/global-cdn-beta#traffic-metrics-unavailable)

**Description:** 
During the GCDN Beta, the Metrics tab will contain zero traffic data at all, even historical data. The phrasing of our previous docs was ambiguous, leading customer to believe that traffic data would only be lost "from the time of GCDN being enabled and moving forward", but in reality the Metrics tab becomes entirely blank, including historical data.