### PR TITLE
check for 00:00:00 timestamps

### DIFF
--- a/.github/workflows/validate-release-notes.yml
+++ b/.github/workflows/validate-release-notes.yml
@@ -41,6 +41,10 @@ jobs:
 
           if echo "$FRONTMATTER" | grep -qE '^published_at:[[:space:]]+\S+'; then
             VALUE=$(echo "$FRONTMATTER" | grep -E '^published_at:' | sed 's/^published_at:[[:space:]]*//' | tr -d '"')
+            if echo "$VALUE" | grep -qE 'T00:00:00Z$'; then
+              echo "::error file=$FILES::published_at has a default midnight timestamp ($VALUE). Update it to the actual publication time."
+              exit 1
+            fi
             echo "OK: $FILES (published_at: $VALUE)"
           else
             echo "::error file=$FILES::Missing 'published_at' in frontmatter. Add 'published_at: \"2026-06-01T00:00:00Z\"' after 'published_date'."


### PR DESCRIPTION
Our `published_at` validator (added in #10099) validates whether a `published_at` timestamp is _set_ but not whether it's _accurate_. While granular accuracy is not explicitly required, having multiple release notes publish with midnight (`00:00:00`) timestamps will suffer from the same problem that the `published_at` frontmatter was designed to solve -- Slack RSS feeds not picking up multiple release notes published on the same day.

This update to the validation CI checks and flags if the timestamp is set to midnight so it can be updated manually. 