### PR TITLE
docs(release-notes): [SITE-5208] Pantheon plugins and modules are PHP 8.5 compatible

### DIFF
--- a/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
@@ -1,0 +1,33 @@
+---
+title: "Pantheon-maintained plugins and modules are now compatible with PHP 8.5"
+published_date: "2026-07-23"
+published_at: "2026-07-23T12:00:00Z"
+categories: [drupal, wordpress]
+description: "All Pantheon-maintained Drupal modules and WordPress plugins now support PHP 8.5, available on the platform."
+---
+
+All Pantheon-maintained Drupal modules and WordPress plugins have been updated to support [PHP 8.5](/guides/php), which is available on the Pantheon platform.
+
+## Drupal modules
+
+The following Drupal modules have been updated for PHP 8.5 compatibility:
+
+- [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache) 2.4.0
+- [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets) 1.1.0
+- [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon) 8.5.0
+- [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher) 1.0.5
+- [Pantheon Domain Masking](https://www.drupal.org/project/pantheon_domain_masking) 2.2.0
+
+## WordPress plugins
+
+The following WordPress plugins have been updated for PHP 8.5 compatibility:
+
+- [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) 2.1.2
+- [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7
+- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
+- [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
+- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.2
+- [Pantheon Content Publisher](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress) 1.3.5
+- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) 1.5.7
+
+To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).

--- a/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
@@ -27,7 +27,7 @@ The following WordPress plugins have been updated for PHP 8.5 compatibility:
 - [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
 - [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
 - [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.2
-- [Pantheon Content Publisher](https://github.com/pantheon-systems/pantheon-content-publisher-wordpress) 1.3.5
+- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.5
 - [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) 1.5.7
 
 To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).

--- a/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-07-23-php85-plugin-module-compatibility.md
@@ -16,7 +16,7 @@ The following Drupal modules have been updated for PHP 8.5 compatibility:
 - [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets) 1.1.0
 - [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon) 8.5.0
 - [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher) 1.0.5
-- [Pantheon Domain Masking](https://www.drupal.org/project/pantheon_domain_masking) 2.2.0
+- [Pantheon Domain Masking](https://github.com/pantheon-systems/pantheon-domain-masking) 2.2.0
 
 ## WordPress plugins
 

--- a/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: "Pantheon-maintained plugins and modules are now compatible with PHP 8.5"
-published_date: "2026-07-23"
-published_at: "2026-07-23T12:00:00Z"
+published_date: "2026-08-14"
+published_at: "2026-08-14T12:00:00Z"
 categories: [drupal, wordpress]
 description: "All Pantheon-maintained Drupal modules and WordPress plugins now support PHP 8.5, available on the platform."
 ---
@@ -26,8 +26,8 @@ The following WordPress plugins have been updated for PHP 8.5 compatibility:
 - [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7
 - [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
 - [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
-- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.2
-- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.5
+- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.4
+- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.6
 - [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) 1.5.7
 
 To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).


### PR DESCRIPTION
## Summary

- Adds release note announcing PHP 8.5 compatibility across all 12 Pantheon-maintained Drupal modules and WordPress plugins (epic SITE-5195).
- Lists all modules/plugins with version numbers and links to drupal.org, wordpress.org, or GitHub as appropriate.
- Links to `/guides/php/php-versions` for customers to switch PHP versions.

## Context

[SITE-5208](https://getpantheon.atlassian.net/browse/SITE-5208)

PHP 8.5 is available on the Pantheon platform. Epic SITE-5195 tracked compatibility work across all Pantheon-maintained plugins and modules. All 12 compat stories are Closed. This release note is the customer-facing announcement.

**Note before merging:** Verify the file name (`2026-07-23-...`) and `published_date` in frontmatter both match the actual merge date. Update both if the PR sits before merge.

## Test plan

- [ ] File name date matches merge day
- [ ] `published_date` in frontmatter matches merge day
- [ ] All 12 plugins/modules listed with correct versions
- [ ] Links to drupal.org/wp.org/GitHub resolve
- [ ] `/guides/php/php-versions` link resolves
- [ ] Docs CI passes

## References

- Jira: [SITE-5208](https://getpantheon.atlassian.net/browse/SITE-5208)
- Epic: [SITE-5195](https://getpantheon.atlassian.net/browse/SITE-5195)

[SITE-5208]: https://getpantheon.atlassian.net/browse/SITE-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5208]: https://getpantheon.atlassian.net/browse/SITE-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ