### PR TITLE
cookies: warn against high-cardinality STYXKEY values

### DIFF
--- a/src/source/content/cookies.md
+++ b/src/source/content/cookies.md
@@ -124,7 +124,7 @@ If you prefer a regular expression, the name must match the following format: `S
 
 Use `STYXKEY` cookies only for low-cardinality values (for example, role, locale, plan, or A/B test bucket). Each distinct cookie value becomes part of the Edge cache key and produces a separate cached object, so a high-cardinality or user-unique value (such as a user ID, session identifier, or JWT) fragments the cache to one entry per value. This effectively disables caching for those responses and consumes cache capacity, the opposite of the intended outcome.
 
-The `STYXKEY` prefix serves two purposes at once: it varies the Edge cache key by the cookie value, and it allows the cookie to pass through to your application. Do not reach for `STYXKEY` purely as a way to forward a per-user cookie to the CMS, as doing so will fragment your cache.
+`STYXKEY` cookies are not stripped at the Edge on cache misses. The cookie value is forwarded to your application to generate the cached variant.  Using `STYXKEY` cookies to forward per-user cookies to the CMS requires a unique value per user, which fragments your cache as described above. To forward a cookie to your application on every request regardless of cache state, use a [cache-busting cookie](/cookies#cache-busting-cookies) instead.
 
 </Alert>
 

--- a/src/source/content/cookies.md
+++ b/src/source/content/cookies.md
@@ -120,6 +120,14 @@ If you prefer a regular expression, the name must match the following format: `S
 
 1. Use the stored value to generate varied content as appropriate for your use case and implementation.
 
+<Alert title="Warning" type="danger">
+
+Use `STYXKEY` cookies only for low-cardinality values (for example, role, locale, plan, or A/B test bucket). Each distinct cookie value becomes part of the Edge cache key and produces a separate cached object, so a high-cardinality or user-unique value (such as a user ID, session identifier, or JWT) fragments the cache to one entry per value. This effectively disables caching for those responses and consumes cache capacity, the opposite of the intended outcome.
+
+The `STYXKEY` prefix serves two purposes at once: it varies the Edge cache key by the cookie value, and it allows the cookie to pass through to your application. Do not reach for `STYXKEY` purely as a way to forward a per-user cookie to the CMS, as doing so will fragment your cache.
+
+</Alert>
+
 ## Setting Cookies for Platform Domains
 
 Setting cookies for the `pantheonsite.io` bare domain is not supported, as this would force all sites on the platform to read cookies from all other sites. However, you can set cookies for platform domains (for example `dev-site-name.pantheonsite.io`) and custom domains (for example `example.com`, `xyz.example.com`).

--- a/src/source/content/cookies.md
+++ b/src/source/content/cookies.md
@@ -2,7 +2,7 @@
 title: Working with Cookies on Pantheon
 description: Tips and tricks for working with cookies on your Pantheon Drupal and WordPress sites.
 contributors: [--]
-reviewed: "2022-12-07"
+reviewed: "2026-06-15"
 contenttype: [doc]
 innav: [true]
 categories: [cache]


### PR DESCRIPTION
Closes #10107

## Problem

The [Cookies and Caching](https://docs.pantheon.io/cookies) page documents the `STYXKEY` mechanism but omits two operational guardrails that readers currently only learn through support:

1. **No value-cardinality warning.** Each `STYXKEY` cookie value becomes part of the Edge cache key, so each distinct value produces a separate cached object. A user-unique value (user ID, session token, JWT) fragments the cache to one entry per value, effectively disabling caching for those responses.
2. **Dual-purpose behavior is not called out.** `STYXKEY` both varies the cache key and forwards the cookie to the application. It is sometimes reached for purely to forward a cookie to the CMS, which silently degrades cache behavior.

## Change

Adds a single `Warning` callout at the end of the **Cache-Varying Cookies** section covering both points. Content-only; no structural changes.

<img width="1177" height="469" alt="Screenshot 2026-06-05 at 11 53 54 PM" src="https://github.com/user-attachments/assets/2048b775-0b47-4f5c-88d5-799098ae1673" />
