### PR TITLE
WordPress 7.0.2 release note

### DIFF
--- a/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
+++ b/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
@@ -17,6 +17,8 @@ This update resolves two security vulnerabilities that were reported via WordPre
 * A facilitated SQL injection issue
 * A REST API batch-route confusion and SQL injection issue leading to Remote Code Execution
 
-For more information on this release, please visit the [HelpHub site](https://wordpress.org/documentation/wordpress-version/version-7-0-2/).
+WordPress 6.9 is affected by both vulnerabilities. Version 6.9.6 has been released with fixes for both and is also available from our [WordPress upstream](https://github.com/pantheon-systems/WordPress/releases/tag/6.9.5).
 
-For full details about WordPress 7.0.2, see the [release notes](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/).
+WordPress 6.8 is only affected by the first vulnerability. Version 6.8.6 has been released with the fix and is available from our [WordPress upstream](https://github.com/pantheon-systems/WordPress/releases/tag/6.8.6).
+
+For more information on this release, please visit the [HelpHub site](https://wordpress.org/documentation/wordpress-version/version-7-0-2/).

--- a/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
+++ b/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
@@ -1,0 +1,22 @@
+---
+title: WordPress 7.0.2 Security Release now available
+published_date: "2026-07-17"
+published_at: "2026-07-17T20:46:12Z"
+categories: [wordpress, action-required]
+---
+
+The latest security release for WordPress, [7.0.2](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/), is available on Pantheon as of July 17, 2026.
+
+### Action required
+Because this is a security update, we recommend upgrade to WordPress 7.0.2 as soon as possible from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+This update resolves two security vulnerabilities that were reported via WordPress core's [HackerOne reporting portal](https://hackerone.com/wordpress). Fixes in this release include:
+
+* A facilitated SQL injection issue
+* A REST API batch-route confusion and SQL injection issue leading to Remote Code Execution
+
+For more information on this release, please visit the [HelpHub site](https://wordpress.org/documentation/wordpress-version/version-7-0-2/).
+
+For full details about WordPress 7.0.2, see the [release notes](https://wordpress.org/news/2026/07/wordpress-7-0-2-release/).


### PR DESCRIPTION
Adds release note for WordPress 7.0.2 security update, already available in the dashboard.