### PR TITLE
document secrets usage for cron contexts

### DIFF
--- a/src/source/content/customer-scheduled-cron-jobs.md
+++ b/src/source/content/customer-scheduled-cron-jobs.md
@@ -11,7 +11,7 @@ product: [terminus]
 integration: [--]
 tags: [--]
 showtoc: true
-reviewed: 2026-07-07
+reviewed: "2026-07-07"
 ---
 
 The [Terminus](/terminus) Scheduled Jobs Plugin allows customers to schedule and automate specific cron jobs according to their requirements. You can specify the desired frequency (e.g., daily, weekly, monthly, hourly), and the actions to be performed. The system then executes the scheduled jobs automatically based on the provided instructions.
@@ -88,7 +88,7 @@ There are currently no restrictions around the number of schedules that can be c
 Timeouts are dynamic and dependent on the remaining budget plus the 15 minute grace period. For instance, the daily available budget at the start of the day is 300 minutes, which means the first job's timeout is 315 minutes. When a job is launched throughout the day and the remaining budget is 60 minutes, the timeout will be calculated to 75 minutes.
 
 ### Pantheon Secrets Usage
-For scenarios where sensitive information (such as access tokens, API keys, etc.) is required for the given scheduled job, we recommend using [Pantheon Secrets](/guides/secrets).
+For cron scenarios where sensitive information (such as access tokens, API keys, etc.) is required, we recommend using [Pantheon Secrets](/guides/secrets).
 
 This allows you to create and manage secrets directly on the Pantheon platform, and then read those secrets securely in context of a given scheduled job. 
 

--- a/src/source/content/customer-scheduled-cron-jobs.md
+++ b/src/source/content/customer-scheduled-cron-jobs.md
@@ -11,7 +11,7 @@ product: [terminus]
 integration: [--]
 tags: [--]
 showtoc: true
-reviewed: 2026-06-11
+reviewed: 2026-07-07
 ---
 
 The [Terminus](/terminus) Scheduled Jobs Plugin allows customers to schedule and automate specific cron jobs according to their requirements. You can specify the desired frequency (e.g., daily, weekly, monthly, hourly), and the actions to be performed. The system then executes the scheduled jobs automatically based on the provided instructions.
@@ -86,6 +86,19 @@ There are currently no restrictions around the number of schedules that can be c
 ### Job Timeouts
 
 Timeouts are dynamic and dependent on the remaining budget plus the 15 minute grace period. For instance, the daily available budget at the start of the day is 300 minutes, which means the first job's timeout is 315 minutes. When a job is launched throughout the day and the remaining budget is 60 minutes, the timeout will be calculated to 75 minutes.
+
+### Pantheon Secrets Usage
+For scenarios where sensitive information (such as access tokens, API keys, etc.) is required for the given scheduled job, we recommend using [Pantheon Secrets](/guides/secrets).
+
+This allows you to create and manage secrets directly on the Pantheon platform, and then read those secrets securely in context of a given scheduled job. 
+
+<Alert type="info" title="Note">
+
+The [secret scope](/guides/secrets/overview#secret-scope) must be set to `ic` at time of secret creation. The scope of an existing secret cannot be changed after creation. If you want to read an existing secret of a different scope you must first delete and recreate the secret with the additional `ic` scope included. 
+
+For detailed steps, refer to [Creating a New Secret](/guides/secrets/create).
+
+</Alert>
 
 ## Commands
 

--- a/src/source/content/guides/secrets/02-secrets-overview.md
+++ b/src/source/content/guides/secrets/02-secrets-overview.md
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/overview
-reviewed: 2026-07-07
+reviewed: "2026-07-07"
 showtoc: true
 ---
 

--- a/src/source/content/guides/secrets/02-secrets-overview.md
+++ b/src/source/content/guides/secrets/02-secrets-overview.md
@@ -12,7 +12,7 @@ product: [secrets]
 integration: [--]
 tags: [reference, cli, local, terminus, workflow]
 permalink: docs/guides/secrets/overview
-reviewed: "2026-06-15"
+reviewed: 2026-07-07
 showtoc: true
 ---
 
@@ -43,7 +43,7 @@ Current types are:
 
 <p>A <dfn id="secret-scope">secret's scope</dfn> is the answer to the question "Where is the secret's value available?". Once set, a secret's scope cannot be changed. The secret must be deleted and recreated to change its scope.</p>
 
-  * `ic`: This secret will be readable during Integrated Composer builds. You should use this scope to get access to your private repositories.
+  * `ic`: This secret will be readable during Integrated Composer builds. You should use this scope to get access to your private repositories. Additionally, you must use this scope to read secrets from [scheduled cron jobs](/customer-scheduled-cron-jobs).
 
   * `web`: this secret will be readable by the application runtime.
 


### PR DESCRIPTION
fixes #10147 

* **Schedule Cron Jobs with Terminus**
  * adds a new h3 "Pantheon Secrets Usage" 
  * [preview link](https://pr-10155-pandocs.pantheonsite.io/customer-scheduled-cron-jobs#pantheon-secrets-usage) | [prod link](https://docs.pantheon.io/customer-scheduled-cron-jobs)
* **Secrets Overview** 
  * updates h2 "Secret Scope" so that scheduled jobs is specified for scope `ic` 
  * [preview link](https://pr-10155-pandocs.pantheonsite.io/guides/secrets/overview#secret-scope) | [prod link](https://docs.pantheon.io/guides/secrets/overview#secret-scope)

