### PR TITLE
docs(integrated-composer): document that composer.lock should always be committed

### DIFF
--- a/src/source/content/guides/integrated-composer/03-dependencies.md
+++ b/src/source/content/guides/integrated-composer/03-dependencies.md
@@ -3,7 +3,7 @@ title: Integrated Composer
 subtitle: Manage Dependencies
 description: Learn how to add or remove an individual site dependency.
 tags: [composer, workflow]
-contributors: [ari, edwardangert]
+contributors: [ari, edwardangert, jazzs3quence]
 showtoc: true
 permalink: docs/guides/integrated-composer/dependencies
 contenttype: [guide]
@@ -13,7 +13,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [composer]
 integration: [--]
-reviewed: "2025-12-10"
+reviewed: "2026-06-15"
 ---
 
 This sections provides information on dependency requirements and how to add or remove individual site dependencies.

--- a/src/source/content/guides/integrated-composer/03-dependencies.md
+++ b/src/source/content/guides/integrated-composer/03-dependencies.md
@@ -30,7 +30,7 @@ Drupal modules / themes and WordPress plugins / themes should always be in the `
 
 You should use the `require-dev` section for dependencies that are not a part of the web application but are necessary to build or test your project. Some examples are `php_codesniffer` and `phpunit`. Dev dependencies are deployed to Pantheon Dev and Multidev environments, but not to Test and Live environments.
 
-Third-party dependencies, such as modules / plugins and themes, are added to the project via `composer.json`. The `composer.lock` file keeps track of the exact version of dependency. [Composer `installer-paths`](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md#how-do-i-install-a-package-to-a-custom-path-for-my-framework-) are used to ensure the dependencies are downloaded into the appropriate directory.
+Third-party dependencies, such as modules / plugins and themes, are added to the project via `composer.json`. The `composer.lock` file records the exact resolved version of every dependency. We highly recommend committing `composer.lock` to your repository so that Integrated Composer installs the precise versions you have tested locally rather than resolving dependencies fresh on each push. [Composer `installer-paths`](https://getcomposer.org/doc/faqs/how-do-i-install-a-package-to-a-custom-path-for-my-framework.md#how-do-i-install-a-package-to-a-custom-path-for-my-framework-) are used to ensure the dependencies are downloaded into the appropriate directory.
 
 ### Select Dependencies Locally
 

--- a/src/source/content/guides/integrated-composer/07-ic-support.md
+++ b/src/source/content/guides/integrated-composer/07-ic-support.md
@@ -43,10 +43,11 @@ This section provides answers to frequently asked Integrated Composer questions.
 
 ### Should I commit `composer.lock`?
 
-Yes. Always commit `composer.lock` to your repository. When you push code to Pantheon, Integrated Composer runs `composer install`, which installs the exact dependency versions recorded in `composer.lock`.
+Yes. Always commit `composer.lock` to your site repository. When you push code to Pantheon, Integrated Composer runs `composer install`, which installs the exact dependency versions recorded in `composer.lock`.
 
 If `composer.lock` is absent, Composer resolves dependencies to their latest compatible versions rather than your pinned versions, then commits the generated `composer.lock` back to your repository. That extra commit triggers a second `sync_code` workflow, causing Quicksilver hooks to fire twice for a single push. When you later pull those changes, you may also encounter merge conflicts if your local copy diverges from the file Pantheon committed, or if `composer.lock` was previously removed from your repository's git history.
 
+**Note:** It is **not** recommended to commit your `composer.lock` file to _upstream_ repositories. A `composer.lock` file in an upstream repository can lead to merge conflicts on downstream sites. For more information, see our documentation about [custom upstream usage](/guides/integrated-composer/ic-upstreams).
 ### What Composer commands does Pantheon run?
 
 All Composer commands are available through the **Commit Log** in the Site Dashboard's development environment.

--- a/src/source/content/guides/integrated-composer/07-ic-support.md
+++ b/src/source/content/guides/integrated-composer/07-ic-support.md
@@ -41,6 +41,12 @@ Visit [our community Slack](https://pantheon-community.slack.com/archives/CT8MC5
 This section provides answers to frequently asked Integrated Composer questions.
 
 
+### Should I commit `composer.lock`?
+
+Yes. Always commit `composer.lock` to your repository. When you push code to Pantheon, Integrated Composer runs `composer install`, which installs the exact dependency versions recorded in `composer.lock`.
+
+If `composer.lock` is absent, Composer resolves dependencies to their latest compatible versions rather than your pinned versions, then commits the generated `composer.lock` back to your repository. That extra commit triggers a second `sync_code` workflow, causing Quicksilver hooks to fire twice for a single push. When you later pull those changes, you may also encounter merge conflicts if your local copy diverges from the file Pantheon committed, or if `composer.lock` was previously removed from your repository's git history.
+
 ### What Composer commands does Pantheon run?
 
 All Composer commands are available through the **Commit Log** in the Site Dashboard's development environment.

--- a/src/source/content/guides/integrated-composer/07-ic-support.md
+++ b/src/source/content/guides/integrated-composer/07-ic-support.md
@@ -3,8 +3,8 @@ title: Integrated Composer
 subtitle: Support and FAQs
 description: Learn about support for Integrated Composer.
 tags: [composer, workflow]
-contributors: [ari, edwardangert]
-reviewed: "2024-10-15"
+contributors: [ari, edwardangert, jazzs3quence]
+reviewed: "2026-06-15"
 showtoc: true
 permalink: docs/guides/integrated-composer/ic-support
 contenttype: [guide]


### PR DESCRIPTION
Closes #10104

## Summary

- Strengthens the description of `composer.lock` in `03-dependencies.md` to explicitly recommend always committing it and explains why
- Adds a new FAQ entry in `07-ic-support.md` — "Should I commit `composer.lock`?" — covering the specific consequences of not committing it (double `sync_code` workflows, duplicate Quicksilver hook execution, potential merge conflicts on pull)
- Bumps `reviewed` dates and adds contributor on both files

## Test plan

- [x] Verify updated prose in the Dependencies section reads correctly
- [x] Verify new FAQ entry appears under the FAQs section on the Integrated Composer support page