### PR TITLE
Configuring New Relic Browser Agent for Drupal 10.2+

### DIFF
--- a/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -112,12 +112,35 @@ You have two options to enable the New Relic Browser Agent. You **must only choo
 #### Option 1: Manual Theme Instrumentation (Recommended)
 This is New Relic’s officially recommended workaround. By manually placing the JavaScript snippet into your theme, you avoid header conflicts entirely.
 
+<TabList>
+
+<Tab title="Add your first browser app" id="create" active={true}>
+
+If you have **not** already created a browser monitor in New Relic for this specific site, follow these steps:
+
 1. Log into your New Relic dashboard.
-1. Navigate to your APM application.
-1. In the left-hand menu, click **Browser/Views** > **Application Settings**.
-1. Select the option to copy the JavaScript snippet.
-1. Paste this snippet directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
+1. Click **Browser** from the lefthand navigation menu.
+1. Select **Add your first browser app** then click **Browser monitoring**.
+1. Click **Place a JavaScript snippet in frontend code**, then enter a name for your browser app and click **Save and continue**.
+1. Based on your site requirements, determine whether to enable [**distributed tracing**](https://docs.newrelic.com/docs/browser/new-relic-browser/browser-pro-features/browser-data-distributed-tracing/) for this browser app.
+1. Copy the provided code snippet from New Relic and paste it directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
 1. Commit and deploy your code.
+
+</Tab>
+
+<Tab title="Existing browser app" id="existing">
+
+If you have existing browser monitor(s) in New Relic for this specific site, follow these steps:
+
+1. Log into your New Relic dashboard.
+1. Click **Browser** from the lefthand navigation menu.
+1. Select the desired entity from your existing browser apps, then scroll down and click **Application Settings**.
+1. Copy the provided code snippet from New Relic and paste it directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
+1. Commit and deploy your code.
+
+</Tab>
+
+</TabList>
 
 #### Option 2: Platform Auto-Injection via `pantheon.yml`
 If you prefer not to edit your theme files, you can instruct our platform to forcefully handle the injection for you. Enabling this setting tells our platform to intercept the Drupal response, strip the `Content-Length` header, and safely inject the New Relic script.

--- a/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -79,7 +79,60 @@ You must manually [remove a deleted Multidev environment in New Relic](https://d
 
 ## Enable Browser Monitoring for Drupal 10.2+
 
-With the release of Drupal 10.2, [a change to http headers in Drupal core](https://www.drupal.org/node/3298551) prevents automatic injection of New Relic Browser Monitoring code. To continue using this feature, manually insert the tracking script into your templates. [Visit the New Relic documentation for an example configuration](https://docs.newrelic.com/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#manual_drupal).
+If you are running Drupal 10.2 or higher, [New Relic’s Browser Agent](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring/) auto-instrumentation is disabled by default. 
+
+### The Context: Why is Auto-Instrumentation disabled?
+Starting in version 10.2, Drupal automatically calculates and sets a `Content-Length` HTTP header for most page responses to optimize web server performance.
+
+Normally, New Relic’s server-side PHP Agent acts as a middleman, automatically injecting the Browser Agent into your HTML before it reaches the user. However, this injection increases the total size of the file. This creates a mismatch between the originally declared `Content-Length` and the new, larger payload size. This mismatch can cause modern browsers to truncate (cut off) the page before it fully loads, breaking your site's layout and functionality.
+
+In order to avoid this, **we automatically disable the Browser auto-injection feature for sites using Drupal 10.2+**. This is in line with New Relic’s official documentation, and your PHP agent instrumentation remains unchanged.
+
+Instead, one option provided by New Relic is to manually instrument your site by pasting the Browser Agent snippets directly into your page templates. This should restore the previous metrics collection, but can be a tedious process.
+
+Another option is to enable Pantheon’s automatic Browser Agent injection, which will automatically add the Browser Agent headers and footers on demand via PHP prepend files behind the scenes.  Because removing this header can negatively impact edge caching and how browsers download your site's assets, we do not strip this header or auto-inject the script by default for Drupal 10.2+ environments.
+
+<Alert title="Note" type="info">
+
+WordPress sites and older versions of Drupal (pre-10.2) do not enforce this header strictly. Auto-instrumentation of New Relic’s Browser agent continues to work out-of-the-box for those frameworks.
+
+</Alert>
+
+### How to Enable Browser Monitoring
+You have two options to enable the New Relic Browser Agent. You **must only choose one**. Using both methods simultaneously will result in double-counted metrics and skewed performance data.
+
+#### Option 1: Manual Theme Instrumentation (Recommended)
+This is New Relic’s officially recommended workaround. By manually placing the JavaScript snippet into your theme, you avoid header conflicts entirely.
+
+1. Log into your New Relic dashboard.
+1. Navigate to your APM application.
+1. In the left-hand menu, click **Browser/Views** > **Application Settings**.
+1. Select the option to copy the JavaScript snippet.
+1. Paste this snippet directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
+1. Commit and deploy your code.
+
+#### Option 2: Platform Auto-Injection via `pantheon.yml`
+If you prefer not to edit your theme files, you can instruct our platform to forcefully handle the injection for you. Enabling this setting tells our platform to intercept the Drupal response, strip the `Content-Length` header, and safely inject the New Relic script.
+
+1. Open your project's code repository.
+1. Locate the `pantheon.yml` file in the root directory.
+1. Look for the following configuration flag and set it to `true`:
+
+    ```yml:title=pantheon.yml
+    # NEW RELIC BROWSER AGENT AUTO-INJECT - For Drupal 10.2+
+    # Warning: Setting this to 'true' will remove Drupal's default Content-Length headers for responses.
+    # DO NOT enable this if you have already manually pasted the New Relic snippet into your theme.
+    nr_browser_auto_inject: true
+    ```
+
+1. Commit and push the `pantheon.yml` file to your environment.
+1. Changes will take effect within 24 hours and you should see data populating in the Browser section in your site’s New Relic.
+
+### Important Considerations
+
+* **Manually Instrumented:** If you previously implemented Option 1 (Manual Instrumentation), you must leave `nr_browser_auto_inject` set to `false` (or omit it entirely). Turning it on may result in incorrect recording of Browser metrics.
+* **Edge Caching impact:** If you choose Option 2, be aware that stripping the `Content-Length` header modifies core Drupal HTTP behavior. While generally safe, if you utilize highly customized edge caching rules that strictly rely on this header, you may experience unexpected caching behavior. If this occurs, revert to Option 1.
+
 
 ## Disable New Relic Browser Monitoring Agent
 

--- a/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -81,6 +81,12 @@ You must manually [remove a deleted Multidev environment in New Relic](https://d
 
 If you are running Drupal 10.2 or higher, [New Relic’s Browser Agent](https://docs.newrelic.com/docs/browser/browser-monitoring/getting-started/introduction-browser-monitoring/) auto-instrumentation is disabled by default. 
 
+<Alert title="Note" type="info">
+
+WordPress sites and older versions of Drupal (pre-10.2) do not enforce this header strictly. Auto-instrumentation of New Relic’s Browser agent continues to work out-of-the-box for those frameworks.
+
+</Alert>
+
 ### The Context: Why is Auto-Instrumentation disabled?
 Starting in version 10.2, Drupal automatically calculates and sets a `Content-Length` HTTP header for most page responses to optimize web server performance.
 
@@ -88,18 +94,20 @@ Normally, New Relic’s server-side PHP Agent acts as a middleman, automatically
 
 In order to avoid this, **we automatically disable the Browser auto-injection feature for sites using Drupal 10.2+**. This is in line with New Relic’s official documentation, and your PHP agent instrumentation remains unchanged.
 
-Instead, one option provided by New Relic is to manually instrument your site by pasting the Browser Agent snippets directly into your page templates. This should restore the previous metrics collection, but can be a tedious process.
+Instead, one option provided by New Relic is to [manually instrument your site](#option-1-manual-theme-instrumentation-recommended) by pasting the Browser Agent snippets directly into your page templates. This should restore the previous metrics collection, but can be a tedious process.
 
-Another option is to enable Pantheon’s automatic Browser Agent injection, which will automatically add the Browser Agent headers and footers on demand via PHP prepend files behind the scenes.  Because removing this header can negatively impact edge caching and how browsers download your site's assets, we do not strip this header or auto-inject the script by default for Drupal 10.2+ environments.
-
-<Alert title="Note" type="info">
-
-WordPress sites and older versions of Drupal (pre-10.2) do not enforce this header strictly. Auto-instrumentation of New Relic’s Browser agent continues to work out-of-the-box for those frameworks.
-
-</Alert>
+Another option is to [enable Pantheon’s automatic Browser Agent injection](#option-2-platform-auto-injection-via-pantheonyml), which will automatically add the Browser Agent headers and footers on demand via PHP prepend files behind the scenes. Because removing this header can negatively impact edge caching and how browsers download your site's assets, we do not strip this header or auto-inject the script by default for Drupal 10.2+ environments.
 
 ### How to Enable Browser Monitoring
 You have two options to enable the New Relic Browser Agent. You **must only choose one**. Using both methods simultaneously will result in double-counted metrics and skewed performance data.
+
+<Alert title="Important Considerations" type="danger">
+
+* If you have previously implemented [Option 1 (manual instrumentation)](#option-1-manual-theme-instrumentation-recommended), you must not use [Option 2 (Pantheon's auto-inject)](#option-2-platform-auto-injection-via-pantheonyml) as it may result in incorrect recording of Browser metrics. Instead, leave `nr_browser_auto_inject` set to `false` (or omit it entirely) within your site's `pantheon.yml` configuration file.
+
+* If you choose [Option 2 (Pantheon's auto-inject)](#option-2-platform-auto-injection-via-pantheonyml), be aware that stripping the `Content-Length` header modifies core Drupal HTTP behavior. While generally safe, if you utilize highly customized edge caching rules that strictly rely on this header, you may experience unexpected caching behavior. If this occurs, revert to [Option 1](#option-1-manual-theme-instrumentation-recommended).
+
+</Alert>
 
 #### Option 1: Manual Theme Instrumentation (Recommended)
 This is New Relic’s officially recommended workaround. By manually placing the JavaScript snippet into your theme, you avoid header conflicts entirely.
@@ -127,12 +135,6 @@ If you prefer not to edit your theme files, you can instruct our platform to for
 
 1. Commit and push the `pantheon.yml` file to your environment.
 1. Changes will take effect within 24 hours and you should see data populating in the Browser section in your site’s New Relic.
-
-### Important Considerations
-
-* **Manually Instrumented:** If you previously implemented Option 1 (Manual Instrumentation), you must leave `nr_browser_auto_inject` set to `false` (or omit it entirely). Turning it on may result in incorrect recording of Browser metrics.
-* **Edge Caching impact:** If you choose Option 2, be aware that stripping the `Content-Length` header modifies core Drupal HTTP behavior. While generally safe, if you utilize highly customized edge caching rules that strictly rely on this header, you may experience unexpected caching behavior. If this occurs, revert to Option 1.
-
 
 ## Disable New Relic Browser Monitoring Agent
 

--- a/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -13,6 +13,7 @@ tags: [code, newrelic, quicksilver, workflow]
 contributors: [whitneymeredith]
 showtoc: true
 permalink: docs/guides/new-relic/troubleshoot-new-relic
+reviewed: "2026-05-11"
 ---
 
 This section provides solutions for common New Relic troubleshooting scenarios.
@@ -103,7 +104,7 @@ You have two options to enable the New Relic Browser Agent. You **must only choo
 
 <Alert title="Important Considerations" type="danger">
 
-* If you have previously implemented [Option 1 (manual instrumentation)](#option-1-manual-theme-instrumentation-recommended), you must not use [Option 2 (Pantheon's auto-inject)](#option-2-platform-auto-injection-via-pantheonyml) as it may result in incorrect recording of Browser metrics. Instead, leave `nr_browser_auto_inject` set to `false` (or omit it entirely) within your site's `pantheon.yml` configuration file.
+* If you have previously implemented [Option 1 (manual instrumentation)](#option-1-manual-theme-instrumentation-recommended), you must not use [Option 2 (Pantheon's auto-inject)](#option-2-platform-auto-injection-via-pantheonyml) as it may result in incorrect recording of Browser metrics. Instead, leave `browser_auto_inject` set to `false` (or omit it entirely) within your site's `pantheon.yml` configuration file.
 
 * If you choose [Option 2 (Pantheon's auto-inject)](#option-2-platform-auto-injection-via-pantheonyml), be aware that stripping the `Content-Length` header modifies core Drupal HTTP behavior. While generally safe, if you utilize highly customized edge caching rules that strictly rely on this header, you may experience unexpected caching behavior. If this occurs, revert to [Option 1](#option-1-manual-theme-instrumentation-recommended).
 
@@ -111,12 +112,6 @@ You have two options to enable the New Relic Browser Agent. You **must only choo
 
 #### Option 1: Manual Theme Instrumentation (Recommended)
 This is New Relic’s officially recommended workaround. By manually placing the JavaScript snippet into your theme, you avoid header conflicts entirely.
-
-<TabList>
-
-<Tab title="Add your first browser app" id="create" active={true}>
-
-If you have **not** already created a browser monitor in New Relic for this specific site, follow these steps:
 
 1. Log into your New Relic dashboard.
 1. Click **Browser** from the lefthand navigation menu.
@@ -126,36 +121,32 @@ If you have **not** already created a browser monitor in New Relic for this spec
 1. Copy the provided code snippet from New Relic and paste it directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
 1. Commit and deploy your code.
 
-</Tab>
-
-<Tab title="Existing browser app" id="existing">
-
-If you have existing browser monitor(s) in New Relic for this specific site, follow these steps:
-
-1. Log into your New Relic dashboard.
-1. Click **Browser** from the lefthand navigation menu.
-1. Select the desired entity from your existing browser apps, then scroll down and click **Application Settings**.
-1. Copy the provided code snippet from New Relic and paste it directly into your Drupal theme's header file (typically `html.html.twig`), placing it as high up in the `<head>` tag as possible.
-1. Commit and deploy your code.
-
-</Tab>
-
-</TabList>
-
 #### Option 2: Platform Auto-Injection via `pantheon.yml`
-If you prefer not to edit your theme files, you can instruct our platform to forcefully handle the injection for you. Enabling this setting tells our platform to intercept the Drupal response, strip the `Content-Length` header, and safely inject the New Relic script.
+If you prefer not to edit your theme files, you can instruct our platform to forcefully handle the injection for you using PHP prepend files and the output buffer. Enabling this setting tells our high-level prepend logic to grab the output buffer, strip the `Content-Length` header, and safely inject the Browser Agent script via the PHP agent according to [New Relic standards](https://docs.newrelic.com/docs/apm/agents/php-agent/features/browser-monitoring-php-agent/#manual_instrumentation).
 
 1. Open your project's code repository.
 1. Locate the `pantheon.yml` file in the root directory.
-1. Look for the following configuration flag and set it to `true`:
+1. Find or add the `new_relic:` key, and add `browser_auto_inject: true` . For example: 
+
     ```yml:title=pantheon.yml
-    # NEW RELIC BROWSER AGENT AUTO-INJECT - For Drupal 10.2+
-    # Warning: Setting this to 'true' will remove Drupal's default Content-Length headers for responses.
-    # DO NOT enable this if you have already manually pasted the New Relic snippet into your theme.
-    nr_browser_auto_inject: true
+    # Put overrides to your pantheon.upstream.yml file here.
+    # For more information, see: https://pantheon.io/docs/pantheon-yml/
+    api_version: 1
+
+    new_relic:
+      browser_auto_inject: true
     ```
 1. Commit and push the `pantheon.yml` file to your environment.
-1. Changes will take effect within 24 hours and you should see data populating in the Browser section in your site’s New Relic.
+1. Changes will take effect within 5 minutes and you should see data populating in the Browser section in your site’s New Relic.
+
+Before touching the output buffer, or injecting the Browser Agent snippet, we run several checks (in the following order) to ensure we are only instrumenting in the correct cases. Auto-injection will not occur unless all of the following are true:
+
+* PHP interface (`php_sapi_name()`) is not cli
+* PHP has the `newrelic` extension loaded
+* Site has Browser Auto-Inject enabled (`browser_auto_inject: true`) in `pantheon.yml`
+* Request is not from a Pantheon healthcheck (`REQUEST_URI` of "`/healthz`")
+* Request is for HTML content (`HTTP_ACCEPT` of '`text/html`')
+
 
 ## Disable New Relic Browser Monitoring Agent
 

--- a/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
+++ b/src/source/content/guides/new-relic/06-troubleshoot-new-relic.md
@@ -148,14 +148,12 @@ If you prefer not to edit your theme files, you can instruct our platform to for
 1. Open your project's code repository.
 1. Locate the `pantheon.yml` file in the root directory.
 1. Look for the following configuration flag and set it to `true`:
-
     ```yml:title=pantheon.yml
     # NEW RELIC BROWSER AGENT AUTO-INJECT - For Drupal 10.2+
     # Warning: Setting this to 'true' will remove Drupal's default Content-Length headers for responses.
     # DO NOT enable this if you have already manually pasted the New Relic snippet into your theme.
     nr_browser_auto_inject: true
     ```
-
 1. Commit and push the `pantheon.yml` file to your environment.
 1. Changes will take effect within 24 hours and you should see data populating in the Browser section in your site’s New Relic.
 


### PR DESCRIPTION
* Adds context for Pantheon disables the NR browser agent for d10+ sites by default 
* Defines two options for how to enable, with considerations before you begin


[Preview link](https://pr-10055-pandocs.pantheonsite.io/guides/new-relic/troubleshoot-new-relic#enable-browser-monitoring-for-drupal-102)

[Production link](https://docs.pantheon.io/guides/new-relic/troubleshoot-new-relic#enable-browser-monitoring-for-drupal-102)