### PR TITLE
docs(SITE-5740): Add release note for PHP 7.2, 7.3, and 8.0 end of sale

### DIFF
--- a/src/source/releasenotes/2026-05-11-php-72-73-80-end-of-sale.md
+++ b/src/source/releasenotes/2026-05-11-php-72-73-80-end-of-sale.md
@@ -1,7 +1,8 @@
 ---
 title: "PHP 7.2, 7.3, and 8.0 are now End of Sale"
-published_date: "2026-05-12"
+published_date: "2026-05-11"
 categories: [infrastructure, action-required]
+description: "PHP 7.2, 7.3, and 8.0 have reached End of Sale on the Pantheon platform. New sites can no longer be created using these PHP versions."
 ---
 PHP 7.2, 7.3, and 8.0 have reached **End of Sale** on the Pantheon platform. New sites can no longer be created using these PHP versions.
 

--- a/src/source/releasenotes/2026-05-12-php-72-73-80-end-of-sale.md
+++ b/src/source/releasenotes/2026-05-12-php-72-73-80-end-of-sale.md
@@ -1,0 +1,18 @@
+---
+title: "PHP 7.2, 7.3, and 8.0 are now End of Sale"
+published_date: "2026-05-12"
+categories: [infrastructure, action-required]
+---
+PHP 7.2, 7.3, and 8.0 have reached **End of Sale** on the Pantheon platform. New sites can no longer be created using these PHP versions.
+
+This was previously announced in the [PHP version removal schedule](/release-notes/2026/03/php-version-removal-schedule-announced) published March 11, 2026.
+
+These versions, along with PHP 5.6, 7.0, and 7.1, are scheduled for **removal on September 30, 2026**. Sites still running a removed PHP version will be automatically upgraded to the oldest available PHP version at the time of removal.
+
+## Action required
+
+If your site is running PHP 7.2, 7.3, or 8.0, upgrade to a [recommended PHP version](/guides/php#supported-php-versions) before September 30, 2026 to avoid disruption. Pantheon recommends PHP 8.3 or 8.4 for all production sites.
+
+For guidance on upgrading, refer to [Upgrade PHP Versions](/guides/php/php-versions).
+
+Sites created with custom upstreams that specify an end-of-sale PHP version may also experience unexpected behavior upon site creation.

--- a/src/source/releasenotes/2026-05-12-php-72-73-80-end-of-sale.md
+++ b/src/source/releasenotes/2026-05-12-php-72-73-80-end-of-sale.md
@@ -5,7 +5,7 @@ categories: [infrastructure, action-required]
 ---
 PHP 7.2, 7.3, and 8.0 have reached **End of Sale** on the Pantheon platform. New sites can no longer be created using these PHP versions.
 
-This was previously announced in the [PHP version removal schedule](/release-notes/2026/03/php-version-removal-schedule-announced) published March 11, 2026.
+This was previously announced in the [PHP version removal schedule](/release-notes/2026/03/php-removal-schedule) published March 11, 2026.
 
 These versions, along with PHP 5.6, 7.0, and 7.1, are scheduled for **removal on September 30, 2026**. Sites still running a removed PHP version will be automatically upgraded to the oldest available PHP version at the time of removal.
 


### PR DESCRIPTION
## Summary

- Adds release note announcing PHP 7.2, 7.3, and 8.0 are now End of Sale as of May 12, 2026
- Links back to the March 11, 2026 removal schedule announcement
- Notes that sites using custom upstreams with EOS PHP versions may see unexpected behavior on site creation
- Scheduled to publish Tuesday, May 12, 2026

**Preview:** https://pr-10067-pandocs.pantheonsite.io/release-notes/2026/05/php-72-73-80-end-of-sale

🤖 Generated with [Claude Code](https://claude.com/claude-code)