### PR TITLE
Terminus Release 4.2.1 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.2.0            | April 13, 2026     |                    |
+| 4.2.1            | April 30, 2026     |                    |
+| 4.2.0            | April 13, 2026     | April 30, 2027     |
 | 4.1.9            | April 08, 2026     | April 13, 2027     |
 | 4.1.8            | March 30, 2026     | April 08, 2027     |
 | 4.1.7            | March 23, 2026     | March 30, 2027     |

--- a/src/source/releasenotes/2026-04-30-terminus-4-2-1.md
+++ b/src/source/releasenotes/2026-04-30-terminus-4-2-1.md
@@ -1,0 +1,30 @@
+---
+title: "Terminus 4.2.1 release now available"
+published_date: "2026-04-30"
+categories: [tools-apis]
+---
+
+Terminus [4.2.1](https://github.com/pantheon-systems/terminus/releases/tag/4.2.1) is now available. This patch release fixes a pagination bug affecting `org:site:list` and a WordPress-specific issue.
+
+## Key improvements in this release
+
+- **Fix incomplete site listings**: `org:site:list` could return truncated results when the API returned short pages, affecting organizations with sites in supporting workspaces ([#2829](https://github.com/pantheon-systems/terminus/pull/2829))
+- **WordPress fix**: Only include `wp_replace_siteurl` if the site is WordPress ([#2825](https://github.com/pantheon-systems/terminus/pull/2825))
+
+## How to upgrade to Terminus 4.2.1
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.2.1).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).


### PR DESCRIPTION
## Summary

Documentation updates for the Terminus 4.2.1 release:
- Added 4.2.1 to the supported versions table
- Set EOL date on 4.2.0
- Created release note for 4.2.1

## References

- Release PR: https://github.com/pantheon-systems/terminus/pull/2830
- BUGS ticket: https://getpantheon.atlassian.net/browse/BUGS-11265

🤖