### PR TITLE
Add Terminus site creation docs and remove outdated plugin references

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -15,6 +15,10 @@ src/source/content/guides/filesystem/ @pantheon-systems/filesystem
 src/source/content/guides/integrated-composer/ @pantheon-systems/developer-experience
 # The developer-experience team is responsible for Secrets
 src/source/content/guides/secrets/ @pantheon-systems/developer-experience
+# The developer-experience team is responsible for Next.js
+src/source/content/nextjs @pantheon-systems/developer-experience
+# The developer-experience team is responsible for GitHub Application
+src/source/content/guides/github-application @pantheon-systems/developer-experience
 # The cms-platform team is responsible for WordPress Multisite
 src/source/content/guides/multisite/ @pantheon-systems/site-experience
 # The cms-platform team is responsible for External Libraries on Pantheon

--- a/src/source/content/guides/github-application/01-introduction.md
+++ b/src/source/content/guides/github-application/01-introduction.md
@@ -35,4 +35,4 @@ The GitHub integration is distinct from [Build Tools](/guides/build-tools). Buil
 
 - [Multidev](/guides/multidev) - Learn about Pantheon's Multidev environments created for each pull request
 - [Next.js Documentation](https://nextjs.org/docs) - Official Next.js documentation
-- [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin) - GitHub repository for the Terminus Repository Plugin
+

--- a/src/source/content/guides/github-application/02-setup.md
+++ b/src/source/content/guides/github-application/02-setup.md
@@ -1,7 +1,7 @@
 ---
 title: GitHub Application
 subtitle: Setup
-description: Instructions for setting up the GitHub Application, including installation of the Terminus Repository Plugin and creating a new site.
+description: Instructions for setting up the GitHub Application and creating a new site via the Pantheon Dashboard or Terminus.
 tags: [continuous-integration, workflow, D8, D9, D10]
 contributors: [stevector,jazzs3quence]
 contenttype: [guide]
@@ -16,9 +16,9 @@ reviewed: "2026-05-22"
 permalink: docs/guides/github-application/setup
 ---
 
-This page provides instructions for setting up a new site using the GitHub Application. You can create new sites through the Pantheon dashboard or via Terminus with the Repository Plugin. You can also create sites using existing GitHub repositories and connect them to Pantheon sites. This guide explains how to set up the GitHub Application for each of these scenarios.
+This page provides instructions for setting up a new site using the GitHub Application. You can create new sites through the Pantheon Dashboard or via Terminus. You can also create sites using existing GitHub repositories and connect them to Pantheon sites. This guide explains how to set up the GitHub Application for each of these scenarios.
 
-Once accepted into the private Beta, there are two main ways of creating a new site with the GitHub Application: through the Pantheon dashboard or through Terminus.
+There are two main ways of creating a new site with the GitHub Application: through the Pantheon Dashboard or through Terminus.
 
 ## Creating a new site with a new GitHub repository
 
@@ -73,10 +73,6 @@ After the site is created, you will be redirected to the Builds page of your new
 </Tab>
 
 <Tab title="Via Terminus">
-
-To create sites via Terminus, you must install the [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin).
-This is a public Terminus plugin that can be installed normally, e.g. `terminus self:plugin:install terminus-repository-plugin`.
-Usage instructions for the specific site creation commands are included in the [README](https://github.com/pantheon-systems/terminus-repository-plugin/blob/main/README.md#creating-a-new-site).
 
 1. Use the `terminus site:create` command as normal (see [documentation](/terminus/commands/site-create)) with the following additional flags: 
 
@@ -133,6 +129,5 @@ If you find yourself at a screen that asks you to *configure* the app, it typica
 
 ## More Resources
 
-- [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin) - GitHub repository and documentation for the Terminus Repository Plugin
 - [Terminus Commands](/terminus/commands/site-create) - Documentation for the `terminus site:create` command
 - [Next.js Documentation](https://nextjs.org/docs) - Official Next.js documentation

--- a/src/source/content/guides/github-application/06-support-considerations.md
+++ b/src/source/content/guides/github-application/06-support-considerations.md
@@ -57,11 +57,11 @@ New sites made with the GitHub Application do not support "[SFTP Mode](/guides/s
 
 ## Support
 
-Before this functionality is made generally available, please direct questions and feedback to [the issue queue on the related Terminus plugin](https://github.com/pantheon-systems/terminus-repository-plugin) rather than general support channels.
+For questions and feedback about the GitHub Application, please use [Pantheon Support](/guides/support/contact-support/) or the [Terminus issue queue](https://github.com/pantheon-systems/terminus/issues).
 
 ## More Resources
 
 - [Pantheon Support](/guides/support) - Learn about Pantheon's support offerings
 - [Multidev](/guides/multidev) - Common questions about Multidev environments
 - [Next.js Documentation](https://nextjs.org/docs) - Official Next.js documentation
-- [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin) - Report issues or contribute
+- [Terminus](https://github.com/pantheon-systems/terminus/issues) - Report issues or contribute

--- a/src/source/content/guides/github-application/06-support-considerations.md
+++ b/src/source/content/guides/github-application/06-support-considerations.md
@@ -57,11 +57,10 @@ New sites made with the GitHub Application do not support "[SFTP Mode](/guides/s
 
 ## Support
 
-For questions and feedback about the GitHub Application, please use [Pantheon Support](/guides/support/contact-support/) or the [Terminus issue queue](https://github.com/pantheon-systems/terminus/issues).
+For questions and feedback about the GitHub Application, please use [Pantheon Support](/guides/support/contact-support/).
 
 ## More Resources
 
 - [Pantheon Support](/guides/support) - Learn about Pantheon's support offerings
 - [Multidev](/guides/multidev) - Common questions about Multidev environments
 - [Next.js Documentation](https://nextjs.org/docs) - Official Next.js documentation
-- [Terminus](https://github.com/pantheon-systems/terminus/issues) - Report issues or contribute

--- a/src/source/content/nextjs/cli-tools.md
+++ b/src/source/content/nextjs/cli-tools.md
@@ -1,7 +1,7 @@
 ---
 title: Command Line Tools to use with Next.js on Pantheon
-description: Terminus plugins and other CLI tools to manage Next.js sites on Pantheon
-reviewed: "2025-10-31"
+description: Terminus commands and other CLI tools to manage Next.js sites on Pantheon
+reviewed: "2026-06-22"
 contenttype: [doc]
 innav: [true]
 audience: [development]
@@ -11,30 +11,53 @@ permalink: docs/nextjs/cli-tools
 
 ---
 
-In addition to Pantheon's primary command line tool, [Terminus](https://docs.pantheon.io/terminus), there are a few plugins and other command line tools that are useful when working with Next.js sites on Pantheon.
+In addition to Pantheon's primary command line tool, [Terminus](/terminus), there are built-in Terminus commands and other CLI tools that are useful when working with Next.js sites on Pantheon.
 
-## Terminus Plugins
+## Terminus Commands
 
-Terminus plugins add functionality to Terminus that is either too specialized or too early in development to be included in the core Terminus tool.
+As of [Terminus 4.2.0](/release-notes/2026/04/terminus-4-2-0), commands for managing Next.js sites — including secrets, repository connections, and build logs — are built directly into Terminus core. No additional plugins are required.
 
-### Secrets Manager Plugin for setting environment variables
+### Create a Next.js site
 
-[The Secrets Manager plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) for Terminus allows you to set and manage environment variables which is especially useful for Next.js sites. It has no equivalent functionality in the Pantheon Dashboard.
+You can create a Next.js site from the [Pantheon Dashboard](/nextjs/hello-world-tutorial) or via Terminus. To create a site via Terminus:
 
-See here for [general documentation on using Secrets Manager](/guides/secrets) and here for [specific documentation on using it with Next.js](/nextjs/environment-variables).
+```bash{promptUser: user}
+terminus site:create <pantheon-site-name> <site-label> <upstream-name|ID> --org=<organization-name|ID> --vcs-provider=github --vcs-org=<github-organization|username> --repository-name=<github-repository-name>
+```
 
-### Node Logs Plugin
+Required arguments and flags:
 
-[This plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin) adds commands to Terminus for viewing build and runtime logs for Node.js applications running on Pantheon.
+- `<upstream-name|ID>` — Any upstream your Pantheon user has access to, e.g. `nextjs16` or an upstream UUID. If omitted, Terminus will display available upstreams.
+- `--org` — The Pantheon organization is required for site creation via Terminus.
+- `--vcs-provider=github` — Required for sites using the GitHub application.
+- `--vcs-org` — The GitHub organization or username. If omitted, you will be prompted.
+- `--repository-name` — The GitHub repository name to create. Must be unique within the organization or user account.
 
-Most developers will prefer to view logs through the Pantheon Dashboard, but this plugin is useful for scripting or automating log retrieval.
+For full details see the [GitHub Application setup guide](/guides/github-application/setup).
 
-### Site Repository Plugin
+### Manage secrets and environment variables
 
-[This plugin](https://github.com/pantheon-systems/terminus-repository-plugin) adds commands to Terminus for connecting external Git repositories (such as GitHub) to Pantheon sites.
+Terminus includes commands for setting and managing secrets, which is the recommended way to manage environment variables for Next.js sites on Pantheon.
 
-It is required when creating a Next.js site on Pantheon through the command line.
-It is not needed if you create the site through the Pantheon Dashboard.
+See [general documentation on using Secrets Manager](/guides/secrets) and [specific documentation on using it with Next.js](/nextjs/environment-variables).
+
+### View build and runtime logs
+
+Terminus includes commands for viewing build and runtime logs for Next.js sites on Pantheon. Most developers will prefer to view logs through the Pantheon Dashboard, but these commands are useful for scripting or automating log retrieval.
+
+To list recent builds for a given site and environment:
+
+```bash{promptUser: user}
+terminus node:logs:build:list <site>.<env>
+```
+
+To retrieve runtime logs:
+
+```bash{promptUser: user}
+terminus node:logs:runtime:get <site>.<env>
+```
+
+For a full list of available Node.js commands, run `terminus help` or see the [Terminus command reference](/terminus/commands).
 
 ## Content Publisher CLI
 

--- a/src/source/content/nextjs/content-publisher-tutorial.md
+++ b/src/source/content/nextjs/content-publisher-tutorial.md
@@ -29,14 +29,11 @@ This tutorial will walk you through:
 * A [Content Publisher account](https://docs.content.pantheon.io/#h.9owhdt6w06gr) with [Administrator access](https://docs.content.pantheon.io/roles)
 * Install the following applications:
   - [Git](https://git-scm.com/)
-  - [Terminus](/terminus/install)*
-  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin)
+  - [Terminus](/terminus/install)* — secrets and log commands are built into Terminus core as of [4.2.0](/release-notes/2026/04/terminus-4-2-0). No additional plugins are required.
   - Content Publisher requirements:
     - [Node.js and npm](https://docs.content.pantheon.io/cli-setup#h.tqdsaj5gmjzp)
     - [Content Publisher CLI](https://docs.content.pantheon.io/cli-setup#h.6sxx14u8zeur)*
     - [Content Publisher Google Docs add-on ](https://docs.content.pantheon.io/add-on-install#h.32fczwiey3t0)
-  - Optional:
-    - [Terminus Node Logs Plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin)
 
 \* Requires logging in after installation.
 

--- a/src/source/content/nextjs/environment-variables.md
+++ b/src/source/content/nextjs/environment-variables.md
@@ -26,11 +26,7 @@ When the site is deployed to Pantheon, these environment variables need to be se
 
 Pantheon provides a way to set environment variables using [Secrets Manager](/guides/secrets) that can be read by applications running on Pantheon.
 
-First, install the [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) if you don't already have it:
-
-```bash{promptUser: user}
-terminus self:plugin:install terminus-secrets-manager-plugin
-```
+Secrets Manager commands are built into [Terminus](/terminus) as of [4.2.0](/release-notes/2026/04/terminus-4-2-0). No additional plugins are required.
 
 ```bash{promptUser: user}
 terminus secret:site:set <site_name> NEXT_PUBLIC_CMS_BASE_URL "http://example.com" --type=env --scope=web

--- a/src/source/content/nextjs/hello-world-tutorial.md
+++ b/src/source/content/nextjs/hello-world-tutorial.md
@@ -22,11 +22,7 @@ This tutorial will walk you through:
 
 * A GitHub account with [SSH configured](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/about-ssh)
 * Install [Git](https://git-scm.com/)
-* (Optional) Install the following applications:
-  - [Terminus](/terminus/install)*
-  - [Terminus Node Logs Plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin)
-
-\* Requires logging in after installation.
+* (Optional) [Terminus](/terminus/install) — required to view build logs from the command line. Requires logging in after installation.
 
 ## Site creation
 

--- a/src/source/content/nextjs/migrating-from-front-end-sites.md
+++ b/src/source/content/nextjs/migrating-from-front-end-sites.md
@@ -53,7 +53,7 @@ terminus site:create my-site-name my-site-label nextjs-16 \
 
 (Even if your codebase is not specific to Next.js 16, use the `nextjs-16` option to create the site.)
 
-This command will provision new infrastructure for your Next.js site and will take a few minutes to complete. You can monitor the progress of the initial build in the Pantheon Dashboard or by using the [Node Logs Plugin for Terminus](/nextjs/cli-tools).
+This command will provision new infrastructure for your Next.js site and will take a few minutes to complete. You can monitor the progress of the initial build in the Pantheon Dashboard or by using [Terminus node log commands](/nextjs/cli-tools).
 
 For many sites, builds will fail until required environment variables are set.
 

--- a/src/source/content/nextjs/migrating-from-front-end-sites.md
+++ b/src/source/content/nextjs/migrating-from-front-end-sites.md
@@ -16,11 +16,7 @@ This guide walks through moving a Next.js site away from Pantheon's earlier [Fro
 ## Requirements
 
 * Administrative access to the GitHub repo used for your Next.js site.
-* Install the following CLI applications:
-  - [Terminus](/terminus/install)
-  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin)
-  - [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin)
-  - [Terminus Node Logs Plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin) (optional)
+* [Terminus](/terminus/install) — secrets, repository, and log commands are built into Terminus core as of [4.2.0](/release-notes/2026/04/terminus-4-2-0). No additional plugins are required.
 
 
 ## Differences between Front-End Sites and new Next.js sites

--- a/src/source/content/nextjs/transfer-repository.md
+++ b/src/source/content/nextjs/transfer-repository.md
@@ -14,7 +14,7 @@ This guide walks through moving a Next.js site's GitHub repository from one GitH
 
 ## Requirements
 
-* [Terminus](/terminus/install) with the [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin)
+* [Terminus](/terminus/install)
 
 ## Step 1: Make sure the GitHub App is installed in the destination organization
 

--- a/src/source/content/nextjs/transfer-site.md
+++ b/src/source/content/nextjs/transfer-site.md
@@ -21,7 +21,7 @@ The actual site transfer between workspaces must be performed by Pantheon suppor
 ## Requirements
 
 * Administrative access to both the source and destination Pantheon workspaces
-* [Terminus](/terminus/install) with the [Terminus Repository Plugin](https://github.com/pantheon-systems/terminus-repository-plugin)
+* [Terminus](/terminus/install)
 
 ## Step 1: Link the VCS connection to the destination workspace
 

--- a/src/source/content/nextjs/wordpress-revalidation-tutorial-next-15.md
+++ b/src/source/content/nextjs/wordpress-revalidation-tutorial-next-15.md
@@ -38,7 +38,6 @@ For Next.js 16-specific features like `'use cache'` and `cacheTag()`, see [WordP
 * Install the following:
   - [Git](https://git-scm.com/)
   - [Terminus](/terminus/install)\*
-  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) (built into Terminus 4.2.0+; earlier versions require the plugin)
 
 \* Requires logging in after installation.
 

--- a/src/source/content/nextjs/wordpress-revalidation-tutorial-pages-router.md
+++ b/src/source/content/nextjs/wordpress-revalidation-tutorial-pages-router.md
@@ -40,7 +40,6 @@ If your site uses the **App Router** (`app/` directory), you do not need `Surrog
 * Install the following:
   - [Git](https://git-scm.com/)
   - [Terminus](/terminus/install)\*
-  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) (built into Terminus 4.2.0+; earlier versions require the plugin)
 
 \* Requires logging in after installation.
 

--- a/src/source/content/nextjs/wordpress-revalidation-tutorial.md
+++ b/src/source/content/nextjs/wordpress-revalidation-tutorial.md
@@ -30,7 +30,6 @@ This tutorial walks you through:
 * Install the following:
   - [Git](https://git-scm.com/)
   - [Terminus](/terminus/install)\*
-  - [Terminus Secrets Manager Plugin](https://github.com/pantheon-systems/terminus-secrets-manager-plugin) (built into Terminus 4.2.0+; earlier versions require the plugin)
 
 \* Requires logging in after installation.
 
@@ -615,7 +614,7 @@ With both sites configured, verify that content changes in WordPress automatical
 If the content does not update, check the following:
 
 * Verify that the secrets are set correctly on both sites using `terminus secret:site:list`.
-* Review the Next.js application logs for revalidation messages using `terminus node:logs:runtime:get <site>.<env>` (built into Terminus 4.2.0+; earlier versions require the [terminus-node-logs-plugin](https://github.com/pantheon-systems/terminus-node-logs-plugin)).
+* Review the Next.js application logs for revalidation messages using `terminus node:logs:runtime:get <site>.<env>`.
 * Confirm the mu-plugin file is in `wp-content/mu-plugins/` and is loaded by WordPress.
 
 ## Conclusion


### PR DESCRIPTION
Closes #10010

## Summary

- Adds `terminus site:create` instructions directly to the Next.js CLI tools doc, resolving the gap where no Next.js docs covered creating a site from the command line
- Removes all outdated references to `terminus-repository-plugin`, `terminus-secrets-manager-plugin`, and `terminus-node-logs-plugin` as separate installs — all three are built into Terminus core as of [4.2.0](/release-notes/2026/04/terminus-4-2-0)
- Removes beta language and plugin issue queue references from the GitHub Application guide
- Also adds @pantheon-systems/developer-experience to CODEOWNERS for Next.js and GitHub Application docs

## Files changed

| File | Change |
|---|---|
| `nextjs/cli-tools.md` | Full rewrite — removes plugin section, adds built-in command docs for site creation, secrets, and log viewing |
| `nextjs/hello-world-tutorial.md` | Remove Node Logs Plugin from optional prerequisites |
| `nextjs/migrating-from-front-end-sites.md` | Remove all three plugin install requirements; update "Node Logs Plugin" text reference |
| `nextjs/transfer-site.md` | Remove Repository Plugin from prerequisites |
| `nextjs/transfer-repository.md` | Remove Repository Plugin from prerequisites |
| `nextjs/environment-variables.md` | Remove Secrets Manager Plugin install step |
| `nextjs/content-publisher-tutorial.md` | Remove Secrets Manager Plugin and Node Logs Plugin from prerequisites |
| `nextjs/wordpress-revalidation-tutorial.md` | Remove Secrets Manager Plugin prereq; clean up node logs plugin parenthetical |
| `nextjs/wordpress-revalidation-tutorial-next-15.md` | Remove Secrets Manager Plugin prereq |
| `nextjs/wordpress-revalidation-tutorial-pages-router.md` | Remove Secrets Manager Plugin prereq |
| `guides/github-application/02-setup.md` | Remove plugin install block from Terminus tab; update description and intro |
| `guides/github-application/01-introduction.md` | Remove Repository Plugin from More Resources |
| `guides/github-application/06-support-considerations.md` | Replace plugin issue queue with Pantheon Support; remove plugin from More Resources |

🤖 Generated with [Claude Code](https://claude.com/claude-code)