### PR TITLE
Docs review automation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,4 +65,5 @@ pnpm-lock.yaml
 
 # Docs audit results
 audit-results.json
+image-audit-results.json
 scripts/dry-run/

--- a/.gitignore
+++ b/.gitignore
@@ -62,3 +62,6 @@ out
 
 pnpm-lock.yaml
 .idea
+
+# Docs audit results
+audit-results.json

--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,4 @@ pnpm-lock.yaml
 
 # Docs audit results
 audit-results.json
+scripts/dry-run/

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "author": "@pantheon-systems",
   "scripts": {
     "audit": "tsx scripts/audit.ts",
+    "evaluate": "tsx --env-file=.env scripts/evaluate.ts",
     "update": "tsx seed/update.ts",
     "build": "next build",
     "coverage": "vitest run --coverage",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "https://docs.pantheon.io",
   "author": "@pantheon-systems",
   "scripts": {
+    "audit": "tsx scripts/audit.ts",
     "update": "tsx seed/update.ts",
     "build": "next build",
     "coverage": "vitest run --coverage",

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -83,6 +83,9 @@ Run from the **`scripts/`** directory.
 | `--dry-run` | Evaluate with Claude, write results to `scripts/dry-run/` instead of opening PRs | off |
 | `--limit <n>` | Number of files to process | `50` |
 | `--audit <path>` | Path to audit JSON | `../audit-results.json` |
+| `--file <path>` | Evaluate a single specific file (e.g. `src/source/content/drupal-s3.md`) | — |
+| `--older-than <n>m` | Staleness threshold (e.g. `6m`, `12m`, `24m`) | `12m` |
+| `--all` | When used with `--file`, evaluate regardless of staleness | off |
 
 ```bash
 cd scripts
@@ -96,8 +99,14 @@ npm run evaluate -- --dry-run --limit 10
 # Live run — opens one draft PR per file
 npm run evaluate
 
-# Live run against a specific audit file
-npm run evaluate -- --audit /path/to/audit-results.json --limit 20
+# Evaluate a specific file
+npm run evaluate -- --dry-run --file src/source/content/drupal-s3.md
+
+# Evaluate a specific file even if not stale
+npm run evaluate -- --dry-run --file src/source/content/jenkins.md --all
+
+# Use a different staleness threshold
+npm run evaluate -- --dry-run --older-than 6m
 ```
 
 Env vars are loaded automatically from the repo root `.env` via `--env-file`. No `source` needed.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,16 +34,18 @@ Files that already have an open `docs-audit/*` PR are automatically excluded fro
 
 Run from the **repo root** via `npm run audit`.
 
+Always writes to a file. Default output is `audit-results.json` in the repo root (or `image-audit-results.json` for `--images`).
+
 | Flag | Description |
 |---|---|
 | `--stale-only` | Output only stale files |
-| `--output <path>` | Write JSON to file instead of stdout |
+| `--output <path>` | Override the default output filename/path |
 | `--images` | Run image scan instead of doc audit (see below) |
 | `--age <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
 
 ```bash
-# Generate audit results (required before running evaluate)
-npm run audit -- --stale-only --output audit-results.json
+# Generate audit results — writes to audit-results.json automatically
+npm run audit -- --stale-only
 ```
 
 ### Image scan
@@ -51,11 +53,11 @@ npm run audit -- --stale-only --output audit-results.json
 Scans `src/source/images/` and flags images not updated in git within the threshold. Uses the last git commit date, not the filesystem mtime. Outputs a separate report — does not affect the main audit results or trigger PR creation.
 
 ```bash
-# Scan for images not updated in the last 12 months (default)
-npm run audit -- --images --output image-audit.json
+# Scan for images not updated in the last 12 months — writes to image-audit-results.json
+npm run audit -- --images
 
 # Use a different age threshold
-npm run audit -- --images --age 6m --output image-audit-6m.json
+npm run audit -- --images --age 6m
 npm run audit -- --images --age 24m --output image-audit-24m.json
 ```
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -44,7 +44,7 @@ Outputs only stale files by default.
 | `--all` | Include non-stale files in output |
 | `--output <path>` | Override the default output filename/path |
 | `--images` | Run image scan instead of doc audit (see below) |
-| `--older-than <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
+| `--older-than <n>m` | Age threshold for scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
 
 ```bash
 # Generate audit results — writes to audit-results.json automatically

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -18,6 +18,7 @@ cd scripts && npm install
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
 VERTEX_CREDENTIALS=/path/to/service-account.json
 VERTEX_REGION=global
+GIT_REMOTE=origin            # optional — defaults to "origin"
 ```
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,10 +6,10 @@ Tooling for identifying and resolving stale documentation using Claude on Vertex
 
 **Prerequisites:** Node.js 22+, `gh` CLI authenticated to `pantheon-systems`, a GCP service account JSON with Vertex AI access.
 
-**One-time install:**
+**One-time install** (installs dependencies for the audit/evaluate scripts, separate from the main project):
 
 ```bash
-cd scripts && npm install
+cd scripts && npm install && cd ..
 ```
 
 **Create `.env` in the repo root** (gitignored):
@@ -77,20 +77,18 @@ Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for a
 
 Claude may flag docs as candidates for **deprecation or removal** when the content is so outdated or ecosystem-changed that updating would be less useful than removing. This appears as a `⚠️ Deprecation consideration` section in the PR description — the final call is always with the human reviewer.
 
-Run from the **`scripts/`** directory.
+Run from the **repo root** via `npm run evaluate`.
 
 | Flag | Description | Default |
 |---|---|---|
 | `--dry-run` | Evaluate with Claude, write results to `scripts/dry-run/` instead of opening PRs | off |
 | `--limit <n>` | Number of files to process | `50` |
-| `--audit <path>` | Path to audit JSON | `../audit-results.json` |
+| `--audit <path>` | Path to audit JSON | `audit-results.json` |
 | `--file <path>` | Evaluate a single specific file (e.g. `src/source/content/drupal-s3.md`) | — |
 | `--older-than <n>m` | Staleness threshold (e.g. `6m`, `12m`, `24m`) | `12m` |
 | `--all` | When used with `--file`, evaluate regardless of staleness | off |
 
 ```bash
-cd scripts
-
 # Dry run — inspect proposed changes before opening PRs
 npm run evaluate -- --dry-run
 
@@ -110,6 +108,6 @@ npm run evaluate -- --dry-run --file src/source/content/jenkins.md --all
 npm run evaluate -- --dry-run --older-than 6m
 ```
 
-Env vars are loaded automatically from the repo root `.env` via `--env-file`. No `source` needed.
+Env vars are loaded automatically from the root `.env`. No `source` needed.
 
 Dry-run output lands in `scripts/dry-run/<doc-slug>.md` — one file per result, containing the PR title, description, and a unified diff of the proposed changes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -38,10 +38,25 @@ Run from the **repo root** via `npm run audit`.
 |---|---|
 | `--stale-only` | Output only stale files |
 | `--output <path>` | Write JSON to file instead of stdout |
+| `--images` | Run image scan instead of doc audit (see below) |
+| `--age <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
 
 ```bash
 # Generate audit results (required before running evaluate)
 npm run audit -- --stale-only --output audit-results.json
+```
+
+### Image scan
+
+Scans `src/source/images/` and flags images not updated in git within the threshold. Uses the last git commit date, not the filesystem mtime. Outputs a separate report — does not affect the main audit results or trigger PR creation.
+
+```bash
+# Scan for images not updated in the last 12 months (default)
+npm run audit -- --images --output image-audit.json
+
+# Use a different age threshold
+npm run audit -- --images --age 6m --output image-audit-6m.json
+npm run audit -- --images --age 24m --output image-audit-24m.json
 ```
 
 ---
@@ -53,6 +68,9 @@ Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for a
 - **Inline files** — only the stale sections are sent to Claude
 - **Frontmatter files** — the full document is sent
 - Each file gets its own draft PR; the 50 oldest stale files are processed per run
+- Files with an open `docs-audit/*` PR are skipped automatically, even if present in the audit JSON
+
+Claude may flag docs as candidates for **deprecation or removal** when the content is so outdated or ecosystem-changed that updating would be less useful than removing. This appears as a `⚠️ Deprecation consideration` section in the PR description — the final call is always with the human reviewer.
 
 Run from the **`scripts/`** directory.
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,80 @@
+# Docs Audit Scripts
+
+Tooling for identifying and resolving stale documentation using Claude on Vertex AI.
+
+## Local setup
+
+**Prerequisites:** Node.js 22+, `gh` CLI authenticated to `pantheon-systems`, a GCP service account JSON with Vertex AI access.
+
+**One-time install:**
+
+```bash
+cd scripts && npm install
+```
+
+**Create `scripts/.env`** (gitignored):
+
+```bash
+GOOGLE_CLOUD_PROJECT=your-gcp-project-id
+VERTEX_CREDENTIALS=/path/to/service-account.json
+VERTEX_REGION=global
+```
+
+---
+
+## Audit script
+
+Crawls `src/source/content/` and identifies stale docs using three mechanisms in priority order:
+
+1. **Inline `<ReviewDate>`** — per-section dates in files like `wordpress-known-issues.md`; flags sections older than 12 months
+2. **Frontmatter `reviewed:`** — flags files where the date is older than 12 months
+3. **Git fallback** — if no date can be determined, uses the last commit date for the file
+
+Run from the **repo root** via `npm run audit`.
+
+| Flag | Description |
+|---|---|
+| `--stale-only` | Output only stale files |
+| `--output <path>` | Write JSON to file instead of stdout |
+
+```bash
+# Generate audit results (required before running evaluate)
+npm run audit -- --stale-only --output audit-results.json
+```
+
+---
+
+## Evaluate script
+
+Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for accuracy evaluation, and opens a draft PR per file with proposed changes.
+
+- **Inline files** — only the stale sections are sent to Claude
+- **Frontmatter files** — the full document is sent
+- Each file gets its own draft PR; the 50 oldest stale files are processed per run
+
+Run from the **`scripts/`** directory with env vars sourced.
+
+| Flag | Description | Default |
+|---|---|---|
+| `--dry-run` | Evaluate with Claude, write results to `scripts/dry-run/` instead of opening PRs | off |
+| `--limit <n>` | Number of files to process | `50` |
+| `--audit <path>` | Path to audit JSON | `../audit-results.json` |
+
+```bash
+cd scripts
+source .env
+
+# Dry run — inspect proposed changes before opening PRs
+npx tsx evaluate.ts --dry-run
+
+# Dry run, smaller batch
+npx tsx evaluate.ts --dry-run --limit 10
+
+# Live run — opens one draft PR per file
+npx tsx evaluate.ts
+
+# Live run against a specific audit file
+npx tsx evaluate.ts --audit /path/to/audit-results.json --limit 20
+```
+
+Dry-run output lands in `scripts/dry-run/<doc-slug>.md` — one file per result, containing the PR title, description, and a unified diff of the proposed changes.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -36,16 +36,18 @@ Run from the **repo root** via `npm run audit`.
 
 Always writes to a file. Default output is `audit-results.json` in the repo root (or `image-audit-results.json` for `--images`).
 
+Outputs only stale files by default.
+
 | Flag | Description |
 |---|---|
-| `--stale-only` | Output only stale files |
+| `--all` | Include non-stale files in output |
 | `--output <path>` | Override the default output filename/path |
 | `--images` | Run image scan instead of doc audit (see below) |
 | `--age <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
 
 ```bash
 # Generate audit results — writes to audit-results.json automatically
-npm run audit -- --stale-only
+npm run audit
 ```
 
 ### Image scan

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -43,7 +43,7 @@ Outputs only stale files by default.
 | `--all` | Include non-stale files in output |
 | `--output <path>` | Override the default output filename/path |
 | `--images` | Run image scan instead of doc audit (see below) |
-| `--age <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
+| `--older-than <n>m` | Age threshold for image scan — e.g. `6m`, `12m`, `24m` (default: `12m`) |
 
 ```bash
 # Generate audit results — writes to audit-results.json automatically
@@ -59,8 +59,8 @@ Scans `src/source/images/` and flags images not updated in git within the thresh
 npm run audit -- --images
 
 # Use a different age threshold
-npm run audit -- --images --age 6m
-npm run audit -- --images --age 24m --output image-audit-24m.json
+npm run audit -- --images --older-than 6m
+npm run audit -- --images --older-than 24m --output image-audit-24m.json
 ```
 
 ---

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -12,7 +12,7 @@ Tooling for identifying and resolving stale documentation using Claude on Vertex
 cd scripts && npm install
 ```
 
-**Create `scripts/.env`** (gitignored):
+**Create `.env` in the repo root** (gitignored):
 
 ```bash
 GOOGLE_CLOUD_PROJECT=your-gcp-project-id
@@ -30,6 +30,8 @@ Crawls `src/source/content/` and identifies stale docs using three mechanisms in
 2. **Frontmatter `reviewed:`** — flags files where the date is older than 12 months
 3. **Git fallback** — if no date can be determined, uses the last commit date for the file
 
+Files that already have an open `docs-audit/*` PR are automatically excluded from results.
+
 Run from the **repo root** via `npm run audit`.
 
 | Flag | Description |
@@ -46,13 +48,13 @@ npm run audit -- --stale-only --output audit-results.json
 
 ## Evaluate script
 
-Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for accuracy evaluation, and opens a draft PR per file with proposed changes.
+Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for accuracy evaluation, and opens a draft PR per file with proposed changes. PRs are automatically labeled `automation: Claude 🤖`.
 
 - **Inline files** — only the stale sections are sent to Claude
 - **Frontmatter files** — the full document is sent
 - Each file gets its own draft PR; the 50 oldest stale files are processed per run
 
-Run from the **`scripts/`** directory with env vars sourced.
+Run from the **`scripts/`** directory.
 
 | Flag | Description | Default |
 |---|---|---|
@@ -62,19 +64,20 @@ Run from the **`scripts/`** directory with env vars sourced.
 
 ```bash
 cd scripts
-source .env
 
 # Dry run — inspect proposed changes before opening PRs
-npx tsx evaluate.ts --dry-run
+npm run evaluate -- --dry-run
 
 # Dry run, smaller batch
-npx tsx evaluate.ts --dry-run --limit 10
+npm run evaluate -- --dry-run --limit 10
 
 # Live run — opens one draft PR per file
-npx tsx evaluate.ts
+npm run evaluate
 
 # Live run against a specific audit file
-npx tsx evaluate.ts --audit /path/to/audit-results.json --limit 20
+npm run evaluate -- --audit /path/to/audit-results.json --limit 20
 ```
+
+Env vars are loaded automatically from the repo root `.env` via `--env-file`. No `source` needed.
 
 Dry-run output lands in `scripts/dry-run/<doc-slug>.md` — one file per result, containing the PR title, description, and a unified diff of the proposed changes.

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -22,6 +22,7 @@ interface InlineAuditResult {
   stale_sections: Section[];
   oldest_stale_date: string | null;
   oldest_stale_days_since_review: number | null;
+  related_issues: number[];
 }
 
 interface DateAuditResult {
@@ -29,6 +30,7 @@ interface DateAuditResult {
   staleness_source: "frontmatter" | "git";
   date: string;
   days_since_review: number;
+  related_issues: number[];
 }
 
 type AuditResult = InlineAuditResult | DateAuditResult;
@@ -123,10 +125,11 @@ function* walkFiles(dir: string): Generator<string> {
   }
 }
 
-function auditFile(filepath: string): AuditResult | null {
+function auditFile(filepath: string, issues: OpenIssue[]): AuditResult | null {
   const raw = readFileSync(filepath, "utf8");
   const { data: frontmatter, content } = matter(raw);
   const relPath = relative(process.cwd(), filepath);
+  const related_issues = relatedIssueNumbers(filepath, issues);
 
   const hasInline = /<ReviewDate date="[^"]+"\s*\/>/.test(content);
   const frontmatterDate = normalizeDateField(frontmatter.reviewed);
@@ -148,6 +151,7 @@ function auditFile(filepath: string): AuditResult | null {
       stale_sections: staleSections,
       oldest_stale_date: oldest?.date ?? null,
       oldest_stale_days_since_review: oldest?.days_since_review ?? null,
+      related_issues,
     };
   }
 
@@ -158,6 +162,7 @@ function auditFile(filepath: string): AuditResult | null {
       staleness_source: "frontmatter",
       date: frontmatterDate,
       days_since_review: days,
+      related_issues,
     };
   }
 
@@ -170,6 +175,7 @@ function auditFile(filepath: string): AuditResult | null {
     staleness_source: "git",
     date: gitDate,
     days_since_review: days,
+    related_issues,
   };
 }
 
@@ -177,6 +183,33 @@ function fileSlug(filepath: string): string {
   return basename(filepath, extname(filepath))
     .replace(/[^a-z0-9]+/gi, "-")
     .toLowerCase();
+}
+
+// ── Issue linking ─────────────────────────────────────────────────────────────
+
+interface OpenIssue { number: number; title: string; body: string; }
+
+let _issueCache: OpenIssue[] | null = null;
+
+function fetchOpenIssues(): OpenIssue[] {
+  if (_issueCache) return _issueCache;
+  try {
+    const out = execSync(
+      "gh issue list --repo pantheon-systems/documentation --state open --json number,title,body --limit 500",
+      { encoding: "utf8" }
+    );
+    _issueCache = JSON.parse(out) as OpenIssue[];
+  } catch {
+    _issueCache = [];
+  }
+  return _issueCache;
+}
+
+function relatedIssueNumbers(filepath: string, issues: OpenIssue[]): number[] {
+  const slug = fileSlug(filepath);
+  return issues
+    .filter((i) => (i.body ?? "").includes(slug) || (i.title ?? "").includes(slug))
+    .map((i) => i.number);
 }
 
 function getOpenPRSlugs(): Set<string> {
@@ -276,11 +309,16 @@ function main() {
     console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
   }
 
+  const openIssues = fetchOpenIssues();
+  if (openIssues.length > 0) {
+    console.error(`Loaded ${openIssues.length} open issues for cross-reference`);
+  }
+
   const results: AuditResult[] = [];
 
   for (const filepath of walkFiles(CONTENT_DIR)) {
     if (openPRSlugs.has(fileSlug(filepath))) continue;
-    const result = auditFile(filepath);
+    const result = auditFile(filepath, openIssues);
     if (!result) continue;
     if (onlyStale && !isStale(result)) continue;
     results.push(result);

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -10,7 +10,8 @@ interface Section {
   heading: string;
   date: string;
   days_since_review: number;
-  stale: boolean;
+  line_start: number;
+  line_end: number;
 }
 
 interface InlineAuditResult {
@@ -21,7 +22,6 @@ interface InlineAuditResult {
   stale_sections: Section[];
   oldest_stale_date: string | null;
   oldest_stale_days_since_review: number | null;
-  stale: boolean;
 }
 
 interface DateAuditResult {
@@ -29,7 +29,6 @@ interface DateAuditResult {
   staleness_source: "frontmatter" | "git";
   date: string;
   days_since_review: number;
-  stale: boolean;
 }
 
 type AuditResult = InlineAuditResult | DateAuditResult;
@@ -69,25 +68,47 @@ function parseInlineSections(content: string): Section[] {
 
     const date = match[1];
     let heading = "(unknown section)";
+    let headingIdx = -1;
+    let headingLevel = 0;
 
     for (let j = i - 1; j >= 0; j--) {
-      const headingMatch = lines[j].match(/^#{1,6}\s+(.+)/);
+      const headingMatch = lines[j].match(/^(#{1,6})\s+(.+)/);
       if (headingMatch) {
-        heading = headingMatch[1].trim();
+        heading = headingMatch[2].trim();
+        headingIdx = j;
+        headingLevel = headingMatch[1].length;
         break;
       }
     }
 
-    const days = daysSince(date);
+    // Find end of section: next heading at same or higher level
+    let endIdx = lines.length;
+    const searchFrom = headingIdx >= 0 ? headingIdx + 1 : i + 1;
+    for (let k = searchFrom; k < lines.length; k++) {
+      const nextHeading = lines[k].match(/^(#{1,6})\s+/);
+      if (nextHeading && nextHeading[1].length <= headingLevel) {
+        endIdx = k;
+        break;
+      }
+    }
+
     sections.push({
       heading,
       date,
-      days_since_review: days,
-      stale: days > STALE_THRESHOLD_DAYS,
+      days_since_review: daysSince(date),
+      line_start: (headingIdx >= 0 ? headingIdx : i) + 1, // 1-indexed
+      line_end: endIdx, // 1-indexed exclusive (points at first line of next section)
     });
   }
 
   return sections;
+}
+
+function isStale(result: AuditResult): boolean {
+  if (result.staleness_source === "inline") {
+    return result.stale_sections.length > 0;
+  }
+  return result.days_since_review > STALE_THRESHOLD_DAYS;
 }
 
 function* walkFiles(dir: string): Generator<string> {
@@ -113,7 +134,7 @@ function auditFile(filepath: string): AuditResult | null {
   if (hasInline) {
     const sections = parseInlineSections(content);
     const staleSections = sections
-      .filter((s) => s.stale)
+      .filter((s) => s.days_since_review > STALE_THRESHOLD_DAYS)
       .sort((a, b) => b.days_since_review - a.days_since_review);
     const oldest = staleSections.at(0) ?? null;
 
@@ -127,7 +148,6 @@ function auditFile(filepath: string): AuditResult | null {
       stale_sections: staleSections,
       oldest_stale_date: oldest?.date ?? null,
       oldest_stale_days_since_review: oldest?.days_since_review ?? null,
-      stale: staleSections.length > 0,
     };
   }
 
@@ -138,7 +158,6 @@ function auditFile(filepath: string): AuditResult | null {
       staleness_source: "frontmatter",
       date: frontmatterDate,
       days_since_review: days,
-      stale: days > STALE_THRESHOLD_DAYS,
     };
   }
 
@@ -151,7 +170,6 @@ function auditFile(filepath: string): AuditResult | null {
     staleness_source: "git",
     date: gitDate,
     days_since_review: days,
-    stale: days > STALE_THRESHOLD_DAYS,
   };
 }
 
@@ -166,11 +184,10 @@ function main() {
   for (const filepath of walkFiles(CONTENT_DIR)) {
     const result = auditFile(filepath);
     if (!result) continue;
-    if (onlyStale && !result.stale) continue;
+    if (onlyStale && !isStale(result)) continue;
     results.push(result);
   }
 
-  // Sort: inline files first (oldest stale section wins), then frontmatter/git by days desc
   results.sort((a, b) => {
     const aDays =
       a.staleness_source === "inline"
@@ -183,10 +200,12 @@ function main() {
     return bDays - aDays;
   });
 
+  const staleCount = results.filter(isStale).length;
+
   const summary = {
     generated_at: new Date().toISOString(),
     total_files_audited: results.length,
-    stale_count: results.filter((r) => r.stale).length,
+    stale_count: staleCount,
     by_source: {
       inline: results.filter((r) => r.staleness_source === "inline").length,
       frontmatter: results.filter((r) => r.staleness_source === "frontmatter")
@@ -199,9 +218,7 @@ function main() {
 
   if (outputFile) {
     writeFileSync(outputFile, output);
-    console.error(
-      `Wrote ${results.length} results (${summary.stale_count} stale) to ${outputFile}`
-    );
+    console.error(`Wrote ${results.length} results (${staleCount} stale) to ${outputFile}`);
   } else {
     console.log(output);
   }

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -250,12 +250,8 @@ function runImageScan(thresholdDays: number, outputFile: string | null): void {
 
   const output = JSON.stringify({ summary, results }, null, 2);
 
-  if (outputFile) {
-    writeFileSync(outputFile, output);
-    console.error(`Wrote ${results.length} potentially stale images to ${outputFile}`);
-  } else {
-    console.log(output);
-  }
+  writeFileSync(outputFile, output);
+  console.error(`Wrote ${results.length} potentially stale images to ${outputFile}`);
 }
 
 // ── Main ──────────────────────────────────────────────────────────────────────
@@ -263,10 +259,12 @@ function runImageScan(thresholdDays: number, outputFile: string | null): void {
 function main() {
   const args = process.argv.slice(2);
   const outputIndex = args.indexOf("--output");
-  const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : null;
+  const isImages = args.includes("--images");
+  const defaultOutput = isImages ? "image-audit-results.json" : "audit-results.json";
+  const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : defaultOutput;
   const onlyStale = args.includes("--stale-only");
 
-  if (args.includes("--images")) {
+  if (isImages) {
     const ageArg = args.find((a, i) => args[i - 1] === "--age") ?? "12m";
     const thresholdDays = parseAgeDays(ageArg);
     runImageScan(thresholdDays, outputFile);
@@ -316,12 +314,8 @@ function main() {
 
   const output = JSON.stringify({ summary, results }, null, 2);
 
-  if (outputFile) {
-    writeFileSync(outputFile, output);
-    console.error(`Wrote ${results.length} results (${staleCount} stale) to ${outputFile}`);
-  } else {
-    console.log(output);
-  }
+  writeFileSync(outputFile, output);
+  console.error(`Wrote ${results.length} results (${staleCount} stale) to ${outputFile}`);
 }
 
 main();

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -209,7 +209,7 @@ interface ImageAuditResult {
 
 function parseAgeDays(ageStr: string): number {
   const m = ageStr.match(/^(\d+)m$/);
-  if (!m) throw new Error(`Invalid --age format "${ageStr}" — use e.g. 12m, 6m, 3m, 24m`);
+  if (!m) throw new Error(`Invalid --older-than format "${ageStr}" — use e.g. 12m, 6m, 3m, 24m`);
   return parseInt(m[1], 10) * 30;
 }
 
@@ -265,7 +265,7 @@ function main() {
   const onlyStale = !args.includes("--all");
 
   if (isImages) {
-    const ageArg = args.find((a, i) => args[i - 1] === "--age") ?? "12m";
+    const ageArg = args.find((a, i) => args[i - 1] === "--older-than") ?? "12m";
     const thresholdDays = parseAgeDays(ageArg);
     runImageScan(thresholdDays, outputFile);
     return;

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -207,11 +207,30 @@ function fetchOpenIssues(): OpenIssue[] {
   return _issueCache;
 }
 
+function fetchInReviewIssues(): OpenIssue[] {
+  try {
+    const out = execSync(
+      'gh issue list --repo pantheon-systems/documentation --state open --label "Process: In Review" --json number,title,body --limit 500',
+      { encoding: "utf8" }
+    );
+    return JSON.parse(out) as OpenIssue[];
+  } catch {
+    return [];
+  }
+}
+
 function relatedIssueNumbers(filepath: string, issues: OpenIssue[]): number[] {
   const slug = fileSlug(filepath);
   return issues
     .filter((i) => (i.body ?? "").includes(slug) || (i.title ?? "").includes(slug))
     .map((i) => i.number);
+}
+
+function isInReview(filepath: string, inReviewIssues: OpenIssue[]): boolean {
+  const slug = fileSlug(filepath);
+  return inReviewIssues.some(
+    (i) => (i.body ?? "").includes(slug) || (i.title ?? "").includes(slug)
+  );
 }
 
 function getOpenPRSlugs(): Set<string> {

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -337,10 +337,16 @@ function main() {
     console.error(`Loaded ${openIssues.length} open issues for cross-reference`);
   }
 
+  const inReviewIssues = fetchInReviewIssues();
+  if (inReviewIssues.length > 0) {
+    console.error(`Found ${inReviewIssues.length} issue(s) with "Process: In Review" label — matching files will be excluded`);
+  }
+
   const results: AuditResult[] = [];
 
   for (const filepath of walkFiles(CONTENT_DIR)) {
     if (openPRSlugs.has(fileSlug(filepath))) continue;
+    if (isInReview(filepath, inReviewIssues)) continue;
     const result = auditFile(filepath, openIssues);
     if (!result) continue;
     if (onlyStale && !isStale(result)) continue;

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -262,7 +262,7 @@ function main() {
   const isImages = args.includes("--images");
   const defaultOutput = isImages ? "image-audit-results.json" : "audit-results.json";
   const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : defaultOutput;
-  const onlyStale = args.includes("--stale-only");
+  const onlyStale = !args.includes("--all");
 
   if (isImages) {
     const ageArg = args.find((a, i) => args[i - 1] === "--age") ?? "12m";

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,4 +1,4 @@
-import { execSync } from "child_process";
+import { execSync, execFileSync } from "child_process";
 import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
 import { join, relative, basename, extname } from "path";
 import matter from "gray-matter";
@@ -48,10 +48,10 @@ function normalizeDateField(val: unknown): string | null {
 
 function getGitDate(filepath: string): string | null {
   try {
-    const result = execSync(`git log -1 --format="%ai" -- "${filepath}"`, {
-      encoding: "utf8",
-      cwd: process.cwd(),
-    }).trim();
+    const result = execFileSync(
+      "git", ["log", "-1", '--format="%ai"', "--", filepath],
+      { encoding: "utf8", cwd: process.cwd() }
+    ).trim();
     return result || null;
   } catch {
     return null;

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -49,7 +49,7 @@ function normalizeDateField(val: unknown): string | null {
 function getGitDate(filepath: string): string | null {
   try {
     const result = execFileSync(
-      "git", ["log", "-1", '--format="%ai"', "--", filepath],
+      "git", ["log", "-1", "--format=%ai", "--", filepath],
       { encoding: "utf8", cwd: process.cwd() }
     ).trim();
     return result || null;
@@ -198,11 +198,80 @@ function getOpenPRSlugs(): Set<string> {
   }
 }
 
+// ── Image scan ────────────────────────────────────────────────────────────────
+
+const IMAGES_DIR = join(process.cwd(), "src/source/images");
+
+interface ImageAuditResult {
+  file: string;
+  days_since_modified: number;
+}
+
+function parseAgeDays(ageStr: string): number {
+  const m = ageStr.match(/^(\d+)m$/);
+  if (!m) throw new Error(`Invalid --age format "${ageStr}" — use e.g. 12m, 6m, 3m, 24m`);
+  return parseInt(m[1], 10) * 30;
+}
+
+function* walkImageFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      yield* walkImageFiles(fullPath);
+    } else if (/\.(png|jpe?g|gif|svg|webp|avif)$/i.test(entry)) {
+      yield fullPath;
+    }
+  }
+}
+
+function runImageScan(thresholdDays: number, outputFile: string | null): void {
+  const results: ImageAuditResult[] = [];
+
+  for (const filepath of walkImageFiles(IMAGES_DIR)) {
+    const gitDate = getGitDate(filepath);
+    if (!gitDate) continue;
+    const days = daysSince(gitDate);
+    if (days > thresholdDays) {
+      results.push({
+        file: relative(process.cwd(), filepath),
+        days_since_modified: days,
+      });
+    }
+  }
+
+  results.sort((a, b) => b.days_since_modified - a.days_since_modified);
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    threshold_days: thresholdDays,
+    stale_image_count: results.length,
+  };
+
+  const output = JSON.stringify({ summary, results }, null, 2);
+
+  if (outputFile) {
+    writeFileSync(outputFile, output);
+    console.error(`Wrote ${results.length} potentially stale images to ${outputFile}`);
+  } else {
+    console.log(output);
+  }
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
 function main() {
   const args = process.argv.slice(2);
   const outputIndex = args.indexOf("--output");
   const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : null;
   const onlyStale = args.includes("--stale-only");
+
+  if (args.includes("--images")) {
+    const ageArg = args.find((a, i) => args[i - 1] === "--age") ?? "12m";
+    const thresholdDays = parseAgeDays(ageArg);
+    runImageScan(thresholdDays, outputFile);
+    return;
+  }
 
   const openPRSlugs = getOpenPRSlugs();
   if (openPRSlugs.size > 0) {

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,0 +1,210 @@
+import { execSync } from "child_process";
+import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
+import { join, relative } from "path";
+import matter from "gray-matter";
+
+const CONTENT_DIR = join(process.cwd(), "src/source/content");
+const STALE_THRESHOLD_DAYS = 365;
+
+interface Section {
+  heading: string;
+  date: string;
+  days_since_review: number;
+  stale: boolean;
+}
+
+interface InlineAuditResult {
+  file: string;
+  staleness_source: "inline";
+  frontmatter_date: string | null;
+  frontmatter_days_since_review: number | null;
+  stale_sections: Section[];
+  oldest_stale_date: string | null;
+  oldest_stale_days_since_review: number | null;
+  stale: boolean;
+}
+
+interface DateAuditResult {
+  file: string;
+  staleness_source: "frontmatter" | "git";
+  date: string;
+  days_since_review: number;
+  stale: boolean;
+}
+
+type AuditResult = InlineAuditResult | DateAuditResult;
+
+function daysSince(dateStr: string): number {
+  const date = new Date(dateStr);
+  const now = new Date();
+  return Math.floor((now.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function normalizeDateField(val: unknown): string | null {
+  if (!val) return null;
+  if (val instanceof Date) return val.toISOString().slice(0, 10);
+  if (typeof val === "string" && val.trim() !== "") return val.trim();
+  return null;
+}
+
+function getGitDate(filepath: string): string | null {
+  try {
+    const result = execSync(`git log -1 --format="%ai" -- "${filepath}"`, {
+      encoding: "utf8",
+      cwd: process.cwd(),
+    }).trim();
+    return result || null;
+  } catch {
+    return null;
+  }
+}
+
+function parseInlineSections(content: string): Section[] {
+  const lines = content.split("\n");
+  const sections: Section[] = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const match = lines[i].match(/<ReviewDate date="([^"]+)"\s*\/>/);
+    if (!match) continue;
+
+    const date = match[1];
+    let heading = "(unknown section)";
+
+    for (let j = i - 1; j >= 0; j--) {
+      const headingMatch = lines[j].match(/^#{1,6}\s+(.+)/);
+      if (headingMatch) {
+        heading = headingMatch[1].trim();
+        break;
+      }
+    }
+
+    const days = daysSince(date);
+    sections.push({
+      heading,
+      date,
+      days_since_review: days,
+      stale: days > STALE_THRESHOLD_DAYS,
+    });
+  }
+
+  return sections;
+}
+
+function* walkFiles(dir: string): Generator<string> {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    const stat = statSync(fullPath);
+    if (stat.isDirectory()) {
+      yield* walkFiles(fullPath);
+    } else if (entry.endsWith(".md")) {
+      yield fullPath;
+    }
+  }
+}
+
+function auditFile(filepath: string): AuditResult | null {
+  const raw = readFileSync(filepath, "utf8");
+  const { data: frontmatter, content } = matter(raw);
+  const relPath = relative(process.cwd(), filepath);
+
+  const hasInline = /<ReviewDate date="[^"]+"\s*\/>/.test(content);
+  const frontmatterDate = normalizeDateField(frontmatter.reviewed);
+
+  if (hasInline) {
+    const sections = parseInlineSections(content);
+    const staleSections = sections
+      .filter((s) => s.stale)
+      .sort((a, b) => b.days_since_review - a.days_since_review);
+    const oldest = staleSections.at(0) ?? null;
+
+    return {
+      file: relPath,
+      staleness_source: "inline",
+      frontmatter_date: frontmatterDate,
+      frontmatter_days_since_review: frontmatterDate
+        ? daysSince(frontmatterDate)
+        : null,
+      stale_sections: staleSections,
+      oldest_stale_date: oldest?.date ?? null,
+      oldest_stale_days_since_review: oldest?.days_since_review ?? null,
+      stale: staleSections.length > 0,
+    };
+  }
+
+  if (frontmatterDate) {
+    const days = daysSince(frontmatterDate);
+    return {
+      file: relPath,
+      staleness_source: "frontmatter",
+      date: frontmatterDate,
+      days_since_review: days,
+      stale: days > STALE_THRESHOLD_DAYS,
+    };
+  }
+
+  const gitDate = getGitDate(filepath);
+  if (!gitDate) return null;
+
+  const days = daysSince(gitDate);
+  return {
+    file: relPath,
+    staleness_source: "git",
+    date: gitDate,
+    days_since_review: days,
+    stale: days > STALE_THRESHOLD_DAYS,
+  };
+}
+
+function main() {
+  const args = process.argv.slice(2);
+  const outputIndex = args.indexOf("--output");
+  const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : null;
+  const onlyStale = args.includes("--stale-only");
+
+  const results: AuditResult[] = [];
+
+  for (const filepath of walkFiles(CONTENT_DIR)) {
+    const result = auditFile(filepath);
+    if (!result) continue;
+    if (onlyStale && !result.stale) continue;
+    results.push(result);
+  }
+
+  // Sort: inline files first (oldest stale section wins), then frontmatter/git by days desc
+  results.sort((a, b) => {
+    const aDays =
+      a.staleness_source === "inline"
+        ? (a.oldest_stale_days_since_review ?? 0)
+        : a.days_since_review;
+    const bDays =
+      b.staleness_source === "inline"
+        ? (b.oldest_stale_days_since_review ?? 0)
+        : b.days_since_review;
+    return bDays - aDays;
+  });
+
+  const summary = {
+    generated_at: new Date().toISOString(),
+    total_files_audited: results.length,
+    stale_count: results.filter((r) => r.stale).length,
+    by_source: {
+      inline: results.filter((r) => r.staleness_source === "inline").length,
+      frontmatter: results.filter((r) => r.staleness_source === "frontmatter")
+        .length,
+      git: results.filter((r) => r.staleness_source === "git").length,
+    },
+  };
+
+  const output = JSON.stringify({ summary, results }, null, 2);
+
+  if (outputFile) {
+    writeFileSync(outputFile, output);
+    console.error(
+      `Wrote ${results.length} results (${summary.stale_count} stale) to ${outputFile}`
+    );
+  } else {
+    console.log(output);
+  }
+}
+
+main();

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,9 +1,11 @@
 import { execSync, execFileSync } from "child_process";
 import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { join, relative, basename, extname } from "path";
+import { join, relative, basename, extname, dirname } from "path";
+import { fileURLToPath } from "url";
 import matter from "gray-matter";
 
-const CONTENT_DIR = join(process.cwd(), "src/source/content");
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+const CONTENT_DIR = join(REPO_ROOT, "src/source/content");
 const STALE_THRESHOLD_DAYS = 365;
 
 interface Section {
@@ -52,7 +54,7 @@ function getGitDate(filepath: string): string | null {
   try {
     const result = execFileSync(
       "git", ["log", "-1", "--format=%ai", "--", filepath],
-      { encoding: "utf8", cwd: process.cwd() }
+      { encoding: "utf8", cwd: REPO_ROOT }
     ).trim();
     return result || null;
   } catch {
@@ -128,7 +130,7 @@ function* walkFiles(dir: string): Generator<string> {
 function auditFile(filepath: string, issues: OpenIssue[]): AuditResult | null {
   const raw = readFileSync(filepath, "utf8");
   const { data: frontmatter, content } = matter(raw);
-  const relPath = relative(process.cwd(), filepath);
+  const relPath = relative(REPO_ROOT, filepath);
   const related_issues = relatedIssueNumbers(filepath, issues);
 
   const hasInline = /<ReviewDate date="[^"]+"\s*\/>/.test(content);
@@ -233,7 +235,7 @@ function getOpenPRSlugs(): Set<string> {
 
 // ── Image scan ────────────────────────────────────────────────────────────────
 
-const IMAGES_DIR = join(process.cwd(), "src/source/images");
+const IMAGES_DIR = join(REPO_ROOT, "src/source/images");
 
 interface ImageAuditResult {
   file: string;
@@ -267,7 +269,7 @@ function runImageScan(thresholdDays: number, outputFile: string | null): void {
     const days = daysSince(gitDate);
     if (days > thresholdDays) {
       results.push({
-        file: relative(process.cwd(), filepath),
+        file: relative(REPO_ROOT, filepath),
         days_since_modified: days,
       });
     }
@@ -293,7 +295,9 @@ function main() {
   const args = process.argv.slice(2);
   const outputIndex = args.indexOf("--output");
   const isImages = args.includes("--images");
-  const defaultOutput = isImages ? "image-audit-results.json" : "audit-results.json";
+  const defaultOutput = isImages
+    ? join(REPO_ROOT, "image-audit-results.json")
+    : join(REPO_ROOT, "audit-results.json");
   const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : defaultOutput;
   const onlyStale = !args.includes("--all");
 

--- a/scripts/audit.ts
+++ b/scripts/audit.ts
@@ -1,6 +1,6 @@
 import { execSync } from "child_process";
 import { readFileSync, readdirSync, statSync, writeFileSync } from "fs";
-import { join, relative } from "path";
+import { join, relative, basename, extname } from "path";
 import matter from "gray-matter";
 
 const CONTENT_DIR = join(process.cwd(), "src/source/content");
@@ -173,15 +173,46 @@ function auditFile(filepath: string): AuditResult | null {
   };
 }
 
+function fileSlug(filepath: string): string {
+  return basename(filepath, extname(filepath))
+    .replace(/[^a-z0-9]+/gi, "-")
+    .toLowerCase();
+}
+
+function getOpenPRSlugs(): Set<string> {
+  try {
+    const output = execSync(
+      "gh pr list --repo pantheon-systems/documentation --state open --json headRefName --limit 200",
+      { encoding: "utf8" }
+    );
+    const prs = JSON.parse(output) as Array<{ headRefName: string }>;
+    const slugs = new Set<string>();
+    for (const pr of prs) {
+      const match = pr.headRefName.match(/^docs-audit\/\d{4}-\d{2}-\d{2}-(.+)$/);
+      if (match) slugs.add(match[1]);
+    }
+    return slugs;
+  } catch {
+    // gh unavailable or unauthenticated — skip filtering
+    return new Set();
+  }
+}
+
 function main() {
   const args = process.argv.slice(2);
   const outputIndex = args.indexOf("--output");
   const outputFile = outputIndex !== -1 ? args[outputIndex + 1] : null;
   const onlyStale = args.includes("--stale-only");
 
+  const openPRSlugs = getOpenPRSlugs();
+  if (openPRSlugs.size > 0) {
+    console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
+  }
+
   const results: AuditResult[] = [];
 
   for (const filepath of walkFiles(CONTENT_DIR)) {
+    if (openPRSlugs.has(fileSlug(filepath))) continue;
     const result = auditFile(filepath);
     if (!result) continue;
     if (onlyStale && !isStale(result)) continue;

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -305,8 +305,8 @@ async function classifyIssues(
   const issues: { number: number; title: string; body: string }[] = [];
   for (const num of issueNumbers) {
     try {
-      const out = execSync(
-        `gh issue view ${num} --repo ${REPO} --json number,title,body`,
+      const out = execFileSync(
+        "gh", ["issue", "view", String(num), "--repo", REPO, "--json", "number,title,body"],
         { encoding: "utf8" }
       );
       issues.push(JSON.parse(out));
@@ -361,8 +361,8 @@ function parseOlderThanDays(arg: string): number {
 function fetchRelatedIssuesForFile(relPath: string): number[] {
   const slug = slugifyPath(relPath);
   try {
-    const out = execSync(
-      `gh issue list --repo ${REPO} --state open --search ${JSON.stringify(slug)} --json number --limit 20`,
+    const out = execFileSync(
+      "gh", ["issue", "list", "--repo", REPO, "--state", "open", "--search", slug, "--json", "number", "--limit", "20"],
       { encoding: "utf8" }
     );
     return (JSON.parse(out) as Array<{ number: number }>).map((i) => i.number);
@@ -374,8 +374,8 @@ function fetchRelatedIssuesForFile(relPath: string): number[] {
 function fileIsInReview(relPath: string): boolean {
   const slug = slugifyPath(relPath);
   try {
-    const out = execSync(
-      `gh issue list --repo ${REPO} --state open --label "Process: In Review" --search ${JSON.stringify(slug)} --json number --limit 1`,
+    const out = execFileSync(
+      "gh", ["issue", "list", "--repo", REPO, "--state", "open", "--label", "Process: In Review", "--search", slug, "--json", "number", "--limit", "1"],
       { encoding: "utf8" }
     );
     return (JSON.parse(out) as Array<{ number: number }>).length > 0;

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -156,7 +156,7 @@ HARD RULES — violating these will break the documentation site:
 For bump_date: the changes array MUST be empty []. Dates are applied programmatically.
 For update_content: return only the specific lines that need to change, not unchanged surrounding lines.
 
-Your training cutoff is August 2025. When evaluating content about third-party plugin versions, security advisories, or external service behavior that may have changed after that date, flag confidence: "low".
+When evaluating content about third-party plugin versions, security advisories, or external service behavior that may have changed after your last training update, flag confidence: "low".
 
 If the document is a strong candidate for deprecation, archiving, or removal — because the underlying product no longer exists, the ecosystem has changed so fundamentally that updating would be misleading, or the content is so outdated it would be less effort to remove than fix — populate the deprecation_note field. This is especially relevant for low-confidence items. The final decision rests with human reviewers; your role is to surface the possibility.`;
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -371,6 +371,19 @@ function fetchRelatedIssuesForFile(relPath: string): number[] {
   }
 }
 
+function fileIsInReview(relPath: string): boolean {
+  const slug = slugifyPath(relPath);
+  try {
+    const out = execSync(
+      `gh issue list --repo ${REPO} --state open --label "Process: In Review" --search ${JSON.stringify(slug)} --json number --limit 1`,
+      { encoding: "utf8" }
+    );
+    return (JSON.parse(out) as Array<{ number: number }>).length > 0;
+  } catch {
+    return false;
+  }
+}
+
 function buildAuditResultForFile(relPath: string): AuditResult {
   const filePath = safeRepoPath(relPath);
   const raw = readFileSync(filePath, "utf8");
@@ -780,6 +793,10 @@ async function main() {
 
   // ── Single-file mode ────────────────────────────────────────────────────────
   if (fileArg) {
+    if (fileIsInReview(fileArg)) {
+      console.error(`Warning: ${fileArg} has an open issue labeled "Process: In Review" — skipping.`);
+      return;
+    }
     const result = buildAuditResultForFile(fileArg);
     if (!includeAll && !fileIsStale(result, thresholdDays)) {
       console.error(`No changes needed — ${fileArg} is not stale.`);

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -314,12 +314,12 @@ function generateDiff(original: string, updated: string, label: string): string 
   writeFileSync(orig, original);
   writeFileSync(upd, updated);
   try {
-    // diff exits 1 when files differ — that's expected, not an error
-    return execSync(`diff -u --label "a/${label}" --label "b/${label}" "${orig}" "${upd}"`, {
-      encoding: "utf8",
-      stdio: "pipe",
-      maxBuffer: 10 * 1024 * 1024, // 10MB — well above any realistic doc diff
-    });
+    // diff exits 1 when files differ — expected, not an error
+    return execFileSync(
+      "diff",
+      ["-u", "--label", `a/${label}`, "--label", `b/${label}`, orig, upd],
+      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 }
+    );
   } catch (err: any) {
     return err.stdout ?? "";
   } finally {
@@ -367,24 +367,21 @@ function createBranchAndPR(
   const slug = slugifyPath(result.file);
   const branchName = `docs-audit/${TODAY}-${slug}`;
   const { title, body } = buildPRContent(result, review);
-  const tmpBody = join(tmpdir(), `pr-body-${Date.now()}.md`);
+  const tmpBody = tmp.fileSync({ prefix: "pr-body-", postfix: ".md", discardDescriptor: true }).name;
 
   try {
     writeFileSync(tmpBody, body, "utf8");
 
-    execSync(`git checkout -b "${branchName}" ${REMOTE}/main 2>/dev/null`, {
-      stdio: "pipe",
-    });
+    execFileSync("git", ["checkout", "-b", branchName, `${REMOTE}/main`], { stdio: "pipe" });
 
     writeFileSync(filePath, updatedContent, "utf8");
-    execSync(`git add "${filePath}"`, { stdio: "pipe" });
-    execSync(`git commit -m "${title}"`, { stdio: "pipe" });
-    execSync(`git push ${REMOTE} "${branchName}" 2>/dev/null`, {
-      stdio: "pipe",
-    });
+    execFileSync("git", ["add", filePath], { stdio: "pipe" });
+    execFileSync("git", ["commit", "-m", title], { stdio: "pipe" });
+    execFileSync("git", ["push", REMOTE, branchName], { stdio: "pipe" });
 
-    execSync(
-      `gh pr create --repo ${REPO} --head "${branchName}" --base main --title "${title}" --body-file "${tmpBody}" --draft`,
+    execFileSync(
+      "gh",
+      ["pr", "create", "--repo", REPO, "--head", branchName, "--base", "main", "--title", title, "--body-file", tmpBody, "--draft"],
       { stdio: "inherit" }
     );
 
@@ -393,7 +390,7 @@ function createBranchAndPR(
     console.error(`  ✗ Failed for ${result.file}:`, (err as Error).message);
   } finally {
     try { unlinkSync(tmpBody); } catch {}
-    execSync(`git checkout "${originalBranch}" 2>/dev/null`, { stdio: "pipe" });
+    execFileSync("git", ["checkout", originalBranch], { stdio: "pipe" });
   }
 }
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -218,6 +218,16 @@ function slugifyPath(filePath: string): string {
     .toLowerCase();
 }
 
+const REPO_ROOT = join(process.cwd(), "..");
+
+function safeRepoPath(relativePath: string): string {
+  const resolved = join(REPO_ROOT, relativePath);
+  if (!resolved.startsWith(REPO_ROOT + "/")) {
+    throw new Error(`Path traversal rejected: ${relativePath}`);
+  }
+  return resolved;
+}
+
 function getCurrentBranch(): string {
   return execSync("git rev-parse --abbrev-ref HEAD", {
     encoding: "utf8",
@@ -260,7 +270,7 @@ function buildPRContent(
   result: AuditResult,
   review: ReviewToolInput
 ): { title: string; body: string } {
-  const filePath = join(process.cwd(), "..", result.file);
+  const filePath = safeRepoPath(result.file);
   const { title: docTitle, url } = docMetadata(filePath);
 
   const reviewDate =
@@ -363,7 +373,7 @@ function createBranchAndPR(
   review: ReviewToolInput,
   originalBranch: string
 ): void {
-  const filePath = join(process.cwd(), "..", result.file);
+  const filePath = safeRepoPath(result.file);
   const slug = slugifyPath(result.file);
   const branchName = `docs-audit/${TODAY}-${slug}`;
   const { title, body } = buildPRContent(result, review);
@@ -401,7 +411,7 @@ async function evaluateFile(
   result: AuditResult
 ): Promise<ReviewToolInput | null> {
   // Path relative to scripts/ parent (the repo root)
-  const filePath = join(process.cwd(), "..", result.file);
+  const filePath = safeRepoPath(result.file);
   const raw = readFileSync(filePath, "utf8");
 
   let userContent: string;
@@ -529,7 +539,7 @@ async function main() {
     );
     console.error(`  ${review.reason.slice(0, 120)}`);
 
-    const filePath = join(process.cwd(), "..", result.file);
+    const filePath = safeRepoPath(result.file);
     const raw = readFileSync(filePath, "utf8");
     const updated = applyReview(raw, result, review);
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -10,7 +10,7 @@ const TODAY = new Date().toISOString().slice(0, 10);
 const BATCH_SIZE = 50;
 const MODEL = "claude-sonnet-4-6";
 const REPO = "pantheon-systems/documentation";
-const REMOTE = "pantheon";
+const REMOTE = process.env.GIT_REMOTE ?? "origin";
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -258,6 +258,95 @@ function safeRepoPath(relativePath: string): string {
   return resolved;
 }
 
+function parseOlderThanDays(arg: string): number {
+  const m = arg.match(/^(\d+)m$/);
+  if (!m) throw new Error(`Invalid --older-than format "${arg}" — use e.g. 12m, 6m, 24m`);
+  return parseInt(m[1], 10) * 30;
+}
+
+function buildAuditResultForFile(relPath: string): AuditResult {
+  const filePath = safeRepoPath(relPath);
+  const raw = readFileSync(filePath, "utf8");
+  const { data: frontmatter, content } = matter(raw);
+
+  const hasInline = /<ReviewDate date="[^"]+"\s*\/>/.test(content);
+
+  if (hasInline) {
+    const lines = content.split("\n");
+    const sections: StaleSection[] = [];
+
+    for (let i = 0; i < lines.length; i++) {
+      const match = lines[i].match(/<ReviewDate date="([^"]+)"\s*\/>/);
+      if (!match) continue;
+
+      const date = match[1];
+      let heading = "(unknown section)";
+      let headingIdx = -1;
+      let headingLevel = 0;
+
+      for (let j = i - 1; j >= 0; j--) {
+        const m = lines[j].match(/^(#{1,6})\s+(.+)/);
+        if (m) { heading = m[2].trim(); headingIdx = j; headingLevel = m[1].length; break; }
+      }
+
+      let endIdx = lines.length;
+      for (let k = (headingIdx >= 0 ? headingIdx : i) + 1; k < lines.length; k++) {
+        const m = lines[k].match(/^(#{1,6})\s+/);
+        if (m && m[1].length <= headingLevel) { endIdx = k; break; }
+      }
+
+      sections.push({
+        heading,
+        date,
+        days_since_review: Math.floor((Date.now() - new Date(date).getTime()) / 86400000),
+        line_start: (headingIdx >= 0 ? headingIdx : i) + 1,
+        line_end: endIdx,
+      });
+    }
+
+    const reviewed = frontmatter.reviewed;
+    const frontmatterDate = reviewed instanceof Date
+      ? reviewed.toISOString().slice(0, 10)
+      : typeof reviewed === "string" && reviewed.trim() ? reviewed.trim() : null;
+
+    const oldest = [...sections].sort((a, b) => b.days_since_review - a.days_since_review)[0];
+
+    return {
+      file: relPath,
+      staleness_source: "inline",
+      frontmatter_date: frontmatterDate,
+      frontmatter_days_since_review: frontmatterDate
+        ? Math.floor((Date.now() - new Date(frontmatterDate).getTime()) / 86400000)
+        : null,
+      stale_sections: sections,
+      oldest_stale_days_since_review: oldest?.days_since_review ?? null,
+    };
+  }
+
+  const reviewed = frontmatter.reviewed;
+  const date = reviewed instanceof Date
+    ? reviewed.toISOString().slice(0, 10)
+    : typeof reviewed === "string" && reviewed.trim()
+      ? reviewed.trim()
+      : null;
+
+  return {
+    file: relPath,
+    staleness_source: date ? "frontmatter" : "git",
+    date: date ?? TODAY,
+    days_since_review: date
+      ? Math.floor((Date.now() - new Date(date).getTime()) / 86400000)
+      : 0,
+  };
+}
+
+function fileIsStale(result: AuditResult, thresholdDays: number): boolean {
+  if (result.staleness_source === "inline") {
+    return result.stale_sections.some((s) => s.days_since_review > thresholdDays);
+  }
+  return result.days_since_review > thresholdDays;
+}
+
 function getCurrentBranch(): string {
   return execSync("git rev-parse --abbrev-ref HEAD", {
     encoding: "utf8",
@@ -520,6 +609,10 @@ async function main() {
   const auditFile =
     args.find((a, i) => args[i - 1] === "--audit") ?? "../audit-results.json";
   const dryRun = args.includes("--dry-run");
+  const includeAll = args.includes("--all");
+  const fileArg = args.find((a, i) => args[i - 1] === "--file");
+  const olderThanArg = args.find((a, i) => args[i - 1] === "--older-than");
+  const thresholdDays = olderThanArg ? parseOlderThanDays(olderThanArg) : 365;
   const limit = parseInt(
     args.find((a, i) => args[i - 1] === "--limit") ?? String(BATCH_SIZE),
     10
@@ -539,28 +632,6 @@ async function main() {
 
   const originalBranch = getCurrentBranch();
 
-  const openPRSlugs = getOpenPRSlugs();
-  if (openPRSlugs.size > 0) {
-    console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
-  }
-
-  const audit = JSON.parse(readFileSync(auditFile, "utf8"));
-  const toProcess: AuditResult[] = (audit.results as AuditResult[])
-    .filter((r) =>
-      r.staleness_source === "inline"
-        ? r.stale_sections.length > 0
-        : r.days_since_review > 365
-    )
-    .filter((r) => !openPRSlugs.has(slugifyPath(r.file)))
-    .sort((a, b) => staleDaysFor(b) - staleDaysFor(a))
-    .slice(0, limit);
-
-  console.error(
-    `\nProcessing ${toProcess.length} files (dry-run: ${dryRun})\n`
-  );
-
-  // VERTEX_CREDENTIALS lets you point at a specific service account key without
-  // overriding your global GOOGLE_APPLICATION_CREDENTIALS.
   const googleAuth = process.env.VERTEX_CREDENTIALS
     ? new GoogleAuth({
         keyFile: process.env.VERTEX_CREDENTIALS,
@@ -574,6 +645,46 @@ async function main() {
     ...(googleAuth ? { googleAuth } : {}),
   });
 
+  // ── Single-file mode ────────────────────────────────────────────────────────
+  if (fileArg) {
+    const result = buildAuditResultForFile(fileArg);
+    if (!includeAll && !fileIsStale(result, thresholdDays)) {
+      console.error(`No changes needed — ${fileArg} is not stale.`);
+      return;
+    }
+    console.error(`→ ${fileArg} [single-file mode]`);
+    const review = await evaluateFile(client, result);
+    if (!review) return;
+    console.error(`  action=${review.action}  confidence=${review.confidence}`);
+    const raw = readFileSync(safeRepoPath(fileArg), "utf8");
+    const updated = applyReview(raw, result, review);
+    if (dryRun) { writeDryRunFile(result, review, raw, updated); }
+    else { createBranchAndPR(result, updated, review, originalBranch); }
+    return;
+  }
+
+  const openPRSlugs = getOpenPRSlugs();
+  if (openPRSlugs.size > 0) {
+    console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
+  }
+
+  const audit = JSON.parse(readFileSync(auditFile, "utf8"));
+  const toProcess: AuditResult[] = (audit.results as AuditResult[])
+    .filter((r) =>
+      r.staleness_source === "inline"
+        ? r.stale_sections.length > 0
+        : r.days_since_review > thresholdDays
+    )
+    .filter((r) => !openPRSlugs.has(slugifyPath(r.file)))
+    .sort((a, b) => staleDaysFor(b) - staleDaysFor(a))
+    .slice(0, limit);
+
+  console.error(
+    `\nProcessing ${toProcess.length} files (dry-run: ${dryRun})\n`
+  );
+
+  // VERTEX_CREDENTIALS lets you point at a specific service account key without
+  // overriding your global GOOGLE_APPLICATION_CREDENTIALS.
   for (const result of toProcess) {
     console.error(`→ ${result.file} [${staleDaysFor(result)}d stale]`);
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,10 +1,10 @@
 import { execSync, execFileSync } from "child_process";
 import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { join, basename, extname } from "path";
-import { tmpdir } from "os";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { GoogleAuth } from "google-auth-library";
 import matter from "gray-matter";
+import tmp from "tmp";
 
 const TODAY = new Date().toISOString().slice(0, 10);
 const BATCH_SIZE = 50;
@@ -309,8 +309,8 @@ function applyReview(
 }
 
 function generateDiff(original: string, updated: string, label: string): string {
-  const orig = join(tmpdir(), `audit-orig-${Date.now()}`);
-  const upd = join(tmpdir(), `audit-upd-${Date.now()}`);
+  const orig = tmp.fileSync({ prefix: "audit-orig-", discardDescriptor: true }).name;
+  const upd = tmp.fileSync({ prefix: "audit-upd-", discardDescriptor: true }).name;
   writeFileSync(orig, original);
   writeFileSync(upd, updated);
   try {

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -157,11 +157,15 @@ function addLineNumbers(content: string): string {
 
 
 function bumpFrontmatterDate(content: string): string {
-  // Handles: reviewed: "2023-01-01"  |  reviewed: 2023-01-01  |  reviewed: ""
-  return content.replace(
-    /^(reviewed:\s*)["']?[\d-]*["']?/m,
-    `$1"${TODAY}"`
-  );
+  // Update existing reviewed: field
+  if (/^reviewed:/m.test(content)) {
+    return content.replace(
+      /^(reviewed:\s*)["']?[\d-]*["']?/m,
+      `$1"${TODAY}"`
+    );
+  }
+  // No reviewed: field (git-fallback files) — insert before closing frontmatter ---
+  return content.replace(/^---\s*$/m, `reviewed: "${TODAY}"\n---`);
 }
 
 function bumpInlineReviewDates(
@@ -337,16 +341,21 @@ function applyReview(
   result: AuditResult,
   review: ReviewToolInput
 ): string {
-  if (review.action === "bump_date") {
-    if (result.staleness_source === "inline") {
-      return bumpInlineReviewDates(
-        raw,
-        result.stale_sections.map((s) => s.heading)
-      );
-    }
-    return bumpFrontmatterDate(raw);
+  if (result.staleness_source === "inline") {
+    const staleHeadings = result.stale_sections.map((s) => s.heading);
+    const withContent =
+      review.action === "update_content"
+        ? applyLineChanges(raw, review.changes)
+        : raw;
+    return bumpInlineReviewDates(withContent, staleHeadings);
   }
-  return applyLineChanges(raw, review.changes);
+
+  // frontmatter or git — always bump the reviewed: date
+  const withContent =
+    review.action === "update_content"
+      ? applyLineChanges(raw, review.changes)
+      : raw;
+  return bumpFrontmatterDate(withContent);
 }
 
 function generateDiff(original: string, updated: string, label: string): string {

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,9 +1,10 @@
 import { execSync, execFileSync } from "child_process";
-import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
 import { join, basename, extname } from "path";
 import { tmpdir } from "os";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { GoogleAuth } from "google-auth-library";
+import matter from "gray-matter";
 
 const TODAY = new Date().toISOString().slice(0, 10);
 const BATCH_SIZE = 50;
@@ -17,7 +18,8 @@ interface StaleSection {
   heading: string;
   date: string;
   days_since_review: number;
-  stale: boolean;
+  line_start: number;
+  line_end: number;
 }
 
 interface InlineAuditResult {
@@ -27,7 +29,6 @@ interface InlineAuditResult {
   frontmatter_days_since_review: number | null;
   stale_sections: StaleSection[];
   oldest_stale_days_since_review: number | null;
-  stale: boolean;
 }
 
 interface DateAuditResult {
@@ -35,7 +36,6 @@ interface DateAuditResult {
   staleness_source: "frontmatter" | "git";
   date: string;
   days_since_review: number;
-  stale: boolean;
 }
 
 type AuditResult = InlineAuditResult | DateAuditResult;
@@ -52,6 +52,8 @@ interface ReviewToolInput {
   action: "bump_date" | "update_content";
   confidence: "high" | "low";
   reason: string;
+  resolution: string;
+  confidence_reason: string;
   changes: LineChange[];
 }
 
@@ -63,7 +65,7 @@ const REVIEW_TOOL = {
     "Submit documentation review results with line-level changes. For bump_date, changes must be an empty array — dates are applied programmatically.",
   input_schema: {
     type: "object" as const,
-    required: ["action", "confidence", "reason", "changes"],
+    required: ["action", "confidence", "reason", "resolution", "confidence_reason", "changes"],
     properties: {
       action: {
         type: "string",
@@ -80,7 +82,17 @@ const REVIEW_TOOL = {
       reason: {
         type: "string",
         description:
-          "Summary of what is outdated, or confirmation that content is still accurate.",
+          "What is outdated and why — the assessment. For bump_date, confirm why the content is still accurate. Format as GitHub-flavored markdown: use numbered lists (1. item), bullet lists (- item), **bold**, paragraphs separated by blank lines. Do not use heading syntax.",
+      },
+      resolution: {
+        type: "string",
+        description:
+          "What should be done to resolve the staleness. For bump_date, state that no content changes are needed. For update_content, describe specifically what needs updating. Format as GitHub-flavored markdown: numbered or bullet lists, **bold** for emphasis, paragraphs separated by blank lines. Do not use heading syntax.",
+      },
+      confidence_reason: {
+        type: "string",
+        description:
+          "One or two sentences explaining the confidence rating. For low: cite the specific reason (e.g. more than 5 lines changed, cannot verify third-party behavior, training data cutoff). For high: state why the assessment is reliable. Plain prose only — no markdown lists or headings.",
       },
       changes: {
         type: "array",
@@ -135,61 +147,6 @@ function addLineNumbers(content: string): string {
     .join("\n");
 }
 
-function extractStaleSections(
-  content: string,
-  staleHeadings: string[]
-): Array<{
-  heading: string;
-  lineStart: number;
-  lineEnd: number;
-  numbered: string;
-}> {
-  const lines = content.split("\n");
-  const results = [];
-
-  for (const heading of staleHeadings) {
-    let headingIdx = -1;
-    let headingLevel = 0;
-
-    for (let i = 0; i < lines.length; i++) {
-      const m = lines[i].match(/^(#{1,6})\s+(.+)/);
-      if (m && m[2].trim() === heading) {
-        headingIdx = i;
-        headingLevel = m[1].length;
-        break;
-      }
-    }
-
-    if (headingIdx === -1) {
-      console.error(`  [warn] Heading not found: "${heading}"`);
-      continue;
-    }
-
-    // End of section = next heading at same or higher level
-    let endIdx = lines.length;
-    for (let i = headingIdx + 1; i < lines.length; i++) {
-      const m = lines[i].match(/^(#{1,6})\s+/);
-      if (m && m[1].length <= headingLevel) {
-        endIdx = i;
-        break;
-      }
-    }
-
-    const sectionLines = lines.slice(headingIdx, endIdx);
-    const numbered = sectionLines
-      .map((line, idx) => `${headingIdx + idx + 1}: ${line}`)
-      .join("\n");
-
-    results.push({
-      heading,
-      lineStart: headingIdx + 1, // 1-indexed
-      lineEnd: endIdx,
-      numbered,
-    });
-  }
-
-  return results;
-}
 
 function bumpFrontmatterDate(content: string): string {
   // Handles: reviewed: "2023-01-01"  |  reviewed: 2023-01-01  |  reviewed: ""
@@ -279,6 +236,127 @@ function staleDaysFor(result: AuditResult): number {
   return result.days_since_review;
 }
 
+function docMetadata(filePath: string): { title: string; url: string } {
+  const raw = readFileSync(filePath, "utf8");
+  const { data } = matter(raw);
+
+  const title = (data.title as string | undefined) ?? basename(filePath, extname(filePath));
+
+  let urlPath: string;
+  if (data.permalink) {
+    // permalink is like "docs/guides/backups/create-backups" — strip leading "docs/"
+    urlPath = (data.permalink as string).replace(/^docs\//, "");
+  } else {
+    // derive from file path: src/source/content/foo/bar.md → foo/bar
+    urlPath = filePath
+      .replace(/.*src\/source\/content\//, "")
+      .replace(/\.md$/, "");
+  }
+
+  return { title, url: `https://docs.pantheon.io/${urlPath}` };
+}
+
+function buildPRContent(
+  result: AuditResult,
+  review: ReviewToolInput
+): { title: string; body: string } {
+  const filePath = join(process.cwd(), "..", result.file);
+  const { title: docTitle, url } = docMetadata(filePath);
+
+  const reviewDate =
+    result.staleness_source === "inline"
+      ? result.oldest_stale_date ?? "unknown"
+      : result.date;
+
+  const confidenceLabel =
+    review.confidence === "high" ? "High" : "Low ⚠️";
+
+  const body = [
+    `[${docTitle}](${url})`,
+    `Date: ${reviewDate}`,
+    `Days since last review: ${staleDaysFor(result)}`,
+    `Confidence rating: ${confidenceLabel}`,
+    ``,
+    `## Review notes`,
+    ``,
+    review.reason,
+    ``,
+    `*Confidence: ${confidenceLabel} — ${review.confidence_reason}*`,
+    ``,
+    `## Suggested resolution`,
+    ``,
+    review.resolution,
+  ].join("\n");
+
+  return { title: `[Update Stale] ${docTitle}`, body };
+}
+
+function applyReview(
+  raw: string,
+  result: AuditResult,
+  review: ReviewToolInput
+): string {
+  if (review.action === "bump_date") {
+    if (result.staleness_source === "inline") {
+      return bumpInlineReviewDates(
+        raw,
+        result.stale_sections.map((s) => s.heading)
+      );
+    }
+    return bumpFrontmatterDate(raw);
+  }
+  return applyLineChanges(raw, review.changes);
+}
+
+function generateDiff(original: string, updated: string, label: string): string {
+  const orig = join(tmpdir(), `audit-orig-${Date.now()}`);
+  const upd = join(tmpdir(), `audit-upd-${Date.now()}`);
+  writeFileSync(orig, original);
+  writeFileSync(upd, updated);
+  try {
+    // diff exits 1 when files differ — that's expected, not an error
+    return execSync(`diff -u --label "a/${label}" --label "b/${label}" "${orig}" "${upd}"`, {
+      encoding: "utf8",
+      stdio: "pipe",
+      maxBuffer: 10 * 1024 * 1024, // 10MB — well above any realistic doc diff
+    });
+  } catch (err: any) {
+    return err.stdout ?? "";
+  } finally {
+    try { unlinkSync(orig); unlinkSync(upd); } catch {}
+  }
+}
+
+function writeDryRunFile(
+  result: AuditResult,
+  review: ReviewToolInput,
+  raw: string,
+  updated: string
+): void {
+  const DRY_RUN_DIR = join(process.cwd(), "dry-run");
+  mkdirSync(DRY_RUN_DIR, { recursive: true });
+
+  const slug = slugifyPath(result.file);
+  const { title, body } = buildPRContent(result, review);
+  const diff = generateDiff(raw, updated, result.file);
+
+  const content = [
+    `# ${title}`,
+    ``,
+    body,
+    ``,
+    `## Diff`,
+    ``,
+    "```diff",
+    diff.trimEnd(),
+    "```",
+  ].join("\n");
+
+  const outPath = join(DRY_RUN_DIR, `${slug}.md`);
+  writeFileSync(outPath, content, "utf8");
+  console.error(`  ✓ dry-run/${slug}.md`);
+}
+
 function createBranchAndPR(
   result: AuditResult,
   updatedContent: string,
@@ -288,68 +366,25 @@ function createBranchAndPR(
   const filePath = join(process.cwd(), "..", result.file);
   const slug = slugifyPath(result.file);
   const branchName = `docs-audit/${TODAY}-${slug}`;
-
-  const staleSections =
-    result.staleness_source === "inline"
-      ? result.stale_sections.filter((s) => s.stale)
-      : [];
-
-  const confidenceNote =
-    review.confidence === "low"
-      ? "\n\n> ⚠️ **Low confidence** — reviewer should independently verify accuracy before merging."
-      : "";
-
-  const sectionList =
-    staleSections.length > 0
-      ? `\n\n**Sections reviewed:**\n${staleSections
-          .map(
-            (s) =>
-              `- \`${s.heading}\` (last reviewed ${s.date}, ${s.days_since_review} days ago)`
-          )
-          .join("\n")}`
-      : "";
-
-  const prBody = [
-    `Automated documentation accuracy review.`,
-    ``,
-    `**Action:** ${review.action === "bump_date" ? "Date bump only — content verified as still accurate" : "Content updated"}`,
-    `**Staleness source:** ${result.staleness_source}`,
-    `**Days since last review:** ${staleDaysFor(result)}`,
-    sectionList,
-    ``,
-    `**Review notes:** ${review.reason}`,
-    confidenceNote,
-    ``,
-    `---`,
-    `*Generated by \`npm run evaluate\` in \`scripts/\`*`,
-  ]
-    .join("\n")
-    .trim();
-
-  const prTitle =
-    review.action === "bump_date"
-      ? `docs: bump reviewed date for ${basename(result.file)}`
-      : `docs: update stale content in ${basename(result.file)}`;
-
+  const { title, body } = buildPRContent(result, review);
   const tmpBody = join(tmpdir(), `pr-body-${Date.now()}.md`);
 
   try {
-    writeFileSync(tmpBody, prBody, "utf8");
+    writeFileSync(tmpBody, body, "utf8");
 
-    // Branch from pantheon/main
     execSync(`git checkout -b "${branchName}" ${REMOTE}/main 2>/dev/null`, {
       stdio: "pipe",
     });
 
     writeFileSync(filePath, updatedContent, "utf8");
     execSync(`git add "${filePath}"`, { stdio: "pipe" });
-    execSync(`git commit -m "${prTitle}"`, { stdio: "pipe" });
+    execSync(`git commit -m "${title}"`, { stdio: "pipe" });
     execSync(`git push ${REMOTE} "${branchName}" 2>/dev/null`, {
       stdio: "pipe",
     });
 
     execSync(
-      `gh pr create --repo ${REPO} --head "${branchName}" --base main --title "${prTitle}" --body-file "${tmpBody}"`,
+      `gh pr create --repo ${REPO} --head "${branchName}" --base main --title "${title}" --body-file "${tmpBody}" --draft`,
       { stdio: "inherit" }
     );
 
@@ -357,12 +392,8 @@ function createBranchAndPR(
   } catch (err) {
     console.error(`  ✗ Failed for ${result.file}:`, (err as Error).message);
   } finally {
-    try {
-      unlinkSync(tmpBody);
-    } catch {}
-    execSync(`git checkout "${originalBranch}" 2>/dev/null`, {
-      stdio: "pipe",
-    });
+    try { unlinkSync(tmpBody); } catch {}
+    execSync(`git checkout "${originalBranch}" 2>/dev/null`, { stdio: "pipe" });
   }
 }
 
@@ -379,27 +410,20 @@ async function evaluateFile(
   let userContent: string;
 
   if (result.staleness_source === "inline") {
-    const staleHeadings = result.stale_sections
-      .filter((s) => s.stale)
-      .map((s) => s.heading);
+    const fileLines = raw.split("\n");
 
-    const sections = extractStaleSections(raw, staleHeadings);
-    if (sections.length === 0) {
-      console.error(`  [warn] Could not extract sections for ${result.file}`);
-      return null;
-    }
-
-    const sectionBlocks = sections
+    const sectionBlocks = result.stale_sections
       .map((s) => {
-        const meta = result.stale_sections.find(
-          (ss) => ss.heading === s.heading
-        );
+        const sectionText = fileLines
+          .slice(s.line_start - 1, s.line_end)
+          .map((line, idx) => `${s.line_start + idx}: ${line}`)
+          .join("\n");
         return [
           `### Section: "${s.heading}"`,
-          `Last reviewed: ${meta?.date ?? "unknown"} (${meta?.days_since_review ?? 0} days ago)`,
-          `Line range in full file: ${s.lineStart}–${s.lineEnd}`,
+          `Last reviewed: ${s.date} (${s.days_since_review} days ago)`,
+          `Line range in full file: ${s.line_start}–${s.line_end}`,
           ``,
-          s.numbered,
+          sectionText,
         ].join("\n");
       })
       .join("\n\n---\n\n");
@@ -470,7 +494,11 @@ async function main() {
 
   const audit = JSON.parse(readFileSync(auditFile, "utf8"));
   const toProcess: AuditResult[] = (audit.results as AuditResult[])
-    .filter((r) => r.stale)
+    .filter((r) =>
+      r.staleness_source === "inline"
+        ? r.stale_sections.length > 0
+        : r.days_since_review > 365
+    )
     .sort((a, b) => staleDaysFor(b) - staleDaysFor(a))
     .slice(0, limit);
 
@@ -504,27 +532,14 @@ async function main() {
     );
     console.error(`  ${review.reason.slice(0, 120)}`);
 
-    if (dryRun) {
-      console.error("  [dry-run] skipping branch/PR\n");
-      continue;
-    }
-
-    // Apply changes to content in memory
     const filePath = join(process.cwd(), "..", result.file);
     const raw = readFileSync(filePath, "utf8");
-    let updated: string;
+    const updated = applyReview(raw, result, review);
 
-    if (review.action === "bump_date") {
-      if (result.staleness_source === "inline") {
-        const staleHeadings = result.stale_sections
-          .filter((s) => s.stale)
-          .map((s) => s.heading);
-        updated = bumpInlineReviewDates(raw, staleHeadings);
-      } else {
-        updated = bumpFrontmatterDate(raw);
-      }
-    } else {
-      updated = applyLineChanges(raw, review.changes);
+    if (dryRun) {
+      writeDryRunFile(result, review, raw, updated);
+      console.error("");
+      continue;
     }
 
     createBranchAndPR(result, updated, review, originalBranch);

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,6 +1,7 @@
 import { execSync, execFileSync } from "child_process";
 import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
-import { join, basename, extname } from "path";
+import { join, basename, extname, dirname } from "path";
+import { fileURLToPath } from "url";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { GoogleAuth } from "google-auth-library";
 import matter from "gray-matter";
@@ -29,6 +30,7 @@ interface InlineAuditResult {
   frontmatter_days_since_review: number | null;
   stale_sections: StaleSection[];
   oldest_stale_days_since_review: number | null;
+  related_issues: number[];
 }
 
 interface DateAuditResult {
@@ -36,9 +38,21 @@ interface DateAuditResult {
   staleness_source: "frontmatter" | "git";
   date: string;
   days_since_review: number;
+  related_issues: number[];
 }
 
 type AuditResult = InlineAuditResult | DateAuditResult;
+
+interface GithubIssue {
+  number: number;
+  title: string;
+  body: string;
+}
+
+interface IssueClassification {
+  issue_number: number;
+  relationship: "fixes" | "should_fix" | "related";
+}
 
 interface LineChange {
   line_start: number;
@@ -248,7 +262,87 @@ function getOpenPRSlugs(): Set<string> {
   }
 }
 
-const REPO_ROOT = join(process.cwd(), "..");
+// Resolves relative to this file's location (scripts/) regardless of cwd
+const REPO_ROOT = join(dirname(fileURLToPath(import.meta.url)), "..");
+
+const CLASSIFY_TOOL = {
+  name: "classify_issues",
+  description: "Classify the relationship between the PR and each related issue",
+  input_schema: {
+    type: "object" as const,
+    required: ["classifications"],
+    properties: {
+      classifications: {
+        type: "array",
+        items: {
+          type: "object",
+          required: ["issue_number", "relationship"],
+          properties: {
+            issue_number: { type: "number" },
+            relationship: {
+              type: "string",
+              enum: ["fixes", "should_fix", "related", "unrelated"],
+              description:
+                '"fixes": PR directly resolves the issue. "should_fix": PR is related and should be expanded to address this issue. "related": loosely related but PR does not fix it. "unrelated": no meaningful connection.',
+            },
+          },
+        },
+      },
+    },
+  },
+};
+
+async function classifyIssues(
+  issueNumbers: number[],
+  docTitle: string,
+  docUrl: string,
+  review: ReviewToolInput,
+  client: AnthropicVertex
+): Promise<IssueClassification[]> {
+  if (issueNumbers.length === 0) return [];
+
+  // Fetch issue details
+  const issues: { number: number; title: string; body: string }[] = [];
+  for (const num of issueNumbers) {
+    try {
+      const out = execSync(
+        `gh issue view ${num} --repo ${REPO} --json number,title,body`,
+        { encoding: "utf8" }
+      );
+      issues.push(JSON.parse(out));
+    } catch { /* skip if unavailable */ }
+  }
+  if (issues.length === 0) return [];
+
+  const issueList = issues
+    .map((i) => `Issue #${i.number}: ${i.title}\n${(i.body ?? "").slice(0, 800)}`)
+    .join("\n\n---\n\n");
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 1024,
+    tools: [CLASSIFY_TOOL],
+    tool_choice: { type: "any" },
+    messages: [{
+      role: "user",
+      content: [
+        `Document: [${docTitle}](${docUrl})`,
+        `PR action: ${review.action}`,
+        `PR notes: ${review.reason.slice(0, 600)}`,
+        ``,
+        `Classify the relationship between this PR and each open issue:`,
+        ``,
+        issueList,
+      ].join("\n"),
+    }],
+  });
+
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use") return [];
+
+  const input = toolUse.input as { classifications: IssueClassification[] };
+  return input.classifications.filter((c) => c.relationship !== "unrelated");
+}
 
 function safeRepoPath(relativePath: string): string {
   const resolved = join(REPO_ROOT, relativePath);
@@ -264,10 +358,24 @@ function parseOlderThanDays(arg: string): number {
   return parseInt(m[1], 10) * 30;
 }
 
+function fetchRelatedIssuesForFile(relPath: string): number[] {
+  const slug = slugifyPath(relPath);
+  try {
+    const out = execSync(
+      `gh issue list --repo ${REPO} --state open --search ${JSON.stringify(slug)} --json number --limit 20`,
+      { encoding: "utf8" }
+    );
+    return (JSON.parse(out) as Array<{ number: number }>).map((i) => i.number);
+  } catch {
+    return [];
+  }
+}
+
 function buildAuditResultForFile(relPath: string): AuditResult {
   const filePath = safeRepoPath(relPath);
   const raw = readFileSync(filePath, "utf8");
   const { data: frontmatter, content } = matter(raw);
+  const related_issues = fetchRelatedIssuesForFile(relPath);
 
   const hasInline = /<ReviewDate date="[^"]+"\s*\/>/.test(content);
 
@@ -320,6 +428,7 @@ function buildAuditResultForFile(relPath: string): AuditResult {
         : null,
       stale_sections: sections,
       oldest_stale_days_since_review: oldest?.days_since_review ?? null,
+      related_issues,
     };
   }
 
@@ -337,6 +446,7 @@ function buildAuditResultForFile(relPath: string): AuditResult {
     days_since_review: date
       ? Math.floor((Date.now() - new Date(date).getTime()) / 86400000)
       : 0,
+    related_issues,
   };
 }
 
@@ -387,7 +497,8 @@ function docMetadata(filePath: string): { title: string; url: string } {
 
 function buildPRContent(
   result: AuditResult,
-  review: ReviewToolInput
+  review: ReviewToolInput,
+  issueClassifications: IssueClassification[] = []
 ): { title: string; body: string } {
   const filePath = safeRepoPath(result.file);
   const { title: docTitle, url } = docMetadata(filePath);
@@ -402,6 +513,25 @@ function buildPRContent(
 
   const deprecationSection = review.deprecation_note
     ? [``, `## ⚠️ Deprecation consideration`, ``, review.deprecation_note]
+    : [];
+
+  const fixes = issueClassifications.filter((c) => c.relationship === "fixes");
+  const shouldFix = issueClassifications.filter((c) => c.relationship === "should_fix");
+  const related = issueClassifications.filter((c) => c.relationship === "related");
+
+  const issueSection = (fixes.length + shouldFix.length + related.length) > 0
+    ? [
+        ``,
+        `## Related issues`,
+        ``,
+        ...fixes.map((c) => `Fixes #${c.issue_number}`),
+        ...related.map((c) => `Possibly related to #${c.issue_number}`),
+        ...(shouldFix.length > 0 ? [
+          ``,
+          `> ⚠️ The following issue(s) are related and this PR should be expanded to address them before merging:`,
+          ...shouldFix.map((c) => `> - #${c.issue_number}`),
+        ] : []),
+      ]
     : [];
 
   const body = [
@@ -420,6 +550,7 @@ function buildPRContent(
     ``,
     review.resolution,
     ...deprecationSection,
+    ...issueSection,
   ].join("\n");
 
   return { title: `[Update Stale] ${docTitle}`, body };
@@ -470,13 +601,14 @@ function writeDryRunFile(
   result: AuditResult,
   review: ReviewToolInput,
   raw: string,
-  updated: string
+  updated: string,
+  issueClassifications: IssueClassification[] = []
 ): void {
-  const DRY_RUN_DIR = join(process.cwd(), "dry-run");
+  const DRY_RUN_DIR = join(dirname(fileURLToPath(import.meta.url)), "dry-run");
   mkdirSync(DRY_RUN_DIR, { recursive: true });
 
   const slug = slugifyPath(result.file);
-  const { title, body } = buildPRContent(result, review);
+  const { title, body } = buildPRContent(result, review, issueClassifications);
   const diff = generateDiff(raw, updated, result.file);
 
   const content = [
@@ -500,12 +632,13 @@ function createBranchAndPR(
   result: AuditResult,
   updatedContent: string,
   review: ReviewToolInput,
-  originalBranch: string
+  originalBranch: string,
+  issueClassifications: IssueClassification[] = []
 ): void {
   const filePath = safeRepoPath(result.file);
   const slug = slugifyPath(result.file);
   const branchName = `docs-audit/${TODAY}-${slug}`;
-  const { title, body } = buildPRContent(result, review);
+  const { title, body } = buildPRContent(result, review, issueClassifications);
   const tmpBody = tmp.fileSync({ prefix: "pr-body-", postfix: ".md", discardDescriptor: true }).name;
 
   try {
@@ -607,7 +740,7 @@ async function evaluateFile(
 async function main() {
   const args = process.argv.slice(2);
   const auditFile =
-    args.find((a, i) => args[i - 1] === "--audit") ?? "../audit-results.json";
+    args.find((a, i) => args[i - 1] === "--audit") ?? join(REPO_ROOT, "audit-results.json");
   const dryRun = args.includes("--dry-run");
   const includeAll = args.includes("--all");
   const fileArg = args.find((a, i) => args[i - 1] === "--file");
@@ -656,10 +789,18 @@ async function main() {
     const review = await evaluateFile(client, result);
     if (!review) return;
     console.error(`  action=${review.action}  confidence=${review.confidence}`);
+    const { title: docTitle, url: docUrl } = docMetadata(safeRepoPath(fileArg));
+    const issueClassifications = await classifyIssues(
+      result.related_issues ?? [],
+      docTitle,
+      docUrl,
+      review,
+      client
+    );
     const raw = readFileSync(safeRepoPath(fileArg), "utf8");
     const updated = applyReview(raw, result, review);
-    if (dryRun) { writeDryRunFile(result, review, raw, updated); }
-    else { createBranchAndPR(result, updated, review, originalBranch); }
+    if (dryRun) { writeDryRunFile(result, review, raw, updated, issueClassifications); }
+    else { createBranchAndPR(result, updated, review, originalBranch, issueClassifications); }
     return;
   }
 
@@ -696,17 +837,29 @@ async function main() {
     );
     console.error(`  ${review.reason.slice(0, 120)}`);
 
+    const { title: docTitle, url: docUrl } = docMetadata(safeRepoPath(result.file));
+    const issueClassifications = await classifyIssues(
+      result.related_issues ?? [],
+      docTitle,
+      docUrl,
+      review,
+      client
+    );
+    if (issueClassifications.length > 0) {
+      console.error(`  issues: ${issueClassifications.map((c) => `#${c.issue_number}(${c.relationship})`).join(", ")}`);
+    }
+
     const filePath = safeRepoPath(result.file);
     const raw = readFileSync(filePath, "utf8");
     const updated = applyReview(raw, result, review);
 
     if (dryRun) {
-      writeDryRunFile(result, review, raw, updated);
+      writeDryRunFile(result, review, raw, updated, issueClassifications);
       console.error("");
       continue;
     }
 
-    createBranchAndPR(result, updated, review, originalBranch);
+    createBranchAndPR(result, updated, review, originalBranch, issueClassifications);
     console.error("");
 
     // Pace API calls

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -54,6 +54,7 @@ interface ReviewToolInput {
   reason: string;
   resolution: string;
   confidence_reason: string;
+  deprecation_note?: string;
   changes: LineChange[];
 }
 
@@ -93,6 +94,11 @@ const REVIEW_TOOL = {
         type: "string",
         description:
           "One or two sentences explaining the confidence rating. For low: cite the specific reason (e.g. more than 5 lines changed, cannot verify third-party behavior, training data cutoff). For high: state why the assessment is reliable. Plain prose only — no markdown lists or headings.",
+      },
+      deprecation_note: {
+        type: "string",
+        description:
+          "Optional. Include only when the document may be a candidate for deprecation, archiving, or removal — for example, when the underlying product/feature no longer exists, the ecosystem has changed so dramatically that the doc is fundamentally misleading, or the content is so outdated it would be less effort to remove than to fix. One or two sentences explaining why removal might be worth considering. Leave absent if the doc should simply be updated.",
       },
       changes: {
         type: "array",
@@ -136,7 +142,9 @@ HARD RULES — violating these will break the documentation site:
 For bump_date: the changes array MUST be empty []. Dates are applied programmatically.
 For update_content: return only the specific lines that need to change, not unchanged surrounding lines.
 
-Your training cutoff is August 2025. When evaluating content about third-party plugin versions, security advisories, or external service behavior that may have changed after that date, flag confidence: "low".`;
+Your training cutoff is August 2025. When evaluating content about third-party plugin versions, security advisories, or external service behavior that may have changed after that date, flag confidence: "low".
+
+If the document is a strong candidate for deprecation, archiving, or removal — because the underlying product no longer exists, the ecosystem has changed so fundamentally that updating would be misleading, or the content is so outdated it would be less effort to remove than fix — populate the deprecation_note field. This is especially relevant for low-confidence items. The final decision rests with human reviewers; your role is to surface the possibility.`;
 
 // ── Content helpers ───────────────────────────────────────────────────────────
 
@@ -218,6 +226,24 @@ function slugifyPath(filePath: string): string {
     .toLowerCase();
 }
 
+function getOpenPRSlugs(): Set<string> {
+  try {
+    const output = execSync(
+      "gh pr list --repo pantheon-systems/documentation --state open --json headRefName --limit 200",
+      { encoding: "utf8" }
+    );
+    const prs = JSON.parse(output) as Array<{ headRefName: string }>;
+    const slugs = new Set<string>();
+    for (const pr of prs) {
+      const match = pr.headRefName.match(/^docs-audit\/\d{4}-\d{2}-\d{2}-(.+)$/);
+      if (match) slugs.add(match[1]);
+    }
+    return slugs;
+  } catch {
+    return new Set();
+  }
+}
+
 const REPO_ROOT = join(process.cwd(), "..");
 
 function safeRepoPath(relativePath: string): string {
@@ -281,6 +307,10 @@ function buildPRContent(
   const confidenceLabel =
     review.confidence === "high" ? "High" : "Low ⚠️";
 
+  const deprecationSection = review.deprecation_note
+    ? [``, `## ⚠️ Deprecation consideration`, ``, review.deprecation_note]
+    : [];
+
   const body = [
     `[${docTitle}](${url})`,
     `Date: ${reviewDate}`,
@@ -296,6 +326,7 @@ function buildPRContent(
     `## Suggested resolution`,
     ``,
     review.resolution,
+    ...deprecationSection,
   ].join("\n");
 
   return { title: `[Update Stale] ${docTitle}`, body };
@@ -499,6 +530,11 @@ async function main() {
 
   const originalBranch = getCurrentBranch();
 
+  const openPRSlugs = getOpenPRSlugs();
+  if (openPRSlugs.size > 0) {
+    console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
+  }
+
   const audit = JSON.parse(readFileSync(auditFile, "utf8"));
   const toProcess: AuditResult[] = (audit.results as AuditResult[])
     .filter((r) =>
@@ -506,6 +542,7 @@ async function main() {
         ? r.stale_sections.length > 0
         : r.days_since_review > 365
     )
+    .filter((r) => !openPRSlugs.has(slugifyPath(r.file)))
     .sort((a, b) => staleDaysFor(b) - staleDaysFor(a))
     .slice(0, limit);
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -381,7 +381,7 @@ function createBranchAndPR(
 
     execFileSync(
       "gh",
-      ["pr", "create", "--repo", REPO, "--head", branchName, "--base", "main", "--title", title, "--body-file", tmpBody, "--draft"],
+      ["pr", "create", "--repo", REPO, "--head", branchName, "--base", "main", "--title", title, "--body-file", tmpBody, "--draft", "--label", "automation: Claude 🤖"],
       { stdio: "inherit" }
     );
 

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -151,7 +151,7 @@ HARD RULES — violating these will break the documentation site:
 2. NEVER change the position or format of <ReviewDate /> components. These are handled programmatically — do not include them in changes[].
 3. NEVER add or remove sections.
 4. Make the minimum viable change. If content is conceptually correct but slightly dated in phrasing, prefer bump_date over rewriting prose.
-5. Set confidence: "low" if: more than 5 lines would change, you cannot verify whether specific version numbers or third-party behavior is current, or the content covers rapidly-changing topics (plugin compatibility, CVEs, external service APIs).
+5. Set confidence: "low" if: more than 5 lines would change, you cannot verify whether specific version numbers or third-party behavior is current, or the content covers rapidly-changing topics (plugin compatibility, CVEs, external service APIs). The confidence rating is independent of how many changes are needed — include all line changes you have identified in changes[] regardless of scope. confidence: "low" tells human reviewers to scrutinize the PR carefully before merging; it does not mean limiting or omitting changes.
 
 For bump_date: the changes array MUST be empty []. Dates are applied programmatically.
 For update_content: return only the specific lines that need to change, not unchanged surrounding lines.

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,11 +1,10 @@
 import { execSync, execFileSync } from "child_process";
-import { readFileSync, writeFileSync, unlinkSync, mkdirSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join, basename, extname, dirname } from "path";
 import { fileURLToPath } from "url";
 import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
 import { GoogleAuth } from "google-auth-library";
 import matter from "gray-matter";
-import tmp from "tmp";
 
 const TODAY = new Date().toISOString().slice(0, 10);
 const BATCH_SIZE = 50;
@@ -352,6 +351,15 @@ function safeRepoPath(relativePath: string): string {
   return resolved;
 }
 
+function isValidContentPath(relPath: string): boolean {
+  return (
+    !relPath.startsWith("/") &&
+    !relPath.includes("..") &&
+    relPath.startsWith("src/source/content/") &&
+    relPath.endsWith(".md")
+  );
+}
+
 function parseOlderThanDays(arg: string): number {
   const m = arg.match(/^(\d+)m$/);
   if (!m) throw new Error(`Invalid --older-than format "${arg}" — use e.g. 12m, 6m, 24m`);
@@ -591,23 +599,74 @@ function applyReview(
   return bumpFrontmatterDate(withContent);
 }
 
-function generateDiff(original: string, updated: string, label: string): string {
-  const orig = tmp.fileSync({ prefix: "audit-orig-", discardDescriptor: true }).name;
-  const upd = tmp.fileSync({ prefix: "audit-upd-", discardDescriptor: true }).name;
-  writeFileSync(orig, original);
-  writeFileSync(upd, updated);
-  try {
-    // diff exits 1 when files differ — expected, not an error
-    return execFileSync(
-      "diff",
-      ["-u", "--label", `a/${label}`, "--label", `b/${label}`, orig, upd],
-      { encoding: "utf8", maxBuffer: 10 * 1024 * 1024 }
-    );
-  } catch (err: any) {
-    return err.stdout ?? "";
-  } finally {
-    try { unlinkSync(orig); unlinkSync(upd); } catch {}
+type DiffOp = "keep" | "insert" | "delete";
+interface DiffEdit { op: DiffOp; line: string; }
+
+function computeEdits(a: string[], b: string[]): DiffEdit[] {
+  const m = a.length, n = b.length;
+  const dp = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0) as number[]);
+  for (let i = 1; i <= m; i++)
+    for (let j = 1; j <= n; j++)
+      dp[i][j] = a[i - 1] === b[j - 1] ? dp[i - 1][j - 1] + 1 : Math.max(dp[i - 1][j], dp[i][j - 1]);
+
+  const edits: DiffEdit[] = [];
+  let i = m, j = n;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && a[i - 1] === b[j - 1]) {
+      edits.unshift({ op: "keep", line: a[i - 1] }); i--; j--;
+    } else if (j > 0 && (i === 0 || dp[i][j - 1] >= dp[i - 1][j])) {
+      edits.unshift({ op: "insert", line: b[j - 1] }); j--;
+    } else {
+      edits.unshift({ op: "delete", line: a[i - 1] }); i--;
+    }
   }
+  return edits;
+}
+
+function generateDiff(original: string, updated: string, label: string): string {
+  if (original === updated) return "";
+
+  const a = original.split("\n");
+  const b = updated.split("\n");
+  const edits = computeEdits(a, b);
+
+  // Annotate each edit with original/updated line numbers
+  const annotated: Array<DiffEdit & { aLine: number; bLine: number }> = [];
+  let ai = 1, bi = 1;
+  for (const e of edits) {
+    annotated.push({ ...e, aLine: ai, bLine: bi });
+    if (e.op !== "insert") ai++;
+    if (e.op !== "delete") bi++;
+  }
+
+  // Collect indices of changed lines, then expand by CONTEXT lines each side
+  const CONTEXT = 3;
+  const changed = new Set(annotated.flatMap((e, idx) => e.op !== "keep" ? [idx] : []));
+  const include = new Set<number>();
+  for (const idx of changed)
+    for (let k = Math.max(0, idx - CONTEXT); k <= Math.min(annotated.length - 1, idx + CONTEXT); k++)
+      include.add(k);
+
+  if (include.size === 0) return "";
+
+  // Group consecutive included indices into hunks
+  const indices = [...include].sort((x, y) => x - y);
+  const hunks: string[] = [];
+  let g = 0;
+  while (g < indices.length) {
+    let end = g;
+    while (end + 1 < indices.length && indices[end + 1] === indices[end] + 1) end++;
+    const group = indices.slice(g, end + 1).map((idx) => annotated[idx]);
+    const aStart = group.find((e) => e.op !== "insert")?.aLine ?? 1;
+    const bStart = group.find((e) => e.op !== "delete")?.bLine ?? 1;
+    const aLen = group.filter((e) => e.op !== "insert").length;
+    const bLen = group.filter((e) => e.op !== "delete").length;
+    const lines = group.map((e) => (e.op === "keep" ? " " : e.op === "insert" ? "+" : "-") + e.line);
+    hunks.push(`@@ -${aStart},${aLen} +${bStart},${bLen} @@\n${lines.join("\n")}`);
+    g = end + 1;
+  }
+
+  return `--- a/${label}\n+++ b/${label}\n${hunks.join("\n")}`;
 }
 
 function writeDryRunFile(
@@ -652,11 +711,8 @@ function createBranchAndPR(
   const slug = slugifyPath(result.file);
   const branchName = `docs-audit/${TODAY}-${slug}`;
   const { title, body } = buildPRContent(result, review, issueClassifications);
-  const tmpBody = tmp.fileSync({ prefix: "pr-body-", postfix: ".md", discardDescriptor: true }).name;
 
   try {
-    writeFileSync(tmpBody, body, "utf8");
-
     execFileSync("git", ["checkout", "-b", branchName, `${REMOTE}/main`], { stdio: "pipe" });
 
     writeFileSync(filePath, updatedContent, "utf8");
@@ -666,7 +722,7 @@ function createBranchAndPR(
 
     execFileSync(
       "gh",
-      ["pr", "create", "--repo", REPO, "--head", branchName, "--base", "main", "--title", title, "--body-file", tmpBody, "--draft", "--label", "automation: Claude 🤖"],
+      ["pr", "create", "--repo", REPO, "--head", branchName, "--base", "main", "--title", title, "--body", body, "--draft", "--label", "automation: Claude 🤖"],
       { stdio: "inherit" }
     );
 
@@ -674,7 +730,6 @@ function createBranchAndPR(
   } catch (err) {
     console.error(`  ✗ Failed for ${result.file}:`, (err as Error).message);
   } finally {
-    try { unlinkSync(tmpBody); } catch {}
     execFileSync("git", ["checkout", originalBranch], { stdio: "pipe" });
   }
 }
@@ -793,6 +848,10 @@ async function main() {
 
   // ── Single-file mode ────────────────────────────────────────────────────────
   if (fileArg) {
+    if (!isValidContentPath(fileArg)) {
+      console.error(`Error: "${fileArg}" is not a valid content path — must be a relative .md path under src/source/content/`);
+      process.exit(1);
+    }
     if (fileIsInReview(fileArg)) {
       console.error(`Warning: ${fileArg} has an open issue labeled "Process: In Review" — skipping.`);
       return;
@@ -832,6 +891,7 @@ async function main() {
     process.exit(1);
   }
   const toProcess: AuditResult[] = ((audit as { results: AuditResult[] }).results)
+    .filter((r) => isValidContentPath(r.file))
     .filter((r) =>
       r.staleness_source === "inline"
         ? r.stale_sections.length > 0

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -826,8 +826,12 @@ async function main() {
     console.error(`Skipping ${openPRSlugs.size} file(s) with open PRs`);
   }
 
-  const audit = JSON.parse(readFileSync(auditFile, "utf8"));
-  const toProcess: AuditResult[] = (audit.results as AuditResult[])
+  const audit: unknown = JSON.parse(readFileSync(auditFile, "utf8"));
+  if (typeof audit !== "object" || audit === null || !Array.isArray((audit as Record<string, unknown>).results)) {
+    console.error(`Error: audit file at ${auditFile} is missing a "results" array`);
+    process.exit(1);
+  }
+  const toProcess: AuditResult[] = ((audit as { results: AuditResult[] }).results)
     .filter((r) =>
       r.staleness_source === "inline"
         ? r.stale_sections.length > 0

--- a/scripts/evaluate.ts
+++ b/scripts/evaluate.ts
@@ -1,0 +1,543 @@
+import { execSync, execFileSync } from "child_process";
+import { readFileSync, writeFileSync, unlinkSync } from "fs";
+import { join, basename, extname } from "path";
+import { tmpdir } from "os";
+import { AnthropicVertex } from "@anthropic-ai/vertex-sdk";
+import { GoogleAuth } from "google-auth-library";
+
+const TODAY = new Date().toISOString().slice(0, 10);
+const BATCH_SIZE = 50;
+const MODEL = "claude-sonnet-4-6";
+const REPO = "pantheon-systems/documentation";
+const REMOTE = "pantheon";
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+interface StaleSection {
+  heading: string;
+  date: string;
+  days_since_review: number;
+  stale: boolean;
+}
+
+interface InlineAuditResult {
+  file: string;
+  staleness_source: "inline";
+  frontmatter_date: string | null;
+  frontmatter_days_since_review: number | null;
+  stale_sections: StaleSection[];
+  oldest_stale_days_since_review: number | null;
+  stale: boolean;
+}
+
+interface DateAuditResult {
+  file: string;
+  staleness_source: "frontmatter" | "git";
+  date: string;
+  days_since_review: number;
+  stale: boolean;
+}
+
+type AuditResult = InlineAuditResult | DateAuditResult;
+
+interface LineChange {
+  line_start: number;
+  line_end: number;
+  replacement: string;
+  reason: string;
+  confidence?: "high" | "low";
+}
+
+interface ReviewToolInput {
+  action: "bump_date" | "update_content";
+  confidence: "high" | "low";
+  reason: string;
+  changes: LineChange[];
+}
+
+// ── Tool definition ───────────────────────────────────────────────────────────
+
+const REVIEW_TOOL = {
+  name: "submit_review",
+  description:
+    "Submit documentation review results with line-level changes. For bump_date, changes must be an empty array — dates are applied programmatically.",
+  input_schema: {
+    type: "object" as const,
+    required: ["action", "confidence", "reason", "changes"],
+    properties: {
+      action: {
+        type: "string",
+        enum: ["bump_date", "update_content"],
+        description:
+          "bump_date if content is still accurate (only the review date needs updating). update_content if specific information is outdated.",
+      },
+      confidence: {
+        type: "string",
+        enum: ["high", "low"],
+        description:
+          'Set "low" if: more than 5 lines would change, you cannot verify whether specific versions or third-party behavior is still current, or the topic changes rapidly.',
+      },
+      reason: {
+        type: "string",
+        description:
+          "Summary of what is outdated, or confirmation that content is still accurate.",
+      },
+      changes: {
+        type: "array",
+        description:
+          "Line-level changes to apply. MUST be [] for bump_date. Line numbers match those shown in the file content.",
+        items: {
+          type: "object",
+          required: ["line_start", "line_end", "replacement", "reason"],
+          properties: {
+            line_start: {
+              type: "number",
+              description: "First line to replace (1-indexed, inclusive)",
+            },
+            line_end: {
+              type: "number",
+              description: "Last line to replace (1-indexed, inclusive)",
+            },
+            replacement: {
+              type: "string",
+              description:
+                "Replacement text. Use empty string to delete lines.",
+            },
+            reason: { type: "string" },
+            confidence: { type: "string", enum: ["high", "low"] },
+          },
+        },
+      },
+    },
+  },
+};
+
+const SYSTEM_PROMPT = `You are a technical documentation reviewer for Pantheon, a WordPress and Drupal hosting platform. Evaluate whether documentation is still accurate given how long it has been since it was last reviewed.
+
+HARD RULES — violating these will break the documentation site:
+1. NEVER modify any heading line (lines starting with # characters). Headings generate anchor links cross-referenced from other docs. Changing them silently breaks incoming links.
+2. NEVER change the position or format of <ReviewDate /> components. These are handled programmatically — do not include them in changes[].
+3. NEVER add or remove sections.
+4. Make the minimum viable change. If content is conceptually correct but slightly dated in phrasing, prefer bump_date over rewriting prose.
+5. Set confidence: "low" if: more than 5 lines would change, you cannot verify whether specific version numbers or third-party behavior is current, or the content covers rapidly-changing topics (plugin compatibility, CVEs, external service APIs).
+
+For bump_date: the changes array MUST be empty []. Dates are applied programmatically.
+For update_content: return only the specific lines that need to change, not unchanged surrounding lines.
+
+Your training cutoff is August 2025. When evaluating content about third-party plugin versions, security advisories, or external service behavior that may have changed after that date, flag confidence: "low".`;
+
+// ── Content helpers ───────────────────────────────────────────────────────────
+
+function addLineNumbers(content: string): string {
+  return content
+    .split("\n")
+    .map((line, i) => `${i + 1}: ${line}`)
+    .join("\n");
+}
+
+function extractStaleSections(
+  content: string,
+  staleHeadings: string[]
+): Array<{
+  heading: string;
+  lineStart: number;
+  lineEnd: number;
+  numbered: string;
+}> {
+  const lines = content.split("\n");
+  const results = [];
+
+  for (const heading of staleHeadings) {
+    let headingIdx = -1;
+    let headingLevel = 0;
+
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/^(#{1,6})\s+(.+)/);
+      if (m && m[2].trim() === heading) {
+        headingIdx = i;
+        headingLevel = m[1].length;
+        break;
+      }
+    }
+
+    if (headingIdx === -1) {
+      console.error(`  [warn] Heading not found: "${heading}"`);
+      continue;
+    }
+
+    // End of section = next heading at same or higher level
+    let endIdx = lines.length;
+    for (let i = headingIdx + 1; i < lines.length; i++) {
+      const m = lines[i].match(/^(#{1,6})\s+/);
+      if (m && m[1].length <= headingLevel) {
+        endIdx = i;
+        break;
+      }
+    }
+
+    const sectionLines = lines.slice(headingIdx, endIdx);
+    const numbered = sectionLines
+      .map((line, idx) => `${headingIdx + idx + 1}: ${line}`)
+      .join("\n");
+
+    results.push({
+      heading,
+      lineStart: headingIdx + 1, // 1-indexed
+      lineEnd: endIdx,
+      numbered,
+    });
+  }
+
+  return results;
+}
+
+function bumpFrontmatterDate(content: string): string {
+  // Handles: reviewed: "2023-01-01"  |  reviewed: 2023-01-01  |  reviewed: ""
+  return content.replace(
+    /^(reviewed:\s*)["']?[\d-]*["']?/m,
+    `$1"${TODAY}"`
+  );
+}
+
+function bumpInlineReviewDates(
+  content: string,
+  staleHeadings: string[]
+): string {
+  const lines = content.split("\n");
+
+  for (const heading of staleHeadings) {
+    let headingIdx = -1;
+    for (let i = 0; i < lines.length; i++) {
+      const m = lines[i].match(/^#{1,6}\s+(.+)/);
+      if (m && m[1].trim() === heading) {
+        headingIdx = i;
+        break;
+      }
+    }
+    if (headingIdx === -1) continue;
+
+    // ReviewDate appears within a few lines of the heading
+    for (
+      let i = headingIdx + 1;
+      i < Math.min(headingIdx + 5, lines.length);
+      i++
+    ) {
+      if (/<ReviewDate date="[^"]+"\s*\/>/.test(lines[i])) {
+        lines[i] = lines[i].replace(
+          /<ReviewDate date="[^"]+"\s*\/>/,
+          `<ReviewDate date="${TODAY}" />`
+        );
+        break;
+      }
+    }
+  }
+
+  return lines.join("\n");
+}
+
+function applyLineChanges(content: string, changes: LineChange[]): string {
+  if (changes.length === 0) return content;
+
+  const lines = content.split("\n");
+  // Apply bottom-up so prior line numbers stay valid
+  const sorted = [...changes].sort((a, b) => b.line_start - a.line_start);
+
+  for (const change of sorted) {
+    const start = change.line_start - 1; // 0-indexed
+    const deleteCount = change.line_end - change.line_start + 1;
+    const replacementLines =
+      change.replacement === "" ? [] : change.replacement.split("\n");
+    lines.splice(start, deleteCount, ...replacementLines);
+  }
+
+  return lines.join("\n");
+}
+
+// ── Git / PR helpers ──────────────────────────────────────────────────────────
+
+function slugifyPath(filePath: string): string {
+  return basename(filePath, extname(filePath))
+    .replace(/[^a-z0-9]+/gi, "-")
+    .toLowerCase();
+}
+
+function getCurrentBranch(): string {
+  return execSync("git rev-parse --abbrev-ref HEAD", {
+    encoding: "utf8",
+  }).trim();
+}
+
+function hasTrackedChanges(): boolean {
+  const status = execSync("git status --porcelain", { encoding: "utf8" });
+  return status.split("\n").some((line) => line.length > 0 && !line.startsWith("??"));
+}
+
+function staleDaysFor(result: AuditResult): number {
+  if (result.staleness_source === "inline") {
+    return result.oldest_stale_days_since_review ?? 0;
+  }
+  return result.days_since_review;
+}
+
+function createBranchAndPR(
+  result: AuditResult,
+  updatedContent: string,
+  review: ReviewToolInput,
+  originalBranch: string
+): void {
+  const filePath = join(process.cwd(), "..", result.file);
+  const slug = slugifyPath(result.file);
+  const branchName = `docs-audit/${TODAY}-${slug}`;
+
+  const staleSections =
+    result.staleness_source === "inline"
+      ? result.stale_sections.filter((s) => s.stale)
+      : [];
+
+  const confidenceNote =
+    review.confidence === "low"
+      ? "\n\n> ⚠️ **Low confidence** — reviewer should independently verify accuracy before merging."
+      : "";
+
+  const sectionList =
+    staleSections.length > 0
+      ? `\n\n**Sections reviewed:**\n${staleSections
+          .map(
+            (s) =>
+              `- \`${s.heading}\` (last reviewed ${s.date}, ${s.days_since_review} days ago)`
+          )
+          .join("\n")}`
+      : "";
+
+  const prBody = [
+    `Automated documentation accuracy review.`,
+    ``,
+    `**Action:** ${review.action === "bump_date" ? "Date bump only — content verified as still accurate" : "Content updated"}`,
+    `**Staleness source:** ${result.staleness_source}`,
+    `**Days since last review:** ${staleDaysFor(result)}`,
+    sectionList,
+    ``,
+    `**Review notes:** ${review.reason}`,
+    confidenceNote,
+    ``,
+    `---`,
+    `*Generated by \`npm run evaluate\` in \`scripts/\`*`,
+  ]
+    .join("\n")
+    .trim();
+
+  const prTitle =
+    review.action === "bump_date"
+      ? `docs: bump reviewed date for ${basename(result.file)}`
+      : `docs: update stale content in ${basename(result.file)}`;
+
+  const tmpBody = join(tmpdir(), `pr-body-${Date.now()}.md`);
+
+  try {
+    writeFileSync(tmpBody, prBody, "utf8");
+
+    // Branch from pantheon/main
+    execSync(`git checkout -b "${branchName}" ${REMOTE}/main 2>/dev/null`, {
+      stdio: "pipe",
+    });
+
+    writeFileSync(filePath, updatedContent, "utf8");
+    execSync(`git add "${filePath}"`, { stdio: "pipe" });
+    execSync(`git commit -m "${prTitle}"`, { stdio: "pipe" });
+    execSync(`git push ${REMOTE} "${branchName}" 2>/dev/null`, {
+      stdio: "pipe",
+    });
+
+    execSync(
+      `gh pr create --repo ${REPO} --head "${branchName}" --base main --title "${prTitle}" --body-file "${tmpBody}"`,
+      { stdio: "inherit" }
+    );
+
+    console.error(`  ✓ PR created: ${branchName}`);
+  } catch (err) {
+    console.error(`  ✗ Failed for ${result.file}:`, (err as Error).message);
+  } finally {
+    try {
+      unlinkSync(tmpBody);
+    } catch {}
+    execSync(`git checkout "${originalBranch}" 2>/dev/null`, {
+      stdio: "pipe",
+    });
+  }
+}
+
+// ── Claude evaluation ─────────────────────────────────────────────────────────
+
+async function evaluateFile(
+  client: AnthropicVertex,
+  result: AuditResult
+): Promise<ReviewToolInput | null> {
+  // Path relative to scripts/ parent (the repo root)
+  const filePath = join(process.cwd(), "..", result.file);
+  const raw = readFileSync(filePath, "utf8");
+
+  let userContent: string;
+
+  if (result.staleness_source === "inline") {
+    const staleHeadings = result.stale_sections
+      .filter((s) => s.stale)
+      .map((s) => s.heading);
+
+    const sections = extractStaleSections(raw, staleHeadings);
+    if (sections.length === 0) {
+      console.error(`  [warn] Could not extract sections for ${result.file}`);
+      return null;
+    }
+
+    const sectionBlocks = sections
+      .map((s) => {
+        const meta = result.stale_sections.find(
+          (ss) => ss.heading === s.heading
+        );
+        return [
+          `### Section: "${s.heading}"`,
+          `Last reviewed: ${meta?.date ?? "unknown"} (${meta?.days_since_review ?? 0} days ago)`,
+          `Line range in full file: ${s.lineStart}–${s.lineEnd}`,
+          ``,
+          s.numbered,
+        ].join("\n");
+      })
+      .join("\n\n---\n\n");
+
+    userContent = [
+      `File: ${result.file}`,
+      ``,
+      `The following sections are stale and need accuracy evaluation. Line numbers shown are absolute references to the full file — use them in your changes[].`,
+      ``,
+      sectionBlocks,
+      ``,
+      `For each section: decide bump_date (content still accurate) or update_content (specific information is outdated). Return a single submit_review covering all sections.`,
+    ].join("\n");
+  } else {
+    userContent = [
+      `File: ${result.file}`,
+      `Last reviewed: ${result.date} (${result.days_since_review} days ago)`,
+      ``,
+      `Evaluate whether this documentation is still accurate. Use bump_date if valid, update_content with minimum changes if not.`,
+      ``,
+      addLineNumbers(raw),
+    ].join("\n");
+  }
+
+  const response = await client.messages.create({
+    model: MODEL,
+    max_tokens: 4096,
+    system: SYSTEM_PROMPT,
+    tools: [REVIEW_TOOL],
+    tool_choice: { type: "any" },
+    messages: [{ role: "user", content: userContent }],
+  });
+
+  const toolUse = response.content.find((b) => b.type === "tool_use");
+  if (!toolUse || toolUse.type !== "tool_use") {
+    console.error(`  [warn] No tool use in response for ${result.file}`);
+    return null;
+  }
+
+  return toolUse.input as ReviewToolInput;
+}
+
+// ── Main ──────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const args = process.argv.slice(2);
+  const auditFile =
+    args.find((a, i) => args[i - 1] === "--audit") ?? "../audit-results.json";
+  const dryRun = args.includes("--dry-run");
+  const limit = parseInt(
+    args.find((a, i) => args[i - 1] === "--limit") ?? String(BATCH_SIZE),
+    10
+  );
+
+  if (!process.env.GOOGLE_CLOUD_PROJECT) {
+    console.error("Error: GOOGLE_CLOUD_PROJECT env var is required");
+    process.exit(1);
+  }
+
+  if (!dryRun && hasTrackedChanges()) {
+    console.error(
+      "Working tree has uncommitted tracked changes. Commit or stash them first."
+    );
+    process.exit(1);
+  }
+
+  const originalBranch = getCurrentBranch();
+
+  const audit = JSON.parse(readFileSync(auditFile, "utf8"));
+  const toProcess: AuditResult[] = (audit.results as AuditResult[])
+    .filter((r) => r.stale)
+    .sort((a, b) => staleDaysFor(b) - staleDaysFor(a))
+    .slice(0, limit);
+
+  console.error(
+    `\nProcessing ${toProcess.length} files (dry-run: ${dryRun})\n`
+  );
+
+  // VERTEX_CREDENTIALS lets you point at a specific service account key without
+  // overriding your global GOOGLE_APPLICATION_CREDENTIALS.
+  const googleAuth = process.env.VERTEX_CREDENTIALS
+    ? new GoogleAuth({
+        keyFile: process.env.VERTEX_CREDENTIALS,
+        scopes: ["https://www.googleapis.com/auth/cloud-platform"],
+      })
+    : undefined;
+
+  const client = new AnthropicVertex({
+    projectId: process.env.GOOGLE_CLOUD_PROJECT,
+    region: process.env.VERTEX_REGION ?? "us-east5",
+    ...(googleAuth ? { googleAuth } : {}),
+  });
+
+  for (const result of toProcess) {
+    console.error(`→ ${result.file} [${staleDaysFor(result)}d stale]`);
+
+    const review = await evaluateFile(client, result);
+    if (!review) continue;
+
+    console.error(
+      `  action=${review.action}  confidence=${review.confidence}  changes=${review.changes.length}`
+    );
+    console.error(`  ${review.reason.slice(0, 120)}`);
+
+    if (dryRun) {
+      console.error("  [dry-run] skipping branch/PR\n");
+      continue;
+    }
+
+    // Apply changes to content in memory
+    const filePath = join(process.cwd(), "..", result.file);
+    const raw = readFileSync(filePath, "utf8");
+    let updated: string;
+
+    if (review.action === "bump_date") {
+      if (result.staleness_source === "inline") {
+        const staleHeadings = result.stale_sections
+          .filter((s) => s.stale)
+          .map((s) => s.heading);
+        updated = bumpInlineReviewDates(raw, staleHeadings);
+      } else {
+        updated = bumpFrontmatterDate(raw);
+      }
+    } else {
+      updated = applyLineChanges(raw, review.changes);
+    }
+
+    createBranchAndPR(result, updated, review, originalBranch);
+    console.error("");
+
+    // Pace API calls
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+
+  console.error("Done.");
+}
+
+main().catch((err) => {
+  console.error("Fatal:", err);
+  process.exit(1);
+});

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -1,0 +1,1024 @@
+{
+  "name": "docs-audit-scripts",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "docs-audit-scripts",
+      "version": "1.0.0",
+      "dependencies": {
+        "@anthropic-ai/vertex-sdk": "^0.16.0",
+        "google-auth-library": "^9.0.0",
+        "gray-matter": "^4.0.3"
+      },
+      "devDependencies": {
+        "tsx": "^4.20.3",
+        "typescript": "^5.8.3"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.91.1",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.91.1.tgz",
+      "integrity": "sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk": {
+      "version": "0.16.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/vertex-sdk/-/vertex-sdk-0.16.0.tgz",
+      "integrity": "sha512-ntxemtRkwPsjVzGQJsmBPRW38tfas6VuVlD1v6pHffDJKLPtCdaiN9KUQeraJ/F34tjxEWlsaCnl3t/orJm1Xw==",
+      "license": "MIT",
+      "dependencies": {
+        "@anthropic-ai/sdk": ">=0.50.3 <1",
+        "google-auth-library": "^9.4.2"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.7.tgz",
+      "integrity": "sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.7.tgz",
+      "integrity": "sha512-jbPXvB4Yj2yBV7HUfE2KHe4GJX51QplCN1pGbYjvsyCZbQmies29EoJbkEc+vYuU5o45AfQn37vZlyXy4YJ8RQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.7.tgz",
+      "integrity": "sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.7.tgz",
+      "integrity": "sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.7.tgz",
+      "integrity": "sha512-5lckdqeuBPlKUwvoCXIgI2D9/ABmPq3Rdp7IfL70393YgaASt7tbju3Ac+ePVi3KDH6N2RqePfHnXkaDtY9fkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.7.tgz",
+      "integrity": "sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-B48PqeCsEgOtzME2GbNM2roU29AMTuOIN91dsMO30t+Ydis3z/3Ngoj5hhnsOSSwNzS+6JppqWsuhTp6E82l2w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.7.tgz",
+      "integrity": "sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.7.tgz",
+      "integrity": "sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.7.tgz",
+      "integrity": "sha512-RZPHBoxXuNnPQO9rvjh5jdkRmVizktkT7TCDkDmQ0W2SwHInKCAV95GRuvdSvA7w4VMwfCjUiPwDi0ZO6Nfe9A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.7.tgz",
+      "integrity": "sha512-GA48aKNkyQDbd3KtkplYWT102C5sn/EZTY4XROkxONgruHPU72l+gW+FfF8tf2cFjeHaRbWpOYa/uRBz/Xq1Pg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.7.tgz",
+      "integrity": "sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.7.tgz",
+      "integrity": "sha512-KabT5I6StirGfIz0FMgl1I+R1H73Gp0ofL9A3nG3i/cYFJzKHhouBV5VWK1CSgKvVaG4q1RNpCTR2LuTVB3fIw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.7.tgz",
+      "integrity": "sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.7.tgz",
+      "integrity": "sha512-hL25LbxO1QOngGzu2U5xeXtxXcW+/GvMN3ejANqXkxZ/opySAZMrc+9LY/WyjAan41unrR3YrmtTsUpwT66InQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.7.tgz",
+      "integrity": "sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.7.tgz",
+      "integrity": "sha512-hzznmADPt+OmsYzw1EE33ccA+HPdIqiCRq7cQeL1Jlq2gb1+OyWBkMCrYGBJ+sxVzve2ZJEVeePbLM2iEIZSxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-OfatkLojr6U+WN5EDYuoQhtM+1xco+/6FSzJJnuWiUw5eVcicbyK3dq5EeV/QHT1uy6GoDhGbFpprUiHUYggrw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.7.tgz",
+      "integrity": "sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.7.tgz",
+      "integrity": "sha512-+A1NJmfM8WNDv5CLVQYJ5PshuRm/4cI6WMZRg1by1GwPIQPCTs1GLEUHwiiQGT5zDdyLiRM/l1G0Pv54gvtKIg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.7.tgz",
+      "integrity": "sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.7.tgz",
+      "integrity": "sha512-ikktIhFBzQNt/QDyOL580ti9+5mL/YZeUPKU2ivGtGjdTYoqz6jObj6nOMfhASpS4GU4Q/Clh1QtxWAvcYKamA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.7.tgz",
+      "integrity": "sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.7.tgz",
+      "integrity": "sha512-SmwKXe6VHIyZYbBLJrhOoCJRB/Z1tckzmgTLfFYOfpMAx63BJEaL9ExI8x7v0oAO3Zh6D/Oi1gVxEYr5oUCFhw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.7.tgz",
+      "integrity": "sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.3.1.tgz",
+      "integrity": "sha512-Ko0uX15oIUS7wJ3Rb30Fs6SkVbLmPBAKdlm7q9+ak9bbIeFf0MwuBsQV6z7+X768/cHsfg+WlysDWJcmthjsjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.27.7",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.7.tgz",
+      "integrity": "sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.27.7",
+        "@esbuild/android-arm": "0.27.7",
+        "@esbuild/android-arm64": "0.27.7",
+        "@esbuild/android-x64": "0.27.7",
+        "@esbuild/darwin-arm64": "0.27.7",
+        "@esbuild/darwin-x64": "0.27.7",
+        "@esbuild/freebsd-arm64": "0.27.7",
+        "@esbuild/freebsd-x64": "0.27.7",
+        "@esbuild/linux-arm": "0.27.7",
+        "@esbuild/linux-arm64": "0.27.7",
+        "@esbuild/linux-ia32": "0.27.7",
+        "@esbuild/linux-loong64": "0.27.7",
+        "@esbuild/linux-mips64el": "0.27.7",
+        "@esbuild/linux-ppc64": "0.27.7",
+        "@esbuild/linux-riscv64": "0.27.7",
+        "@esbuild/linux-s390x": "0.27.7",
+        "@esbuild/linux-x64": "0.27.7",
+        "@esbuild/netbsd-arm64": "0.27.7",
+        "@esbuild/netbsd-x64": "0.27.7",
+        "@esbuild/openbsd-arm64": "0.27.7",
+        "@esbuild/openbsd-x64": "0.27.7",
+        "@esbuild/openharmony-arm64": "0.27.7",
+        "@esbuild/sunos-x64": "0.27.7",
+        "@esbuild/win32-arm64": "0.27.7",
+        "@esbuild/win32-ia32": "0.27.7",
+        "@esbuild/win32-x64": "0.27.7"
+      }
+    },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/get-tsconfig": {
+      "version": "4.14.0",
+      "resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
+      "integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "resolve-pkg-maps": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
+      }
+    },
+    "node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.1.tgz",
+      "integrity": "sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "^1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.1.tgz",
+      "integrity": "sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.1",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/resolve-pkg-maps": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
+      "integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+      }
+    },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT"
+    },
+    "node_modules/tsx": {
+      "version": "4.21.0",
+      "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.21.0.tgz",
+      "integrity": "sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "~0.27.0",
+        "get-tsconfig": "^4.7.5"
+      },
+      "bin": {
+        "tsx": "dist/cli.mjs"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/scripts/package-lock.json
+++ b/scripts/package-lock.json
@@ -9,8 +9,9 @@
       "version": "1.0.0",
       "dependencies": {
         "@anthropic-ai/vertex-sdk": "^0.16.0",
-        "google-auth-library": "^9.0.0",
-        "gray-matter": "^4.0.3"
+        "google-auth-library": "^10.0.0",
+        "gray-matter": "^4.0.3",
+        "tmp": "^0.2.5"
       },
       "devDependencies": {
         "tsx": "^4.20.3",
@@ -45,6 +46,46 @@
       "dependencies": {
         "@anthropic-ai/sdk": ">=0.50.3 <1",
         "google-auth-library": "^9.4.2"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/gcp-metadata": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
+      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.1.1",
+        "google-logging-utils": "^0.0.2",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/google-auth-library": {
+      "version": "9.15.1",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
+      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@anthropic-ai/vertex-sdk/node_modules/google-logging-utils": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
+      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@babel/runtime": {
@@ -551,6 +592,15 @@
       "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
       "license": "BSD-3-Clause"
     },
+    "node_modules/data-uri-to-buffer": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
+      "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -650,6 +700,41 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/fetch-blob": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/fetch-blob/-/fetch-blob-3.2.0.tgz",
+      "integrity": "sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "node-domexception": "^1.0.0",
+        "web-streams-polyfill": "^3.0.3"
+      },
+      "engines": {
+        "node": "^12.20 || >= 14.13"
+      }
+    },
+    "node_modules/formdata-polyfill": {
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/formdata-polyfill/-/formdata-polyfill-4.0.10.tgz",
+      "integrity": "sha512-buewHzMvYL29jdeQTVILecSaZKnt/RJWjoZCF5OW60Z67/GmSLBkOFM7qh1PI3zFNtJbaZL5eQu1vLfazOwj4g==",
+      "license": "MIT",
+      "dependencies": {
+        "fetch-blob": "^3.1.2"
+      },
+      "engines": {
+        "node": ">=12.20.0"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -666,33 +751,31 @@
       }
     },
     "node_modules/gaxios": {
-      "version": "6.7.1",
-      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
-      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-7.1.4.tgz",
+      "integrity": "sha512-bTIgTsM2bWn3XklZISBTQX7ZSddGW+IO3bMdGaemHZ3tbqExMENHLx6kKZ/KlejgrMtj8q7wBItt51yegqalrA==",
       "license": "Apache-2.0",
       "dependencies": {
         "extend": "^3.0.2",
         "https-proxy-agent": "^7.0.1",
-        "is-stream": "^2.0.0",
-        "node-fetch": "^2.6.9",
-        "uuid": "^9.0.1"
+        "node-fetch": "^3.3.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/gcp-metadata": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.1.tgz",
-      "integrity": "sha512-a4tiq7E0/5fTjxPAaH4jpjkSv/uCaU2p5KC6HVGrvl0cDjA8iBZv4vv1gyzlmK0ZUKqwpOyQMKzZQe3lTit77A==",
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-8.1.2.tgz",
+      "integrity": "sha512-zV/5HKTfCeKWnxG0Dmrw51hEWFGfcF2xiXqcA3+J90WDuP0SvoiSO5ORvcBsifmx/FoIjgQN3oNOGaQ5PhLFkg==",
       "license": "Apache-2.0",
       "dependencies": {
-        "gaxios": "^6.1.1",
-        "google-logging-utils": "^0.0.2",
+        "gaxios": "^7.0.0",
+        "google-logging-utils": "^1.0.0",
         "json-bigint": "^1.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/get-tsconfig": {
@@ -709,26 +792,26 @@
       }
     },
     "node_modules/google-auth-library": {
-      "version": "9.15.1",
-      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.1.tgz",
-      "integrity": "sha512-Jb6Z0+nvECVz+2lzSMt9u98UsoakXxA2HGHMCxh+so3n90XgYWkq5dur19JAJV7ONiJY22yBTyJB1TSkvPq9Ng==",
+      "version": "10.6.2",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-10.6.2.tgz",
+      "integrity": "sha512-e27Z6EThmVNNvtYASwQxose/G57rkRuaRbQyxM2bvYLLX/GqWZ5chWq2EBoUchJbCc57eC9ArzO5wMsEmWftCw==",
       "license": "Apache-2.0",
       "dependencies": {
         "base64-js": "^1.3.0",
         "ecdsa-sig-formatter": "^1.0.11",
-        "gaxios": "^6.1.1",
-        "gcp-metadata": "^6.1.0",
-        "gtoken": "^7.0.0",
+        "gaxios": "^7.1.4",
+        "gcp-metadata": "8.1.2",
+        "google-logging-utils": "1.1.3",
         "jws": "^4.0.0"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/google-logging-utils": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-0.0.2.tgz",
-      "integrity": "sha512-NEgUnEcBiP5HrPzufUkBzJOD/Sxsco3rLNo1F1TNf7ieU8ryUzBhqba8r756CjLX7rn3fHl6iLEwPYuqpoKgQQ==",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/google-logging-utils/-/google-logging-utils-1.1.3.tgz",
+      "integrity": "sha512-eAmLkjDjAFCVXg7A1unxHsLf961m6y17QFqXqAXGj/gVkKFrEICfStRfwUlGNfeCEjNRa32JEWOUTlYXPyyKvA==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=14"
@@ -782,18 +865,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
-      }
-    },
-    "node_modules/is-stream": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
-      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/js-yaml": {
@@ -867,24 +938,42 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "deprecated": "Use your platform's native DOMException instead",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.5.0"
+      }
+    },
     "node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "version": "3.3.2",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
+      "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
       "license": "MIT",
       "dependencies": {
-        "whatwg-url": "^5.0.0"
+        "data-uri-to-buffer": "^4.0.0",
+        "fetch-blob": "^3.1.4",
+        "formdata-polyfill": "^4.0.10"
       },
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/node-fetch"
       }
     },
     "node_modules/resolve-pkg-maps": {
@@ -945,11 +1034,14 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
-      "license": "MIT"
+    "node_modules/tmp": {
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.14"
+      }
     },
     "node_modules/ts-algebra": {
       "version": "2.0.0",
@@ -991,33 +1083,13 @@
         "node": ">=14.17"
       }
     },
-    "node_modules/uuid": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
-      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
-      "funding": [
-        "https://github.com/sponsors/broofa",
-        "https://github.com/sponsors/ctavan"
-      ],
+    "node_modules/web-streams-polyfill": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.3.3.tgz",
+      "integrity": "sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==",
       "license": "MIT",
-      "bin": {
-        "uuid": "dist/bin/uuid"
-      }
-    },
-    "node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
-      "license": "MIT",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
+      "engines": {
+        "node": ">= 8"
       }
     }
   }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -9,12 +9,15 @@
   },
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.16.0",
-    "google-auth-library": "^9.0.0",
+    "google-auth-library": "^10.0.0",
     "gray-matter": "^4.0.3",
     "tmp": "^0.2.5"
   },
   "devDependencies": {
     "tsx": "^4.20.3",
     "typescript": "^5.8.3"
+  },
+  "overrides": {
+    "gaxios": "^7.1.4"
   }
 }

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -10,7 +10,8 @@
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.16.0",
     "google-auth-library": "^9.0.0",
-    "gray-matter": "^4.0.3"
+    "gray-matter": "^4.0.3",
+    "tmp": "^0.2.5"
   },
   "devDependencies": {
     "tsx": "^4.20.3",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "audit": "tsx audit.ts",
-    "evaluate": "tsx evaluate.ts"
+    "evaluate": "tsx --env-file=../.env evaluate.ts"
   },
   "dependencies": {
     "@anthropic-ai/vertex-sdk": "^0.16.0",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "docs-audit-scripts",
+  "version": "1.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "audit": "tsx audit.ts",
+    "evaluate": "tsx evaluate.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/vertex-sdk": "^0.16.0",
+    "google-auth-library": "^9.0.0",
+    "gray-matter": "^4.0.3"
+  },
+  "devDependencies": {
+    "tsx": "^4.20.3",
+    "typescript": "^5.8.3"
+  }
+}

--- a/scripts/tsconfig.json
+++ b/scripts/tsconfig.json
@@ -1,0 +1,10 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,6 @@
     ".next/types/**/*.ts",
     "src/components/common/marketo-form.jsx"
   ],
-  "exclude": ["node_modules"],
+  "exclude": ["node_modules", "scripts"],
   "types": ["react", "react-dom"]
 }


### PR DESCRIPTION
The PR adds review automation.

Currently, the automation must run locally although there are parts of it that could be run via automation. There are two main components of the automation.

## `scripts/audit.ts`

The audit script scans all of our docs and looks at 
* the last reviewed date in frontmatter
* the last reviewed date _inline_ (if it exists)
* the last modified date of the file

It then generates an audit report with the number of outdated files and how they are outdated, e.g.:

```json
{
  "summary": {
    "generated_at": "2026-04-28T21:23:50.336Z",
    "total_files_audited": 363,
    "stale_count": 363,
    "by_source": {
      "inline": 5,
      "frontmatter": 358,
      "git": 0
    }
  },
  "results": [
    {
      "file": "src/source/content/drupal-s3.md",
      "staleness_source": "frontmatter",
      "date": "2016-09-01",
      "days_since_review": 3526
    },
    {
      "file": "src/source/content/pingdom-uptime-check.md",
      "staleness_source": "frontmatter",
      "date": "2017-05-14",
      "days_since_review": 3271
    },
    {
      "file": "src/source/content/modules-known-issues.md",
      "staleness_source": "inline",
      "frontmatter_date": null,
      "frontmatter_days_since_review": null,
      "stale_sections": [
        {
          "heading": "[Front](https://www.drupal.org/project/front)",
          "date": "2018-01-03",
          "days_since_review": 3037,
          "line_start": 149,
          "line_end": 158
        },
        {
          "heading": "[Honeypot http:BL](https://www.drupal.org/project/httpbl)",
          "date": "2019-07-10",
          "days_since_review": 2484,
          "line_start": 165,
          "line_end": 171
        },
...
```

This automation can be run at any time and could be run on a cron schedule, but currently there's no logic to _do anything_ with this automation.

## `scripts/evaluate.ts`

The **evaluate** script takes the results of the **audit** and looks at each file and sends that to Claude via VertexAI to evaluate what actually needs to be changed. Claude reviews the doc and generates a pull request (draft) based on its understanding and assessment of the issue(s) and gives each a confidence rating. Any changes that affect more than 5 lines are automatically given a **low** confidence rating. The prompt instructs Claude to avoid modifying headings and to make the smallest possible changes. The [ull request includes a standardized title (`[Update Stale] {doc name}`) and some standardized fields at the top, followed by its notes and suggested resolution. Example:

```md
[AWS S3 Setup for Drupal](https://docs.pantheon.io/drupal-s3)
Date: 2016-09-01
Days since last review: 3526
Confidence rating: Low ⚠️

## Review notes

This document was last reviewed nearly 10 years ago (2016-09-01). Several areas are outdated:

1. **AWS Console UI changes** — The AWS IAM console has been significantly redesigned since 2016. Steps like "Create your Own Policy," "Add more permissions," "Create New Group," "Create New Users," and "Show User Security Credentials" no longer match the current AWS Console UI flow. The modern IAM console uses a visual policy editor and different button labels.

2. **Bucket permissions UI** — The step referencing "Select Permissions within the bucket properties and click Add more permissions" does not reflect the current S3 console UI, which was redesigned significantly (including the introduction of Block Public Access settings).

3. **Drush version references** — The document references Drush 8 and sites created prior to November 4, 2015, which is deeply outdated. Drush 8 is end-of-life; Drupal 7 sites on Pantheon now use Drush 8 by default for compatibility but this framing is stale. More importantly, `drush make` (used to install the AWS SDK) is a Drush 8 concept and is no longer available in Drush 9+.

4. **AWS SDK Library version** — The doc references AWS SDK 2.x, which is very old. The s3fs module for Drupal 7 has since updated its requirements.

5. **IAM Group creation workflow** — AWS IAM has deprecated the "Groups" UI path in favor of IAM Identity Center for multi-user scenarios; creating IAM users directly is still supported but the UI steps differ.

6. **`drush make` command** — This command is Drush 8-era and not available in modern Drush versions. The s3fs module installation path via `drush make` is outdated.

The number of outdated lines exceeds 5, and some changes involve third-party (AWS Console) UI behavior that cannot be fully verified against current state.

*Confidence: Low ⚠️ — More than 5 lines require changes, and the accuracy of multiple AWS Console UI steps and Drush/SDK version details cannot be fully verified against current third-party behavior given the nearly 10-year gap since last review.*

## Suggested resolution

- **AWS Console steps (lines 39–55, 61–73, 81–105)** need to be updated to reflect the current AWS Console UI. However, since the exact current AWS UI flow cannot be verified with certainty, a low-confidence flag is appropriate and a subject-matter expert should re-verify all AWS Console steps.

- **Lines 113–118** referencing Drush 8 and November 4, 2015 cutoff dates should be updated or removed, as this framing is no longer relevant.

- **Lines 135–143** referencing AWS SDK Library 2.x and `drush make` should be updated — `drush make` is not available in modern Drush, and the SDK version requirement may have changed.

- A full re-test and rewrite of this document by someone with access to a current AWS Console and a Drupal 7 site on Pantheon is strongly recommended before simply bumping the date.
```

In some cases, all that the PR might need is a date bump. In those cases, that would be noted in the PR. 

## Batch size

The script batches PRs to max at 50 at a time to not overload the queue. PRs are opened as drafts so we can evaluate as needed. The script can be run manually from a local machine with the `--limit` flag to limit the number of PRs to open. 

Each file processed opens its own PR, regardless of how it was flagged for staleness. That is to say, if a file has many `<ReviewDate>` inline tags, it will get a single PR with all those changes. If a file was flagged because the frontmatter showed it hadn't been reviewed in the last 12 months, it will get a PR. We won't get PRs for discrete changes in a single file.

## Automating and auth

Per security policy, we will need to implement a Workload Identity Federation setup (WIF) rather than storing the VertexAI API key in the repository secrets, which is why this is currently limited to local environment setups only. See https://github.com/pantheon-systems/pantheon-skills/pull/148 
I'll be working with @JGrubb on this.

## Local setup

**Prerequisites:** Node.js 22+, `gh` CLI authenticated to `pantheon-systems`, a GCP service account JSON with Vertex AI access.

**One-time install:**

```bash
cd scripts && npm install
```

**Create `scripts/.env`** (gitignored):

```bash
GOOGLE_CLOUD_PROJECT=your-gcp-project-id
VERTEX_CREDENTIALS=/path/to/service-account.json
VERTEX_REGION=global
```

---

## Audit script

Crawls `src/source/content/` and identifies stale docs using three mechanisms in priority order:

1. **Inline `<ReviewDate>`** — per-section dates in files like `wordpress-known-issues.md`; flags sections older than 12 months
2. **Frontmatter `reviewed:`** — flags files where the date is older than 12 months
3. **Git fallback** — if no date can be determined, uses the last commit date for the file

Run from the **repo root** via `npm run audit`.

| Flag | Description |
|---|---|
| `--stale-only` | Output only stale files |
| `--output <path>` | Write JSON to file instead of stdout |

```bash
# Generate audit results (required before running evaluate)
npm run audit -- --stale-only --output audit-results.json
```

---

## Evaluate script

Reads the audit JSON, sends stale content to Claude (Sonnet via Vertex AI) for accuracy evaluation, and opens a draft PR per file with proposed changes.

- **Inline files** — only the stale sections are sent to Claude
- **Frontmatter files** — the full document is sent
- Each file gets its own draft PR; the 50 oldest stale files are processed per run

Run from the **`scripts/`** directory with env vars sourced.

| Flag | Description | Default |
|---|---|---|
| `--dry-run` | Evaluate with Claude, write results to `scripts/dry-run/` instead of opening PRs | off |
| `--limit <n>` | Number of files to process | `50` |
| `--audit <path>` | Path to audit JSON | `../audit-results.json` |

```bash
cd scripts
# Dry run — inspect proposed changes before opening PRs
npm run evaluate -- --dry-run
# Dry run, smaller batch
npm run evaluate -- --dry-run --limit 10
# Live run — opens one draft PR per file
npm run evaluate
# Live run against a specific audit file
npm run evaluate -- --audit /path/to/audit-results.json --limit 20
```

Dry-run output lands in `scripts/dry-run/<doc-slug>.md` — one file per result, containing the PR title, description, and a unified diff of the proposed changes.

