### PR TITLE
[Update Stale] AWS S3 Setup for Drupal

### DIFF
--- a/src/source/content/drupal-s3.md
+++ b/src/source/content/drupal-s3.md
@@ -110,11 +110,13 @@ You will need to install the appropriate Drupal module(s) and the AWS SDK librar
 
 The following instructions use Drupal and [Terminus](/terminus), Pantheon's CLI which allows you to call Drush remotely without using a local installation.
 
-These steps require Drush 8, which is run by default on Pantheon for newly created Drupal sites. Sites created prior to November 4, 2015 run 5.x by default.
+These steps require Drush, which is run by default on Pantheon. Check your site's Drush version and update if needed.
 
 Before you begin:
 
-- [Set your site’s Drush version](/guides/drush/drush-versions/#configure-drush-version) to Drush 8 if needed.
+- [Set your site's Drush version](/guides/drush/drush-versions/#configure-drush-version) to a supported version if needed.
+- Either copy the [`default.settings.php`](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php) file to `settings.php` or create an empty `settings.php` file within the `sites/default` directory if you have not done so already.
+- Set the site's connection mode to SFTP within the site Dashboard or via [Terminus](/terminus):
 - Either copy the [`default.settings.php`](https://github.com/pantheon-systems/drops-7/blob/master/sites/default/default.settings.php) file to `settings.php` or create an empty `settings.php` file within the `sites/default` directory if you have not done so already.
 - Set the site's connection mode to SFTP within the site Dashboard or via [Terminus](/terminus):
 
@@ -126,21 +128,19 @@ Before you begin:
 
 #### S3 File System
 
-Install the [Libraries API](https://www.drupal.org/project/libraries) and [S3 File System](https://www.drupal.org/project/s3fs) modules:
+Install the [S3 File System](https://www.drupal.org/project/s3fs) module. For Drupal 7, also install the [Libraries API](https://www.drupal.org/project/libraries) module:
 
 ```bash{promptUser: user}
-terminus drush <site>.<env> -- en libraries s3fs -y
+terminus drush <site>.<env> -- en s3fs -y
 ```
 
-Get the [AWS SDK Library 2.x](https://github.com/aws/aws-sdk-php/releases):
+Get the [AWS SDK Library 3.x](https://github.com/aws/aws-sdk-php/releases) via Composer:
 
-```bash{outputLines: 2-3}
-terminus drush <site>.<env> -- make --no-core sites/all/modules/s3fs/s3fs.make -y
-  //or if you have a contrib subfolder for modules use:
-  //terminus drush <site>.<env> -- make --no-core sites/all/modules/contrib/s3fs/s3fs.make -y
+```bash{promptUser: user}
+composer require aws/aws-sdk-php
 ```
 
-The above command will add the AWS SDK version 2.x library into the `sites/all/libraries/awssdk2` directory.
+The above command will add the AWS SDK version 3.x library as a Composer dependency.
 
 #### S3 File System CORS
 


### PR DESCRIPTION
[AWS S3 Setup for Drupal](https://docs.pantheon.io/drupal-s3)
Date: 2016-09-01
Days since last review: 3527
Confidence rating: Low ⚠️

## Review notes

This document is nearly 9 years old (last reviewed 2016-09-01) and covers multiple third-party services and modules that have changed significantly:

1. **AWS Console UI** (lines 39–105): The AWS IAM console has been substantially redesigned since 2016. Steps like "Create your Own Policy" (line 65), "Add more permissions" (line 53), and "Create New Group" (line 83) no longer reflect the current AWS console UI. IAM Groups for new users now follows a different flow.

2. **AWS SDK Library version** (lines 135–143): The doc references AWS SDK Library **2.x**, which is now ancient. The s3fs Drupal module has moved to requiring AWS SDK **3.x** for many years.

3. **Drush version guidance** (lines 113–117): References to Drush 8 as default and "sites created prior to November 4, 2015 run 5.x" are extremely outdated. Drush 8 itself is end-of-life. Current Drupal sites on Pantheon use Drush 10/11/12 depending on Drupal version.

4. **s3fs.make file / Drush make** (lines 137–141): `drush make` is a Drush 8 feature that is not available in Drush 9+. The s3fs module now recommends Composer for dependency management.

5. **Libraries API module** (line 129): For modern Drupal (8/9/10), the Libraries API module is not used; the AWS SDK is managed via Composer. Even for Drupal 7, this workflow has changed.

6. **`sites/default/default.settings.php` reference** (line 118): Links to `drops-7`, implying this is Drupal 7 only — but the document title says "Drupal" generically, which is misleading given Pantheon now primarily supports Drupal 10/11.

7. **S3 File System CORS module** (lines 147–153): The s3fs_cors module's status and compatibility should be verified; the `jquery_update` dependency referenced is also very dated.

The sheer number of outdated references — spanning AWS console UI, Drush versions, SDK versions, and module management workflows — makes this document significantly inaccurate. More than 5 lines require changes.

*Confidence: Low ⚠️ — More than 5 lines require changes across AWS console UI steps, Drush version guidance, SDK version references, and Composer vs. drush-make workflows. Many of these involve third-party behavior (AWS console, Drupal modules, Drush) that cannot be fully verified against current state from training data alone.*

## Suggested resolution

Given the scope of changes required across AWS console UI steps, Drush version guidance, SDK version references, and module management workflows, a substantial rewrite or replacement is needed. Specific updates should include:

- **Lines 113–117**: Update Drush version guidance to reflect current Drush 10/11/12 usage on Pantheon; remove references to Drush 8 and the November 4, 2015 cutoff.
- **Lines 118**: Clarify that this doc applies to Drupal 7 only, or expand to cover modern Drupal with Composer-based workflows.
- **Lines 135–143**: Replace the `drush make` / AWS SDK 2.x instructions with Composer-based installation of the AWS SDK 3.x.
- **Lines 39–55**: Note that the AWS S3 bucket creation UI has changed; "Add more permissions" and the Permissions tab workflow no longer match the current console.
- **Lines 61–105**: Note that IAM console UI steps (e.g., "Create your Own Policy", "Create New Group", "Create New Users") no longer match current AWS console labels and flows.
- **Lines 129, 152**: Revisit Libraries API and jquery_update dependencies; these are not applicable for modern Drupal or current s3fs versions.

Because more than 5 lines need to change and third-party (AWS console, Drupal module, Drush) behavior cannot be fully verified against current state, confidence is set to **low**. A subject-matter expert should audit and rewrite this document before republishing.