### PR TITLE
docs: [SITE-5883][SITE-5884] Document + announce WordPress update-notice dismiss & hide controls

### DIFF
--- a/src/source/content/core-updates.md
+++ b/src/source/content/core-updates.md
@@ -342,7 +342,13 @@ Updates are available within 72 hours of upstream availability whenever a new Wo
 
 ## Suppress WordPress Admin Notice
 
-On Pantheon, WordPress core updates are applied through the Pantheon Dashboard, so the Pantheon mu-plugin replaces the default WordPress update nag with its own upstream update notice. You can hide or disable that notice in several ways.
+On Pantheon, WordPress core updates are applied through the Pantheon Dashboard, so the Pantheon mu-plugin replaces the default WordPress update nag with its own upstream update notice. You can dismiss, hide, or disable that notice in several ways.
+
+### Dismiss the notice
+
+Any user who sees the notice can dismiss it with the **X** in the top corner. The dismissal is saved per user, so it persists across page loads and logins. The notice reappears only when a newer WordPress version becomes available.
+
+The options below hide the notice more permanently, or for everyone.
 
 ### Hide the notice with CSS
 

--- a/src/source/content/core-updates.md
+++ b/src/source/content/core-updates.md
@@ -342,11 +342,47 @@ Updates are available within 72 hours of upstream availability whenever a new Wo
 
 ## Suppress WordPress Admin Notice
 
-WordPress admin checks for new upstream updates by default, instead of the default WordPress update nag. You can disable this by setting the `DISABLE_PANTHEON_UPDATE_NOTICES` constant to `true` in your `wp-config.php` file. This only disables the text and notice in the WordPress admin; you will still see upstream updates in the Pantheon dashboard.
+On Pantheon, WordPress core updates are applied through the Pantheon Dashboard, so the Pantheon mu-plugin replaces the default WordPress update nag with its own upstream update notice. You can hide or disable that notice in several ways.
+
+### Hide the notice with CSS
+
+The notice renders with `id="pantheon-update-notice"` and a `.pantheon-update-notice` class. Target either from a custom plugin or theme:
+
+```css
+#pantheon-update-notice { display: none; }
+```
+
+### Hide the notice with a filter
+
+Return `false` from the `pantheon_show_update_notice` filter:
+
+```php
+add_filter( 'pantheon_show_update_notice', '__return_false' );
+```
+
+### Hide the notice with a constant
+
+Define `PANTHEON_SHOW_UPDATE_NOTICE` as `false` in your `wp-config.php` file:
+
+```php:title=wp-config.php
+define( 'PANTHEON_SHOW_UPDATE_NOTICE', false );
+```
+
+### Disable Pantheon's update-notice handling
+
+Define `DISABLE_PANTHEON_UPDATE_NOTICES` as `true` in your `wp-config.php` file:
 
 ```php:title=wp-config.php
 define( 'DISABLE_PANTHEON_UPDATE_NOTICES', true );
 ```
+
+<Alert title="Note" type="info">
+
+The CSS, filter, and `PANTHEON_SHOW_UPDATE_NOTICE` options only hide Pantheon's notice while Pantheon continues to manage updates. Updates still appear in the Pantheon Dashboard.
+
+`DISABLE_PANTHEON_UPDATE_NOTICES` is different: it stops Pantheon's update-notice handling from loading at all. Pantheon no longer replaces the WordPress core update notification, so WordPress's own default update nag can appear instead. Use it only if you want Pantheon to step out of update-notice handling, not just hide the notice.
+
+</Alert>
 
 ## Troubleshooting
 

--- a/src/source/releasenotes/2026-07-15-wordpress-update-notice-controls.md
+++ b/src/source/releasenotes/2026-07-15-wordpress-update-notice-controls.md
@@ -1,0 +1,23 @@
+---
+title: Hide or dismiss the WordPress core update notice
+published_date: "2026-07-15"
+published_at: "2026-07-15T12:00:00Z"
+categories: [new-feature, wordpress]
+description: "The Pantheon WordPress core update notice can now be dismissed per user, or hidden site-wide with CSS, a filter, or a constant."
+---
+
+The Pantheon [WordPress core update notice](/core-updates#suppress-wordpress-admin-notice) ("A new WordPress update is available!") can now be dismissed or hidden.
+
+## Dismiss the notice
+
+Any user who sees the notice can dismiss it with the **X** in the corner. The dismissal is saved per user, so it persists across page loads and logins. The notice reappears only when a newer WordPress version becomes available.
+
+## Hide the notice
+
+To hide the notice more permanently, or for everyone, you can:
+
+- Target `#pantheon-update-notice` (or the `.pantheon-update-notice` class) with CSS.
+- Return `false` from the `pantheon_show_update_notice` filter.
+- Define the `PANTHEON_SHOW_UPDATE_NOTICE` constant as `false` in `wp-config.php`.
+
+For details, see [Suppress WordPress Admin Notice](/core-updates#suppress-wordpress-admin-notice).

--- a/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
+++ b/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
@@ -1,7 +1,7 @@
 ---
 title: Hide or dismiss the WordPress core update notice
-published_date: "2026-07-15"
-published_at: "2026-07-15T12:00:00Z"
+published_date: "2026-08-18"
+published_at: "2026-08-18T12:00:00Z"
 categories: [new-feature, wordpress]
 description: "The Pantheon WordPress core update notice can now be dismissed per user, or hidden site-wide with CSS, a filter, or a constant."
 ---


### PR DESCRIPTION
## Summary

- Document how to control the Pantheon WordPress core update notice in [Suppress WordPress Admin Notice](/core-updates#suppress-wordpress-admin-notice): **dismiss** it (per-user, persists until a newer version — SITE-5883), and **hide** it via CSS (`#pantheon-update-notice`), the `pantheon_show_update_notice` filter, or the `PANTHEON_SHOW_UPDATE_NOTICE` constant (SITE-5884).
- Correct the existing `DISABLE_PANTHEON_UPDATE_NOTICES` description. The old text said it "only disables the text and notice in the WordPress admin." That is inaccurate: the constant stops the plugin's update-notice handling from loading entirely, so WordPress's own default update nag can appear instead. Add a note distinguishing the cosmetic hide options from this subsystem-level opt-out.
- **Add a release note** announcing the dismiss + hide controls (`src/source/releasenotes/2026-07-15-wordpress-update-notice-controls.md`).

## Changes

| File | Change |
|---|---|
| `src/source/content/core-updates.md` | Rewrote the "Suppress WordPress Admin Notice" section: dismiss + CSS/filter/constant hide options + corrected `DISABLE_` behavior in an Alert |
| `src/source/releasenotes/2026-07-15-wordpress-update-notice-controls.md` | New release note (categories: `new-feature`, `wordpress`) |

## Context

Companion to the plugin work: pantheon-systems/pantheon-mu-plugin#119 (SITE-5884: CSS hook + `pantheon_show_update_notice` filter + `PANTHEON_SHOW_UPDATE_NOTICE` constant) and pantheon-systems/pantheon-mu-plugin#121 (SITE-5883: dismissible notice), both merged.

The corrected `DISABLE_` behavior was verified against the mu-plugin source and WordPress core:
- The constant gates whether `inc/pantheon-updates.php` loads (`pantheon.php`). That file is the only place that removes WordPress's native `update_nag` and forces `WP_AUTO_UPDATE_CORE = false`.
- WordPress core registers `update_nag` on `admin_notices` (priority 3) by default and renders it whenever a core update is available.
- The plugin never suppresses core-update detection, so with the file unloaded the native nag is no longer removed and can render.

## Blocked on release

<Alert title="Do not merge yet" type="warning">

These features are unreleased. They ship in `pantheon-mu-plugin` 1.5.7 (release cut by pantheon-systems/pantheon-mu-plugin#123) and reach sites when that version is bundled into the WordPress upstream. Hold this PR until then, and set the release note's `published_date` / `published_at` to the actual ship date before merging.

</Alert>

## Test plan

- [ ] Preview renders the "Suppress WordPress Admin Notice" section (dismiss + three hide options + the Alert).
- [ ] Preview renders the new release note.
- [ ] Set the release note date to the real ship date.
- [ ] Merge only after `pantheon-mu-plugin` 1.5.7 ships to the WordPress upstream.

## References

- Jira: [SITE-5883](https://getpantheon.atlassian.net/browse/SITE-5883), [SITE-5884](https://getpantheon.atlassian.net/browse/SITE-5884)
- Plugin PRs: pantheon-systems/pantheon-mu-plugin#121 (dismiss), pantheon-systems/pantheon-mu-plugin#119 (hide options)
- Release PR: pantheon-systems/pantheon-mu-plugin#123 (1.5.7)


[SITE-5883]: https://getpantheon.atlassian.net/browse/SITE-5883?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ