### PR TITLE
docs(release-notes): [SITE-5240] Tika 1 rejection release note

### DIFF
--- a/src/source/releasenotes/2026-05-13-tika-1-rejected-pantheon-yml.md
+++ b/src/source/releasenotes/2026-05-13-tika-1-rejected-pantheon-yml.md
@@ -6,7 +6,6 @@ categories: [infrastructure, action-required, drupal]
 
 Setting `tika_version: 1` in `pantheon.yml` is now rejected at validation time. Sites with this setting will receive a validation error on their next commit:
 
-```none
 1 is not one of [3, 'none']
 ```
 

--- a/src/source/releasenotes/2026-05-13-tika-1-rejected-pantheon-yml.md
+++ b/src/source/releasenotes/2026-05-13-tika-1-rejected-pantheon-yml.md
@@ -1,0 +1,25 @@
+---
+title: "Tika 1 is no longer accepted in pantheon.yml"
+published_date: "2026-05-13"
+categories: [infrastructure, action-required, drupal]
+---
+
+Setting `tika_version: 1` in `pantheon.yml` is now rejected at validation time. Sites with this setting will receive a validation error on their next commit:
+
+```none
+1 is not one of [3, 'none']
+```
+
+Tika 1.18 and 1.21 were [removed from the platform on April 28, 2026](/release-notes/2026/04/tika-3-ocr-config-and-removal-timeline). Since that date, `tika_version: 1` was silently ignored and sites automatically used Tika 3. This change formalizes the rejection so that sites receive a clear error instead of a silent fallback.
+
+## Action Required
+
+Update your `pantheon.yml` to use a supported value:
+
+```yml:title=pantheon.yml
+tika_version: 3
+```
+
+Or remove the `tika_version` setting entirely if your site does not use Tika. To explicitly disable Tika, set `tika_version: none`.
+
+For Tika 3 configuration details, including how to disable OCR, see [External Libraries: Apache Tika](/external-libraries#apache-tika).


### PR DESCRIPTION
## Summary

- Add release note announcing tika_version: 1 is now rejected in pantheon.yml
- Cross-references the April 2 release note that announced the removal timeline
- Includes exact validation error and action required steps

## Context

[SITE-5240](https://getpantheon.atlassian.net/browse/SITE-5240)

Tika 1.18 and 1.21 were removed from the platform on April 28. Since then, tika_version: 1 was silently ignored (auto-using Tika 3). The titan-mt PR (#21682) formalizes this as a schema validation rejection. This release note informs customers of the change.

## CCB

[CCB-2838](https://getpantheon.atlassian.net/browse/CCB-2838)

## Test plan

- [x] Release note renders correctly
- [x] Link to April 2 release note resolves
- [x] Link to external-libraries#apache-tika resolves

## References

- Jira: [SITE-5240](https://getpantheon.atlassian.net/browse/SITE-5240)
- Related PR: pantheon-systems/titan-mt#21682

[SITE-5240]: https://getpantheon.atlassian.net/browse/SITE-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CCB-2838]: https://getpantheon.atlassian.net/browse/CCB-2838?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5240]: https://getpantheon.atlassian.net/browse/SITE-5240?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ