### PR TITLE
Clarify Solr version compatibility by Drupal version in pantheon.yml

### DIFF
--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -267,7 +267,7 @@ search:
 #### Considerations
 
 - The valid values for the versions are `3`, `8`, and `9`.
-- Solr 8 and Solr 9 are supported for [Drupal 9 and higher](/guides/solr-drupal/solr-drupal) sites.
+- Drupal 7 supports Solr 3/9. [Drupal 10+](/guides/solr-drupal/solr-drupal) supports Solr 8/9.
 
 ### Drush Version
 

--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -267,7 +267,7 @@ search:
 #### Considerations
 
 - The valid values for the versions are `3`, `8`, and `9`.
-- Drupal 7 supports Solr 3/9. [Drupal 10+](/guides/solr-drupal/solr-drupal) supports Solr 8/9.
+- [Drupal 7](/guides/pantheon-search/solr-drupal/solr-drupal-7) supports Solr 3/9. [Drupal 10+](/guides/pantheon-search/solr-drupal/solr-drupal) supports Solr 8/9.
 
 ### Drush Version
 


### PR DESCRIPTION
## Summary

- Corrects the Solr compatibility note in the \`pantheon.yml\` docs, which previously stated Solr 8 and 9 were both for "Drupal 9 and higher"
- Actual compatibility matrix: Drupal 7 supports Solr 3/9; Drupal 10+ supports Solr 8/9

## Test plan

- [x] Verify the Considerations section under "Specify a Solr Version" reads correctly
- [ ] Confirm links to the Solr Drupal guide resolve