### PR TITLE
[DEVX-7174] Add Build Tools CI Docker image deprecation release note

### DIFF
--- a/src/source/releasenotes/2026-06-04-build-tools-ci-deprecated.md
+++ b/src/source/releasenotes/2026-06-04-build-tools-ci-deprecated.md
@@ -13,16 +13,17 @@ We've released the final update to the `build-tools-ci` Docker image. We will no
 - `quay.io/pantheon-public/build-tools-ci:9.x-php8.3`
 - `quay.io/pantheon-public/build-tools-ci:9.x-php8.4`
 
+## Background
+
+These base images were created at a time when CI providers recommend using customized Docker images to speed up execution and reduce the need for replicating boilerplate configration. It has since become more common to run CI jobs on standard base images for speed and the reduction in boilerplate code comes from reusable GitHub Actions or CircleCI Orbs.
 ## Recommended migration
 
 Use a standard base image from your CI provider and install the Pantheon tools you need during the CI run. Standard images are better cached by CI runners, so your pipelines will perform better overall than with a custom image.
 
-To install Terminus in a CI job, use the [Terminus GitHub Action](https://github.com/marketplace/actions/setup-terminus) or download the phar directly:
+Learn more about Pantheon's reusable [GitHub Actions](/github-actions) and [CircleCI Orb](https://github.com/pantheon-systems/circleci-orb).
 
-```bash
-curl -L https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar -o /usr/local/bin/terminus
-chmod +x /usr/local/bin/terminus
-```
+
+
 
 ## Action required
 

--- a/src/source/releasenotes/2026-06-04-build-tools-ci-deprecated.md
+++ b/src/source/releasenotes/2026-06-04-build-tools-ci-deprecated.md
@@ -1,0 +1,29 @@
+---
+title: "Build Tools CI Docker image deprecated"
+published_date: "2026-06-04"
+categories: [deprecation, tools-apis]
+---
+
+We've released the final update to the `build-tools-ci` Docker image. We will not publish any further updates, bug fixes, or security patches to the following tags:
+
+- `pantheonpublic/build-tools-ci:9.x-php8.2`
+- `pantheonpublic/build-tools-ci:9.x-php8.3`
+- `pantheonpublic/build-tools-ci:9.x-php8.4`
+- `quay.io/pantheon-public/build-tools-ci:9.x-php8.2`
+- `quay.io/pantheon-public/build-tools-ci:9.x-php8.3`
+- `quay.io/pantheon-public/build-tools-ci:9.x-php8.4`
+
+## Recommended migration
+
+Use a standard base image from your CI provider and install the Pantheon tools you need during the CI run. Standard images are better cached by CI runners, so your pipelines will perform better overall than with a custom image.
+
+To install Terminus in a CI job, use the [Terminus GitHub Action](https://github.com/marketplace/actions/setup-terminus) or download the phar directly:
+
+```bash
+curl -L https://github.com/pantheon-systems/terminus/releases/latest/download/terminus.phar -o /usr/local/bin/terminus
+chmod +x /usr/local/bin/terminus
+```
+
+## Action required
+
+If you use any of the `build-tools-ci` image tags listed above, migrate to a standard base image before the included dependencies become outdated.

--- a/src/source/releasenotes/2026-06-15-build-tools-ci-deprecated.md
+++ b/src/source/releasenotes/2026-06-15-build-tools-ci-deprecated.md
@@ -1,6 +1,7 @@
 ---
 title: "Build Tools CI Docker image deprecated"
-published_date: "2026-06-04"
+published_date: "2026-06-15"
+published_at: 2026-06-15T16:28:34.000Z
 categories: [deprecation, tools-apis]
 ---
 


### PR DESCRIPTION
## Summary
- Add release note announcing the final update and deprecation of the `build-tools-ci` Docker image
- Lists all affected image tags (9.x-php8.2, 8.3, 8.4 on both Docker Hub and Quay)
- Recommends migrating to standard CI base images for better pipeline performance

## Test plan
- [x] Verify release note renders correctly on the docs site
- [x] Confirm frontmatter categories and date are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)