### PR TITLE
[Update Stale] Using Pantheon as a Training Platform for WordPress and Drupal

### DIFF
--- a/src/source/content/trainers.md
+++ b/src/source/content/trainers.md
@@ -10,7 +10,7 @@ product: [--]
 integration: [--]
 tags: [collaborate, sandbox, upstreams, webops]
 contributors: [stevector, dwayne, davidneedham, tessak22]
-reviewed: "2018-03-26"
+reviewed: "2026-07-01"
 ---
 
 Pantheon makes it easy for educators training students on Drupal and WordPress to spin up and manage free sandbox sites for their students. Using Pantheon allows you and your students to focus on the CMS rather than setting up local sites or remote infrastructure. [Please contact us if you need assistance using Pantheon to conduct your trainings.](https://pantheon.io/trainers)


### PR DESCRIPTION
[Using Pantheon as a Training Platform for WordPress and Drupal](https://docs.pantheon.io/trainers)
Date: 2018-03-26
Days since last review: 2970
Confidence rating: High

## Review notes

The document's core content remains accurate. Key points checked:

- The Pantheon trainers contact URL (https://pantheon.io/trainers) is still referenced appropriately.
- The account registration URL (https://pantheon.io/register) is still valid.
- The Agency/Workspace creation link (https://dashboard.pantheon.io/organizations/create-agency) is still the correct path.
- The limitation of one Workspace per unique email is still a known Pantheon constraint.
- The platform considerations doc path (`/guides/platform-considerations`), custom upstreams path (`/guides/custom-upstream`), and start-state path (`/start-state`) are all still valid internal references.
- The three "More Resources" links — Getting Started Guide, Going Live, and Delete Account — all map to current guide paths.
- The note that Pantheon does not support Drupal multisite and that Node.js is not available on containers remains accurate for the Pantheon platform.
- The workflow described (trainer creates agency, students create accounts and add the workspace as a Supporting Workspace) reflects how Pantheon's team/org model still works.

*Confidence: High — The content describes stable Pantheon platform workflows (account creation, agency/workspace setup, sandbox sites, supporting organizations) that have not fundamentally changed. All internal doc links use current path conventions, and the platform constraints cited (no Drupal multisite, no Node.js) remain accurate.*

## Suggested resolution

No content changes are needed. The review date should be bumped to reflect the current review pass.