### PR TITLE
Update filesystem docs for GCS Fuse migration (Generations, rollout, path limits)

### DIFF
--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -31,7 +31,7 @@ Pantheon is migrating sites from Valhalla (Generation 1) to Google Cloud Storage
 
 The Pantheon architecture relies on highly available [application containers](/application-containers) that are seamlessly integrated with a cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 
-Pantheon refers to filesystem versions as **Generations**. Valhalla, Pantheon's original Cassandra-backed filesystem, is Generation 1. Google Cloud Storage Fuse, Pantheon's current filesystem, is Generation 2. Both may be in use across the platform during the migration period described above; the customer-facing experience is the same on either generation.
+Pantheon refers to filesystem versions as **Generations**. Valhalla, Pantheon's original filesystem, is Generation 1. Google Cloud Storage FUSE, Pantheon's current filesystem, is Generation 2. Both may be in use across the platform during the migration period described above; the customer-facing experience is the same on either generation.
 
 Your Generation 1 (Valhalla) or Generation 2 (gcsfuse) filesystem creates a symbolic link (**symlink**) to the `files` directory in the appropriate location of your docroot:
 

--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -23,7 +23,7 @@ Files are static content not stored in your database, and usually consist of ima
 
 <Alert title="Filesystem Migration in Progress" type="info">
 
-Pantheon is migrating sites from Valhalla (Generation 1) to Google Cloud Storage Fuse, or GCS Fuse (Generation 2). New sites created on or after August 3, 2026 use GCS Fuse by default. Existing sites are migrated in batches starting September 1, 2026, with completion targeted by the end of 2026. Migrations are managed by Pantheon and require no action for most sites. See [known limitations](/guides/filesystem/large-files#file-path-length) for details on the small number of sites that may be affected.
+Pantheon is migrating sites from Valhalla (Generation 1) to Google Cloud Storage FUSE, or gcsfuse, (Generation 2). New sites created on or after August 3, 2026 use gcsfuse by default. Existing sites are migrated in batches starting September 1, 2026, with completion targeted by the end of 2026. Migrations are managed by Pantheon and require no action for most sites. See [known limitations](/guides/filesystem/large-files#file-path-length) for details on the small number of sites that may be affected.
 
 </Alert>
 

--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -50,7 +50,7 @@ You can connect directly to the filesystem with an SFTP client, such as [WinSCP]
 
 ## Pantheon-Related Files
 
-On Generation 1 (Valhalla) sites, Pantheon places the files below in your application container because they contain important information:
+Pantheon places the files below in your application container because they contain important information:
 
 **fusedav_version**: shows the version of fusedav being used.
 

--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -21,7 +21,7 @@ Files are static content not stored in your database, and usually consist of ima
 - [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore)
 - [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/.gitignore)
 
-<Alert title="Filesystem migration in progress" type="info">
+<Alert title="Filesystem Migration in Progress" type="info">
 
 Pantheon is migrating sites from Valhalla (Generation 1) to Google Cloud Storage Fuse, or GCS Fuse (Generation 2). New sites created on or after August 3, 2026 use GCS Fuse by default. Existing sites are migrated in batches starting September 1, 2026, with completion targeted by the end of 2026. Migrations are managed by Pantheon and require no action for most sites. See [known limitations](/guides/filesystem/large-files#file-path-length) for details on the small number of sites that may be affected.
 

--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -33,7 +33,7 @@ The Pantheon architecture relies on highly available [application containers](/a
 
 Pantheon refers to filesystem versions as **Generations**. Valhalla, Pantheon's original Cassandra-backed filesystem, is Generation 1. Google Cloud Storage Fuse, Pantheon's current filesystem, is Generation 2. Both may be in use across the platform during the migration period described above; the customer-facing experience is the same on either generation.
 
-Your Generation 1 (Valhalla) or Generation 2 (GCS Fuse) filesystem creates a symbolic link (**symlink**) to the `files` directory in the appropriate location of your docroot:
+Your Generation 1 (Valhalla) or Generation 2 (gcsfuse) filesystem creates a symbolic link (**symlink**) to the `files` directory in the appropriate location of your docroot:
 
 - **WordPress:** `wp-content/uploads`
 - **Drupal:** `sites/default/files`

--- a/src/source/content/guides/filesystem/01-introduction.md
+++ b/src/source/content/guides/filesystem/01-introduction.md
@@ -21,11 +21,19 @@ Files are static content not stored in your database, and usually consist of ima
 - [Drupal 7](https://github.com/pantheon-systems/drops-7/blob/master/.gitignore)
 - [WordPress](https://github.com/pantheon-systems/WordPress/blob/default/.gitignore)
 
+<Alert title="Filesystem migration in progress" type="info">
+
+Pantheon is migrating sites from Valhalla (Generation 1) to Google Cloud Storage Fuse, or GCS Fuse (Generation 2). New sites created on or after August 3, 2026 use GCS Fuse by default. Existing sites are migrated in batches starting September 1, 2026, with completion targeted by the end of 2026. Migrations are managed by Pantheon and require no action for most sites. See [known limitations](/guides/filesystem/large-files#file-path-length) for details on the small number of sites that may be affected.
+
+</Alert>
+
 ## Files and Application Containers
 
-The Pantheon architecture relies on highly available [application containers](/application-containers) that are seamlessly integrated with Valhalla, our cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
+The Pantheon architecture relies on highly available [application containers](/application-containers) that are seamlessly integrated with a cloud-based filesystem. This means that your files are not local to the application containers running your site's codebase.
 
-Valhalla creates a symbolic link (**symlink**) to the `files` directory in the appropriate location of your docroot:
+Pantheon refers to filesystem versions as **Generations**. Valhalla, Pantheon's original Cassandra-backed filesystem, is Generation 1. Google Cloud Storage Fuse, Pantheon's current filesystem, is Generation 2. Both may be in use across the platform during the migration period described above; the customer-facing experience is the same on either generation.
+
+Your Generation 1 (Valhalla) or Generation 2 (GCS Fuse) filesystem creates a symbolic link (**symlink**) to the `files` directory in the appropriate location of your docroot:
 
 - **WordPress:** `wp-content/uploads`
 - **Drupal:** `sites/default/files`
@@ -42,7 +50,7 @@ You can connect directly to the filesystem with an SFTP client, such as [WinSCP]
 
 ## Pantheon-Related Files
 
-Pantheon places the files below in your application container because they contain important information:
+On Generation 1 (Valhalla) sites, Pantheon places the files below in your application container because they contain important information:
 
 **fusedav_version**: shows the version of fusedav being used.
 

--- a/src/source/content/guides/filesystem/03-large-files.md
+++ b/src/source/content/guides/filesystem/03-large-files.md
@@ -55,10 +55,6 @@ Google Cloud Storage FUSE (Generation 2 filesystem) enforces a hard limit of 1,0
 
 Disk-based caching plugins — such as W3 Total Cache, WP Rocket, and Drupal's AdvAgg module — can generate file paths that approach or exceed this limit, depending on configuration. If your site is affected, Pantheon will identify it in advance and reach out with specific guidance before migration.
 
-<Alert title="Info" type="info">
-
-To avoid regenerating long file paths after migrating to Generation 2, configure caching plugins to use a Redis backend instead of disk-based caching. Redis is available on all plan tiers.
-
 </Alert>
 
 ## Large Code Repository

--- a/src/source/content/guides/filesystem/03-large-files.md
+++ b/src/source/content/guides/filesystem/03-large-files.md
@@ -55,7 +55,6 @@ Google Cloud Storage FUSE (Generation 2 filesystem) enforces a hard limit of 1,0
 
 Disk-based caching plugins — such as W3 Total Cache, WP Rocket, and Drupal's AdvAgg module — can generate file paths that approach or exceed this limit, depending on configuration. If your site is affected, Pantheon will identify it in advance and reach out with specific guidance before migration.
 
-</Alert>
 
 ## Large Code Repository
 

--- a/src/source/content/guides/filesystem/03-large-files.md
+++ b/src/source/content/guides/filesystem/03-large-files.md
@@ -49,6 +49,18 @@ To optimize performance:
 
 Useful tools for offloading are detailed below under CDNs.
 
+## File Path Length
+
+Google Cloud Storage Fuse (Generation 2 filesystem) enforces a hard limit of 1,024 bytes per file path. Most sites are unaffected by this limit.
+
+Disk-based caching plugins — such as W3 Total Cache, WP Rocket, and Drupal's AdvAgg module — can generate file paths that approach or exceed this limit, depending on configuration. If your site is affected, Pantheon will identify it in advance and reach out with specific guidance before migration.
+
+<Alert title="Info" type="info">
+
+To avoid regenerating long file paths after migrating to Generation 2, configure caching plugins to use a Redis backend instead of disk-based caching. Redis is available on all plan tiers.
+
+</Alert>
+
 ## Large Code Repository
 
 A code repository larger than 2GB increases the possibility of Git errors when committing code on Pantheon. Review the options below to improve performance:

--- a/src/source/content/guides/filesystem/03-large-files.md
+++ b/src/source/content/guides/filesystem/03-large-files.md
@@ -51,7 +51,7 @@ Useful tools for offloading are detailed below under CDNs.
 
 ## File Path Length
 
-Google Cloud Storage Fuse (Generation 2 filesystem) enforces a hard limit of 1,024 bytes per file path. Most sites are unaffected by this limit.
+Google Cloud Storage FUSE (Generation 2 filesystem) enforces a hard limit of 1,024 bytes per file path. Most sites are unaffected by this limit.
 
 Disk-based caching plugins — such as W3 Total Cache, WP Rocket, and Drupal's AdvAgg module — can generate file paths that approach or exceed this limit, depending on configuration. If your site is affected, Pantheon will identify it in advance and reach out with specific guidance before migration.
 


### PR DESCRIPTION
## Summary
Updates the filesystem guide to reflect the Valhalla → GCS Fuse migration:

- Adds an info-level alert to `01-introduction.md` noting the migration is in progress, with rollout dates
- Introduces "Generation 1" (Valhalla) / "Generation 2" (GCS Fuse) terminology, per the naming convention agreed in the 7/23 Cloud-Native Runtimes sync
- Clarifies that `fusedav_version`/`fusedav.conf` apply to Generation 1 sites only
- Adds a new "File Path Length" section to `03-large-files.md` documenting the 1,024-byte GCS Fuse path limit as a known limitation, and recommending Redis over disk-based caching to avoid it

## Related
- Program plan / internal + external FAQ: [Cloud-Native Customer Runtimes - Program Plan](https://docs.google.com/document/d/165tuJcyMcnT0E6I1fTqF28WmKNDqrL7tiYWkRciD-Zk/edit)
- Questions: #ask-cloud-native-runtimes

## Notes for reviewers
- Scope is intentionally minimal — this does not cover the full rollout-timeline page, the 18-site long-filename remediation plan, or the dashboard generation indicator, which are tracked separately.
- Known limitation language avoids naming the specific affected sites, per the decision to handle that via targeted customer outreach rather than general docs.