### PR TITLE
docs(release-notes): GCDN Beta now available for Multi-Zone Failover sites

### DIFF
--- a/src/source/releasenotes/2026-04-30-gcdn-beta-multi-zone-failover-eligible.md
+++ b/src/source/releasenotes/2026-04-30-gcdn-beta-multi-zone-failover-eligible.md
@@ -1,0 +1,20 @@
+---
+title: "Global CDN Beta now available for Multi-Zone Failover sites"
+published_date: "2026-04-30"
+categories: [new-feature]
+---
+
+Sites with Multi-Zone Failover enabled are now eligible for the Global CDN (GCDN) Beta. Previously, Multi-Zone Failover sites were excluded from the Beta — that restriction has been removed.
+
+## What's changed
+
+- Multi-Zone Failover is no longer listed as an excluded configuration for the GCDN Beta.
+- Eligible Multi-Zone Failover sites will see the GCDN Beta banner in the Pantheon site dashboard.
+
+## Action Required
+
+No action is required. If you operate a Multi-Zone Failover site, simply look for the GCDN Beta banner on your site dashboard and follow the guided steps when you're ready to migrate.
+
+## More information
+
+For full details on the GCDN Beta, see the [GCDN Beta documentation](/guides/global-cdn/global-cdn-beta).

--- a/src/source/releasenotes/2026-04-30-gcdn-beta-multi-zone-failover-eligible.md
+++ b/src/source/releasenotes/2026-04-30-gcdn-beta-multi-zone-failover-eligible.md
@@ -1,19 +1,17 @@
 ---
-title: "Global CDN Beta now available for Multi-Zone Failover sites"
+title: "Global CDN Beta now available for Multizone Failover sites"
 published_date: "2026-04-30"
-categories: [new-feature]
+categories: [new-feature, infrastructure]
 ---
 
-Sites with Multi-Zone Failover enabled are now eligible for the Global CDN (GCDN) Beta. Previously, Multi-Zone Failover sites were excluded from the Beta — that restriction has been removed.
+Sites with [Multizone Failover](/multizone-failover) enabled are now eligible for the [Global CDN (GCDN) Beta](/guides/global-cdn/global-cdn-beta). Previously, Multizone Failover sites were excluded from the Beta — that restriction has been removed.
 
 ## What's changed
 
-- Multi-Zone Failover is no longer listed as an excluded configuration for the GCDN Beta.
-- Eligible Multi-Zone Failover sites will see the GCDN Beta banner in the Pantheon site dashboard.
+- Multizone Failover is no longer listed as an excluded configuration for the GCDN Beta.
+- Eligible Multizone Failover sites will see the GCDN Beta banner in the Pantheon site dashboard.
 
-## Action Required
-
-No action is required. If you operate a Multi-Zone Failover site, simply look for the GCDN Beta banner on your site dashboard and follow the guided steps when you're ready to migrate.
+No action is required. If you operate a Multizone Failover site, simply look for the GCDN Beta banner on your site dashboard and follow the guided steps when you're ready to migrate.
 
 ## More information
 


### PR DESCRIPTION
## Summary

- Adds a release note announcing that Multi-Zone Failover sites are now eligible for the GCDN Beta.
- Companion PR (#10061) removes Multi-Zone Failover from the eligibility exclusions on the GCDN Beta guide.

No customer action is required — eligible Multi-Zone Failover sites will see the activation banner in the dashboard automatically.

## Test plan

- [ ] Verify the release note renders correctly under `/release-notes/`.
- [ ] Confirm the link to `/guides/global-cdn/global-cdn-beta` resolves.
- [ ] Confirm the date (2026-04-30) and category (`new-feature`) are correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)