### PR TITLE
docs(release-notes): [SITE-6012] PHP 8.2, 8.3, 8.4, 8.5 security patch releases

### DIFF
--- a/src/source/releasenotes/2026-07-07-php-82-83-84-85-security-updates.md
+++ b/src/source/releasenotes/2026-07-07-php-82-83-84-85-security-updates.md
@@ -1,0 +1,8 @@
+---
+title: "PHP 8.2, 8.3, 8.4 and 8.5 updated to their latest security patch releases"
+published_date: "2026-07-07"
+categories: [infrastructure, security]
+description: "PHP versions 8.2.32, 8.3.32, 8.4.23, and 8.5.8 are now available on the platform."
+---
+PHP versions [8.2.32](https://www.php.net/ChangeLog-8.php#8.2.32), [8.3.32](https://www.php.net/ChangeLog-8.php#8.3.32), [8.4.23](https://www.php.net/ChangeLog-8.php#8.4.23), and [8.5.8](https://www.php.net/ChangeLog-8.php#8.5.8) are now available on the platform. These updates include important security fixes, along with bug fixes and enhancements that improve performance and stability.
+Updates will be applied automatically over the next few days, so no manual action is required.

--- a/src/source/releasenotes/2026-07-07-php-82-83-84-85-security-updates.md
+++ b/src/source/releasenotes/2026-07-07-php-82-83-84-85-security-updates.md
@@ -1,6 +1,7 @@
 ---
 title: "PHP 8.2, 8.3, 8.4 and 8.5 updated to their latest security patch releases"
 published_date: "2026-07-07"
+published_at: "2026-07-07T14:48:45Z"
 categories: [infrastructure, security]
 description: "PHP versions 8.2.32, 8.3.32, 8.4.23, and 8.5.8 are now available on the platform."
 ---


### PR DESCRIPTION
## Summary

- Add release note announcing PHP 8.2.32, 8.3.32, 8.4.23, and 8.5.8 on the platform.

## Context

[SITE-6012](https://getpantheon.atlassian.net/browse/SITE-6012)

Freexian PHP patch versions were bumped in cos-runtime-php#914 (merged 2026-07-06). The runtime PR checklist requires a matching release note in the documentation repo. Releases 8.4.23 and 8.5.8 carry CVE-2026-14355 (OpenSSL `openssl_encrypt` memory corruption); the fix is backported across all supported branches, so the note is categorized `[infrastructure, security]`, matching the prior 2026-05-12 PHP security note.

## Test plan

- [x] Release note renders under the infrastructure and security categories with correct php.net changelog links.

## References

- Jira: [SITE-6012](https://getpantheon.atlassian.net/browse/SITE-6012)
- Runtime PR: pantheon-systems/cos-runtime-php#914

[SITE-6012]: https://getpantheon.atlassian.net/browse/SITE-6012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-6012]: https://getpantheon.atlassian.net/browse/SITE-6012?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ