### PR TITLE
docs(known-issues): add WPML multi-environment license key solution

### DIFF
--- a/src/source/content/wordpress-known-issues.md
+++ b/src/source/content/wordpress-known-issues.md
@@ -1695,7 +1695,37 @@ Learn more in the [WPML Guide](https://wpml.org/faq/install-wpml/#registration-u
 
 ___
 
-**Issue 3:** Your wp-admin becomes too slow or upon activating WPML String Translation plugin, you may see this error:
+**Issue 3:** When pushing the database between environments, the WPML site key stored in the database is overwritten, causing WPML to lose its registration on the destination environment. This results in WPML prompting for re-registration after every database push.
+
+**Solution:** Generate a unique site key for each environment from your [WPML account page](https://wpml.org/account/sites/), then define each key in `wp-config.php` using the `OTGS_INSTALLER_SITE_KEY_WPML` constant. This constant takes precedence over any value stored in the database, so database pushes between environments will not affect registration.
+
+Dev, Test, and Multidev environment keys are registered as "development" sites in your WPML account and do not consume production license seats — all environments can be registered under the same WPML subscription.
+
+```php:title=wp-config.php
+if ( isset( $_ENV['PANTHEON_ENVIRONMENT'] ) ) {
+    switch ( $_ENV['PANTHEON_ENVIRONMENT'] ) {
+        case 'live':
+            $site_key_wpml = 'your-live-site-key';
+            break;
+        case 'test':
+            $site_key_wpml = 'your-test-site-key';
+            break;
+        case 'dev':
+            $site_key_wpml = 'your-dev-site-key';
+            break;
+        default:
+            $site_key_wpml = 'your-default-site-key';
+            break;
+    }
+    define( 'OTGS_INSTALLER_SITE_KEY_WPML', $site_key_wpml );
+}
+```
+
+Learn more in [WPML's guide to automatic registration across environments](https://wpml.org/faq/automatic-wpml-registration-using-php-for-easy-moves-between-production-development-and-staging/).
+
+___
+
+**Issue 4:** Your wp-admin becomes too slow or upon activating WPML String Translation plugin, you may see this error:
 
 >WPML String Translation is attempting to write .mo files with translations to folder:
 >


### PR DESCRIPTION
## Summary

Adds a new Issue 3 to the WPML known issues entry covering license key management across Pantheon environments.

- Explains that database pushes overwrite the WPML site key stored in the DB
- Provides the correct `OTGS_INSTALLER_SITE_KEY_WPML` switch pattern so each environment uses its own key without needing re-registration after DB pushes
- Clarifies that dev/test/Multidev keys are "development" registrations in the WPML account and do not consume production license seats
- Links to WPML's own documentation for this pattern
- Renumbers the former Issue 3 (`.mo` file write error) to Issue 4

Fixes #9691

## Test plan

- [x] Verify code block renders correctly
- [x] Verify links to WPML account page and WPML FAQ resolve
- [x] Confirm issue numbering in the WPML section is sequential