### PR TITLE
GitHub application beta removal 

### DIFF
--- a/src/source/content/guides/getstarted/06-addsite.md
+++ b/src/source/content/guides/getstarted/06-addsite.md
@@ -10,8 +10,8 @@ audience: [business, sysadmin, development]
 product: [--]
 integration: [--]
 tags: [--]
-contributors: [wordsmither]
-reviewed: "2025-12-10"
+contributors: [wordsmither, jazzs3quence]
+reviewed: "2026-05-22"
 showtoc: true
 permalink: docs/guides/getstarted/addsite
 editpath: getstarted/addsite.md
@@ -58,6 +58,12 @@ When you complete this step, your site will be live for anyone to see, at the Pa
 You have successfully finished adding a site in its Live environment.  Click **Visit Live Site** to view your site.
 
 At this point, you have a live site with a Pantheon URL, like `http://my-site.pantheonsite.io/`. To change that to a more friendly URL, you'll need to purchase a domain from a DNS provider.  Refer to our [Domains on Pantheon Guide](/guides/domains) for more information.
+
+### Create a Site with the GitHub Application
+
+Pantheon's [GitHub Application](/guides/github-application/setup) directly integrates a GitHub repository with a Pantheon site, allowing you to use GitHub as your code repository while Pantheon handles hosting and deployments. It supports WordPress, Drupal, and Next.js, and automatically creates a Multidev environment for each pull request. Merging to the `main` branch of your GitHub repository deploys code to your Pantheon Dev environment.
+
+See the [GitHub Application Setup guide](/guides/github-application/setup) to get started.
 
 ## Migrate an Existing Site
 

--- a/src/source/content/guides/github-application/01-introduction.md
+++ b/src/source/content/guides/github-application/01-introduction.md
@@ -12,14 +12,12 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-02"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application
 ---
 
 Pantheon's GitHub Application directly integrates a GitHub repository with a Pantheon site.
 This allows you to use GitHub as your code repository while still using Pantheon to run your site.
-
-The GitHub Application is currently in private Beta. [Request access for your Pantheon workspace here](https://docs.google.com/forms/d/e/1FAIpQLSf0vYrRbPQBxR-hT8kGJ4bEdYPtpkTtfDvPM89xD2dNZeqLqA/viewform).
 
 Once enabled, this application accommodates a pull request workflow where a Multidev environment is created for each pull request. This allows you to test the code in the pull request before merging it.
 

--- a/src/source/content/guides/github-application/02-setup.md
+++ b/src/source/content/guides/github-application/02-setup.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Application (Private Beta)
+title: GitHub Application
 subtitle: Setup
 description: Instructions for setting up the GitHub Application, including installation of the Terminus Repository Plugin and creating a new site.
 tags: [continuous-integration, workflow, D8, D9, D10]
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-03"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application/setup
 ---
 

--- a/src/source/content/guides/github-application/03-setup-wordpress.md
+++ b/src/source/content/guides/github-application/03-setup-wordpress.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Application (Private Beta)
+title: GitHub Application
 subtitle: Setup WordPress
 description: Configure a WordPress GitHub repository for Pantheon's GitHub integration with the required file structure and platform settings.
 tags: [continuous-integration, workflow, wordpress]
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-12"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application/setup-wordpress
 ---
 

--- a/src/source/content/guides/github-application/04-setup-drupal.md
+++ b/src/source/content/guides/github-application/04-setup-drupal.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Application (Private Beta)
+title: GitHub Application
 subtitle: Setup Drupal
 description: Configure a Drupal GitHub repository for Pantheon's GitHub integration with the required file structure and platform settings.
 tags: [continuous-integration, workflow, drupal]
@@ -12,7 +12,7 @@ cms: [drupal]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-12"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application/setup-drupal
 ---
 

--- a/src/source/content/guides/github-application/05-usage.md
+++ b/src/source/content/guides/github-application/05-usage.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Application (Private Beta)
+title: GitHub Application
 subtitle: Usage
 description: Instructions for using the GitHub Application, including managing pull requests and deploying code.
 tags: [continuous-integration, workflow, D8, D9, D10]
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-02"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application/usage
 ---
 

--- a/src/source/content/guides/github-application/06-support-considerations.md
+++ b/src/source/content/guides/github-application/06-support-considerations.md
@@ -1,5 +1,5 @@
 ---
-title: GitHub Application (Private Beta)
+title: GitHub Application
 subtitle: Support & Considerations
 description: Additional notes about the GitHub Application, including assumptions, limitations, and support information.
 tags: [continuous-integration, workflow, D8, D9, D10]
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [terminus]
 integration: [--]
-reviewed: "2026-03-02"
+reviewed: "2026-05-22"
 permalink: docs/guides/github-application/support-considerations
 ---
 
@@ -49,16 +49,7 @@ Depending on the size and nature of your company, you may not want your Pantheon
 
 </Alert>
 
-## Limitations prior to General Availability
-
-The GitHub Application is currently in private Beta.
-
-We will address these limitations before the application is made generally available.
-
-### Limited to new projects created by the Terminus
-
-Activating the GitHub Application presently runs through a Terminus command that creates a new site on Pantheon and a new GitHub repository. The GitHub Application does not yet support retrofitting existing GitHub repositories or Pantheon sites.
-Follow [this issue](https://github.com/pantheon-systems/terminus/issues/2683) in the queue to find out when this limitation is removed.
+## Limitations
 
 ### No On Server Development  (SFTP Mode)
 

--- a/src/source/content/nextjs/comparison-to-cms.md
+++ b/src/source/content/nextjs/comparison-to-cms.md
@@ -110,7 +110,7 @@ Pantheon infrastructure supports [Yarn](https://yarnpkg.com/) but as of now, tha
 
 Pantheon began many years ago as a Drupal-only platform. But the nature of our free trial allowed many customers to try other LAMP stack frameworks, many of which worked. In 2014 we made our support for WordPress official. We made that policy change because our ecosystem has so much overlapping usage between WordPress and Drupal and because we value the success of web teams, and the web as a whole over the success of any given framework.
 
-Similarly, the technology we now use to run Next.js is capable of serving many other frameworks. However, to increase the likelihood of success for teams during the Beta period, we primarily focused our attention on Next.js specifically. If you have a strong need to run a non-Next.js framework on Pantheon, [please let us know through our Roadmap site](https://roadmap.pantheon.io/) and tell us more about your projects.
+Similarly, the technology we now use to run Next.js is capable of serving many other frameworks. However, we primarily focused our attention on Next.js specifically. If you have a strong need to run a non-Next.js framework on Pantheon, [please let us know through our Roadmap site](https://roadmap.pantheon.io/) and tell us more about your projects.
 
 ### Webhooks and build triggers
 


### PR DESCRIPTION
fixes #10084 
fixes #10085 

Removes `(Private Beta)` from docs titles and any lingering references to GitHub application beta. Also removes a reference to Next.js being in beta and adds a section for creating a site with the GitHub application on the getting started guide.