### PR TITLE
Remove PHP Runtime Generation 1 references

### DIFF
--- a/src/components/omni-components/web-infrastructure.ts
+++ b/src/components/omni-components/web-infrastructure.ts
@@ -14,7 +14,7 @@ const webInfrastructure = () => {
         ),
         simpleLink(
           "/php-runtime-generation-2",
-          "PHP Runtime Generation 2 (Beta)"
+          "PHP Runtime Generation 2"
         ),
         simpleLink("/horizontal-scalability", "Horizontal Scalability"),
         // This page is oddly short.

--- a/src/source/content/external-libraries.md
+++ b/src/source/content/external-libraries.md
@@ -16,7 +16,7 @@ There are some scenarios when an external library is required. The Pantheon plat
 
 ## wkhtmltopdf (Deprecated)
 
-wkhtmltopdf has been abandoned by its maintainers and no longer receives updates. While it is still available on PHP Runtime Generation 1, the package is not available on [PHP Runtime Generation 2](/php-runtime-generation-2). We recommend all sites using wkhtmltopdf switch to [dompdf](https://github.com/dompdf/dompdf).
+wkhtmltopdf has been abandoned by its maintainers and no longer receives updates. As such, the package is not available on [PHP Runtime Generation 2](/php-runtime-generation-2). We recommend all sites using wkhtmltopdf switch to [dompdf](https://github.com/dompdf/dompdf).
 
 ### Switching from wkhtmltopdf to dompdf
 
@@ -44,10 +44,6 @@ From `<your_url>/admin/config/user-interface/print/pdf`, choose dompdf as PDF Ge
 The [Apache Tika](https://tika.apache.org/) toolkit detects and extracts metadata and structured text content from various documents using existing parser libraries.
 
 Tika can extract content from a number of document formats such as HTML, XML, Microsoft Office document formats, and PDFs and more.
-
-<TabList>
-
-<Tab title="PHP Runtime Generation 2" id="tab-1-anchor" active={true}>
 
 The Tika 3.x jar is available at:
 
@@ -77,19 +73,6 @@ If your Drupal site uses the [Search API Attachments](https://www.drupal.org/pro
 
 ![Search API Attachments Tika configuration](../images/search-api-attachments-tika-config.png)
 
-</Tab>
-<Tab title="PHP Runtime Generation 1" id="tab-2-id">
-
-Tika 1.18 and 1.21 are available for PHP Runtime Generation 1. These versions are available at the following paths:
-
-- `/srv/bin/tika-app-1.18.jar`
-- `/srv/bin/tika-app-1.21.jar`
-
-Sites that are using these older versions of Tika should be upgraded to a newer version of Tika as soon as possible. See the PHP Runtime Generation 2 tab for more information.
-
-
-</Tab>
-</TabList>
 
 ## ImageMagick
 

--- a/src/source/content/guides/php/01-introduction.md
+++ b/src/source/content/guides/php/01-introduction.md
@@ -25,8 +25,8 @@ Click the links below to display complete PHP information for each version, incl
 
 | Version                                          | Available   | Recommended | End of Sale | Removal Date |
 | ------------------------------------------------ | :---------: | :---------: | :---------: | :----------: |
-| [8.5](https://v85-php-info.pantheonsite.io/)   | <span style="color:green">✔</span> <Popover title="Note" content="Setting PHP version to 8.5 will automatically upgrade your site to the new <a href='/php-runtime-generation-2'>PHP Runtime Generation 2</a>."/> | <span style="color:green">✔</span>     | TBD | TBD |
-| [8.4](https://v84-php-info.pantheonsite.io/)   | <span style="color:green">✔</span> <Popover title="Note" content="Setting PHP version to 8.4 will automatically upgrade your site to the new <a href='/php-runtime-generation-2'>PHP Runtime Generation 2</a>."/> | <span style="color:green">✔</span>     | TBD | TBD |
+| [8.5](https://v85-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>  | <span style="color:green">✔</span>     | TBD | TBD |
+| [8.4](https://v84-php-info.pantheonsite.io/)   | <span style="color:green">✔</span> | <span style="color:green">✔</span>     | TBD | TBD |
 | [8.3](https://v83-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | TBD | TBD |
 | [8.2](https://v82-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | TBD | TBD |
 | [8.1](https://v81-php-info.pantheonsite.io/)   | <span style="color:green">✔</span>         | ❌           | September 30, 2026 | TBD |

--- a/src/source/content/guides/php/09-php-jit.md
+++ b/src/source/content/guides/php/09-php-jit.md
@@ -18,7 +18,6 @@ PHP's JIT (Just-In-Time) compiler compiles PHP bytecode into native machine code
 ## Requirements
 
 - **PHP 8.3 or higher**
-- **[PHP Runtime Generation 2](/php-runtime-generation-2)**
 
 ## Configuration
 

--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -159,7 +159,7 @@ php_jit: low
 
 #### Considerations
 
-- Requires **PHP 8.3 or higher** and [PHP Runtime Generation 2](/php-runtime-generation-2).
+- Requires **PHP 8.3 or higher**.
 - Valid values are `off` (default), `low`, and `high`. Any other value will cause a validation error.
 - The JIT buffer size is allocated automatically based on your site's plan tier. Refer to the [PHP JIT guide](/guides/php/php-jit) for the full memory allocation table and additional details.
 

--- a/src/source/content/tls-compatibility.md
+++ b/src/source/content/tls-compatibility.md
@@ -30,7 +30,6 @@ A TLS connection is initiated by a "handshake". You can think of this as two com
 
 TLS 1.0 and 1.1 were published in 1999 and 2006, respectively. Both were deprecated in 2021 and are considered outdated and insecure. Pantheon servers support TLS 1.2 and 1.3 connections. This means any outgoing HTTP requests being made from the _application level_ must be with servers that also support TLS 1.2 or 1.3.
 
-For site environments using [PHP Runtime Generation 2](/php-runtime-generation-2), Pantheon application servers will _reject_ connections to external servers that do not support TLS 1.2+.
 
 <Alert title="What's affected?" type="info">
 


### PR DESCRIPTION
## Summary
- Remove references to PHP Runtime Generation 1 throughout the docs
- Remove "(Beta)" label from PHP Runtime Generation 2
- Remove Gen 1-specific Tika tab and paths from external libraries page
- Remove Gen 2 popovers from PHP version table (no longer needed since all versions use Gen 2)
- Remove Gen 2 requirement callouts from JIT, pantheon.yml, and TLS docs

## Test plan
- [ ] Verify external libraries page renders correctly without the Gen 1 Tika tab
- [ ] Verify PHP version table displays correctly without popover components
- [ ] Confirm all internal links to `/php-runtime-generation-2` still resolve