### PR TITLE
add Safari CORS note, fix Drupal wildcard origins, update WordPress CORS example

### DIFF
--- a/src/source/content/guides/platform-considerations/02-platform-site-info.md
+++ b/src/source/content/guides/platform-considerations/02-platform-site-info.md
@@ -63,8 +63,9 @@ Sample `services.yml` file:
     allowedHeaders: ['x-csrf-token','authorization','content-type','accept','origin','x-requested-with', 'access-control-allow-origin','x-allowed-header','*']
     # Specify allowed request methods, specify ['*'] to allow all possible ones.
     allowedMethods: ['*']
-    # Configure requests allowed from specific origins.
-    allowedOrigins: ['http://localhost/','http://localhost:3000','http://localhost:3001','http://localhost:3002','*']
+    # List each allowed origin explicitly. http:// and https:// are distinct origins,
+    # as are www and non-www. Wildcard origins are not valid when supportsCredentials is true.
+    allowedOrigins: ['http://localhost/','http://localhost:3000','http://localhost:3001','http://localhost:3002','https://example.com','https://www.example.com']
     # Sets the Access-Control-Expose-Headers header.
     exposedHeaders: false
     # Sets the Access-Control-Max-Age header.
@@ -72,6 +73,18 @@ Sample `services.yml` file:
     # Sets the Access-Control-Allow-Credentials header.
     supportsCredentials: true
 ```
+
+<Alert title="Safari and CORS" type="info">
+
+Safari enforces CORS more strictly than Chromium-based browsers. Even with correctly configured headers, you may encounter CORS errors in Safari that do not appear in other browsers:
+
+- **Wildcard subdomains are not supported.** `*.example.com` is not a valid `Access-Control-Allow-Origin` value. Each origin must be listed explicitly.
+- **Protocol is part of the origin.** `http://example.com` and `https://example.com` are distinct origins and must be listed separately if both are needed.
+- **`www` and non-`www` are distinct origins** and must each be listed if your site serves traffic on both.
+- **Wildcard origins cannot be used with credentialed requests** in any browser. If `supportsCredentials` (Drupal) or `Access-Control-Allow-Credentials` (WordPress) is enabled, every allowed origin must be explicit.
+- **Safari's Intelligent Tracking Prevention (ITP)** may block credentialed cross-origin requests regardless of your CORS configuration. This is a browser-enforced privacy restriction with no server-side workaround.
+
+</Alert>
 
 
 ## CSS Preprocessors

--- a/src/source/content/guides/platform-considerations/02-platform-site-info.md
+++ b/src/source/content/guides/platform-considerations/02-platform-site-info.md
@@ -81,11 +81,11 @@ Safari enforces CORS more strictly than Chromium-based browsers. Even with corre
 - **Wildcard subdomains are not supported.** `*.example.com` is not a valid `Access-Control-Allow-Origin` value. Each origin must be listed explicitly.
 - **Protocol is part of the origin.** `http://example.com` and `https://example.com` are distinct origins and must be listed separately if both are needed.
 - **`www` and non-`www` are distinct origins** and must each be listed if your site serves traffic on both.
-- **Wildcard origins cannot be used with credentialed requests** in any browser. If `supportsCredentials` (Drupal) or `Access-Control-Allow-Credentials` (WordPress) is enabled, every allowed origin must be explicit.
 - **Safari's Intelligent Tracking Prevention (ITP)** may block credentialed cross-origin requests regardless of your CORS configuration. This is a browser-enforced privacy restriction with no server-side workaround.
 
 </Alert>
 
+**Note:** Wildcard origins cannot be used with credentialed requests in any browser. If `supportsCredentials` (Drupal) or `Access-Control-Allow-Credentials` (WordPress) is enabled, every allowed origin must be listed explicitly — `Access-Control-Allow-Origin: *` will be rejected by the browser.
 
 ## CSS Preprocessors
 

--- a/src/source/content/guides/wordpress-configurations/03-mu-plugin.md
+++ b/src/source/content/guides/wordpress-configurations/03-mu-plugin.md
@@ -175,16 +175,23 @@ function dynamic_cors_headers( $headers ) {
 	if ( ! array_key_exists( 'HTTP_ORIGIN', $_SERVER ) ) {
 		return $headers;
 	}
-	// Each of the domains in this array will be given an allow header
-	// Note that http or https and the www subdomain are each different origins
+	// List each allowed origin explicitly.
+	// http:// and https:// are distinct origins and must each be listed separately.
+	// www and non-www are distinct origins and must each be listed separately.
+	// Wildcard subdomains (e.g. *.example.com) are not valid CORS origin values.
 	$allowed_domains = array(
 		'https://dev-exampleallowedurl.pantheonsite.io',
 		'http://localhost:8084',
 		'http://example.com',
+		'https://example.com',
+		'http://www.example.com',
 		'https://www.example.com',
 	);
 	if ( in_array( $_SERVER['HTTP_ORIGIN'], $allowed_domains ) ) {
 		$headers['Access-Control-Allow-Origin'] = $_SERVER['HTTP_ORIGIN'];
+		// Required for cross-origin requests that include credentials (cookies, HTTP auth).
+		// Must be used with a specific origin above — never with Access-Control-Allow-Origin: *
+		$headers['Access-Control-Allow-Credentials'] = 'true';
 	}
 	return $headers;
 }


### PR DESCRIPTION
## Summary

- Fixes the Drupal `services.yml` example which combined `allowedOrigins: ['*']` with `supportsCredentials: true` — this is broken per the CORS spec in all browsers (wildcard origins cannot be used with credentialed requests)
- Updates the WordPress mu-plugin CORS example to add `Access-Control-Allow-Credentials: true`, fix inconsistent example domains (now shows all four http/https + www/non-www combinations), and improves comments to explain why explicit origins are required
- Adds a Safari-specific alert to the platform-considerations CORS section noting that Safari enforces CORS more strictly and that issues may persist there even with correct configuration, including the ITP limitation

Closes #9178

## Test plan

- [x] Verify Drupal services.yml renders correctly
- [x] Verify WordPress PHP code block renders correctly
- [x] Verify Alert component renders in platform-considerations
- [x] Confirm the wildcard + credentials bullet point in the alert is accurate across browsers