### PR TITLE
[DEVREL-95] update Secrets guide for Terminus 4.2.0 GA and dashboard UI

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -13,6 +13,8 @@ src/source/content/bots-and-indexing @pantheon-systems/platform-edge-routing
 src/source/content/guides/filesystem/ @pantheon-systems/filesystem
 # The developer-experience team is responsible for Integrated Composer
 src/source/content/guides/integrated-composer/ @pantheon-systems/developer-experience
+# The developer-experience team is responsible for Secrets
+src/source/content/guides/secrets/ @pantheon-systems/developer-experience
 # The cms-platform team is responsible for WordPress Multisite
 src/source/content/guides/multisite/ @pantheon-systems/site-experience
 # The cms-platform team is responsible for External Libraries on Pantheon

--- a/src/source/content/guides/secrets/01-introduction.md
+++ b/src/source/content/guides/secrets/01-introduction.md
@@ -41,6 +41,8 @@ To get started:
 
 To see all available Terminus secrets commands, refer to the [Terminus command reference](/terminus/commands).
 
+![A list of secrets for a site, displayed in the Pantheon dashboard](../../../images/dashboard/secrets/secrets-management.png)
+
 ### Older plugins now deprecated
 Terminus 4.2.0 integrates secrets management directly into Terminus core. If you previously installed the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) separately, you no longer need it — the same commands are available in Terminus 4.2.0 and later without any plugin installation.
 

--- a/src/source/content/guides/secrets/01-introduction.md
+++ b/src/source/content/guides/secrets/01-introduction.md
@@ -2,7 +2,7 @@
 title: Pantheon Secrets Guide
 subtitle: Introduction
 description: Securely store secrets in the Pantheon Platform.
-contributors: [stovak]
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,17 +12,17 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets
-reviewed: "2026-01-26"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 Pantheon Secrets is key to maintaining industry best practices for secure builds and application implementation. This feature provides a convenient mechanism for you to manage your secrets and API keys directly on the Pantheon platform.
 
-This guide covers features and use cases of the Pantheon Secrets feature; it could also be referred as Secrets Manager because that is the Terminus plugin name.
+This guide covers features and use cases of Pantheon Secrets, which you can manage via the Site Dashboard or via [Terminus](/terminus).
 
 ## Features
 Key features include:
 * **Secure**: Secrets are encrypted at rest and securely hosted on Pantheon.
-* **Easy to use**: Create and update secrets via Terminus.
+* **Easy to use**: Create and update secrets via the Site Dashboard or Terminus.
 * **Governable**: Secrets can be set at organization level and shared with all the sites owned by that organization.
 * **Overridable**: Secrets can be overridden at environment level when needed.
 
@@ -32,33 +32,24 @@ This feature also supports:
 * The ability to define the degree of secrecy for each managed item.
 
 ## Access & Availability
-This feature is available for anyone to use today at no additional cost. Currently released for Limited Availability, the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) will eventually be merged into Terminus core once released for General Availability in the future.
+Pantheon Secrets is available to all Pantheon users at no additional cost. Secrets management commands are built into [Terminus](/terminus) 4.2.0 and later — no additional plugin installation is required.
 
 ### Installation
-How to get started and use this feature:
+To get started:
 1. [Install & authenticate Terminus](/terminus/install) if you have not done so already.
-1. Install the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin):
-    
-   ```bash{promptUser: user}
-   terminus self:plugin:install terminus-secrets-manager-plugin
-   ```
-     
-1. You can now use the newly installed Terminus commands, such as `secret:site:set`, to manage secrets securely on Pantheon.
+1. You can now use Terminus commands such as `secret:site:set` to manage secrets securely on Pantheon, or manage site-owned secrets directly from the **Secrets** tab in your [Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard).
 
-To see all available commands added by this plugin, refer to the [plugin's README file](https://github.com/pantheon-systems/terminus-secrets-manager-plugin?tab=readme-ov-file#site-secrets-commands).
+To see all available Terminus secrets commands, refer to the [Terminus command reference](/terminus/commands).
 
-### Older plugin now deprecated
-The new [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) replaces the older [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin).  The key differences are:
+### Older plugins now deprecated
+Terminus 4.2.0 integrates secrets management directly into Terminus core. If you previously installed the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) separately, you no longer need it — the same commands are available in Terminus 4.2.0 and later without any plugin installation.
 
-- The new Terminus Secrets Manager Plugin stores secrets in an encrypted backend service.
-- The older secrets plugin simply writes unencrypted values to a json file in `/files/private`.
-
-Once the Pantheon Secrets service becomes generally available and merged into Terminus core, the older `terminus-secrets-plugin` will be discontinued. If you use the older plugin to manage secrets today, we strongly encourage you to upgrade your security and experience by adopting this new feature.
+The Terminus Secrets Manager Plugin itself replaced the older [Terminus Secrets Plugin](https://github.com/pantheon-systems/terminus-secrets-plugin), which wrote unencrypted values to a JSON file in `/files/private`. If you still use the older plugin, we strongly encourage you to upgrade by adopting Pantheon Secrets.
 
 ## Support
-The [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin), [PHP Secrets SDK](https://github.com/pantheon-systems/customer-secrets-php-sdk), and [Pantheon Secrets](https://github.com/pantheon-systems/pantheon_secrets) Drupal module are open source. You can view the projects, file issues and feature requests, and contribute in their respective repositories on GitHub.
+[Terminus](https://github.com/pantheon-systems/terminus), the [PHP Secrets SDK](https://github.com/pantheon-systems/customer-secrets-php-sdk), and the [Pantheon Secrets](https://github.com/pantheon-systems/pantheon_secrets) Drupal module are open source. You can view the projects, file issues and feature requests, and contribute in their respective repositories on GitHub.
 
-* [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin)
+* [Terminus](https://github.com/pantheon-systems/terminus)
 * [Secrets SDK](https://github.com/pantheon-systems/customer-secrets-php-sdk)
 * Pantheon Secrets Drupal module
   * [github repo](https://github.com/pantheon-systems/pantheon_secrets) for issues & PRs

--- a/src/source/content/guides/secrets/02-secrets-overview.md
+++ b/src/source/content/guides/secrets/02-secrets-overview.md
@@ -2,7 +2,7 @@
 title: Pantheon Secrets Guide
 subtitle: Secrets Overview
 description: Gaining familiarity with some concepts about Pantheon Secrets will help you make the most of this feature.
-contributors: [stovak]
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/overview
-reviewed: "2024-08-22"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 
@@ -26,7 +26,7 @@ This represents how the secret is used.  A secret can only have one type.
 
 Current types are:
 
-  * `runtime`: This secret type can be retreived directly from your application code using the `pantheon_get_secret()` function.  This is the recommended type if you want your application to be able to use the secret while it's operating.
+  * `runtime`: This secret type can be retrieved directly from your application code using the `pantheon_get_secret()` function.  This is the recommended type if you want your application to be able to use the secret while it's operating.
 
   * `env`: This type is used to set environment variables. Environment variables are currently only supported for Integrated Composer builds; setting environment variables on the application server is unsupported.
 
@@ -47,16 +47,16 @@ Current types are:
 
   * `web`: this secret will be readable by the application runtime.
 
-  * `user`: this secret will be readable by the user. This scope should be set if you want to see the value of your secret displayed when listing site secrets with Terminus. The value for secrets without the the user scope is redacted in the Terminus secrets list.
+  * `user`: this secret will be readable by the user. This scope should be set if you want to see the value of your secret displayed when listing site secrets with Terminus. The value for secrets without the user scope is redacted in the Terminus secrets list.
 
 ## Owning Entity
 <p>Secrets are either owned by a site or an organization. Within that <dfn id="secret-owning-entity">owning entity</dfn>, the secret may have zero or more environment overrides.</p>
 
 ### Organization-owned secrets
-Organization-owned secrets are available to every site and environment that are associated with the owning organization. A common use-cases is for a CI system and infrastructure that's shared among all sites in an organization. Note that secrets from "Supporting" Organizations are explicitly ***not shared*** with the sites they support. Sites receive secret key/value pairs from their Primary Organization only.
+Organization-owned secrets are available to every site and environment that are associated with the owning organization. A common use case is for a CI system and infrastructure that's shared among all sites in an organization. Note that secrets from "Supporting" Organizations are explicitly ***not shared*** with the sites they support. Sites receive secret key/value pairs from their Primary Organization only.
 
 ### Site-owned secrets
-Site-owned secrets are available to the site and all of its environments. A common use-case is Github tokens that a site's composer build can use to access private repos referenced in the composer file.
+Site-owned secrets are available to the site and all of its environments. A common use case is GitHub tokens that a site's Composer build can use to access private repos referenced in the composer file. Site-owned secrets can be managed via the **Secrets** tab in your [Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) or via Terminus.
 
 ### Environment override
 Environment overrides provide overrides to a secret value for a specific environment. A common use case for this are API keys that are different in production and non-production environments.
@@ -72,9 +72,9 @@ Due to platform design, the "environment" for Integrated Composer will always be
 
 1. Organization values have the lowest priority. They form the base value that is used when there is no more specific value provided for the site or environment.
 
-3. Site values will replace the organization values when present. To return the secret to it's organization value, simply delete the site value.
+1. Site values will replace the organization values when present. To return the secret to its organization value, simply delete the site value.
 
-4. Environmental overrides have the highest priority. If the override exists, it will become the value provided to the calling function.
+1. Environmental overrides have the highest priority. If the override exists, it will become the value provided to the calling function.
 
 ### The life of a secret
 

--- a/src/source/content/guides/secrets/02-secrets-overview.md
+++ b/src/source/content/guides/secrets/02-secrets-overview.md
@@ -58,6 +58,8 @@ Organization-owned secrets are available to every site and environment that are 
 ### Site-owned secrets
 Site-owned secrets are available to the site and all of its environments. A common use case is GitHub tokens that a site's Composer build can use to access private repos referenced in the composer file. Site-owned secrets can be managed via the **Secrets** tab in your [Site Dashboard](/guides/account-mgmt/workspace-sites-teams/sites#site-dashboard) or via Terminus.
 
+![A list of secrets for a site, displayed in the Pantheon dashboard](../../../images/dashboard/secrets/secrets-management.png)
+
 ### Environment override
 Environment overrides provide overrides to a secret value for a specific environment. A common use case for this are API keys that are different in production and non-production environments.
 

--- a/src/source/content/guides/secrets/03-create-secret.md
+++ b/src/source/content/guides/secrets/03-create-secret.md
@@ -2,17 +2,18 @@
 title: Pantheon Secrets Guide
 subtitle: Create new secret
 description: Learn how to create a new secret using either the Dashboard or the CLI.
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 permalink: docs/guides/secrets/create
 showtoc: true
-reviewed: "2026-01-26"
+reviewed: "2026-06-15"
 ---
 ## Before you begin
 1. Determine what [owning entity](/guides/secrets/overview#owning-entity) is appropriate for the given secret (site vs org).
     * Only site-owned secrets can be managed via the dashboard interface, setting organization-owned secrets is only supported [via the command-line](#from-the-command-line).
 1. Determine the [secret type](/guides/secrets/overview#secret-type) and [secret scope](/guides/secrets/overview#secret-scope) required for your given scenario:
    * For example, setting an API key for third-party email integration should use the `runtime` type and `web` scope. 
-1. Consider whether your scenario requies different values based on the given environment.
+1. Consider whether your scenario requires different values based on the given environment.
    * For example, if you want to use different accounts on live and non-live environments for your site's third-party email integration.
      * If yes, first create the secret with your non-live API key and then [add an environment override for that new secret](#add-environment-override) to change the API key for the live environment.
 
@@ -41,8 +42,14 @@ Only [site-owned secrets](/guides/secrets/overview#site-owned-secrets) can be ma
 1. Click **Save Changes**.
 
 ### From the command-line
-1. [Install](/terminus/install#installation-and-update-methods) and authenticate [Terminus](/terminus/install#authentication) if you have not done so already. 
-1. Install the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin#installation).
+
+<Alert type="info" title="Note">
+
+Secrets management commands require Terminus 4.2.0 or later. Run `terminus --version` to check your installed version, and `terminus self:update` to upgrade if needed.
+
+</Alert>
+
+1. [Install](/terminus/install#installation-and-update-methods) and authenticate [Terminus](/terminus/install#authentication) if you have not done so already.
 1. Run the following command to set EITHER a [site-owned secret](/guides/secrets/overview#site-owned-secrets) (replace `<site>` `<secret_name>` `<secret_value>` `<secret_type>` and `<secret_scope>`):
     
    ```bash{promptUser: user}
@@ -76,7 +83,7 @@ Environment overrides are used for scenarios that require different values for a
    ```
 
 ## Next Steps
-This feature works with WordPress, Drupal, and Next.js sites hosted on Pantheon. After secret creation, your application will require additional configuration to make use of these key/value pairs. See the following documentaiton for usage based on your site framework: 
+This feature works with WordPress, Drupal, and Next.js sites hosted on Pantheon. After secret creation, your application will require additional configuration to make use of these key/value pairs. See the following documentation for usage based on your site framework: 
 * [WordPress - reading secrets from PHP](/guides/secrets/php)
 * [Drupal - using the Key module](/guides/secrets/drupal)
 

--- a/src/source/content/guides/secrets/04-php.md
+++ b/src/source/content/guides/secrets/04-php.md
@@ -2,7 +2,7 @@
 title: Pantheon Secrets Guide
 subtitle: PHP Usage
 description: How to read Pantheon Secrets from code.
-contributors: [stovak]
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,16 +12,20 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/php
-reviewed: "2025-12-10"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 
 ## Reading secrets from PHP
-Secrets can be read, updated, created, and deleted via the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin). WordPress and Drupal however, can only read secrets at runtime - there is no way to modify secrets via the application or in code.
+Secrets can be read, updated, created, and deleted via [Terminus](/terminus) or the Site Dashboard. WordPress and Drupal however, can only read secrets at runtime - there is no way to modify secrets via the application or in code.
 
 Secrets must have the scope `web` to be visible from your application. Secrets are cached in the server for 15 minutes, so you must wait for a while after modifying secret values before they will be available for use. This cache is also encrypted at rest.
 
-Note: this also applies to quicksilver scripts.
+<Alert title="Note" type="info">
+
+This also applies to Quicksilver scripts.
+
+</Alert>
 
 ### Use the pantheon_get_secret PHP function
 
@@ -40,9 +44,7 @@ In this guide we will go over an end-to-end example on how to setup secrets for 
 
 - Make sure you have access to a WordPress site on Pantheon.
 
-- Make sure you have [Terminus installed](https://docs.pantheon.io/terminus/install#install-terminus) on your local machine.
-
-- Install the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin#installation).
+- Make sure you have [Terminus](/terminus/install#install-terminus) 4.2.0 or later installed on your local machine.
 
 ### Steps
 

--- a/src/source/content/guides/secrets/05-drupal.md
+++ b/src/source/content/guides/secrets/05-drupal.md
@@ -58,6 +58,10 @@ In this guide we will go over an end-to-end example on how to setup secrets for 
     terminus secret:site:set <site> sendgrid_api <api_key> --scope=web --type=runtime
     ```
 
+    Alternatively, you can set this secret via the Site Dashboard. See [Create a new secret](/guides/secrets/create) for dashboard instructions.
+
+    ![Create new secret in the dashboard with options for type and scope](../../../images/dashboard/secrets/secrets-creation-markedup.png)
+
     As a best practice, the non-production environments should be the default and then override that value with a [secret environment override](/guides/secrets/overview#environment-override) to change the API key for the live environment (for example, if you want to use different SendGrid accounts for live and dev environments).
 
 1. Add the Key entity in one of the different available ways:

--- a/src/source/content/guides/secrets/05-drupal.md
+++ b/src/source/content/guides/secrets/05-drupal.md
@@ -2,7 +2,7 @@
 title: Pantheon Secrets Guide
 subtitle: Drupal Key Usage
 description: How to configure Sendgrid using Pantheon Secrets with Drupal's Key module.
-contributors: [stovak]
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/drupal
-reviewed: "2024-08-22"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 
@@ -24,11 +24,15 @@ In this guide we will go over an end-to-end example on how to setup secrets for 
 
 ### Prerequisites
 
-- Make sure you have access to a Drupal 9.4 or greater site running PHP 8.0 or above hosted on Pantheon.
+- Make sure you have access to a Drupal 9.4 or 10 site running PHP 8.0 or above hosted on Pantheon.
 
-- Make sure you have [Terminus installed](https://docs.pantheon.io/terminus/install#install-terminus) on your local machine.
+  <Alert title="Note" type="info">
 
-- Install the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin#installation).
+  The [SendGrid Mailer](https://www.drupal.org/project/sendgrid_mailer) module used in this example does not support Drupal 11. If you are running Drupal 11, you will need to use a different mail module.
+
+  </Alert>
+
+- Make sure you have [Terminus](/terminus/install#install-terminus) 4.2.0 or later installed on your local machine.
 
 ### Steps
 

--- a/src/source/content/guides/secrets/06-composer.md
+++ b/src/source/content/guides/secrets/06-composer.md
@@ -2,7 +2,7 @@
 title: Pantheon Secrets Guide
 subtitle: Integrated Composer Usage
 description: How to use Pantheon Secrets with Pantheon's Integrated Composer.
-contributors: [stovak]
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/composer
-reviewed: "2024-08-22"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 
@@ -27,7 +27,7 @@ If your Composer-based dependency is private, and the repository supports OAuth 
 
 1. [Generate a GitHub token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token). The GitHub token must have all "repo" permissions selected.
 
-    **Note:** Check the repo box that selects all child boxes. **Do not** check all child boxes individually as this does not set the correct permissions.
+    Check the repo box that selects all child boxes. Do not check all child boxes individually as this does not set the correct permissions.
 
     ![image](https://user-images.githubusercontent.com/87093053/191616923-67732035-08aa-41c3-9a69-4d954ca02560.png)
 

--- a/src/source/content/guides/secrets/07-local.md
+++ b/src/source/content/guides/secrets/07-local.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Secrets Guide
 subtitle: Local Development Usage
-description: Developing locally presents some unique challenges once Pantheon Secrets are built into your workflow. These are some tips to help you get past struggling with trying to reproduced secret behavior while developing locally.
-contributors: [stovak]
+description: Developing locally presents some unique challenges once Pantheon Secrets are built into your workflow. These are some tips to help you get past struggling with trying to reproduce secret behavior while developing locally.
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,16 +12,16 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/local
-reviewed: "2024-08-22"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 ## Local Environment Usage
 
 The [Pantheon Secrets SDK](https://github.com/pantheon-systems/customer-secrets-php-sdk) includes a `CustomerSecretsFakeClient` implementation that is used when the SDK runs outside of Pantheon infrastructure. This client uses a secrets JSON file to build the secrets information emulating what happens on the platform using the Secrets service.
 
-To get this file, you should use the [plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin/) `secret:site:local-generate` command and then set an environment variable into your local environment (or docker container if you are running a docker-ized environment) with name `CUSTOMER_SECRETS_FAKE_FILE` and use the absolute path to the file as the value.
+To get this file, use the `terminus secret:site:local-generate` command and then set an environment variable in your local environment (or Docker container) named `CUSTOMER_SECRETS_FAKE_FILE` with the absolute path to the file as the value.
 
-1.  To get generate this file, run `terminus secret:site:local-generate` in your terminal in your project root:
+1. To generate this file, run `terminus secret:site:local-generate` in your terminal in your project root:
 
     ```bash
     terminus secret:site:local-generate <site>
@@ -54,7 +54,7 @@ To get this file, you should use the [plugin](https://github.com/pantheon-system
 
 ### DDEV configuration
 
-1. CD to your DDEV root directory
+1. Navigate to your DDEV root directory.
 1. Add to your `.ddev/config.yml`:
     ```yaml
     web_environment:
@@ -109,10 +109,10 @@ This approach allows your code to work seamlessly both on Pantheon (where `panth
 
 ### Drupal-Specific
 If using Drupal with the Key module and Pantheon Secrets module:
-1. Go to the Key module configuration
-2. Click the "Sync Pantheon Secrets" tab
-3. Click the "Sync Keys" button
-4. Your secrets from the JSON file should appear in the available list of keys
+1. Go to the Key module configuration.
+1. Click the **Sync Pantheon Secrets** tab.
+1. Click **Sync Keys**.
+1. Your secrets from the JSON file should appear in the available list of keys.
 
 ## Restrictions
 For secrets without "user" scope, the `secret:site:local-generate` command will set the value of the secret to "null". You must manually set test values in your local `secrets.json` file.

--- a/src/source/content/guides/secrets/08-troubleshooting.md
+++ b/src/source/content/guides/secrets/08-troubleshooting.md
@@ -1,8 +1,8 @@
 ---
 title: Pantheon Secrets Guide
 subtitle: Troubleshooting
-description: Securely store secrets in the Pantheon Platform.
-contributors: [stovak]
+description: Troubleshoot common issues with Pantheon Secrets.
+contributors: [stovak, jazzs3quence]
 contenttype: [guide]
 innav: [true]
 categories: [secrets]
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/troubleshooting
-reviewed: "2025-12-10"
+reviewed: "2026-06-15"
 showtoc: true
 ---
 
@@ -75,15 +75,15 @@ Some possible causes for this error:
 
 - **Problem:** Secrets are not correctly set for the site. Secrets for Integrated Composer to use need to be type `composer` and have scope `ic`. Secret types and scopes are covered in the [Overview](/guides/secrets/overview) documentation.
 
-  **Solution:** ask the client to delete and recreate the secret if scope and type do not match for the given secret name
+  **Solution:** Delete and recreate the secret if the scope and type do not match for the given secret name.
 
 - **Problem:** Secret value/token may be expired
 
-  **Solution:** ask the client to set the secret again to an updated value
+  **Solution:** Set the secret again with an updated value.
 
 - **Problem**: Site may be running on a PHP version below 8.0. If this is the case, there will be a message in the job output: “Skipping setting up secrets as it is not supported in PHP below 8.0”
 
-  **Solution**: Upgrade the client to a supported PHP version.
+  **Solution**: Upgrade your PHP version to 8.0 or above.
 
 - **Problem:** Errors with paid WordPress plugins.
 
@@ -113,7 +113,7 @@ Some possible causes for this error:
 
 ## Rate limiting
 ### Pantheon rate limiting
-The service supports up to 3 requests per second per user through Terminus. If you hit that limit, the API will return a `429` error code and the plugin will throw an error.
+The service supports up to 3 requests per second per user through Terminus. If you hit that limit, the API will return a `429` error code and Terminus will throw an error.
 
 The PHP SDK and `pantheon_get_secret()` function are not affected by this rate limiting.
 


### PR DESCRIPTION
Closes #10047
Relates to DEVREL-95

## Summary

- Updates all pages in the Secrets guide to reflect that secrets management is now built into Terminus 4.2.0 — removes all references to installing `terminus-secrets-manager-plugin` separately
- Removes "Limited Availability" language from the introduction; reflects GA status
- Adds Terminus 4.2.0 version requirement callout to CLI sections
- Adds dashboard UI as an alternative to Terminus throughout where applicable
- Adds `secrets-management.png` screenshot to introduction and overview pages
- Adds `secrets-creation-markedup.png` screenshot to Drupal page as dashboard alternative for setting secrets
- Fixes D11 incompatibility note for SendGrid Mailer in Drupal prerequisites (closes #10047)
- Fixes typos, stale descriptions, support-runbook language, and numbered list formatting across all pages
- Bumps `reviewed` dates and adds contributor on all pages

## Test plan

- [x] Verify introduction no longer references plugin install or Limited Availability
- [x] Verify Terminus version callout appears in CLI sections
- [x] Verify dashboard screenshots render correctly on introduction, overview, and Drupal pages
- [x] Verify D11/SendGrid Mailer warning appears in Drupal prerequisites
- [x] Verify no broken image paths