### PR TITLE
Update pantheon.yml docs to suggest PHP 8.5

### DIFF
--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -171,7 +171,7 @@ JIT compilation can cause unexpected behavior on some sites, including white scr
 
 ### Specify a Version of MariaDB
 
-<ReviewDate date="2026-04-17" />
+<ReviewDate date="2026-02-04" />
 
 Specify the site's version of MariaDB to keep the software your site uses current and up to date, or set a specific version to avoid incompatibilities:
 

--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -2,7 +2,7 @@
 title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
 tags: [https, launch, code, workflow]
-reviewed: "2026-02-04"
+reviewed: "2026-04-17"
 contenttype: [doc]
 innav: [true]
 categories: [config]
@@ -137,10 +137,10 @@ Refer to [Integrated Composer](/guides/integrated-composer) for more information
 
 Override the upstream's default PHP version with the `php_version` property. PHP version is managed in version control and deployed along with the rest of your site's code to encourage testing before making a change on your Live site.
 
-For example, to override the upstream default value at the site level to PHP 8:
+For example, to override the upstream default value at the site level to PHP 8.5:
 
 ```yaml:title=pantheon.yml
-php_version: 8.0
+php_version: 8.5
 ```
 
 #### Considerations
@@ -171,7 +171,7 @@ JIT compilation can cause unexpected behavior on some sites, including white scr
 
 ### Specify a Version of MariaDB
 
-<ReviewDate date="2026-02-04" />
+<ReviewDate date="2026-04-17" />
 
 Specify the site's version of MariaDB to keep the software your site uses current and up to date, or set a specific version to avoid incompatibilities:
 


### PR DESCRIPTION
## Summary
- Updates the PHP version example in the pantheon.yml configuration doc from PHP 8.0 to PHP 8.5
- Updates the reviewed date to 2026-04-17