### PR TITLE
[DEVREL-144] remove beta language for Elasticsearch and promote to GA

### DIFF
--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -20,6 +20,8 @@ showtoc: true
 
 Elasticsearch on Pantheon gives WordPress teams a fully managed search service that goes beyond basic site search — offloading database queries, handling traffic spikes, and delivering features like fuzzy matching and autosuggest without the overhead of managing an external provider.
 
+<Youtube src="m5K2JdQoVFU" title="Getting Started with Elasticsearch on Pantheon" />
+
 ## Overview
 
 Pantheon provides integrated Elasticsearch support for WordPress sites through the [ElasticPress](https://wordpress.org/plugins/elasticpress/) plugin. Elasticsearch is a powerful search and query engine that offloads demanding `WP_Query` requests from your database, delivering faster search results, superior search features, and improved overall site performance for your visitors.

--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -4,7 +4,7 @@ subtitle: Pantheon Search powered by Elasticsearch
 navtitle: Introduction
 description: Detailed information on using Elasticsearch with your Pantheon WordPress site with ElasticPress.
 tags: [elasticsearch,search]
-reviewed: "2026-06-11"
+reviewed: "2026-06-16"
 contenttype: [doc]
 innav: [true]
 categories: [search]
@@ -19,8 +19,6 @@ showtoc: true
 ---
 
 Elasticsearch on Pantheon gives WordPress teams a fully managed search service that goes beyond basic site search — offloading database queries, handling traffic spikes, and delivering features like fuzzy matching and autosuggest without the overhead of managing an external provider.
-
-<Partial file="elasticsarch-pre-ga.md" />
 
 ## Overview
 
@@ -46,7 +44,6 @@ Pantheon is deprecating Solr 3 support. WordPress sites using the Solr Power plu
 
 ## Support
 
-During Beta, please report any issues or questions to the Pantheon team in the private `#beta-elasticsearch` channel in the [Pantheon Community Slack](https://pantheon.io/customer-community). To participate in the Beta, simply toggle the **Elasticsearch (beta)** add-on in your Site Settings.
-<!--This is not true yet>For support with Elasticsearch on Pantheon, contact Pantheon Support through the Dashboard. Include details about your site, the environment you're working in, and the specific issue you're encountering.<!-->
+For support with Elasticsearch on Pantheon, contact Pantheon Support through the Dashboard. Include details about your site, the environment you're working in, and the specific issue you're encountering.
 
 For ElasticPress plugin-specific questions, refer to the [ElasticPress documentation](https://www.elasticpress.io/resources/articles/).

--- a/src/source/content/guides/elasticsearch/02-setup-config.md
+++ b/src/source/content/guides/elasticsearch/02-setup-config.md
@@ -14,10 +14,8 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/setup-config
 editpath: search/02-setup-config.md
-reviewed: "2026-06-11"
+reviewed: "2026-06-16"
 ---
-
-<Partial file="elasticsarch-pre-ga.md" />
 
 Getting Elasticsearch running on your Pantheon WordPress site involves activating the service on the platform and then installing and configuring the ElasticPress plugin within WordPress.
 

--- a/src/source/content/guides/elasticsearch/03-query-optimization.md
+++ b/src/source/content/guides/elasticsearch/03-query-optimization.md
@@ -15,10 +15,8 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/query-optimization
 editpath: search/03-query-optimization.md
-reviewed: "2026-06-11"
+reviewed: "2026-06-16"
 ---
-
-<Partial file="elasticsarch-pre-ga.md" />
 
 One of the most powerful aspects of Elasticsearch on Pantheon is its ability to offload `WP_Query` requests from your database. The ElasticPress plugin integrates with WordPress at the query level, routing eligible queries to Elasticsearch instead of MySQL.
 

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -15,10 +15,8 @@ contributors: [jazzsequence, carolynshannon]
 showtoc: true
 permalink: docs/guides/pantheon-search/elasticsearch/troubleshooting
 editpath: search/04-troubleshooting.md
-reviewed: "2026-06-11"
+reviewed: "2026-06-16"
 ---
-
-<Partial file="elasticsarch-pre-ga.md" />
 
 ## Troubleshooting
 

--- a/src/source/content/guides/elasticsearch/04-troubleshooting.md
+++ b/src/source/content/guides/elasticsearch/04-troubleshooting.md
@@ -55,11 +55,9 @@ The Instant Results feature requires a stored search template on ElasticPress.io
 
 ### Do I have to pay extra for Elasticsearch?
 
-Access to Elasticsearch is included for sites on Performance plans and above. 
+Access to Elasticsearch is included for sites on Performance plans and above.
 
-During the Beta phase, the Elasticsearch add-on is able to be activated via Site Settings in the Pantheon Dashboard. There is no need to submit a form to participate in the Beta.
-
-<!-- This is not true yet>Activating Elasticsearch is a self-serve operation, similar to how Solr or Redis are enabled on Pantheon.<!-->
+Activating Elasticsearch is a self-serve operation, similar to how Solr or Redis are enabled on Pantheon.
 
 <Partial file="pantheon-search-table.md" />
 

--- a/src/source/content/partials/pantheon-search-table.md
+++ b/src/source/content/partials/pantheon-search-table.md
@@ -10,4 +10,3 @@
 | **WooCommerce Support** | Yes | No |
 | **`WP_Query` Offloading** | Yes | Yes |
 | **Related Content** | Yes | Manual |
-| **Status** | Beta | Generally Available |


### PR DESCRIPTION
Removes beta language from the Elasticsearch documentation following the GA launch.

## Changes

- Remove `<Partial file="elasticsarch-pre-ga.md" />` include from all four guide pages
- Rewrite the Support section in the introduction to use standard Dashboard support language (removes beta Slack channel reference)
- Update the "Do I have to pay extra?" FAQ to remove beta phase language
- Remove the Status row from the search comparison table (both products are now GA)
- Embed the Elasticsearch demo video on the introduction page
- Bump `reviewed` date to 2026-06-16 on all modified pages
