### PR TITLE
Use supported version of Node.js in backstop_vrt job

### DIFF
--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -75,7 +75,7 @@ jobs:
 
   backstop_vrt:
     runs-on: macos-latest
-    needs: http_status_checker_on_sta
+    # needs: http_status_checker_on_sta
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -81,7 +81,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: lts/*
 

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -83,7 +83,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: lts/*
+          node-version: '22'
 
       - name: Install backstop
         shell: bash

--- a/.github/workflows/pr-e2e.yml
+++ b/.github/workflows/pr-e2e.yml
@@ -75,7 +75,7 @@ jobs:
 
   backstop_vrt:
     runs-on: macos-latest
-    # needs: http_status_checker_on_sta
+    needs: http_status_checker_on_sta
 
     steps:
       - name: Checkout repository

--- a/tests/playwright/tests/release-notes.spec.ts
+++ b/tests/playwright/tests/release-notes.spec.ts
@@ -25,7 +25,7 @@ test('Direct navigation to single category returns the expected value', async ({
 });
 
 test('Direct navigation to single category returns the expected value - 2', async ({ page }) => {
-  await page.goto('/release-notes/1/category=billing');
+  await page.goto('/release-notes/1/?category=billing');
   const expectedString = 'Track invoice statuses with new Paid and Unpaid tags';
   const h2s1 = await page.locator('h2').allTextContents();
   expect(h2s1.some(text => text.includes(expectedString))).toBeTruthy();

--- a/tests/playwright/tests/release-notes.spec.ts
+++ b/tests/playwright/tests/release-notes.spec.ts
@@ -25,8 +25,8 @@ test('Direct navigation to single category returns the expected value', async ({
 });
 
 test('Direct navigation to single category returns the expected value - 2', async ({ page }) => {
-  await page.goto('/release-notes/1/?category=action-required');
-  const expectedString = 'WordPress 6.9.4 available';
+  await page.goto('/release-notes/1/category=billing');
+  const expectedString = 'Track invoice statuses with new Paid and Unpaid tags';
   const h2s1 = await page.locator('h2').allTextContents();
   expect(h2s1.some(text => text.includes(expectedString))).toBeTruthy();
 });


### PR DESCRIPTION
The `backstop_vrt` CI job is failing, seemingly because it is using an old version of Node.