### PR TITLE
Remove stale Beta references from next-gen GCDN docs

### DIFF
--- a/src/source/content/guides/global-cdn/06-next-gen-global-cdn.md
+++ b/src/source/content/guides/global-cdn/06-next-gen-global-cdn.md
@@ -119,7 +119,7 @@ After you click upgrade, your platform hostnames (`*.pantheonsite.io`) are autom
 
 After activating the next-generation GCDN through the dashboard, you will need to update your DNS records to point to the new infrastructure.
 
-1. The dashboard will provide TXT records for domain verification. Add these TXT records to your DNS provider. **TXT record validation is the only supported method for issuing SSL/TLS certificates during the Beta.** HTTP validation and other methods are not available.
+1. The dashboard will provide TXT records for domain verification. Add these TXT records to your DNS provider. **TXT record validation is the only supported method for issuing SSL/TLS certificates.** HTTP validation and other methods are not available.
 
 1. Once domain verification completes and your SSL/TLS certificate has been issued, the dashboard will display the recommended DNS settings (CNAME targets).
 
@@ -164,7 +164,7 @@ Before proceeding with Terminus commands, you must first install the GCDN Termin
 
 <Alert title="Note" type="info">
 
-During the Beta, DNS-01 TXT record validation is the only supported method for domain verification. You will need to add TXT records to your DNS provider to verify domain ownership.
+DNS-01 TXT record validation is the only supported method for domain verification. You will need to add TXT records to your DNS provider to verify domain ownership.
 
 </Alert>
 

--- a/src/source/content/guides/global-cdn/07-global-cdn-faq.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-faq.md
@@ -157,7 +157,7 @@ Yes. Sites using [customer-provided TLS certificates](/custom-certificates) are 
 
 ### I use AGCDN. What should I do?
 
-No action is required. AGCDN has its own migration initiative and timeline. Your current AGCDN configuration continues to work. AGCDN customers are excluded from the Beta.
+No action is required. AGCDN has its own migration initiative and timeline. Your current AGCDN configuration continues to work. AGCDN customers are excluded from the current migration phase.
 
 ### What is the timeline for AGCDN to be supported?
 
@@ -181,7 +181,7 @@ Yes. The Drupal module and WordPress plugin for Pantheon Advanced Page Cache wor
 
 ### What is Content Converter?
 
-Content Converter (Markdown for Agents) is a feature enabled on all GCDN Beta zones. When a request includes the `Accept: text/markdown` header, the CDN converts HTML responses to Markdown in real time. This makes your site's content easier for LLMs and AI agents to consume. Standard browser traffic is not affected.
+Content Converter (Markdown for Agents) is a feature enabled on all next-generation GCDN zones. When a request includes the `Accept: text/markdown` header, the CDN converts HTML responses to Markdown in real time. This makes your site's content easier for LLMs and AI agents to consume. Standard browser traffic is not affected.
 
 ### My automated integration stopped working after migration. What do I do?
 


### PR DESCRIPTION
Next-generation GCDN is now GA (#10159, #10154), but four "Beta" references survived the GA docs update:

- **next-gen-global-cdn.md**: "during the Beta" qualifiers on the TXT-record certificate validation notes (dashboard and Terminus tabs). TXT validation is still the only supported method, so the constraint stays — only the Beta framing is removed.
- **global-cdn-faq.md**: "AGCDN customers are excluded from the Beta" → "excluded from the current migration phase"; "enabled on all GCDN Beta zones" → "enabled on all next-generation GCDN zones" (Content Converter).

The `gcdn-beta-banner.png` image filename still contains "beta" but is not visible text on the rendered pages.