### PR TITLE
Update Elasticsearch docs for accuracy ahead of GA

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -17,5 +17,13 @@ src/source/content/guides/integrated-composer/ @pantheon-systems/developer-exper
 src/source/content/guides/multisite/ @pantheon-systems/site-experience
 # The cms-platform team is responsible for External Libraries on Pantheon
 src/source/content/external-libraries @pantheon-systems/site-experience
+# The site-experience team is responsible for Elasticsearch docs
+src/source/content/guides/elasticsearch/ @pantheon-systems/site-experience
+# The site-experience team is responsible for Solr docs
+src/source/content/guides/solr-drupal/ @pantheon-systems/site-experience
+src/source/content/solr.md @pantheon-systems/site-experience
+src/source/content/opensolr.md @pantheon-systems/site-experience
+# The site-experience team is responsible for WordPress developer docs
+src/source/content/guides/wordpress-developer/ @pantheon-systems/site-experience
 # There is a team just for release note permissions
 src/source/releasenotes/ @pantheon-systems/release-note-authors

--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -36,6 +36,12 @@ Elasticsearch is available for WordPress sites on **Performance** and **Elite** 
 
 Pantheon also offers [Solr-based search](/solr). You can have both Solr and Elasticsearch activated on a site at the same time, which is useful during migration. However, running both simultaneously in production is not recommended. For new search implementations, Elasticsearch with ElasticPress is the recommended path.
 
+<Alert type="warning" title="Solr 3 deprecation">
+
+Pantheon is deprecating Solr 3 support. WordPress sites using the Solr Power plugin will lose Solr 3 support in January 2027. If your WordPress site currently uses Solr, plan your migration to Elasticsearch before that date.
+
+</Alert>
+
 <Partial file="pantheon-search-table.md" />
 
 ## Support

--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -4,7 +4,7 @@ subtitle: Pantheon Search powered by Elasticsearch
 navtitle: Introduction
 description: Detailed information on using Elasticsearch with your Pantheon WordPress site with ElasticPress.
 tags: [elasticsearch,search]
-reviewed: "2026-02-10"
+reviewed: "2026-06-11"
 contenttype: [doc]
 innav: [true]
 categories: [search]

--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -38,24 +38,6 @@ Pantheon also offers [Solr-based search](/solr). You can have both Solr and Elas
 
 <Partial file="pantheon-search-table.md" />
 
-## Known Issues
-
-There are currently a few known issues with the Elasticsearch integration on Pantheon in the Beta phase. If you find any others, please let the team know in the `#beta-elasticsearch` channel in the Pantheon Community Slack.
-
-### ElasticPress WP-CLI commands require full URL flag
-
-Currently, when running ElasticPress WP-CLI commands through Terminus, you must include the `--url` flag with your site's URL for the command to work properly. This is due to how ElasticPress detects the host connection and how the Pantheon hostname is read on the platform. For example:
-
-```bash
-terminus wp <site>.<env> -- elasticpress sync --url=https://yoursite.com
-```
-
-### Elasticsearch instance is not reachable on Pantheon platform domains (`*.pantheonsite.io`)
-
-Currently, if your environment has a Pantheon platform domain (e.g. `<env>-<site>.pantheonsite.io`) and _that is not the domain configured in the Elasticsearch instance_ (during Beta this is the one that you would have given to the team for the site you are testing on), then requests to the Elasticsearch instance from the site will fail. This is because the Elasticsearch instance is configured to only accept requests from the domain you provided, and the Pantheon platform domain does not match that.
-
-This means that multidev environments are not currently able to connect to the Elasticsearch instance, since they use the Pantheon platform domain, and Dev and Test environments will only work if you have attached a domain to those environments in the Pantheon dashboard (e.g. `dev.yoursite.com`, `test.yoursite.com`).
-
 ## Support
 
 During Beta, please report any issues or questions to the Pantheon team in the private `#beta-elasticsearch` channel in the [Pantheon Community Slack](https://pantheon.io/customer-community). To participate in the Beta, simply toggle the **Elasticsearch (beta)** add-on in your Site Settings.

--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -63,7 +63,7 @@ terminus search:enable <site>
 
 <Alert type="info" title="Note">
 
-During the Beta phase, activating Elasticsearch may take up to 12 minutes to complete.
+Activating Elasticsearch may take up to a minute to complete.
 
 </Alert>
 

--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -14,7 +14,7 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/setup-config
 editpath: search/02-setup-config.md
-reviewed: "2026-02-10"
+reviewed: "2026-06-11"
 ---
 
 <Partial file="elasticsarch-pre-ga.md" />
@@ -78,7 +78,7 @@ terminus wp <site>.<env> -- plugin install elasticpress --activate
 ### Step 3: Activate ElasticPress in WordPress
 
 1. In your WordPress admin, navigate to **ElasticPress > Settings**.
-2. Verify that the host connection is established. If the constants are configured correctly, the ElasticPress.io Host URL, Subscription ID and Subscription Token fields should be pre-populated.
+2. Verify that the host connection is established. The ElasticPress.io Host URL, Subscription ID and Subscription Token fields should be pre-populated.
 3. Run your first **index sync** from the ElasticPress dashboard. This sends your WordPress content to Elasticsearch so it can be searched.
 
 ### Step 4: Enable ElasticPress Features

--- a/src/source/content/guides/elasticsearch/03-query-optimization.md
+++ b/src/source/content/guides/elasticsearch/03-query-optimization.md
@@ -15,7 +15,7 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/query-optimization
 editpath: search/03-query-optimization.md
-reviewed: "2026-02-10"
+reviewed: "2026-06-11"
 ---
 
 <Partial file="elasticsarch-pre-ga.md" />

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -25,7 +25,6 @@ reviewed: "2026-02-11"
 ### ElasticPress cannot connect to the host
 
 - Verify that Elasticsearch has been activated in the Pantheon Dashboard or via Terminus.
-- If you are in the Beta phase, confirm that the EP constants are properly defined in `wp-config.php`.
 - Check the ElasticPress Status Report for connection errors and details.
 - Use the ElasticPress WP-CLI command `wp elasticpress status` to check connectivity from the command line (`terminus wp <site>.<env> -- elasticpress status`).
 

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -15,7 +15,7 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/troubleshooting
 editpath: search/04-troubleshooting.md
-reviewed: "2026-02-11"
+reviewed: "2026-06-11"
 ---
 
 <Partial file="elasticsarch-pre-ga.md" />

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -75,7 +75,7 @@ Yes. Solr can be enabled at the same time as Elasticsearch to support migration.
 
 ### Do I get a dedicated Elasticsearch instance?
 
-Pantheon uses shared Elasticsearch clusters. For high-value enterprise sites requiring total isolation, dedicated clusters may be provisioned upon request and approval.
+Pantheon uses shared Elasticsearch clusters.
 
 ### Do I get all the features of ElasticPress?
 


### PR DESCRIPTION
## Summary

- Removes outdated known issues that no longer apply
- Fixes activation time (12 minutes → 1 minute per engineering spec)
- Removes reference to constants in \`wp-config.php\` (beta-only behavior, not applicable at GA)
- Removes hand-wavy reference to dedicated clusters being available "upon request and approval" (not a confirmed offering)
- Adds Solr 3 deprecation notice to the Elasticsearch/Solr section, directing WordPress users to migrate before January 2027
- Adds @pantheon-systems/site-experience to CODEOWNERS for Elasticsearch / Solr and related docs.