### PR TITLE
fix: always render guide title; display subtitle as styled h2

### DIFF
--- a/src/components/common/header-body/index.tsx
+++ b/src/components/common/header-body/index.tsx
@@ -48,7 +48,7 @@ const HeaderBody = ({
         </p> */}
         <h1 className="docs-title">{title}</h1>
 
-        {subtitle && <h2 className="docs-subtitle">{subtitle}</h2>}
+        {subtitle && <h2 className={styles.docSubtitle}>{subtitle}</h2>}
 
         <p className="pds-lead-text pds-lead-text--sm pds-spacing-mar-block-end-xl">
           {description}

--- a/src/components/common/header-body/index.tsx
+++ b/src/components/common/header-body/index.tsx
@@ -46,9 +46,9 @@ const HeaderBody = ({
             {lastReviewed}
           </time>
         </p> */}
-        {!subtitle && <h1 className="docs-title">{title}</h1>}
+        <h1 className="docs-title">{title}</h1>
 
-        {subtitle && <h1>{subtitle}</h1>}
+        {subtitle && <h2 className="docs-subtitle">{subtitle}</h2>}
 
         <p className="pds-lead-text pds-lead-text--sm pds-spacing-mar-block-end-xl">
           {description}

--- a/src/components/common/header-body/index.tsx
+++ b/src/components/common/header-body/index.tsx
@@ -46,9 +46,14 @@ const HeaderBody = ({
             {lastReviewed}
           </time>
         </p> */}
-        <h1 className="docs-title">{title}</h1>
-
-        {subtitle && <h2 className={styles.docSubtitle}>{subtitle}</h2>}
+        {subtitle ? (
+          <>
+            <p className="pds-overline-text">{title}</p>
+            <h1>{subtitle}</h1>
+          </>
+        ) : (
+          <h1 className="docs-title">{title}</h1>
+        )}
 
         <p className="pds-lead-text pds-lead-text--sm pds-spacing-mar-block-end-xl">
           {description}

--- a/src/components/common/header-body/style.module.css
+++ b/src/components/common/header-body/style.module.css
@@ -4,16 +4,6 @@
   padding-block-end: var(--pds-spacing-m);
 }
 
-/* Subtitle sits between the guide title (h1) and the description paragraph.
-   Sized and weighted to match PDS h3 (1.728rem / weight 600) so it sits
-   clearly between the h1 title (2.986rem / 700) above and the
-   pds-lead-text--sm description (1.44rem, Aleo serif) below. */
-.docSubtitle {
-  font-size: 1.728rem;
-  font-weight: 600;
-  margin-block-end: var(--pds-spacing-s, 0.512rem);
-}
-
 .docContentHeaderActions {
   display: flex;
   flex-wrap: wrap;

--- a/src/components/common/header-body/style.module.css
+++ b/src/components/common/header-body/style.module.css
@@ -4,6 +4,16 @@
   padding-block-end: var(--pds-spacing-m);
 }
 
+/* Subtitle sits between the guide title (h1) and the description paragraph.
+   Sized and weighted to match PDS h3 (1.728rem / weight 600) so it sits
+   clearly between the h1 title (2.986rem / 700) above and the
+   pds-lead-text--sm description (1.44rem, Aleo serif) below. */
+.docSubtitle {
+  font-size: 1.728rem;
+  font-weight: 600;
+  margin-block-end: var(--pds-spacing-s, 0.512rem);
+}
+
 .docContentHeaderActions {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary

Fixes a bug in `header-body/index.tsx` where the guide title was suppressed whenever a `subtitle` field was present. The subtitle was rendered as the sole `h1`, leaving the guide title invisible.

**Before:** `!subtitle && <h1>{title}</h1>` + `subtitle && <h1>{subtitle}</h1>`
**After:** `<h1>{title}</h1>` always + `subtitle && <h2 className={styles.docSubtitle}>{subtitle}</h2>`

The `.docSubtitle` class uses PDS h3 scale values (1.728rem / weight 600) to give clear visual hierarchy between the guide title above and the `pds-lead-text--sm` description below:

| Element | Size | Weight | Font |
|---|---|---|---|
| h1 title | 2.986rem | 700 | Poppins |
| h2 subtitle | 1.728rem | 600 | Poppins |
| description | 1.44rem | 400 | Aleo serif |

## Related

Flagged in review on #10136. Separated from that PR as a distinct templating concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)