### PR TITLE
Add Solr 9 GA release note for D7 & D10+

### DIFF
--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -1,6 +1,6 @@
 ---
 title: Solr 9 now generally available on Pantheon
-published_date: "2026-06-29"
+published_date: "2026-06-30"
 categories: [new-feature, drupal]
 ---
 

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -1,0 +1,32 @@
+---
+title: Solr 9 now generally available on Pantheon
+published_date: "2026-06-29"
+categories: [new-feature, drupal]
+---
+
+Pantheon Search now supports [Apache Solr 9.10.0](https://solr.apache.org/guide/solr/latest/) for Drupal 7, 10, and 11 sites, with improved security defaults, the unified highlighter, and performance enhancements. See the [major changes in Solr 9](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html) for details.
+
+## How to get Solr 9
+
+### Drupal 10 and 11
+
+Solr 9 support is available through [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon) version **8.5.0**.
+
+For detailed setup instructions, see the [Solr for Drupal 10/11 guide](/guides/solr-drupal/solr-drupal).
+
+### Drupal 7
+
+Solr 9 support is available through the **Pantheon Drupal 7 upstream version 7.105.1**.
+
+For detailed setup instructions, see the [Solr for Drupal 7 guide](/guides/solr-drupal/solr-drupal-7).
+
+## Solr 3 and Solr 8 removal timeline
+
+With Solr 9 now generally available, the previously announced [removal schedule](/release-notes/2026/05/solr-9-ga-solr-3-8-removal-dates) is in effect:
+
+- **Solr 3** will be removed on **February 9, 2027**. Drupal 7 sites using Solr 3 must migrate to Solr 9 before this date.
+- **Solr 8** will be removed on **July 11, 2027**. Drupal 10 and 11 sites using Solr 8 should migrate to Solr 9 before this date.
+
+## Feedback
+
+Report issues or provide feedback in the [drupal.org issue queue](https://www.drupal.org/project/issues/search_api_pantheon?categories=All) for Drupal 10/11, or through [Pantheon Support](https://pantheon.io/support) for Drupal 7.

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -4,7 +4,7 @@ published_date: "2026-06-29"
 categories: [new-feature, drupal]
 ---
 
-Pantheon Search now supports [Apache Solr 9.10.0](https://solr.apache.org/guide/solr/latest/) for Drupal 7, 10, and 11 sites, with improved security defaults, the unified highlighter, and performance enhancements. See the [major changes in Solr 9](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html) for details.
+Pantheon Search now supports [Apache Solr 9.10.1](https://solr.apache.org/guide/solr/latest/) for Drupal 7, 10, and 11 sites, with improved security defaults, the unified highlighter, and performance enhancements. See the [major changes in Solr 9](https://solr.apache.org/guide/solr/latest/upgrade-notes/major-changes-in-solr-9.html) for details.
 
 ## How to get Solr 9
 

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -22,7 +22,7 @@ For detailed setup instructions, see the [Solr for Drupal 7 guide](/guides/solr-
 
 ## Solr 3 and Solr 8 removal timeline
 
-With Solr 9 now generally available, the previously announced [removal schedule](/release-notes/2026/05/solr-9-ga-solr-3-8-removal-dates) is in effect:
+The previously announced [removal schedule](/release-notes/2026/05/solr-9-ga-solr-3-8-removal-dates) still holds:
 
 - **Solr 3** will be removed on **February 9, 2027**. Drupal 7 sites using Solr 3 must migrate to Solr 9 before this date.
 - **Solr 8** will be removed on **July 11, 2027**. Drupal 10 and 11 sites using Solr 8 should migrate to Solr 9 before this date.

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -1,7 +1,7 @@
 ---
 title: Solr 9 now generally available on Pantheon
 published_date: "2026-06-30"
-published_at: "2026-06-30T13:00:00Z"
+published_at: "2026-06-30T14:16:00Z"
 categories: [new-feature, drupal]
 ---
 

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -1,6 +1,7 @@
 ---
 title: Solr 9 now generally available on Pantheon
 published_date: "2026-06-30"
+published_at: "2026-06-30T13:00:00Z"
 categories: [new-feature, drupal]
 ---
 

--- a/src/source/releasenotes/2026-06-29-solr-9-ga.md
+++ b/src/source/releasenotes/2026-06-29-solr-9-ga.md
@@ -24,7 +24,7 @@ For detailed setup instructions, see the [Solr for Drupal 7 guide](/guides/solr-
 
 The previously announced [removal schedule](/release-notes/2026/05/solr-9-ga-solr-3-8-removal-dates) still holds:
 
-- **Solr 3** will be removed on **February 9, 2027**. Drupal 7 sites using Solr 3 must migrate to Solr 9 before this date.
+- **Solr 3** will be removed on **February 9, 2027**. Drupal sites using Solr 3 must migrate to Solr 9 before this date. WordPress sites using Solr 3 through the [Solr Power](https://wordpress.org/plugins/solr-power/) plugin should consider switching to [Elasticsearch](/guides/pantheon-search/elasticsearch).
 - **Solr 8** will be removed on **July 11, 2027**. Drupal 10 and 11 sites using Solr 8 should migrate to Solr 9 before this date.
 
 ## Feedback


### PR DESCRIPTION
## Summary
- Adds release note announcing Solr 9 (Apache Solr 9.10.1) general availability on Pantheon for Drupal 7, 10, and 11 

## Before merging

- [x]  Update published_at — currently set to 2026-06-30T13:00:00Z as a placeholder. Replace with the actual publish timestamp before merging.
- [x]  Hold for 30 June