### PR TITLE
Addsearch widget results

### DIFF
--- a/src/components/common/addsearch.css
+++ b/src/components/common/addsearch.css
@@ -72,6 +72,12 @@
   font-weight: var(--pds-typography-font-weight-semibold);
   padding-inline: var(--pds-spacing-4xs);
 }
+.addsWg--highlight em {
+  background-color: #fff1a9;
+  font-weight: var(--pds-typography-font-weight-semibold) !important;
+  padding-inline: var(--pds-spacing-4xs);
+  font-style: normal;
+}
 
 /* Pagination */
 .search-results__pager {

--- a/src/components/header/search-bar.tsx
+++ b/src/components/header/search-bar.tsx
@@ -59,7 +59,7 @@ function SearchBarForm({}: {
                     "search_suggestion_position": "left",
                     "default_sortby": "relevance",
                     "display_date": false,
-                    "display_meta_description": true,
+                    "display_meta_description": false,
                     "display_result_image": false,
                     "link_target": "_blank",
                     "hide_logo": true,


### PR DESCRIPTION
* Disable descriptions for search widget, that way we see keywords highlighted
* Align styling to separate page results styling  

<img width="1914" height="996" alt="Screenshot 2026-07-09 at 7 18 39 PM" src="https://github.com/user-attachments/assets/74bb60b6-f8b2-486b-bcbc-b19cb380ebf4" />