### PR TITLE
[SITE-5794] Add content filtering notice to Elasticsearch setup guide

### DIFF
--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -103,3 +103,18 @@ Navigate to **ElasticPress > Features** in your WordPress admin to enable and co
 
 </Alert>
 
+### Content Filtering Considerations
+
+<Alert type="warning" title="Review What Content Gets Indexed">
+
+When Elasticsearch indexes your site, it sends post content and metadata to the ElasticPress service. Be mindful of content on your site that may contain sensitive information such as user profiles, or posts with personally identifiable information (PII), and consider whether those post types should be included in the search index.
+
+ElasticPress provides filters to control what gets indexed:
+
+- **Exclude post types from indexing** — Use the [`ep_indexable_post_types`](https://www.elasticpress.io/resources/articles/excluding-post-types-from-being-indexed/) filter to prevent specific post types (such as orders or account pages) from being sent to Elasticsearch.
+- **Exclude metadata from indexing** — Use the [`ep_prepare_meta_data`](https://www.elasticpress.io/resources/articles/how-to-exclude-metadata-from-indexing/) filter to remove sensitive meta fields before they are indexed.
+
+After changing your indexing filters, run a full [index sync](/guides/pantheon-search/elasticsearch/query-optimization#keeping-your-index-current) to rebuild the index without the excluded content.
+
+</Alert>
+

--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -105,8 +105,6 @@ Navigate to **ElasticPress > Features** in your WordPress admin to enable and co
 
 ### Content Filtering Considerations
 
-<Alert type="warning" title="Review What Content Gets Indexed">
-
 When Elasticsearch indexes your site, it sends post content and metadata to the ElasticPress service. Be mindful of content on your site that may contain sensitive information such as user profiles, or posts with personally identifiable information (PII), and consider whether those post types should be included in the search index.
 
 ElasticPress provides filters to control what gets indexed:
@@ -115,6 +113,4 @@ ElasticPress provides filters to control what gets indexed:
 - **Exclude metadata from indexing** — Use the [`ep_prepare_meta_data`](https://www.elasticpress.io/resources/articles/how-to-exclude-metadata-from-indexing/) filter to remove sensitive meta fields before they are indexed.
 
 After changing your indexing filters, run a full [index sync](/guides/pantheon-search/elasticsearch/query-optimization#keeping-your-index-current) to rebuild the index without the excluded content.
-
-</Alert>
 


### PR DESCRIPTION
## Summary

- Adds a warning callout to the Elasticsearch setup/config page advising customers to review what content types and metadata are sent to Elasticsearch
- Calls out sensitive content like user profiles and PII as things to consider excluding from indexing
- Links to ElasticPress documentation for the `ep_indexable_post_types` and `ep_prepare_meta_data` filters
- Links to the existing index sync instructions for re-indexing after filter changes

## Preview

[Elasticsearch Setup and Config page](https://pr-10109-pandocs.pantheonsite.io/docs/guides/pantheon-search/elasticsearch/setup-config)