### PR TITLE
Update YouTube link to video no Pantheon's account

### DIFF
--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -4,7 +4,7 @@ subtitle: Pantheon Search powered by Elasticsearch
 navtitle: Introduction
 description: Detailed information on using Elasticsearch with your Pantheon WordPress site with ElasticPress.
 tags: [elasticsearch,search]
-reviewed: "2026-06-16"
+reviewed: "2026-07-01"
 contenttype: [doc]
 innav: [true]
 categories: [search]

--- a/src/source/content/guides/elasticsearch/01-introduction.md
+++ b/src/source/content/guides/elasticsearch/01-introduction.md
@@ -20,7 +20,7 @@ showtoc: true
 
 Elasticsearch on Pantheon gives WordPress teams a fully managed search service that goes beyond basic site search — offloading database queries, handling traffic spikes, and delivering features like fuzzy matching and autosuggest without the overhead of managing an external provider.
 
-<Youtube src="m5K2JdQoVFU" title="Getting Started with Elasticsearch on Pantheon" />
+<Youtube src="SKu-NY5lQ50" title="Getting Started with Elasticsearch on Pantheon" />
 
 ## Overview
 


### PR DESCRIPTION
The YouTube video I published was uploaded under my personal `@pantheon.io` YouTube account, rather than going into the main Pantheon account. This updates the YouTube embedded video to one that's actually on the Pantheon brand account.

## Test plan
- [x] Validate updated YouTube embed renders