### PR TITLE
Terminus Release 4.3.0 - Version Updates

### DIFF
--- a/src/source/content/terminus/10-supported-terminus.md
+++ b/src/source/content/terminus/10-supported-terminus.md
@@ -23,7 +23,8 @@ After this period, the version will reach End Of Life (**EOL**), and will no lon
 
 | Version          | Release Date       | EOL Date           |
 |------------------|--------------------|--------------------|
-| 4.2.2            | May 13, 2026       |                    |
+| 4.3.0            | May 26, 2026       |                    |
+| 4.2.2            | May 13, 2026       | May 26, 2027       |
 | 4.2.1            | April 30, 2026     | May 13, 2027       |
 | 4.2.0            | April 13, 2026     | April 30, 2027     |
 | 4.1.9            | April 08, 2026     | April 13, 2027     |

--- a/src/source/releasenotes/2026-05-26-terminus-4-3-0.md
+++ b/src/source/releasenotes/2026-05-26-terminus-4-3-0.md
@@ -1,0 +1,31 @@
+---
+title: "Terminus 4.3.0 release now available"
+published_date: "2026-05-26"
+categories: [tools-apis]
+---
+
+Terminus [4.3.0](https://github.com/pantheon-systems/terminus/releases/tag/4.3.0) is now available. This release adds GitHub Enterprise Server (GHES) support for VCS commands, enabling customers using GHES to provision and manage their repositories through Terminus.
+
+## Key improvements in this release
+
+- **GHES provisioning command**: New `vcs:github-host:add` command allows provisioning GitHub Enterprise Server hosts for use with Pantheon VCS integrations ([#2838](https://github.com/pantheon-systems/terminus/pull/2838))
+- **GHES support in VCS commands**: Existing VCS commands now accept a `--github-host` option to target GitHub Enterprise Server instances ([#2840](https://github.com/pantheon-systems/terminus/pull/2840))
+- **Twig dependency update**: Updated the twig templating dependency ([#2841](https://github.com/pantheon-systems/terminus/pull/2841))
+
+## How to upgrade to Terminus 4.3.0
+
+If you use Homebrew (macOS-only) to manage your Terminus installation, you should upgrade using:
+
+```shell{promptUser: user}
+brew upgrade terminus
+```
+
+If you installed Terminus directly from the `.phar` file, you should upgrade using the `self:update` command:
+
+```shell{promptUser: user}
+terminus self:update
+```
+
+For more information about this release, visit the [GitHub release page](https://github.com/pantheon-systems/terminus/releases/tag/4.3.0).
+
+If you have questions or concerns around Terminus, please use the [Terminus issue queue](https://github.com/pantheon-systems/terminus).


### PR DESCRIPTION
## Summary

**[Version Updates](https://docs.pantheon.io/terminus/supported-terminus)** - Terminus Release 4.3.0

- Updated supported versions table with 4.3.0 release date and 4.2.2 EOL date
- Added release note for Terminus 4.3.0

## Links

- Terminus Release PR: https://github.com/pantheon-systems/terminus/pull/2843
- CCB ticket: https://getpantheon.atlassian.net/browse/CCB-2864