### PR TITLE
Updated code snippet in PANTHEON_STRIPPED documentation

### DIFF
--- a/src/source/content/pantheon_stripped.md
+++ b/src/source/content/pantheon_stripped.md
@@ -101,7 +101,7 @@ curl -i "https://live-mysite.pantheon.io/landing_page.html?utm_source=test-sourc
 
 To resolve these links before they hit the application, place the following within `settings.php` (Drupal) or `wp-config.php` (WordPress):
 
-```php:title=settings.php%20or%20wp-config.php
+```php
 // Remove query strings and tracking parameters from URLs
 $strip = array('/[&?]__.+?(&|$)$/', '/[&?]utm_.+?(&|$)$/');
 $_SERVER['REQUEST_URI'] = preg_replace($strip, '', $_SERVER['REQUEST_URI']);


### PR DESCRIPTION
Removed the filename indicator from the PHP code snippet. It was getting rendered with percent-encoded spaces since two different filenames were being used. It's redundant anyway, since the code is right after the text telling you which file(s) to put it in.