### PR TITLE
ci: add release note validation workflow and remove DOCS_PAT dependency

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -20,64 +20,7 @@ jobs:
       uses: actions/checkout@v6
       # We need to fetch all tags to find the highest one
       with:
-        token: ${{ secrets.DOCS_PAT }}
         fetch-depth: 0
-
-    - name: Set timestamps on new release notes
-      id: set_timestamps
-      env:
-        COMMIT_MSG: ${{ github.event.head_commit.message }}
-      run: |
-        # Avoid re-processing the commit this step itself pushes
-        if [[ "$COMMIT_MSG" == "chore: set published_at timestamp"* ]]; then
-          echo "Skipping - timestamp commit detected"
-          echo "deploy_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        TIMESTAMP=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
-
-        # Get list of release note files added in this commit (not modified)
-        NEW_FILES=$(git diff --name-only --diff-filter=A HEAD~1 HEAD -- 'src/source/releasenotes/*.md' 2>/dev/null || true)
-
-        if [ -z "$NEW_FILES" ]; then
-          echo "No new release note files"
-          echo "deploy_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
-          exit 0
-        fi
-
-        MODIFIED=false
-        MODIFIED_FILES=""
-        for file in $NEW_FILES; do
-          # Skip if file already has published_at
-          if grep -q "^published_at:" "$file"; then
-            echo "Skipping $file - already has published_at"
-            continue
-          fi
-
-          # Add published_at after the published_date line
-          if grep -q "^published_date:" "$file"; then
-            sed -i "s/^published_date: \(.*\)$/published_date: \1\npublished_at: \"$TIMESTAMP\"/" "$file"
-            echo "Added published_at to $file"
-            MODIFIED=true
-            MODIFIED_FILES="$MODIFIED_FILES $(basename "$file" .md)"
-          fi
-        done
-
-        if [ "$MODIFIED" = true ]; then
-          FILE_LIST=$(echo "$MODIFIED_FILES" | xargs | tr ' ' ', ')
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git add -A
-          git commit -m "chore: set published_at timestamp for $FILE_LIST [skip ci]"
-          git push
-          # Output the new commit SHA for subsequent steps
-          NEW_SHA=$(git rev-parse HEAD)
-          echo "deploy_commit=$NEW_SHA" >> $GITHUB_OUTPUT
-          echo "Pushed timestamp commit: $NEW_SHA"
-        else
-          echo "deploy_commit=${{ github.sha }}" >> $GITHUB_OUTPUT
-        fi
 
     - uses: ./.github/actions/pantheon-auto-tag
       with:
@@ -85,7 +28,7 @@ jobs:
 
     - uses: ./.github/actions/wait-for-deployment
       with:
-        expected_commit: ${{ steps.set_timestamps.outputs.deploy_commit }}
+        expected_commit: ${{ github.sha }}
         env_name: live
         pantheon_site_name: ${{ vars.PANTHEON_SITE_MACHINE_NAME }}
         pantheon_machine_token: ${{ secrets.PANTHEON_MACHINE_TOKEN }}

--- a/.github/workflows/validate-release-notes.yml
+++ b/.github/workflows/validate-release-notes.yml
@@ -1,0 +1,48 @@
+name: Validate Release Notes
+
+on:
+  pull_request:
+    paths:
+      - 'src/source/releasenotes/*.md'
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate release note
+        run: |
+          FILES=$(git diff --name-only --diff-filter=AM \
+            "${{ github.event.pull_request.base.sha }}" \
+            "${{ github.event.pull_request.head.sha }}" \
+            -- 'src/source/releasenotes/*.md')
+
+          COUNT=$(echo "$FILES" | grep -c '.' || true)
+
+          if [ "$COUNT" -gt 1 ]; then
+            echo "::error::PRs must contain only one release note. Found $COUNT:"
+            echo "$FILES"
+            exit 1
+          fi
+
+          if [ -z "$FILES" ]; then
+            echo "No release note files added or modified — skipping."
+            exit 0
+          fi
+
+          FRONTMATTER=$(awk '/^---/{count++; if(count==2) exit} count==1' "$FILES")
+
+          if echo "$FRONTMATTER" | grep -qE '^published_at:[[:space:]]+\S+'; then
+            VALUE=$(echo "$FRONTMATTER" | grep -E '^published_at:' | sed 's/^published_at:[[:space:]]*//' | tr -d '"')
+            echo "OK: $FILES (published_at: $VALUE)"
+          else
+            echo "::error file=$FILES::Missing 'published_at' in frontmatter. Add 'published_at: \"2026-06-01T00:00:00Z\"' after 'published_date'."
+            exit 1
+          fi

--- a/src/source/releasenotes/2026-06-01-user-agent-parsing.md
+++ b/src/source/releasenotes/2026-06-01-user-agent-parsing.md
@@ -1,6 +1,7 @@
 ---
 title: "User Agent Parsing"
 published_date: "2026-06-01"
+published_at: "2026-06-01T19:13:36Z"
 categories: [new-feature, user-interface]
 description: "A User Agent Parser in the site metrics traffic tables translates raw user agent strings into readable browser, OS, device, and CPU details."
 ---


### PR DESCRIPTION
## Summary

- Adds `validate-release-notes.yml` to enforce `published_at` frontmatter on release note PRs
- Blocks PRs that contain more than one release note
- Removes the `Set timestamps` step and `DOCS_PAT` token from `auto-tag.yml` — the bot commit approach was incompatible with the org's signed commit requirement
- Fixes `wait-for-deployment` to reference `github.sha` directly instead of the now-removed step output
- Adds `published_at` to the UA parser release note that was missed when `auto-tag.yml` failed