### PR TITLE
chore(DELENG-720): replace docs-admins with devrel as docs owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,44 +1,44 @@
-# These owners will be the default owners for everything in the repo. Unless a later match takes precedence, @pantheon-systems/docs-admins, as primary maintainers will be requested for review when someone opens a Pull Request.
+# These owners will be the default owners for everything in the repo. Unless a later match takes precedence, @pantheon-systems/devrel, as primary maintainers will be requested for review when someone opens a Pull Request.
 # Additional code owners can be added for specific paths.
 # For more information about CODEOWNERS files, refer to https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
-* @pantheon-systems/docs-admins
+* @pantheon-systems/devrel
 
 # The Platform-Edge-Routing team is responsible for connecting custom domains to Pantheon
-src/source/content/guides/domains/ @pantheon-systems/platform-edge-routing @pantheon-systems/docs-admins
+src/source/content/guides/domains/ @pantheon-systems/platform-edge-routing @pantheon-systems/devrel
 # The Platform-Edge-Routing team is responsible for traffic limits
-src/source/content/guides/account-mgmt/traffic/ @pantheon-systems/platform-edge-routing @pantheon-systems/docs-admins
+src/source/content/guides/account-mgmt/traffic/ @pantheon-systems/platform-edge-routing @pantheon-systems/devrel
 # The Platform-Edge-Routing team is responsible for bots and indexing
-src/source/content/bots-and-indexing @pantheon-systems/platform-edge-routing @pantheon-systems/docs-admins
+src/source/content/bots-and-indexing @pantheon-systems/platform-edge-routing @pantheon-systems/devrel
 # The FileSystem team is responsible for managing static files on Pantheon
-src/source/content/guides/filesystem/ @pantheon-systems/filesystem @pantheon-systems/docs-admins
+src/source/content/guides/filesystem/ @pantheon-systems/filesystem @pantheon-systems/devrel
 # The developer-experience team is responsible for Integrated Composer
-src/source/content/guides/integrated-composer/ @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/guides/integrated-composer/ @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for Terminus
-src/source/content/terminus/ @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/terminus/ @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for Secrets
-src/source/content/guides/secrets/ @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/guides/secrets/ @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for the eVCS
-src/source/content/guides/external-vcs/ @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/guides/external-vcs/ @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for Next.js
-src/source/content/nextjs/ @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/nextjs/ @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for Next.js
-src/source/content/nextjs @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/nextjs @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The developer-experience team is responsible for GitHub Application
-src/source/content/guides/github-application @pantheon-systems/developer-experience @pantheon-systems/docs-admins
+src/source/content/guides/github-application @pantheon-systems/developer-experience @pantheon-systems/devrel
 # The cms-platform team is responsible for WordPress Multisite
-src/source/content/guides/multisite/ @pantheon-systems/site-experience @pantheon-systems/docs-admins
+src/source/content/guides/multisite/ @pantheon-systems/site-experience @pantheon-systems/devrel
 # The cms-platform team is responsible for External Libraries on Pantheon
-src/source/content/external-libraries @pantheon-systems/site-experience @pantheon-systems/docs-admins
+src/source/content/external-libraries @pantheon-systems/site-experience @pantheon-systems/devrel
 # The site-experience team is responsible for Elasticsearch docs
-src/source/content/guides/elasticsearch/ @pantheon-systems/site-experience @pantheon-systems/docs-admins
+src/source/content/guides/elasticsearch/ @pantheon-systems/site-experience @pantheon-systems/devrel
 # The site-experience team is responsible for Solr docs
-src/source/content/guides/solr-drupal/ @pantheon-systems/site-experience @pantheon-systems/docs-admins
-src/source/content/solr.md @pantheon-systems/site-experience @pantheon-systems/docs-admins
-src/source/content/opensolr.md @pantheon-systems/site-experience @pantheon-systems/docs-admins
+src/source/content/guides/solr-drupal/ @pantheon-systems/site-experience @pantheon-systems/devrel
+src/source/content/solr.md @pantheon-systems/site-experience @pantheon-systems/devrel
+src/source/content/opensolr.md @pantheon-systems/site-experience @pantheon-systems/devrel
 # The site-experience team is responsible for WordPress developer docs
-src/source/content/guides/wordpress-developer/ @pantheon-systems/site-experience @pantheon-systems/docs-admins
+src/source/content/guides/wordpress-developer/ @pantheon-systems/site-experience @pantheon-systems/devrel
 # There is a team just for release note permissions
-src/source/releasenotes/ @pantheon-systems/release-note-authors @pantheon-systems/docs-admins
+src/source/releasenotes/ @pantheon-systems/release-note-authors @pantheon-systems/devrel
 # Edge Routing handles GCDN and AGCDN
-src/source/content/guides/global-cdn/ @pantheon-systems/platform-edge-routing @pantheon-systems/docs-admins
-src/source/content/guides/agcdn/ @pantheon-systems/platform-edge-routing @pantheon-systems/docs-admins
+src/source/content/guides/global-cdn/ @pantheon-systems/platform-edge-routing @pantheon-systems/devrel
+src/source/content/guides/agcdn/ @pantheon-systems/platform-edge-routing @pantheon-systems/devrel

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,4 +9,4 @@ metadata:
 spec:
   type: service
   lifecycle: mature
-  owner: docs-admins
+  owner: devrel


### PR DESCRIPTION
## Summary
Replaces all `docs-admins` references with `devrel` to reflect devrel as the owner of Pantheon Docs.

## Changes
- **CODEOWNERS**: `@pantheon-systems/docs-admins` → `@pantheon-systems/devrel` on all 22 rule lines + the header comment
- **catalog-info.yaml**: `owner: docs-admins` → `owner: devrel`

devrel gains the required write access via `pan-owner: devrel` in the paired github-terraform PR.

## Related
Paired with the `github-terraform` PR (pan-owner + branch protection).

## Ticket
DELENG-720

🤖 Generated with [Claude Code](https://claude.com/claude-code)