### PR TITLE
docs(DEVX-7090): add bun support and Node.js version updates

### DIFF
--- a/src/source/content/nextjs/overview.md
+++ b/src/source/content/nextjs/overview.md
@@ -22,7 +22,7 @@ Support for Next.js is available to customers with Gold, Platinum or Diamond Wor
 * **Node versions:**
   * Pantheon provides the latest 3 LTS versions of Node.js. Pantheon derives which one to use by looking at the engines property in `package.json`, so ensure this is set in your project’s configuration.
 * **Package managers:**
-  * Pantheon will use `npm`, `yarn`, or `pnpm` depending on which lock file you have present in your repository. Having a lock file for more than one package manager can create unpredictable behavior.
+  * Pantheon will use `npm`, `yarn`, `pnpm`, or `bun` depending on which lock file you have present in your repository. Having a lock file for more than one package manager can create unpredictable behavior.
 * **Expected commands in `package.json`:**
   * Pantheon assumes that a Next.js site has a `package.json` file with `build` and `start` commands. Sites using `yarn` must have a `gcp-build` script instead of, or in addition to `build`. We consider inconsistency a bug in underlying Google Cloud build processes we leverage and [will update this guidance once it is resolved](https://github.com/pantheon-systems/documentation/issues/9888).
 

--- a/src/source/releasenotes/2026-05-25-nextjs-bun-node26.md
+++ b/src/source/releasenotes/2026-05-25-nextjs-bun-node26.md
@@ -1,0 +1,31 @@
+---
+title: Bun package manager and Node.js 26 support for Next.js sites
+published_date: "2026-05-25"
+categories: [nextjs, new-feature]
+---
+
+Pantheon now supports [Bun](https://bun.sh) as a package manager for Next.js sites, alongside npm, yarn, and pnpm. Pantheon also adds support for Node.js 26 (LTS).
+
+## Bun support
+
+To use Bun, add a `bun.lock` file to your repository. Pantheon automatically detects the lock file and uses Bun to install your dependencies during the build process.
+
+You can specify a Bun version in the `engines.bun` or `packageManager` field of your `package.json`. If no version is specified, Pantheon defaults to the latest stable release.
+
+## Node.js 26 support
+
+Node.js 26 is now available as an LTS runtime for Next.js sites. Set the `engines.node` field in your `package.json` to use it:
+
+```json
+{
+  "engines": {
+    "node": "26"
+  }
+}
+```
+
+## Node.js 20 removed
+
+Node.js 20 has reached end of life and is no longer available as a runtime. Sites using Node.js 20 must upgrade to Node.js 22 or later.
+
+For more details about Next.js on Pantheon, see our [Next.js documentation](/nextjs).

--- a/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
+++ b/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
@@ -1,6 +1,6 @@
 ---
 title: Bun package manager and Node.js 26 support for Next.js sites
-published_date: "2026-05-25"
+published_date: "2026-06-22"
 categories: [nextjs, new-feature]
 ---
 

--- a/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
+++ b/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
@@ -1,6 +1,7 @@
 ---
 title: Bun package manager and Node.js 26 support for Next.js sites
 published_date: "2026-06-22"
+published_at: "2026-06-22T19:18:48Z"
 categories: [nextjs, new-feature]
 ---
 

--- a/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
+++ b/src/source/releasenotes/2026-06-22-nextjs-bun-node26.md
@@ -4,7 +4,7 @@ published_date: "2026-06-22"
 categories: [nextjs, new-feature]
 ---
 
-Pantheon now supports [Bun](https://bun.sh) as a package manager for Next.js sites, alongside npm, yarn, and pnpm. Pantheon also adds support for Node.js 26 (LTS).
+Pantheon now supports [Bun](https://bun.sh) as a package manager for Next.js sites, alongside npm, yarn, and pnpm. We've also added support for Node.js 26 (LTS).
 
 ## Bun support
 


### PR DESCRIPTION
## Summary
- Add bun to the list of supported package managers in the Next.js overview page
- Add release note documenting bun support, Node.js 26 (LTS) support, and Node.js 20 removal

## Test plan
- [x] Verify the overview page renders correctly with the updated package manager list
- [x] Verify the release note renders correctly and links work

🤖 Generated with [Claude Code](https://claude.com/claude-code)