### PR TITLE
[DEVREL-144] add Elasticsearch for WordPress GA release note

### DIFF
--- a/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
+++ b/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
@@ -3,7 +3,7 @@ title: "Elasticsearch for WordPress is now available"
 published_date: "2026-06-30"
 published_at: "2026-06-30T00:00:00Z"
 categories: [new-feature, wordpress]
-description: "Elasticsearch is now available as an add-on for WordPress sites on Pantheon for all Performance sites and above."
+description: "Pantheon Search powered by Elasticsearch is now available as a managed add-on for WordPress sites on Performance Small plans and above."
 ---
 
 Elasticsearch is now available as an add-on for WordPress sites on Pantheon for all Performance sites and above. This new capability is powered by [ElasticPress](https://elasticpress.io/), the leading Elasticsearch solution for WordPress.

--- a/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
+++ b/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
@@ -1,7 +1,7 @@
 ---
 title: "Elasticsearch for WordPress is now available"
 published_date: "2026-06-30"
-published_at: "2026-06-30T00:00:00Z"
+published_at: "2026-06-30T17:11:25Z"
 categories: [new-feature, wordpress]
 description: "Pantheon Search powered by Elasticsearch is now available as a managed add-on for WordPress sites."
 ---

--- a/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
+++ b/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
@@ -26,8 +26,8 @@ Elasticsearch is available to WordPress sites on **Performance Small** plans and
 
 ## How to enable it
 
-Review the [Setup and Configuration](https://docs.pantheon.io/guides/pantheon-search/elasticsearch/setup-config) documentation for detailed instructions on setting up Elasticsearch and ElasticPress.
+Review the [Setup and Configuration](/guides/pantheon-search/elasticsearch/setup-config) documentation for detailed instructions on setting up Elasticsearch and ElasticPress.
 
 ## More information
 
-For additional guidance and a walkthrough of these features, see the [Elasticsearch on Pantheon](https://docs.pantheon.io/guides/pantheon-search/elasticsearch) documentation.
+For additional guidance and a walkthrough of these features, see the [Elasticsearch on Pantheon](/guides/pantheon-search/elasticsearch) documentation.

--- a/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
+++ b/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
@@ -3,7 +3,7 @@ title: "Elasticsearch for WordPress is now available"
 published_date: "2026-06-30"
 published_at: "2026-06-30T00:00:00Z"
 categories: [new-feature, wordpress]
-description: "Pantheon Search powered by Elasticsearch is now available as a managed add-on for WordPress sites on Performance Small plans and above."
+description: "Pantheon Search powered by Elasticsearch is now available as a managed add-on for WordPress sites."
 ---
 
 Elasticsearch is now available as an add-on for WordPress sites on Pantheon for all Performance sites and above. This new capability is powered by [ElasticPress](https://elasticpress.io/), the leading Elasticsearch solution for WordPress.

--- a/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
+++ b/src/source/releasenotes/2026-06-30-elasticsearch-wordpress-ga.md
@@ -1,0 +1,33 @@
+---
+title: "Elasticsearch for WordPress is now available"
+published_date: "2026-06-30"
+published_at: "2026-06-30T00:00:00Z"
+categories: [new-feature, wordpress]
+description: "Elasticsearch is now available as an add-on for WordPress sites on Pantheon for all Performance sites and above."
+---
+
+Elasticsearch is now available as an add-on for WordPress sites on Pantheon for all Performance sites and above. This new capability is powered by [ElasticPress](https://elasticpress.io/), the leading Elasticsearch solution for WordPress.
+
+## What's included?
+
+ElasticPress improves the overall search experience and performance of your WordPress sites, as well as allowing for better `WP_Query` performance and reduced load on your application server. Capabilities include:
+
+- **Full-text search** — Fuzzy matching, synonyms, and weighted fields for more relevant search results.
+- **Instant Search** — Real-time search-as-you-type results without full page reloads.
+- **`WP_Query` integration** — ElasticPress allows you to offload `WP_Query` requests to Elasticsearch, reducing database load and improving page load times.
+- **Faceted filtering** — Narrow results by category, tag, custom taxonomy, and other attributes.
+- **WooCommerce support** — Product search and filtering for WooCommerce storefronts.
+- **Related content** — Surface related posts and pages automatically.
+- **Custom content indexing** — Index posts, pages, custom post types, and custom fields.
+
+## Who has access?
+
+Elasticsearch is available to WordPress sites on **Performance Small** plans and above.
+
+## How to enable it
+
+Review the [Setup and Configuration](https://docs.pantheon.io/guides/pantheon-search/elasticsearch/setup-config) documentation for detailed instructions on setting up Elasticsearch and ElasticPress.
+
+## More information
+
+For additional guidance and a walkthrough of these features, see the [Elasticsearch on Pantheon](https://docs.pantheon.io/guides/pantheon-search/elasticsearch) documentation.


### PR DESCRIPTION
## Summary

- Adds release note for Elasticsearch for WordPress GA (`2026-06-30-elasticsearch-wordpress-ga.md`)
- Content sourced from the [release note draft Google Doc](https://docs.google.com/document/d/1FINU69xv3fTCUVQeCGJ_RDprIzhBNMlDwE28X4ER9t8/edit?usp=sharing)

## Before merging

- [x] **Update `published_at`** — currently set to `2026-06-30T00:00:00Z` as a placeholder. Replace with the actual publish timestamp before merging.
- [x] Hold for 30 June
