### PR TITLE
Update 07-global-cdn-beta.md to fix frontmatter

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -31,3 +31,6 @@ src/source/content/opensolr.md @pantheon-systems/site-experience
 src/source/content/guides/wordpress-developer/ @pantheon-systems/site-experience
 # There is a team just for release note permissions
 src/source/releasenotes/ @pantheon-systems/release-note-authors
+# Edge Routing handles GCDN and AGCDN
+src/source/content/guides/global-cdn/ @pantheon-systems/platform-edge-routing
+src/source/content/guides/agcdn/ @pantheon-systems/platform-edge-routing

--- a/src/source/content/guides/global-cdn/07-global-cdn-beta.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-beta.md
@@ -5,6 +5,8 @@ description: The GCDN Beta introduces built-in bot protection. Learn what's incl
 tags: [cache, cdn, security]
 contributors: [conorbauer, jazzsequence]
 showtoc: true
+contributors: [conorbauer23, jazzsequence]
+reviewed: "2026-06-24"
 permalink: docs/guides/global-cdn/global-cdn-beta
 contenttype: [guide]
 innav: [false]
@@ -13,8 +15,6 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [cdn]
 integration: [--]
-reviewed: "2026-06-24"
-contributors: [conorbauer23, jazzsequence]
 ---
 
 The new GCDN provides the same caching and content delivery you rely on today, plus new security features built into the CDN layer.

--- a/src/source/content/guides/global-cdn/07-global-cdn-beta.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-beta.md
@@ -5,7 +5,6 @@ description: The GCDN Beta introduces built-in bot protection. Learn what's incl
 tags: [cache, cdn, security]
 contributors: [conorbauer, jazzsequence]
 showtoc: true
-contributors: [conorbauer23, jazzsequence]
 reviewed: "2026-06-24"
 permalink: docs/guides/global-cdn/global-cdn-beta
 contenttype: [guide]


### PR DESCRIPTION
Previous PR added a second `contributors` frontmatter which broke the page rendering. Removing the duplicate and bumping the reviewed date up.

Also adding @pantheon-systems/platform-edge-routing to CODEOWNERS for AGCDN and GCDN docs