### PR TITLE
Terminus Release 4.2.2 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.2.1            | April 30, 2026     |                    |
+| 4.2.2            | May 13, 2026       |                    |
+| 4.2.1            | April 30, 2026     | May 13, 2027       |
 | 4.2.0            | April 13, 2026     | April 30, 2027     |
 | 4.1.9            | April 08, 2026     | April 13, 2027     |
 | 4.1.8            | March 30, 2026     | April 08, 2027     |

--- a/src/source/releasenotes/2026-05-13-terminus-4-2-2.md
+++ b/src/source/releasenotes/2026-05-13-terminus-4-2-2.md
@@ -1,0 +1,33 @@
+---
+title: "Terminus 4.2.2 release now available"
+published_date: "2026-05-13"
+categories: [tools-apis]
+---
+
+Terminus [4.2.2](https://github.com/pantheon-systems/terminus/releases/tag/4.2.2) is now available. This release adds object cache and search visibility to `site:info`, upstream fields to site listing commands, and Node.js dependency update support.
+
+## Key improvements in this release
+
+- **Object Cache and Search status in site:info**: `site:info` now shows whether Object Cache (Redis) is enabled and which search index (Elasticsearch, Solr, or both) is active ([#2812](https://github.com/pantheon-systems/terminus/pull/2812))
+- **Upstream fields in site:list**: `site:list` and `org:site:list` now support `upstream` and `upstream_label` as optional `--fields` values ([#2835](https://github.com/pantheon-systems/terminus/pull/2835))
+- **Node.js dependency updates**: `upstream:updates` commands now support Node.js sites for dependency management ([#2828](https://github.com/pantheon-systems/terminus/pull/2828))
+- **EVCS site creation validation**: Site creation for EVCS sites now uses server-side repo name validation for more accurate error messages ([#2831](https://github.com/pantheon-systems/terminus/pull/2831))
+- **PHP 8.2 fix**: Resolved deprecation warnings for dynamic property creation in the Site model ([#2813](https://github.com/pantheon-systems/terminus/pull/2813))
+
+## How to upgrade to Terminus 4.2.2
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.2.2).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).


### PR DESCRIPTION
**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Terminus Release 4.2.2

Links:
- Terminus Release PR: https://github.com/pantheon-systems/terminus/pull/2837
- CCB ticket: https://getpantheon.atlassian.net/browse/CCB-2837