### PR TITLE
docs(release-notes): [SITE-5641] PHP 8.4.20 and 8.5.5 patch releases

### DIFF
--- a/src/source/releasenotes/2026-05-04-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-05-04-php-84-85-patch-updates.md
@@ -1,0 +1,10 @@
+---
+title: "PHP 8.4 and 8.5 updated to their latest patch releases"
+published_date: "2026-05-04"
+categories: [infrastructure]
+description: "PHP versions 8.4.20 and 8.5.5 are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability."
+---
+PHP versions [8.4.20](https://www.php.net/ChangeLog-8.php#8.4.20) and [8.5.5](https://www.php.net/ChangeLog-8.php#8.5.5) are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability.
+Updates will be applied automatically over the next few days, so no manual action is required.
+
+PHP 8.4 and 8.5 are only available with the new [PHP Runtime Generation 2](/php-runtime-generation-2).

--- a/src/source/releasenotes/2026-05-04-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-05-04-php-84-85-patch-updates.md
@@ -7,4 +7,3 @@ description: "PHP versions 8.4.20 and 8.5.5 are now available on the platform. T
 PHP versions [8.4.20](https://www.php.net/ChangeLog-8.php#8.4.20) and [8.5.5](https://www.php.net/ChangeLog-8.php#8.5.5) are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability.
 Updates will be applied automatically over the next few days, so no manual action is required.
 
-PHP 8.4 and 8.5 are only available with the new [PHP Runtime Generation 2](/php-runtime-generation-2).


### PR DESCRIPTION
## Summary

- Add release note for PHP 8.4.20 and 8.5.5 patch releases now available on the platform

## Context

[SITE-5641](https://getpantheon.atlassian.net/browse/SITE-5641)

PHP 8.4.20 and 8.5.5 are patch releases containing bug fixes and security fixes. Platform PR: [cos-runtime-php#881](https://github.com/pantheon-systems/cos-runtime-php/pull/881)

## Test plan

- [ ] Release note renders correctly on local preview
- [ ] Links to PHP changelogs resolve correctly
- [ ] PHP Runtime Generation 2 link resolves correctly

[SITE-5641]: https://getpantheon.atlassian.net/browse/SITE-5641?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ