### PR TITLE
SITE-5745 update elastic documentation

### DIFF
--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -61,4 +61,4 @@ This means that multidev environments are not currently able to connect to the E
 During Beta, please report any issues or questions to the Pantheon team in the private `#beta-elasticsearch` channel in the [Pantheon Community Slack](https://pantheon.io/customer-community). To participate in the Beta, simply toggle the **Elasticsearch (beta)** add-on in your Site Settings.
 <!--This is not true yet>For support with Elasticsearch on Pantheon, contact Pantheon Support through the Dashboard. Include details about your site, the environment you're working in, and the specific issue you're encountering.<!-->
 
-For ElasticPress plugin-specific questions, refer to the [ElasticPress documentation](https://www.elasticpress.io/resources/).
+For ElasticPress plugin-specific questions, refer to the [ElasticPress documentation](https://www.elasticpress.io/resources/articles/).

--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -54,7 +54,7 @@ Elasticsearch will be provisioned for all environments on your site. Each enviro
 **Via Terminus:**
 
 ```bash
-terminus site:addon:enable <site>.<env> elasticsearch
+terminus search:enable <site>
 ```
 
 </Tab>
@@ -96,3 +96,10 @@ ElasticPress offers several features you can enable based on your needs:
 Additionally, the [ElasticPress](https://www.elasticpress.io/) service provides admin-level capabilities including **Synonyms** (connecting different terms to the same content), **Weighted Results** (prioritizing specific fields like titles or categories), and **Custom Results** (shaping rankings for specific queries) — these are managed through the ElasticPress settings rather than the Features screen.
 
 Navigate to **ElasticPress > Features** in your WordPress admin to enable and configure each feature.
+
+<Alert type="warning" title="Important: Feature Dependencies">
+
+**Instant Results** and **Autosuggest** require the **Search** feature to be active. If Search is not enabled, these features will not function correctly. Always enable Search first before enabling Instant Results or Autosuggest.
+
+</Alert>
+

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -40,6 +40,15 @@ reviewed: "2026-02-11"
 - Check that `ep_integrate` is not set to `false` on your critical queries.
 - Use the ElasticPress Status Report (under **ElasticPress > Status Report**) to verify that queries are being routed to Elasticsearch.
 
+### Instant Results returns "Search template not found"
+
+The Instant Results feature requires a stored search template on ElasticPress.io. This template is separate from your index mappings and synced content.
+
+- **Verify the template exists:** Run `terminus wp <site>.<env> -- elasticpress get-search-template`. If it returns `null`, the template is missing.
+- **Push the template:** Run `terminus wp <site>.<env> -- elasticpress put-search-template`, then verify again with `get-search-template`.
+- **If `put-search-template` reports success but `get-search-template` still returns `null`:** The **Search** feature ("Post Search & Filter") is likely not active. Instant Results depends on it to generate the template. Enable it first: `terminus wp <site>.<env> -- elasticpress activate-feature search`, then retry `put-search-template`.
+- **The template is not pushed by `sync` or `sync --setup`**. It must be pushed explicitly via `put-search-template` or by saving the Instant Results settings in wp-admin (**ElasticPress > Features > Instant Results > Save**).
+
 ### Plugin activation errors
 
 - Ensure you are running a supported version of WordPress and PHP.

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -47,7 +47,7 @@ The Instant Results feature requires a stored search template on ElasticPress.io
 - **Verify the template exists:** Run `terminus wp <site>.<env> -- elasticpress get-search-template`. If it returns `null`, the template is missing.
 - **Push the template:** Run `terminus wp <site>.<env> -- elasticpress put-search-template`, then verify again with `get-search-template`.
 - **If `put-search-template` reports success but `get-search-template` still returns `null`:** The **Search** feature ("Post Search & Filter") is likely not active. Instant Results depends on it to generate the template. Enable it first: `terminus wp <site>.<env> -- elasticpress activate-feature search`, then retry `put-search-template`.
-- **The template is not pushed by `sync` or `sync --setup`**. It must be pushed explicitly via `put-search-template` or by saving the Instant Results settings in wp-admin (**ElasticPress > Features > Instant Results > Save**).
+- **The template is automatically pushed** at the end of `sync` and `sync --setup`, but only if both the **Instant Results** and **Search** features are active. If the Search feature is inactive, the template body will be empty and the push will silently fail.
 
 ### Plugin activation errors
 


### PR DESCRIPTION
  ## Summary                                                
                                                                                                                                                                                                                                                                             
  - Fixed incorrect Terminus command in setup guide (`terminus site:addon:enable <site>.<env> elasticsearch` → `terminus search:enable <site>`)                                                                                                                              
  - Added feature dependency warning: Search must be active before enabling Instant Results or Autosuggest
  - Added troubleshooting section for "Search template not found" 404 error, covering the silent failure when Search feature is inactive and clarifying that `sync --setup` does not push the template                                                                       
                                                                                                                                                                                                                                                                             
  ## Changes                                                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                             
  ### Setup guide (`02-setup-config.md`)                                                                                                                                                                                                                                     
  - Corrected the Terminus command to match the actual CLI (`search:enable <site>`)
  - Added alert about Instant Results and Autosuggest requiring the Search feature to be active first                                                                                                                                                                        
                                                            
  ### Troubleshooting guide (`04-troubleshooting.md`)                                                                                                                                                                                                                        
  - Added "Instant Results returns Search template not found" section with steps to diagnose and fix (verify template, push template, activate Search feature if push silently fails)