### PR TITLE
Update Drupal 8 and 9 support status to unsupported

### DIFF
--- a/src/source/content/supported-drupal.md
+++ b/src/source/content/supported-drupal.md
@@ -20,8 +20,8 @@ The following table indicates availability of the specified Drupal versions, as 
 | Drupal CMS          | <span style="color:green">✔</span> | <span style="color:green">✔</span>           | <span style="color:green">✔</span>
 | 11          | <span style="color:green">✔</span> | <span style="color:green">✔</span>           | <span style="color:green">✔</span>
 | 10          | <span style="color:green">✔</span>         | <span style="color:green">✔</span>           | <span style="color:green">✔</span>          |
-| 9           |<span style="color:green">✔</span> <Popover title="Drupal 9 Availability" content="Drupal 9 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
-| 8           |<span style="color:green">✔</span> <Popover title="Drupal 8 Availability" content="Drupal 8 is past its end of life date and is not an available option during site creation in the Pantheon dashboard. For a workaround, see the  <a href='#drupal-8-and-9-on-pantheon'>section below.</a>  While it remains functional on the platform, do not build for the future on it." /> | ❌           | <span style="color:green">✔</span> |
+| 9           |<span style="color:green">✔</span> <Popover title="Drupal 9 — End of Life" content="Drupal 9 reached its end of life on November 1, 2023. It no longer receives security updates from the Drupal community. Existing sites continue to run on Pantheon, but we strongly recommend migrating to Drupal 10 or 11." /> | ❌           | ❌ |
+| 8           |<span style="color:green">✔</span> <Popover title="Drupal 8 — End of Life" content="Drupal 8 reached its end of life in November 2021. It no longer receives security updates from the Drupal community. Existing sites continue to run on Pantheon, but we strongly recommend migrating to Drupal 10 or 11." /> | ❌           | ❌ |
 | 7           | <span style="color:green">✔</span>         | ❌           | <span style="color:green">✔</span> <Popover title="Drupal 7 LTS" content="Pantheon offers Long-Term Support for Drupal 7 sites on the platform at no extra cost. For more information, see the <a href='#drupal-7-long-term-support'>section below.</a>" />        |
 | 6           | ❌          | ❌           | ❌          |
 
@@ -42,11 +42,10 @@ Refer to [Create a New CMS Site](/guides/getstarted/addsite/#create-a-new-cms-si
 If you already have a Drupal 10 site on Pantheon, you can upgrade your existing site to [Drupal 11 via Composer](https://www.drupal.org/docs/upgrading-drupal/upgrading-from-drupal-8-or-later/how-to-upgrade-from-drupal-10-to-drupal-11).
 
 ## Drupal 8 and 9 on Pantheon
-Drupal 8 and 9 are not available as an option during site creation in the Pantheon dashboard. However, they can still be created on the platform using [Terminus](/terminus). For example:
 
-```bash{promptUser: user}
-terminus site:create <site> <label> drupal8
-```
+**Drupal 8** reached its end of life in [November 2021](https://www.drupal.org/psa-2021-11-30). **Drupal 9** reached its end of life on [November 1, 2023](https://www.drupal.org/psa-2023-11-01). Neither version receives security updates from the Drupal community.
+
+Existing Drupal 8 and 9 sites continue to run on the Pantheon platform, but Pantheon does not provide support for issues specific to these end-of-life Drupal versions. New Drupal 8 and 9 sites are not available for creation in the Pantheon dashboard.
 
 ## Drupal 7 on Pantheon
 Refer to [Create a New CMS Site](/guides/getstarted/addsite/#create-a-new-cms-site) for how to create a new Drupal 7 site from the Pantheon dashboard.

--- a/src/source/content/supported-drupal.md
+++ b/src/source/content/supported-drupal.md
@@ -2,7 +2,7 @@
 title: Supported Drupal Versions
 description: Learn which versions of Drupal are currently supported, as well as additional compatibility information.
 tags: [libraries, updates]
-contributors: [wordsmither, scottbuscemi]
+contributors: [wordsmither, scottbuscemi, rkunjappan]
 contenttype: [doc]
 innav: [true]
 categories: [cms]
@@ -10,7 +10,7 @@ cms: [drupal]
 audience: [development]
 product: [--]
 integration: [--]
-reviewed: "2025-05-02"
+reviewed: "2026-05-28"
 ---
 
 The following table indicates availability of the specified Drupal versions, as well as our usage recommendations and our support scope.


### PR DESCRIPTION

## Summary

- Mark D8 and D9 as **Supported: ❌** in the version table (keep Available: ✔)
- Rewrite the D8/D9 section with EOL dates linking to official [Drupal PSAs](https://www.drupal.org/psa-2021-11-30)
- Remove Terminus `site:create` instructions for D8/D9 (If these versions are unsupported, should we remove the terminus command from the documentation?)

## Context

Drupal 8 reached EOL in November 2021. Drupal 9 reached EOL on November 1, 2023. Neither has an LTS arrangement. The previous docs marked both as "Supported: ✔," which is inconsistent — they receive no security updates from the Drupal community, and Pantheon does not provide version-specific support for them.
