### PR TITLE
docs: Add release note for WordPress 7.0 (Armstrong)

### DIFF
--- a/src/source/releasenotes/2026-05-20-wordpress-7-0.md
+++ b/src/source/releasenotes/2026-05-20-wordpress-7-0.md
@@ -1,0 +1,22 @@
+---
+title: WordPress 7.0 (Armstrong) release now available
+published_date: "2026-05-20"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [7.0 (Armstrong)](https://wordpress.org/news/2026/05/armstrong/), is available on Pantheon as of May 20, 2026.
+
+### Action required
+Upgrade to WordPress 7.0 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+* **AI integration** — A new provider-agnostic AI Client and Abilities API let WordPress communicate with generative AI models (Anthropic, Google, OpenAI, or custom), managed from a central Connectors screen in the dashboard.
+* **Modernized admin dashboard** — A refreshed color scheme, smooth view transitions between screens, and a new `Cmd+K` / `Ctrl+K` command palette shortcut accessible from anywhere in the admin.
+* **New blocks** — Breadcrumbs, Icon, and an enhanced Heading block join the editor, along with lightbox slideshow support in the Gallery block and video backgrounds in Cover blocks.
+* **Block-level custom CSS and responsive visibility** — Apply custom CSS to individual blocks and show or hide blocks by device type for more granular design control.
+* **Font Library** — A dedicated font management page for uploading, installing, and managing fonts across block, hybrid, and classic themes.
+* **PHP-only block registration** — Create blocks entirely server-side without JavaScript, auto-registered with the block API.
+* [...and more](https://wordpress.org/download/releases/7-0/)
+
+For full details about WordPress 7.0, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-7-0/) or the [WordPress 7.0 Field Guide](https://make.wordpress.org/core/2026/05/14/wordpress-7-0-field-guide/).


### PR DESCRIPTION
## Summary
- Adds release note for the WordPress 7.0 (Armstrong) upstream update, released May 20, 2026
- Highlights AI integration, modernized admin dashboard, new blocks, block-level CSS, Font Library, and PHP-only block registration