### PR TITLE
Removing broken link

### DIFF
--- a/src/source/content/guides/github-application/04-setup-drupal.md
+++ b/src/source/content/guides/github-application/04-setup-drupal.md
@@ -191,7 +191,6 @@ Use this checklist to verify your Drupal 11 repository is ready for Pantheon's G
 ## More Resources
 
 - [Drupal on Pantheon](/develop-drupal) - Comprehensive guide to running Drupal on Pantheon
-- [Using Git with Drupal](/guides/git/drupal) - Learn Git workflows specifically for Drupal development
 - [Integrated Composer](/guides/integrated-composer) - Managing Drupal dependencies with Composer
 - [Drush on Pantheon](/guides/drush) - Command-line tools for managing Drupal sites
 - [pantheon.yml](/pantheon-yml) - Platform configuration file reference


### PR DESCRIPTION
CI is currently failing because of this broken link. We have a script that (incompletely) crawls pages to look for broken links.

I think https://github.com/pantheon-systems/documentation/pull/10087 caused this page to get crawled and the broken link was found.

@jazzsequence, if there is a page that you think this link should go to, please update.