### PR TITLE
fix broken mu-plugin link in Yoast LLMs.txt entry

### DIFF
--- a/src/source/content/wordpress-known-issues.md
+++ b/src/source/content/wordpress-known-issues.md
@@ -1841,7 +1841,7 @@ ___
    git push origin master
    ```
 
-1. Add the following to a [custom MU plugin](/guides/wordpress-configurations/plugins#create-a-custom-mu-plugin) to redirect Yoast’s file writes to the uploads directory. Update the path if your uploads directory is not at the default location:
+1. Add the following to a [custom MU plugin](/guides/wordpress-configurations/mu-plugin) to redirect Yoast’s file writes to the uploads directory. Update the path if your uploads directory is not at the default location:
 
    ```php:title=wp-content/mu-plugins/yoast-llmstxt-path.php
    <?php


### PR DESCRIPTION
Fixes a broken link introduced in #9885 — `/guides/wordpress-configurations/plugins#create-a-custom-mu-plugin` does not exist. Corrected to `/guides/wordpress-configurations/mu-plugin`.