### PR TITLE
Fix WP 6.9 patch version in 7.0.2 release note

### DIFF
--- a/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
+++ b/src/source/releasenotes/2026-07-17-wordpress-7-0-2.md
@@ -17,7 +17,7 @@ This update resolves two security vulnerabilities that were reported via WordPre
 * A facilitated SQL injection issue
 * A REST API batch-route confusion and SQL injection issue leading to Remote Code Execution
 
-WordPress 6.9 is affected by both vulnerabilities. Version 6.9.6 has been released with fixes for both and is also available from our [WordPress upstream](https://github.com/pantheon-systems/WordPress/releases/tag/6.9.5).
+WordPress 6.9 is affected by both vulnerabilities. Version 6.9.5 has been released with fixes for both and is also available from our [WordPress upstream](https://github.com/pantheon-systems/WordPress/releases/tag/6.9.5).
 
 WordPress 6.8 is only affected by the first vulnerability. Version 6.8.6 has been released with the fix and is available from our [WordPress upstream](https://github.com/pantheon-systems/WordPress/releases/tag/6.8.6).
 


### PR DESCRIPTION
The WordPress 7.0.2 release note listed `6.9.6` as the patched version for WordPress 6.9. The correct version is `6.9.5`, which also matches the linked upstream release tag.

Corrected line 20 of `src/source/releasenotes/2026-07-17-wordpress-7-0-2.md`.