### PR TITLE
fix published_at timestamp on new release notes

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -25,6 +25,13 @@ jobs:
     - name: Set timestamps on new release notes
       id: set_timestamps
       run: |
+        # Avoid re-processing the commit this step itself pushes
+        if [[ "${{ github.event.head_commit.message }}" == "chore: set published_at timestamp"* ]]; then
+          echo "Skipping - timestamp commit detected"
+          echo "deploy_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+
         TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 
         # Get list of release note files added in this commit (not modified)
@@ -38,12 +45,6 @@ jobs:
 
         MODIFIED=false
         for file in $NEW_FILES; do
-          # Skip files that already exist in origin/main (e.g., came in via merge)
-          if git cat-file -e "origin/main:$file" 2>/dev/null; then
-            echo "Skipping $file - already exists in main"
-            continue
-          fi
-
           # Skip if file already has published_at
           if grep -q "^published_at:" "$file"; then
             echo "Skipping $file - already has published_at"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -24,9 +24,11 @@ jobs:
 
     - name: Set timestamps on new release notes
       id: set_timestamps
+      env:
+        COMMIT_MSG: ${{ github.event.head_commit.message }}
       run: |
         # Avoid re-processing the commit this step itself pushes
-        if [[ "${{ github.event.head_commit.message }}" == "chore: set published_at timestamp"* ]]; then
+        if [[ "$COMMIT_MSG" == "chore: set published_at timestamp"* ]]; then
           echo "Skipping - timestamp commit detected"
           echo "deploy_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
           exit 0


### PR DESCRIPTION
## Problem

PR #9944 introduced a GitHub Actions step to inject an actual `published_at` timestamp into new release note files at merge time, fixing an RSS ordering issue where same-day notes published out of order due to a hash-derived time.

The step was not working. Every new release note file was being skipped due to this check:

```bash
if git cat-file -e "origin/main:$file" 2>/dev/null; then
  echo "Skipping $file - already exists in main"
  continue
fi
```

This check runs **after** the push to `main` has already completed. At that point `origin/main` points to the commit that just landed — including the newly added files. So every file added by the commit is found in `origin/main` and skipped. No `published_at` fields were ever written.

The check was intended to skip files that already existed in `main` before the current commit (e.g., files brought in via a merge that weren't truly new). However, `--diff-filter=A` already handles this — it only selects files *Added* in the current commit, not modified ones. The `origin/main` check was redundant and broken.

## Fix

- Remove the `origin/main` check entirely. The `--diff-filter=A` filter and the existing `published_at` grep are sufficient guards.
- Add a self-trigger guard at the top of the step so the workflow exits early when it detects it was triggered by its own timestamp commit, avoiding a full unnecessary second run.