### PR TITLE
Add Orange-to-Orange (O2O) setup section to GCDN Beta guide

### DIFF
--- a/src/components/omni-components/web-infrastructure.ts
+++ b/src/components/omni-components/web-infrastructure.ts
@@ -25,6 +25,7 @@ const webInfrastructure = () => {
         simpleLink("/pantheon-yml", "App Configuration", [
           simpleLink("/pantheon-yml", "pantheon.yml"),
           simpleLink("/nested-docroot", "Nested Docroot"),
+          simpleLink("/frontend-builds", "Frontend Asset Builds"),
           simpleLink(
             "/server_name-and-server_port",
             "Server Name and Server Port"

--- a/src/source/content/frontend-builds.md
+++ b/src/source/content/frontend-builds.md
@@ -1,0 +1,52 @@
+---
+title: Frontend Asset Builds
+description: Learn how to compile frontend assets on Pantheon.
+reviewed: "2026-07-06"
+contenttype: [doc]
+innav: [true]
+showtoc: true
+---
+
+Pantheon allows you to compile frontend assets (themes, design systems, and other Node.js-based tooling) automatically on the platform as a build step. This build step runs on every code push, so compiled assets no longer need to be committed to your site repository. 
+
+## Compatibility & Requirements
+
+* Supported for both WordPress and Drupal sites, with or without [Integrated Composer](/guides/integrated-composer/) 
+* **Node Versions**: 
+  * Frontend builds support Node.js 22, 24, and 26 (default)
+* **Package manager**: 
+  * Selected based on the lock file present in each configured build path. The platform checks for lock files in the following order and uses the first match:
+    1. **bun** — `bun.lock` or `bun.lockb`
+    1. **pnpm** — `pnpm-lock.yaml`
+    1. **yarn** — `yarn.lock`
+    1. **npm** — `package-lock.json`
+
+    <Alert type="info" title="Note">
+
+    A lock file is **required**. If no lock file is found in a build path, the build fails. Commit the lock file for your chosen package manager to enable reproducible installs.
+
+    </Alert>
+
+
+## Usage
+
+Add a `frontend_build` block to your `pantheon.yml`:
+
+```yaml:title=pantheon.yml
+frontend_build:
+  enabled: true
+  paths:
+    - path: web/themes/custom/mytheme
+      node_version: 26
+      build_command: build
+```
+
+Each entry under `paths` describes one directory to build:
+
+- **`path`** — the directory containing the `package.json` and lock file, relative to your repository root.
+- **`node_version`** — the Node.js major version to build with. Defaults to **26**.
+- **`build_command`** — the script to run (executed as `<package-manager> run <build_command>`). Defaults to **`build`**.
+
+You can list multiple paths to build several themes or packages in a single deploy.
+
+After configuring your site's `pantheon.yml` file as described above, you must also update your `.gitignore` file so that you ignore all the artifacts that the build process will produce.

--- a/src/source/content/guides/account-mgmt/account/01-introduction.md
+++ b/src/source/content/guides/account-mgmt/account/01-introduction.md
@@ -1,6 +1,6 @@
 ---
 title: "Manage Your Account"
-subtitle: Introduction
+subtitle: Start Free Trial
 description: Learn how to create, delete, and recover your account.
 contenttype: [guide]
 innav: [true]
@@ -13,17 +13,22 @@ tags: [workspaces, sites, teams]
 contributors: [wordsmither]
 permalink: docs/guides/account-mgmt/account
 editpath: docs/guides/account-mgmt/account/01-introduction.md
-reviewed: "2022-09-19"
+reviewed: "2026-07-08"
+showtoc: "true"
 ---
 
-The first thing you need to do when starting with Pantheon is create an account. A Pantheon account lets you:
+## Free 30-day trial
+Every new Pantheon account starts with a full 30-day free trial of our [Silver plan](/guides/account-mgmt/plans/workspace-plans#silver-account-plan), and includes: 
+* One professional workspace
+* Up to 2 sandbox sites, including Dev, Test, and Live environments
+* Additional tools like [New Relic](/guides/new-relic), [Object Cache](/object-cache), and [Pantheon Search](/pantheon-search)
 
-- Purchase plans
-- Manage your workspaces
-- Pay your bills
-- Customize your email communication preferences
+Advanced features, including [Multidev](/guides/multidev), [Custom Upstreams](/guides/custom-upstream), [Autopilot](/guides/autopilot), and [Custom Domains](/guides/domains/custom-domains) are available on paid plans only. 
 
-[Create your account for free](https://pantheon.io/register?docs).
+[For additional details on free trial accounts see the following FAQ bellow.](#frequently-asked-questions)
+
+### Create your account
+The first thing you need to do when starting with Pantheon is [create your account for free](https://pantheon.io/register?docs).
 
 After creating your account, you can manage your [email preferences](/personal-settings#email-preferences) to control which marketing communications you receive from Pantheon.
 
@@ -33,3 +38,31 @@ After creating your account, you can manage your [email preferences](/personal-s
 <Partial file="dashboard-login-session-length.md" />
 
 </Alert>
+
+## Frequently Asked Questions
+### Which CMS platforms are supported in the trial?
+Pantheon currently supports WordPress, Drupal, and Next.js.
+
+### Do I need a credit card to start? 
+No. You can sign up and start building right away.
+
+### What happens when my trial ends? 
+At the end of 30 days, your site is paused—not deleted. You'll still be able to log in and view everything you built. To make changes or publish, choose any paid site plan and your account unlocks immediately.
+
+### Will I loose my work? 
+No. Your site content is saved for 90 days after your trial ends, giving you time to decide. If you upgrade within that window, you'll pick up right where you left off.
+
+### Can I extend my trial? 
+Standard free trials are 30 days. If you're evaluating Pantheon for a larger project and need more time, [contact our sales team](https://pantheon.io/live-demo-request). We're happy to talk through your needs.
+
+### What if I just want to walk away? 
+That's okay too. Your work stays saved for 90 days in case you change your mind. After that, sandbox site content is removed in line with our standard data retention policy.
+
+### Do I need to agree to terms when I sign up? 
+Yes. All trial users agree to our [Terms of Use](https://pantheon.pactsafe.io/ClientLegalCenter.html#contract-s1gsfzboel) at signup. Paying customers agree to our [Master Subscription Agreement](https://pantheon.pactsafe.io/MasterServicesAgreement.html) when they purchase a plan. 
+
+### How will Pantheon contact me about my trial? 
+We'll send email reminders as your trial progresses, including notice before it ends—so you always know where you stand. 
+
+### Still have questions? 
+[Contact our team](https://pantheon.io/contact-us) or visit our [Help Center](https://dashboard.pantheon.io/login?_gl=1*12hlcev*_gcl_au*Nzk0MDYxMjU2LjE3ODAzMzk4NzA.*_ga*MTk4NDAwMzY4Ni4xNzI4MzMwMTQ2*_ga_CPJLBDH983*czE3ODA2MTg4OTIkbzE3MCRnMSR0MTc4MDYxOTAyNiRqNDckbDAkaDA.).

--- a/src/source/content/guides/account-mgmt/plans/09-workspace-plans.md
+++ b/src/source/content/guides/account-mgmt/plans/09-workspace-plans.md
@@ -7,7 +7,7 @@ contributors: [wordsmither]
 showtoc: true
 permalink: docs/guides/account-mgmt/plans/workspace-plans
 editpath: docs/guides/account-mgmt/plans/09-workspace-plans.md
-reviewed: "2022-09-19"
+reviewed: "2026-07-06"
 contenttype: [guide]
 innav: [false]
 categories: [plans]
@@ -61,8 +61,6 @@ As a Pantheon Partner, you receive access to:
 - A listing in our Agency Directory
 - Sales playbooks, training, and [Gold Level Support](/guides/support/#support-features-and-response-times)
 - Preferred Pricing on site hosting plans
-
-**Partner Trial**: If you are creating a workspace for a web agency, you will be assigned a [Partner Trial Account](https://pantheon.io/partners/find-pantheon-partner) workspace that lets you try Gold Account Plan features free for 90 days.
 
 **Registered Agency**: This is recommended for any professional website developer or agency that develops websites for clients. Registering as an agency will start your path to partnership with Pantheon. You'll receive access to Pantheon Partner benefits for 90 days. After your trial period, your account plan will become a Registered Agency, and you will lose access to Gold Account Plan benefits until you qualify as a Pantheon Partner.
 

--- a/src/source/content/guides/build-tools/01-introduction.md
+++ b/src/source/content/guides/build-tools/01-introduction.md
@@ -19,6 +19,8 @@ integration: [--]
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 ## What Is Build Tools?
 
 Build Tools connects Pantheon with your CI service and external Git provider. It also includes Composer support, Automated Testing, and best practice recommendations for your advanced [Website Operations workflow](https://pantheon.io/webops). This is an extension of the [Pantheon WebOps workflow](/pantheon-workflow).

--- a/src/source/content/guides/build-tools/02-create-project.md
+++ b/src/source/content/guides/build-tools/02-create-project.md
@@ -17,6 +17,8 @@ integration: [--]
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 In this section, we will use the Terminus Build Tools Plugin to create a new project consisting of a Git repository, [Composer](https://getcomposer.org), a Continuous Integration (CI) service, and a Pantheon site with Automated Testing. This guide will get you started, but you will need to customize and maintain the CI/testing set up for your projects.
 
 <Alert title="Note" type="info">

--- a/src/source/content/guides/build-tools/03-pr-workflow.md
+++ b/src/source/content/guides/build-tools/03-pr-workflow.md
@@ -17,6 +17,8 @@ integration: [--]
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 ## Pull Request/Merge Request Introduction
 
 This section demonstrates the Build Tools project workflow by making a code change on a Git feature branch and opening a pull request (GitHub) or merge request (GitLab) to accept that change into the `master` branch.

--- a/src/source/content/guides/build-tools/04-configure.md
+++ b/src/source/content/guides/build-tools/04-configure.md
@@ -18,6 +18,8 @@ integration: [--]
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 In this lesson, we'll use the Configuration Management system within the Drupal Admin interface to set block placements for our example site. Continuing from the previous step, we'll be working in the feature branch environment, not Dev.
 
 <Accordion title="Configuration Management" id="understand-config" icon="lightbulb">

--- a/src/source/content/guides/build-tools/05-extend.md
+++ b/src/source/content/guides/build-tools/05-extend.md
@@ -15,6 +15,9 @@ product: [--]
 integration: [--]
 image: buildToolsGuide-thumb.png
 ---
+
+<Partial file="build-tools-cta.md" />
+
 Next, we'll add a module to our existing `slogan` branch using Composer. You should already have a Pull Request open for this branch in GitHub, [created in a previous lesson](/guides/build-tools/pr-workflow#create-a-pull-request).
 
 ## Local Setup

--- a/src/source/content/guides/build-tools/06-tests.md
+++ b/src/source/content/guides/build-tools/06-tests.md
@@ -17,6 +17,8 @@ reviewed: "2022-12-13"
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 The Pantheon example projects include some basic tests to validate basic capabilities of the given framework. You can customize these tests and add more to fit your project needs. Drupal uses [Behat](http://behat.org/en/latest/) and the WordPress example uses [WordHat](https://github.com/paulgibbs/behat-wordpress-extension).
 
 The [`behat-pantheon.yml`](https://github.com/pantheon-systems/example-drops-8-composer/blob/master/tests/behat/behat-pantheon.yml) file sets the path for a project's collection of Behat tests. Any file with a `.feature` suffix in a listed directory will be executed as part of the standard test run on CircleCI.

--- a/src/source/content/guides/build-tools/07-merge.md
+++ b/src/source/content/guides/build-tools/07-merge.md
@@ -15,6 +15,9 @@ product: [--]
 integration: [--]
 image: buildToolsGuide-thumb.png
 ---
+
+<Partial file="build-tools-cta.md" />
+
 This lesson demonstrates the final process of the Pull Request workflow, merging. After completing an internal peer review process for a given Pull Request, work is considered ready for production and accepted into the master branch.
 
 1.  Go to your GitHub project page, click on the **Pull requests** tab and navigate to the PR open against the `slogan` branch, which we [started in an earlier lesson](/guides/build-tools/pr-workflow#create-a-pull-request).

--- a/src/source/content/guides/build-tools/08-custom-theme.md
+++ b/src/source/content/guides/build-tools/08-custom-theme.md
@@ -15,6 +15,9 @@ product: [--]
 integration: [--]
 image: buildToolsGuide-thumb.png
 ---
+
+<Partial file="build-tools-cta.md" />
+
 This lesson demonstrates how to create a custom theme from the default [Bartik](https://www.drupal.org/project/bartik) theme using the [Terminus Drupal Console plugin](https://github.com/pantheon-systems/terminus-drupal-console-plugin). 
 
 1. Start by creating a new branch based off the tip of master, then push it up to GitHub:

--- a/src/source/content/guides/build-tools/09-update.md
+++ b/src/source/content/guides/build-tools/09-update.md
@@ -15,6 +15,8 @@ integration: [--]
 image: buildToolsGuide-thumb.png
 ---
 
+<Partial file="build-tools-cta.md" />
+
 In this lesson, we'll take a closer look at how to update dependencies in a Composer workflow.
 
 <Accordion title="Composer" id="understand-composer" icon="lightbulb">

--- a/src/source/content/guides/global-cdn/07-global-cdn-beta.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-beta.md
@@ -5,7 +5,7 @@ description: The GCDN Beta introduces built-in bot protection. Learn what's incl
 tags: [cache, cdn, security]
 contributors: [conorbauer, jazzsequence]
 showtoc: true
-reviewed: "2026-06-24"
+reviewed: "2026-07-09"
 permalink: docs/guides/global-cdn/global-cdn-beta
 contenttype: [guide]
 innav: [false]
@@ -231,6 +231,83 @@ terminus gcdn:verify my-site.live www.example.com
 
 </TabList>
 
+## Using Cloudflare in Front of Pantheon (Orange-to-Orange)
+
+If your domain is already proxied through your own Cloudflare zone (orange-clouded), the GCDN Beta supports Cloudflare's [Orange-to-Orange (O2O)](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/) configuration. This lets you keep your existing Cloudflare zone — including your WAF rules, Workers, and other settings — in front of Pantheon's GCDN.
+
+<Alert title="Terminus Plugin Required" type="danger">
+
+O2O setup is only available through the [GCDN Terminus plugin](https://github.com/pantheon-systems/terminus-gcdn-plugin). The dashboard migration flow does not support O2O. Install the plugin and upgrade your site with `terminus gcdn:upgrade` (see the **Terminus CLI** tab in [Setup](#setup)) before starting the steps below.
+
+</Alert>
+
+Because your DNS is hosted in Cloudflare, the standard TXT-record verification flow does not apply. Instead, you will add a specific set of records in your Cloudflare zone. The order matters: do not point traffic at Pantheon until hostname ownership is verified and your certificate is active.
+
+### Before You Begin
+
+- Your site must already be upgraded to the GCDN Beta (`terminus gcdn:upgrade <site>`).
+- You need access to your Cloudflare account with permission to edit DNS records, SSL/TLS settings, and Zone Holds.
+
+### 1. Get your O2O record set
+
+```bash{promptUser: user}
+terminus gcdn:o2o <site>.live
+```
+
+This prints the records to add for each domain: the hostname ownership TXT record, the DCV delegation CNAME, and the final traffic CNAME. Pass a domain as a second argument to limit output to a single hostname.
+
+### 2. Release your Zone Hold (if applicable)
+
+If your Cloudflare zone has a [Zone Hold](https://developers.cloudflare.com/fundamentals/account/account-security/zone-holds/) enabled, release it temporarily so Cloudflare can process the new custom hostname. You will re-enable it at the end.
+
+### 3. Set your SSL/TLS encryption mode to Full or Full (strict)
+
+In your Cloudflare zone, set **SSL/TLS** > **Overview** to **Full** or **Full (strict)**. Other modes (such as Flexible) cause infinite redirect loops between your Cloudflare zone and the GCDN.
+
+### 4. Add the hostname ownership TXT record
+
+Add the TXT record from the `gcdn:o2o` output to your Cloudflare DNS:
+
+```none
+_cf-custom-hostname.<hostname>  TXT  <ownership_value>
+```
+
+This verifies that you control the hostname.
+
+### 5. Delete any existing `_acme-challenge` TXT records
+
+If your Cloudflare DNS has existing `_acme-challenge` TXT records for the hostname, delete them. They conflict with the DCV delegation record added in the next step.
+
+### 6. Add the DCV delegation CNAME
+
+Add the CNAME from the `gcdn:o2o` output, set to **DNS only** (grey-clouded):
+
+```none
+_acme-challenge.<hostname>  CNAME  <hostname>.<zone_dcv_id>.dcv.cloudflare.com
+```
+
+This delegates certificate validation to the GCDN for both initial issuance and automatic renewal. **Leave this record in place permanently and keep it grey-clouded** — removing it or proxying it will break certificate renewal.
+
+### 7. Point traffic at the GCDN
+
+Only after hostname ownership is verified and the certificate is active, update your hostname's CNAME to the GCDN edge:
+
+```none
+<hostname>  CNAME  fe.<zone>.edge.pantheon.io
+```
+
+Traffic routes to Pantheon as soon as this record is in place. The record can be **Proxied** (orange-clouded, O2O) to keep your Cloudflare zone in front, or **DNS only** if you want traffic to reach the GCDN directly.
+
+### 8. Re-enable your Zone Hold (if applicable)
+
+Once traffic is flowing, re-enable the Zone Hold released in step 2 to re-secure your zone.
+
+<Alert title="Note" type="info">
+
+O2O requires CNAME records. Using A/AAAA records is not compatible with O2O and may result in site downtime or inaccessibility. We are actively testing this configuration during the Beta and welcome feedback in the `#beta-gcdn` channel in Pantheon Community Slack.
+
+</Alert>
+
 ## Known Limitations
 
 ### Traffic Metrics Unavailable
@@ -287,15 +364,11 @@ Content Converter (Markdown for Agents) is a feature enabled on all GCDN Beta zo
 
 Your bot or automated service may be receiving a managed challenge from bot protection. Check whether the service's user agent is being challenged by reviewing its error logs (look for 403 responses or HTML challenge pages). Contact Pantheon support to request a bot exclusion for your user agent.
 
-### I have another CDN or WAF in front of my site. Is that supported?
+### I have Cloudflare in front of my site. Is that supported?
 
-The new Pantheon GCDN supports Orange-to-Orange (O2O) configurations, allowing you to keep your existing CDN or WAF in front of Pantheon. Your site's DNS entries must use CNAME records pointing to the Pantheon GCDN zone entries (e.g., `fe1.cfp-us-central1-ch-1.edge.pantheon.io`).
-
-O2O requires CNAME records. Using A/AAAA records is not compatible with O2O and may result in site downtime or inaccessibility.
+Yes. The new Pantheon GCDN supports Orange-to-Orange (O2O) configurations, allowing you to keep your own Cloudflare zone in front of Pantheon. O2O setup requires the [GCDN Terminus plugin](https://github.com/pantheon-systems/terminus-gcdn-plugin) and a specific DNS record sequence in your Cloudflare zone — see [Using Cloudflare in Front of Pantheon (Orange-to-Orange)](#using-cloudflare-in-front-of-pantheon-orange-to-orange) for the full steps.
 
 For more information on how O2O works, refer to the [SaaS customer documentation](https://developers.cloudflare.com/cloudflare-for-platforms/cloudflare-for-saas/saas-customers/how-it-works/).
-
-We are actively testing this configuration during the Beta and welcome customer feedback in the `#beta-gcdn` channel in Pantheon Community Slack.
 
 ### I use a platform vanity domain. Can I migrate?
 

--- a/src/source/content/pantheon-yml.md
+++ b/src/source/content/pantheon-yml.md
@@ -2,7 +2,7 @@
 title: Pantheon YAML Configuration Files
 description: Learn how to manage advanced site configuration
 tags: [https, launch, code, workflow]
-reviewed: "2026-04-17"
+reviewed: "2026-07-06"
 contenttype: [doc]
 innav: [true]
 categories: [config]
@@ -132,6 +132,20 @@ build_step: true
 ```
 
 Refer to [Integrated Composer](/guides/integrated-composer) for more information.
+
+### Frontend Asset Builds
+
+Install Node.js dependencies and run frontend compiling script(s) as part of a build step on Pantheon:
+
+```yaml:title=pantheon.yml
+frontend_build:
+  enabled: true
+  paths:
+    - path: web/themes/custom/mytheme
+      node_version: 26
+      build_command: build
+```
+Refer to [Frontend Asset Builds](/frontend-builds) for more information.
 
 ### PHP Version
 

--- a/src/source/content/partials/build-tools-cta.md
+++ b/src/source/content/partials/build-tools-cta.md
@@ -1,0 +1,13 @@
+<Alert type="info" title="Still using Build Tools?">
+
+Pantheon [recently released the final update to the `build-tools-ci` Docker image](/release-notes/2026/06/build-tools-ci-deprecated). No further updates, bug fixes, or security patches will be provided for [Build Tools](/guides/build-tools). 
+
+Site(s) still using Build Tools today should move to our newer platform capabilities: 
+
+* [External Repositories](/guides/external-repositories)
+* [Push to Pantheon](/github-actions)
+* [Scheduled Cron Jobs](/customer-scheduled-cron-jobs)
+* [Integrated Composer](/guides/integrated-composer)
+* [Frontend Asset Builds](/frontend-builds)
+
+</Alert>

--- a/src/source/releasenotes/2026-07-08-free-30-day-trial.md
+++ b/src/source/releasenotes/2026-07-08-free-30-day-trial.md
@@ -1,0 +1,18 @@
+---
+title: "Introducing the Pantheon 30-day Trial"
+published_date: "2026-07-08"
+published_at: "2026-07-08T22:48:24Z"
+categories: [general]
+description: "Starting today, all new signups get a free 30-day trial of Pantheon. When the trial ends, site assets are stored and locked for 90 days, then unlocked as soon as the user upgrades."
+---
+Starting today, all new signups get a free 30-day trial of Pantheon. When the trial ends, site assets are stored and locked for 90 days, then unlocked as soon as the user upgrades. 
+
+Existing customers with active paid workspaces will not have changes to their current set up or experience. Existing sandbox users will receive an email in the coming months about moving to the new trial experience.
+
+## What's included in the trial? 
+* One professional workspace
+* Up to 2 sandbox sites, including Dev, Test, and Live environments
+* Additional tools like New Relic, Object Cache, and Pantheon Search
+
+For more details, see [this related documentation](/guides/account-mgmt/account). 
+

--- a/src/source/releasenotes/2026-07-09-frontend-asset-builds.md
+++ b/src/source/releasenotes/2026-07-09-frontend-asset-builds.md
@@ -1,0 +1,30 @@
+---
+title: Frontend asset builds are now supported via pantheon.yml
+published_date: "2026-07-09"
+published_at: "2026-07-09T14:57:15Z"
+categories: [new-feature, drupal, wordpress]
+description: "Sites can now compile frontend assets (themes, design systems, and other Node.js-based tooling) automatically as part of the build process."
+---
+
+Sites can now compile frontend assets (themes, design systems, and other Node.js-based tooling) automatically as part of the build process. 
+
+When enabled, Pantheon installs your Node.js dependencies and runs your build script for each configured path on every code push, so compiled assets no longer need to be committed to your repository. Frontend builds work on any site, whether or not you use Integrated Composer.
+
+## Enable frontend builds
+
+Add a `frontend_build` block to your [`pantheon.yml` file](/pantheon-yml#frontend-asset-builds):
+
+```yaml:title=pantheon.yml
+frontend_build:
+  enabled: true
+  paths:
+    - path: web/themes/custom/mytheme
+      node_version: 26
+      build_command: build
+```
+
+Pantheon selects a package manager automatically based on the lock file present in each build path. Supported package managers include `bun`, `pnpm`, `yarn`, and `npm`. 
+
+For full configuration details and examples, see the [frontend asset builds documentation](/frontend-builds).
+
+<Partial file="build-tools-cta.md" />


### PR DESCRIPTION
## Summary

Promotes Orange-to-Orange (O2O) from a single FAQ answer to a full setup section in the GCDN Beta guide.

- Adds a new **Using Cloudflare in Front of Pantheon (Orange-to-Orange)** section between Setup and Known Limitations with the complete 8-step record sequence: release Zone Hold, set encryption mode to Full/Full (strict), hostname ownership TXT, remove stale `_acme-challenge` TXT records, DCV delegation CNAME (grey-clouded, permanent), traffic CNAME to `fe.<zone>.edge.pantheon.io`, re-enable Zone Hold.
- Calls out that O2O setup requires the [GCDN Terminus plugin](https://github.com/pantheon-systems/terminus-gcdn-plugin) (`terminus gcdn:o2o`) — the dashboard flow does not support O2O.
- Emphasizes ordering: traffic must not be pointed at the GCDN until hostname ownership is verified and the certificate is active.
- Rewrites the O2O FAQ entry as a pointer to the new section; standardizes the example CNAME target on the `fe.` prefix (was `fe1.`).
- Bumps the `reviewed` date.