### PR TITLE
[Update Stale] Drupal Modules with Known Issues

### DIFF
--- a/src/source/content/modules-known-issues.md
+++ b/src/source/content/modules-known-issues.md
@@ -109,7 +109,7 @@ ___
 
 This module has been deprecated by its authors for Drupal 8 and above. The suggestions made below are for Drupal 7 users, and are not guaranteed to be successful in all use cases.
 
-If you're creating a new site that needs Composer-managed libraries, we strongly recommend using Drupal 9 or newer.
+If you're creating a new site that needs Composer-managed libraries, we strongly recommend using Drupal 10 or newer.
 
 **Issue**: Composer Manager expects write access to the site's codebase via SFTP, which is prevented in Test and Live environments on Pantheon by design.
 
@@ -342,7 +342,7 @@ ___
 
 <ReviewDate date="2020-05-05" />
 
-**Issue 1:** If your site is running PHP 5.3, form submissions that use the reCAPTCHA module might continually fail and display the error: `The answer you entered for the CAPTCHA was not correct`. This is because the default arg_separator.output for PHP 5.3 is `&amp;` while for PHP 5.5 it is `&`.
+**Issue 1:** If your site is running an outdated version of PHP, form submissions that use the reCAPTCHA module might continually fail and display the error: `The answer you entered for the CAPTCHA was not correct`. This can be caused by a mismatch in the default `arg_separator.output` value.
 
 **Solution:** Override the default arg_separator.output value in `settings.php` by adding the following line:
 
@@ -412,9 +412,8 @@ ___
 
 **Issue**: This module requires a very specific set of permissions for the folder and the keys to be uploaded.
 
-**Solution**: Apply the following patches (which have been tested and validated by Pantheon), based on your site's PHP version, to solve for this issue:
+**Solution**: Apply the following patch (which has been tested and validated by Pantheon) to solve for this issue:
 * [Oauth Permission Patch - Required to resolve Pantheon known issues (PHP 8.0+)](https://patch-diff.githubusercontent.com/raw/pantheon-systems/oauth2-server/pull/1.patch)
-* [Oauth Permission Patch - Required to resolve Pantheon known issues (PHP 7.4)](https://patch-diff.githubusercontent.com/raw/pantheon-systems/oauth2-server/pull/2.patch)
 
 ___
 


### PR DESCRIPTION
[Drupal Modules with Known Issues](https://docs.pantheon.io/modules-known-issues)
Date: 2018-01-03
Days since last review: 3038
Confidence rating: Low ⚠️

## Review notes

Multiple sections across this document are significantly stale (some over 2,000 days old) and require evaluation:

1. **Front (line 166)** — References Drupal 7 specifically. The patch link at drupal.org may still be valid, but the module's D7 status and the patch applicability are hard to verify after 3,000+ days.

2. **Dynamic Entity Reference (line 158)** — MySQL trigger restriction on Pantheon is a platform-level constraint that has not changed. Content appears accurate.

3. **Honeypot http:BL (lines 166–168)** — References Drupal 7 behavior and a specific patch. The Front section content is what appears here (line range 165–171 corresponds to the Front section). The patch link is very old and may be stale.

4. **ImageAPI Optimize (lines 209–218)** — Code snippet and caching instructions appear to be standard Drupal 7 patterns. No version-specific details that are clearly outdated.

5. **S3 File System / reCAPTCHA section (lines 361–370)** — The reCAPTCHA `$_SERVER['SERVER_NAME']` issue is a real Pantheon platform constraint. The link to the workaround doc appears valid. Content is still accurate.

6. **Adaptive Image Styles intro (lines 19–21)** — The GitHub URLs for filing issues and submitting PRs reference `pantheon-systems/documentation` which has been migrated to `pantheon-systems/documentation` (still valid). Content is accurate.

7. **Composer Manager (lines 110–116)** — References Drupal 9 as "newer" when Drupal 10 and 11 are now current. The recommendation to use "Drupal 9 or newer" is outdated phrasing since Drupal 9 reached end-of-life in November 2023.

8. **JS module (lines 232–237)** — Platform constraint about `.htaccess`/`nginx.conf` not being modifiable is still accurate.

9. **Live CSS (lines 245–249)** — Platform constraint about write access to codebase in Test/Live is still accurate.

10. **Pathologic section (lines 288–293)** — The drush command `webform-export` referenced is a Drush 8 command. The drushcommands.com link may be stale.

11. **Search Api Solr Date Sort (lines 383–406)** — References Apache Solr service; the typo "gereater" exists at line 406. The content itself references older Drupal 7 APIs.

12. **reCAPTCHA (lines 345)** — PHP 5.3 is extremely outdated (EOL since 2014). This issue is no longer relevant as Pantheon requires PHP 7.4+ at minimum. This entry is misleading.

13. **DropzoneJS section (lines 135–143)** — Composer Merge Plugin deprecation note still valid.

14. **Basic HTTP Authentication (lines 60–69)** — Content appears accurate for platform constraints.

15. **Update Manager (lines 421–424)** — Drupal 9 core module reference; Drupal 9 is EOL. Section title still says "Drupal 9 (core)" which may need updating.

16. **Composer Merge Plugin (lines 122–132, 141–143)** — Deprecation and path repository solution still appear valid.

17. **Replica - Database Configuration (lines 317–327, 330–337)** — Platform constraint, still accurate.

18. **Ludwig (lines 240–249)** — Content appears accurate.

19. **Simple OAuth (lines 410–418)** — PHP 7.4 is EOL (Pantheon dropped support). The PHP 7.4 patch reference is no longer relevant.

20. **Menu Item Extras (lines 265–273)** — Recently reviewed, appears accurate.

Key changes needed:
- **Composer Manager**: "Drupal 9 or newer" should reference Drupal 10 or newer since Drupal 9 is EOL.
- **reCAPTCHA Issue 1**: PHP 5.3 reference is completely obsolete and potentially misleading.
- **Simple OAuth**: PHP 7.4 patch reference is obsolete since Pantheon no longer supports PHP 7.4.

*Confidence: Low ⚠️ — More than 5 lines would change across multiple sections, and several references involve third-party patch URLs and external Drupal.org issue queues whose current validity cannot be confirmed. PHP version support timelines and Drupal version EOL status are verifiable facts that ground the high-confidence changes, but the broader set of changes exceeds the 5-line threshold for high confidence.*

## Suggested resolution

1. **Composer Manager (line 112)**: Update "Drupal 9 or newer" to "Drupal 10 or newer" since Drupal 9 reached end-of-life in November 2023.

2. **reCAPTCHA Issue 1 (lines 345–351)**: Remove or update the PHP 5.3 issue entirely — PHP 5.3 has been EOL since 2014 and is not supported on Pantheon. This entry is misleading to current users.

3. **Simple OAuth (lines 416–417)**: Remove the PHP 7.4 patch reference since Pantheon no longer supports PHP 7.4. Retain only the PHP 8.0+ patch.