### PR TITLE
docs(SITE-5182): Add release note for Tika 1.x removal

### DIFF
--- a/src/source/releasenotes/2026-04-29-tika-1-removal.md
+++ b/src/source/releasenotes/2026-04-29-tika-1-removal.md
@@ -1,0 +1,11 @@
+---
+title: "Tika 1.x removed: all sites now use Tika 3"
+published_date: "2026-04-29"
+categories: [infrastructure, action-required, drupal]
+---
+
+As [previously announced](/release-notes/2026/04/tika-3-ocr-config-and-removal-timeline), Tika 1.18 and 1.21 have been removed from the Pantheon platform. All sites now run Tika 3 regardless of the `tika_version` setting in `pantheon.yml`. Any `tika_version: 1` entries will be ignored until May 12, 2026, at which point they will be rejected and prevent deployments.
+
+If you have not already done so, remove `tika_version: 1` from your `pantheon.yml` before May 12, 2026.
+
+Existing Tika 1.x file paths will continue to symlink to the new Tika 3 location for the time being, but these symlinks will be removed at a later date. See [External Libraries: Apache Tika](/external-libraries#apache-tika) for the current Tika 3 path and integration guidance.

--- a/src/source/releasenotes/2026-04-29-tika-1-removal.md
+++ b/src/source/releasenotes/2026-04-29-tika-1-removal.md
@@ -4,8 +4,11 @@ published_date: "2026-04-29"
 categories: [infrastructure, action-required, drupal]
 ---
 
-As [previously announced](/release-notes/2026/04/tika-3-ocr-config-and-removal-timeline), Tika 1.18 and 1.21 have been removed from the Pantheon platform. All sites now run Tika 3 regardless of the `tika_version` setting in `pantheon.yml`. Any `tika_version: 1` entries will be ignored until May 12, 2026, at which point they will be rejected and prevent deployments.
+As [previously announced](/release-notes/2026/04/tika-3-ocr-config-and-removal-timeline), Tika 1.18 and 1.21 have been removed from the Pantheon platform. All sites now run Tika 3 regardless of the `tika_version` setting in `pantheon.yml`.
 
-If you have not already done so, remove `tika_version: 1` from your `pantheon.yml` before May 12, 2026.
+## Action Required
 
-Existing Tika 1.x file paths will continue to symlink to the new Tika 3 location for the time being, but these symlinks will be removed at a later date. See [External Libraries: Apache Tika](/external-libraries#apache-tika) for the current Tika 3 path and integration guidance.
+* If you have not already done so, remove `tika_version: 1` from your `pantheon.yml` before May 12, 2026.
+  * Any `tika_version: 1` entries will be ignored until May 12, 2026, at which point **they will be rejected and prevent deployments**.
+* Update the used Tika 1.x path to Tika 3, for details [related documentation](/external-libraries#apache-tika).
+  * Existing Tika 1.x file paths will continue to symlink to the new Tika 3 location for the time being, but these symlinks will be removed at a later date.

--- a/src/source/releasenotes/2026-04-29-tika-1-removal.md
+++ b/src/source/releasenotes/2026-04-29-tika-1-removal.md
@@ -10,5 +10,5 @@ As [previously announced](/release-notes/2026/04/tika-3-ocr-config-and-removal-t
 
 * If you have not already done so, remove `tika_version: 1` from your `pantheon.yml` before May 12, 2026.
   * Any `tika_version: 1` entries will be ignored until May 12, 2026, at which point **they will be rejected and prevent deployments**.
-* Update the used Tika 1.x path to Tika 3, for details [related documentation](/external-libraries#apache-tika).
+* Update the used Tika 1.x path to Tika 3, for details see [related documentation](/external-libraries#apache-tika).
   * Existing Tika 1.x file paths will continue to symlink to the new Tika 3 location for the time being, but these symlinks will be removed at a later date.


### PR DESCRIPTION
## Summary

- Adds release note for the removal of Tika 1.x from the platform, scheduled to publish 2026-04-29
- Notes the May 12, 2026 deadline for removing `tika_version: 1` from `pantheon.yml`
- Notes that legacy Tika 1.x file paths will symlink to Tika 3 temporarily before being removed

## Related

- SITE-5182
- Prior announcements: [April 2026](/release-notes/2026/04/tika-3-ocr-config-and-removal-timeline), [October 2025](/release-notes/2025/10/tika1x-eol)
- https://github.com/pantheon-systems/titan-mt/pull/21444