### PR TITLE
add PAT to checkout

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -17,9 +17,10 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       # We need to fetch all tags to find the highest one
       with:
+        token: ${{ secrets.DOCS_PAT }}
         fetch-depth: 0
 
     - name: Set timestamps on new release notes

--- a/src/source/releasenotes/2026-05-13-terminus-4-2-2.md
+++ b/src/source/releasenotes/2026-05-13-terminus-4-2-2.md
@@ -1,6 +1,7 @@
 ---
 title: "Terminus 4.2.2 release now available"
 published_date: "2026-05-13"
+published_at: "2026-05-15T18:13:44Z"
 categories: [tools-apis]
 ---
 

--- a/src/source/releasenotes/2026-05-15-terminus-4-2-2.md
+++ b/src/source/releasenotes/2026-05-15-terminus-4-2-2.md
@@ -1,6 +1,6 @@
 ---
 title: "Terminus 4.2.2 release now available"
-published_date: "2026-05-13"
+published_date: "2026-05-15"
 published_at: "2026-05-15T18:13:44Z"
 categories: [tools-apis]
 ---


### PR DESCRIPTION
release notes need to commit back to the repository but this is blocked on main by our branch protection rules. this uses a PAT associated with a user who is added to the exclusions list for who can bypass the branch protections