### PR TITLE
[SITE-5761] Update Solr docs to reference Change Search Version workflow

### DIFF
--- a/src/source/content/guides/solr-drupal/02-solr-drupal.md
+++ b/src/source/content/guides/solr-drupal/02-solr-drupal.md
@@ -11,7 +11,7 @@ product: [search]
 integration: [--]
 tags: [solr, search, modules]
 contributors: [carolynshannon, joan-ing, jazzsequence, rkunjappan, mehta-asim]
-reviewed: "2026-06-04"
+reviewed: "2026-06-15"
 showtoc: true
 permalink: docs/guides/pantheon-search/solr-drupal/solr-drupal
 editpath: solr-drupal/02-solr-drupal.md

--- a/src/source/content/guides/solr-drupal/02-solr-drupal.md
+++ b/src/source/content/guides/solr-drupal/02-solr-drupal.md
@@ -318,7 +318,7 @@ Update the module before switching `pantheon.yml`. This order ensures the correc
 
 1. **Post the schema for the new Solr version:**
 
-   Wait for the **Change Search Version** workflow to complete in your Site Dashboard, then verify the core is ready by running the diagnose command or checking the server status page (`admin/config/search/search-api` > Pantheon Search). Post the schema:
+   Wait for the **Change Search Version** workflow to complete on your site dashboard. Once complete, verify the core is ready by running the diagnose command or checking the server status page (`admin/config/search/search-api` > Pantheon Search), then post the schema:
 
    ```shell{promptUser:user}
    terminus drush $SITE.$ENV -- search-api-pantheon:diagnose
@@ -363,7 +363,7 @@ For some reason if you need to revert to Solr 8 after upgrading, the `search_api
 
 1. **Re-post the Solr 8 schema:**
 
-   Wait for the **Change Search Version** workflow to complete in your Site Dashboard, then re-post the schema:
+   Wait for the **Change Search Version** workflow to complete on your site dashboard. Once complete, re-post the schema:
 
    ```shell{promptUser:user}
    terminus drush $SITE.$ENV -- search-api-pantheon:postSchema

--- a/src/source/content/guides/solr-drupal/02-solr-drupal.md
+++ b/src/source/content/guides/solr-drupal/02-solr-drupal.md
@@ -318,7 +318,7 @@ Update the module before switching `pantheon.yml`. This order ensures the correc
 
 1. **Post the schema for the new Solr version:**
 
-   Wait a few minutes for the platform to provision the new Solr 9 core. Verify the core is ready by running the diagnose command or checking the server status page (`admin/config/search/search-api` > Pantheon Search), then post the schema:
+   Wait for the **Change Search Version** workflow to complete in your Site Dashboard, then verify the core is ready by running the diagnose command or checking the server status page (`admin/config/search/search-api` > Pantheon Search). Post the schema:
 
    ```shell{promptUser:user}
    terminus drush $SITE.$ENV -- search-api-pantheon:diagnose
@@ -362,6 +362,8 @@ For some reason if you need to revert to Solr 8 after upgrading, the `search_api
    ```
 
 1. **Re-post the Solr 8 schema:**
+
+   Wait for the **Change Search Version** workflow to complete in your Site Dashboard, then re-post the schema:
 
    ```shell{promptUser:user}
    terminus drush $SITE.$ENV -- search-api-pantheon:postSchema


### PR DESCRIPTION
## Summary
- Updated the Solr Drupal migration guide to reference the **Change Search Version** workflow in the site dashboard instead of telling users to "wait a few minutes" for Solr core provisioning
