### PR TITLE
Update Drupal 8 and 9 support status to unsupported

### DIFF
--- a/src/source/content/supported-drupal.md
+++ b/src/source/content/supported-drupal.md
@@ -20,8 +20,8 @@ The following table indicates availability of the specified Drupal versions, as 
 | Drupal CMS          | <span style="color:green">✔</span> | <span style="color:green">✔</span>           | <span style="color:green">✔</span>
 | 11          | <span style="color:green">✔</span> | <span style="color:green">✔</span>           | <span style="color:green">✔</span>
 | 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
-| 9           |<span style="color:green">✔</span> <Popover title="Drupal 9 Availability" content="Drupal 9 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
-| 8           |<span style="color:green">✔</span> <Popover title="Drupal 8 Availability" content="Drupal 8 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
+| 9           |<span style="color:green">✔</span> <Popover title="Drupal 9 — End of Life" content="Drupal 9 reached its end of life on November 1, 2023. It no longer receives security updates from the Drupal community. Existing sites continue to run on Pantheon, but we strongly recommend migrating to Drupal 10 or 11." /> | ❌           | ❌ |
+| 8           |<span style="color:green">✔</span> <Popover title="Drupal 8 — End of Life" content="Drupal 8 reached its end of life on November 2, 2021. It no longer receives security updates from the Drupal community. Existing sites continue to run on Pantheon, but we strongly recommend migrating to Drupal 10 or 11." /> | ❌           | ❌ |
 | 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span> <Popover title="Drupal 7 LTS" content="Pantheon offers Long-Term Support for Drupal 7 sites on the platform at no extra cost. For more information, see the <a href='#drupal-7-long-term-support'>section below.</a>" />        |
 | 6           | ❌          | ❌           | ❌          |
 
@@ -42,11 +42,10 @@ Refer to [Create a New CMS Site](/guides/getstarted/addsite/#create-a-new-cms-si
 If you already have a Drupal 10 site on Pantheon, you can upgrade your existing site to [Drupal 11 via Composer](https://www.drupal.org/docs/upgrading-drupal/upgrading-from-drupal-8-or-later/how-to-upgrade-from-drupal-10-to-drupal-11).
 
 ## Drupal 8 and 9 on Pantheon
-Drupal 8 and 9 are not available as an option during site creation in the Pantheon dashboard. However, they can still be created on the platform using [Terminus](/terminus). For example:
 
-```bash{promptUser: user}
-terminus site:create <site> <label> drupal8
-```
+**Drupal 8** reached its end of life in [November 2021](https://www.drupal.org/psa-2021-11-30). **Drupal 9** reached its end of life on [November 1, 2023](https://www.drupal.org/psa-2023-11-01). Neither version receives security updates from the Drupal community.
+
+Existing Drupal 8 and 9 sites continue to run on the Pantheon platform, but Pantheon does not provide support for issues specific to these end-of-life Drupal versions. New Drupal 8 and 9 sites are not available for creation in the Pantheon dashboard.
 
 ## Drupal 7 on Pantheon
 Refer to [Create a New CMS Site](/guides/getstarted/addsite/#create-a-new-cms-site) for how to create a new Drupal 7 site from the Pantheon dashboard.

--- a/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
+++ b/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
@@ -1,0 +1,39 @@
+---
+title: "Pantheon Search: Solr 9 GA target date and Solr 3/8 removal dates"
+published_date: "2026-05-12"
+categories: [infrastructure, security, action-required]
+---
+
+We are removing Solr 3 and Solr 8 from the platform. Solr 9 will reach General Availability ahead of these removals. After a Solr version is removed, sites using that version will no longer be able to index content or return search results. Views, blocks, or other components that rely on Solr-powered search indexes may return no results or throw errors.
+
+| Solr version | Milestone | Date |
+|---|---|---|
+| Solr 9 | General Availability | June 30, 2026 |
+| Solr 3 | Platform removal | February 9, 2027 |
+| Solr 8 | Platform removal | July 11, 2027 |
+
+## Solr 9 — General Availability: June 30, 2026
+
+Solr 9 is [available as a Beta](/release-notes/2026/04/search-api-pantheon-solr-9-beta) for Drupal 10 and 11 sites through `search_api_pantheon` version 8.5.0-beta1. Solr 9 Beta for Drupal 7 is now available as of **May 12, 2026**. General Availability is targeted for **June 30, 2026**.
+
+## Solr 3 — Removal: February 9, 2027
+
+Solr 3 will be removed from the Pantheon platform on **February 9, 2027**. Solr 3 is a legacy search version that no longer receives security updates.
+
+Previous milestones:
+
+* [Solr 3 support for Drupal 9.4+ ended December 9, 2025](/release-notes/2025/08/solr-3-drupal-94-eol)
+* [WordPress Solr support ends January 11, 2027](/release-notes/2026/04/solr-3-end-of-life)
+
+Drupal 7 sites still using Solr 3 must migrate to Solr 9 before this date. See the [Solr for Drupal 7 guide](/guides/pantheon-search/solr-drupal/solr-drupal-7) for upgrade steps.
+
+## Solr 8 — Removal: July 11, 2027
+
+Solr 8 (8.11.4) will be removed from the platform on **July 11, 2027**. Drupal 10 and 11 sites currently running Solr 8 should migrate to Solr 9 before this date. Upgrade instructions are available in the [Solr 9 Beta announcement](/release-notes/2026/04/search-api-pantheon-solr-9-beta).
+
+## Action required
+
+* **Solr 3 sites**: Migrate to Solr 9 before **February 9, 2027**.
+* **Solr 8 sites**: Migrate to Solr 9 before **July 11, 2027**.
+
+For guidance on upgrading, refer to [Pantheon Search documentation](/guides/solr-drupal).

--- a/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
+++ b/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
@@ -4,17 +4,11 @@ published_date: "2026-05-12"
 categories: [infrastructure, security, action-required]
 ---
 
-We are removing Solr 3 and Solr 8 from the platform. Solr 9 will reach General Availability ahead of these removals. After a Solr version is removed, sites using that version will no longer be able to index content or return search results. Views, blocks, or other components that rely on Solr-powered search indexes may return no results or throw errors.
-
-| Solr version | Milestone | Date |
-|---|---|---|
-| Solr 9 | General Availability | June 30, 2026 |
-| Solr 3 | Platform removal | February 9, 2027 |
-| Solr 8 | Platform removal | July 11, 2027 |
+We are removing Solr 3 from the platform on **February 9, 2027** and Solr 8 on **July 11, 2027**. Solr 9 will reach General Availability on **June 30, 2026** ahead of these removals. After a Solr version is removed, sites using that version will no longer be able to index content or return search results. Views, blocks, or other components that rely on Solr-powered search indexes may return no results or throw errors.
 
 ## Solr 9 — General Availability: June 30, 2026
 
-Solr 9 is [available as a Beta](/release-notes/2026/04/search-api-pantheon-solr-9-beta) for Drupal 10 and 11 sites through `search_api_pantheon` version 8.5.0-beta1. Solr 9 Beta for Drupal 7 is now available as of **May 12, 2026**. General Availability is targeted for **June 30, 2026**.
+Solr 9 has been [available as a Beta](/release-notes/2026/04/search-api-pantheon-solr-9-beta) for Drupal 10 and 11 sites through `search_api_pantheon` version 8.5.0-beta1. Solr 9 Beta for Drupal 7 is now available as of **May 12, 2026**.
 
 ## Solr 3 — Removal: February 9, 2027
 
@@ -25,11 +19,11 @@ Previous milestones:
 * [Solr 3 support for Drupal 9.4+ ended December 9, 2025](/release-notes/2025/08/solr-3-drupal-94-eol)
 * [WordPress Solr support ends January 11, 2027](/release-notes/2026/04/solr-3-end-of-life)
 
-Drupal 7 sites still using Solr 3 must migrate to Solr 9 before this date. See the [Solr for Drupal 7 guide](/guides/pantheon-search/solr-drupal/solr-drupal-7) for upgrade steps.
+Drupal 7 sites still using Solr 3 must migrate to Solr 9 before this date. See the [Solr for Drupal 7 guide](/guides/pantheon-search/solr-drupal/solr-drupal-7) for upgrade steps. WordPress sites should migrate to [Elasticsearch or another supported search solution](/release-notes/2026/04/solr-3-end-of-life) before January 11, 2027.
 
 ## Solr 8 — Removal: July 11, 2027
 
-Solr 8 (8.11.4) will be removed from the platform on **July 11, 2027**. Drupal 10 and 11 sites currently running Solr 8 should migrate to Solr 9 before this date. Upgrade instructions are available in the [Solr 9 Beta announcement](/release-notes/2026/04/search-api-pantheon-solr-9-beta).
+Solr 8 (8.11.4) will be removed from the platform on **July 11, 2027**. Solr 9 supersedes Solr 8 with improved security defaults and other enhancements. Drupal 10 and 11 sites currently running Solr 8 should migrate to Solr 9 before this date. Upgrade instructions are available in the [Solr 9 Beta announcement](/release-notes/2026/04/search-api-pantheon-solr-9-beta).
 
 ## Action required
 

--- a/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
+++ b/src/source/releasenotes/2026-05-12-solr-9-ga-solr-3-8-removal-dates.md
@@ -8,7 +8,7 @@ We are removing Solr 3 from the platform on **February 9, 2027** and Solr 8 on *
 
 ## Solr 9 — General Availability: June 30, 2026
 
-Solr 9 has been [available as a Beta](/release-notes/2026/04/search-api-pantheon-solr-9-beta) for Drupal 10 and 11 sites through `search_api_pantheon` version 8.5.0-beta1. Solr 9 Beta for Drupal 7 is now available as of **May 12, 2026**.
+Solr 9 has been [available as a Beta](/release-notes/2026/04/search-api-pantheon-solr-9-beta) for Drupal 10 and 11 sites through `search_api_pantheon` version 8.5.0-beta1. Solr 9 Beta for Drupal 7 is now available as of **May 12, 2026**. General Availability is targeted for **June 30, 2026**.
 
 ## Solr 3 — Removal: February 9, 2027
 


### PR DESCRIPTION
## Summary

- Mark Drupal 8 and 9 as **Supported: ❌** in the version table (keep Available: ✔ since existing sites still run)
- Update Popover hover text with official EOL dates and migration recommendation
- Rewrite the D8/D9 section with EOL dates linking to official [Drupal PSAs](https://www.drupal.org/psa-2021-11-30)
- Remove Terminus `site:create` instructions for D8/D9

## Context

Drupal 8 reached EOL in November 2021. Drupal 9 reached EOL on November 1, 2023. Neither has an LTS arrangement. The previous docs marked both as "Supported: ✔" which is inconsistent — they receive no security updates from the Drupal community and Pantheon does not provide version-specific support for them.

## Test plan

- [ ] Verify the support table renders correctly with the updated Popover content
- [ ] Verify the D8/D9 section links to the correct Drupal.org PSAs
- [ ] Confirm no broken anchor links (`#drupal-8-and-9-on-pantheon`)