### PR TITLE
Add release note: Pantheon's next-generation Global CDN is now generally available

### DIFF
--- a/src/source/releasenotes/2026-07-13-global-cdn-ga.md
+++ b/src/source/releasenotes/2026-07-13-global-cdn-ga.md
@@ -1,7 +1,7 @@
 ---
 title: "Pantheon's next-generation Global CDN is now generally available"
 published_date: "2026-07-13"
-published_at: "2026-07-13T14:00:00Z"
+published_at: "2026-07-13T21:34:07Z"
 categories: [new-feature, action-required]
 ---
 

--- a/src/source/releasenotes/2026-07-13-global-cdn-ga.md
+++ b/src/source/releasenotes/2026-07-13-global-cdn-ga.md
@@ -1,0 +1,33 @@
+---
+title: "Pantheon's next-generation Global CDN is now generally available"
+published_date: "2026-07-13"
+published_at: "2026-07-13T14:00:00Z"
+categories: [new-feature, action-required]
+---
+
+After a successful Beta phase, Pantheon's next-generation Global CDN (GCDN) is now generally available. Built on Cloudflare, the new GCDN delivers built-in bot protection, expanded site eligibility, and the same self-serve migration experience customers have been using in the Beta — now production-ready for the majority of sites on the platform.
+
+## What's included
+
+- **Built-in bot protection** — Incoming traffic is automatically scored, with managed challenges issued to suspicious requests and verified bots (such as search engine crawlers) allowed through.
+- **Multizone Failover support** — Sites with [Multizone Failover](/multizone-failover) enabled can migrate to GCDN and continue to benefit from automated regional failover.
+- **Custom Certificates support** — Sites using [customer-provided TLS certificates](/custom-certificates) are now supported on GCDN. Migration for these sites is owned by our Professional Services team and coordinated through support — [open a support ticket](/guides/support/contact-support/) to get started.
+- **Platform vanity domain support** — Organization-owned [vanity hostnames](/guides/domains/vanity-domains) (e.g., `live-mysite.example-agency.com`) are fully supported. Migration for these sites is owned by our Professional Services team and coordinated through support — [open a support ticket](/guides/support/contact-support/) to get started.
+
+## Action Required
+
+Eligible sites will display a GCDN banner in the Pantheon dashboard. To migrate:
+
+1. Locate the GCDN banner on an eligible site.
+2. Click it and complete the guided process.
+3. Point your DNS records to the new GCDN infrastructure.
+
+Domain verification supports DNS-01 TXT record validation, requiring TXT records added at your DNS provider.
+
+## Eligibility
+
+GCDN is available to all sites on the platform except those currently using [Advanced Global CDN (AGCDN)](/guides/agcdn). AGCDN customers will be migrated in a future phase — no action is required from them at this time.
+
+## More information
+
+For full details on GCDN, refer to the [Global CDN guide](/guides/global-cdn) on the Pantheon docs site.

--- a/src/source/releasenotes/2026-07-13-global-cdn-ga.md
+++ b/src/source/releasenotes/2026-07-13-global-cdn-ga.md
@@ -30,4 +30,4 @@ GCDN is available to all sites on the platform except those currently using [Adv
 
 ## More information
 
-For full details on GCDN, refer to the [Global CDN guide](/guides/global-cdn) on the Pantheon docs site.
+For full details on GCDN, refer to the [Global CDN guide](/guides/global-cdn/global-cdn-beta) on the Pantheon docs site.

--- a/src/source/releasenotes/2026-07-13-global-cdn-ga.md
+++ b/src/source/releasenotes/2026-07-13-global-cdn-ga.md
@@ -30,4 +30,4 @@ GCDN is available to all sites on the platform except those currently using [Adv
 
 ## More information
 
-For full details on GCDN, refer to the [Global CDN guide](/guides/global-cdn/global-cdn-beta) on the Pantheon docs site.
+For full details on GCDN, refer to the [Global CDN guide](/guides/global-cdn/next-gen-global-cdn) on the Pantheon docs site.

--- a/src/source/releasenotes/2026-07-13-global-cdn-ga.md
+++ b/src/source/releasenotes/2026-07-13-global-cdn-ga.md
@@ -1,7 +1,7 @@
 ---
 title: "Pantheon's next-generation Global CDN is now generally available"
-published_date: "2026-07-13"
-published_at: "2026-07-13T21:34:07Z"
+published_date: "2026-07-15"
+published_at: "2026-07-15T14:54:28Z"
 categories: [new-feature, action-required]
 ---
 


### PR DESCRIPTION
## Summary

Adds the release note announcing GA of the next-generation Global CDN (GCDN), built on Cloudflare, following the Beta phase.

Highlights:
- Built-in bot protection (scoring, managed challenges, verified bot allowance)
- Multizone Failover support
- Custom Certificates support (migration owned by Professional Services, coordinated via support ticket)
- Platform vanity domain support (same coordination path)
- Self-serve migration via dashboard banner for eligible sites; AGCDN sites excluded until a future phase

## Notes for reviewers

- **The GA date is TBD** — `published_date`/`published_at` in the frontmatter and the filename date are set to a placeholder of **2026-07-13** and should be updated once the launch date is confirmed.
- All GCDN detail links point to `/guides/global-cdn/global-cdn-beta`, which is the current source of truth for the new GCDN.
- Other links: Multizone Failover, Custom Certificates, vanity domains, AGCDN guide, and contact support.

## Todo
- [x] Update `published_at` and publish date to correct date/time (when known)
- [x] Update link to (no longer) beta docs when that URL has been updated
- [x] Hold for release (7/15)