### PR TITLE
docs: custom upstream credentials are now editable in the dashboard

### DIFF
--- a/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
@@ -12,12 +12,12 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [custom-upstreams]
 integration: [--]
-reviewed: "2026-08-03"
+reviewed: "2026-08-05"
 ---
 
 This section provides information on editing an existing Custom Upstream.
 
-## Change Custom Upstream Name or Description
+## Update Name or Description
 
 Follow the steps below if you want to change the name or description of your Custom Upstream.
 
@@ -29,9 +29,7 @@ Follow the steps below if you want to change the name or description of your Cus
 
 1. Make desired changes > click **Update**.
 
-## Change Custom Upstream Repository URL or Password
-
-### Repository Credentials
+## Update Repository Credentials
 
 You can update the access token used to authenticate to your private repository — a GitHub personal access token or a Bitbucket repository access token — directly from the Dashboard:
 
@@ -43,13 +41,17 @@ You can update the access token used to authenticate to your private repository 
 
 1. In the **Repository credentials** section, click **Update credentials** (or **Add credentials** if none are set yet), enter the new credentials, then click **Save**.
 
-### Repository URL
+## Update Repository URL
 
 You cannot modify the repository URL on an existing Custom Upstream. We recommend creating a new Custom Upstream if there is a new URL you need to use.
 
-<Alert title="Important" type="info">
+<Alert title="Warning" type="warning">
 
-To switch existing sites to the new Custom Upstream, it must **share Git history** with the one they currently use (for example, forked from or based on the original repository). A site cannot switch to an upstream with an unrelated commit history. Review [Switch Your Custom Upstream](/guides/custom-upstream/switch-custom-upstream) before switching.
+To switch existing sites to the new Custom Upstream, it must **share Git history** with the one they currently use (for example, forked from or based on the original repository). 
+
+A site cannot switch to an upstream with an unrelated commit history. 
+
+Review [Switch Your Custom Upstream](/guides/custom-upstream/switch-custom-upstream) before switching.
 
 </Alert>
 

--- a/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [custom-upstreams]
 integration: [--]
-reviewed: "2022-12-13"
+reviewed: "2026-08-03"
 ---
 
 This section provides information on editing an existing Custom Upstream.
@@ -31,7 +31,21 @@ Follow the steps below if you want to change the name or description of your Cus
 
 ## Change Custom Upstream Repository URL or Password
 
-You cannot modify the repository details on an existing Custom Upstream. we recommend creating a new Custom Upstream if there is a new URL or password you need to use. You will need to switch each site to the new upstream individually with [Terminus](/terminus):
+### Repository Credentials
+
+You can update the credentials (the username and password, or personal access token) used to authenticate to a private repository directly from the Dashboard:
+
+1. Navigate to the **[<Icon icon="users" />Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
+
+1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+
+1. Click **Settings** next to the existing upstream requiring an update.
+
+1. In the **Repository credentials** section, click **Update credentials** (or **Add credentials** if none are set yet), enter the new credentials, then click **Save**.
+
+### Repository URL
+
+You cannot modify the repository URL on an existing Custom Upstream. We recommend creating a new Custom Upstream if there is a new URL you need to use. You will need to switch each site to the new upstream individually with [Terminus](/terminus):
 
 ```bash{promptUser: user}
 terminus site:upstream:set my-site "My New Custom Upstream"

--- a/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
@@ -45,7 +45,15 @@ You can update the access token used to authenticate to your private repository 
 
 ### Repository URL
 
-You cannot modify the repository URL on an existing Custom Upstream. We recommend creating a new Custom Upstream if there is a new URL you need to use. You will need to switch each site to the new upstream individually with [Terminus](/terminus):
+You cannot modify the repository URL on an existing Custom Upstream. We recommend creating a new Custom Upstream if there is a new URL you need to use.
+
+<Alert title="Important" type="info">
+
+To switch existing sites to the new Custom Upstream, it must **share Git history** with the one they currently use (for example, forked from or based on the original repository). A site cannot switch to an upstream with an unrelated commit history. Review [Switch Your Custom Upstream](/guides/custom-upstream/switch-custom-upstream) before switching.
+
+</Alert>
+
+You will need to switch each site to the new upstream individually with [Terminus](/terminus):
 
 ```bash{promptUser: user}
 terminus site:upstream:set my-site "My New Custom Upstream"

--- a/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
@@ -33,7 +33,7 @@ Follow the steps below if you want to change the name or description of your Cus
 
 ### Repository Credentials
 
-You can update the credentials (the username and password, or personal access token) used to authenticate to a private repository directly from the Dashboard:
+You can update the access token used to authenticate to your private repository — a GitHub personal access token or a Bitbucket repository access token — directly from the Dashboard:
 
 1. Navigate to the **[<Icon icon="users" />Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
 

--- a/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/04-edit-custom-upstream.md
@@ -21,23 +21,19 @@ This section provides information on editing an existing Custom Upstream.
 
 Follow the steps below if you want to change the name or description of your Custom Upstream.
 
-1. Navigate to the **[<Icon icon="users" />Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
+1. Navigate to your [workspace dashboard](/guides/account-mgmt/workspace-sites-teams/workspaces#switch-between-workspaces), then select the **Upstreams** tab.
 
-1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
+1. Next to the existing upstream requiring an update, click the dropdown icon and then click **Edit settings**.
 
-1. Click **Settings** next to the existing upstream requiring an update.
-
-1. Make desired changes > click **Update**.
+1. Make desired changes, then click **Save**.
 
 ## Update Repository Credentials
 
 You can update the access token used to authenticate to your private repository — a GitHub personal access token or a Bitbucket repository access token — directly from the Dashboard:
 
-1. Navigate to the **[<Icon icon="users" />Organizations](https://dashboard.pantheon.io/#organizations")** tab within the Pantheon Dashboard and select your organization.
+1. Navigate to your [workspace dashboard](/guides/account-mgmt/workspace-sites-teams/workspaces#switch-between-workspaces), then select the **Upstreams** tab.
 
-1. Select the **<span class="upstreams-regular"></span> Upstreams** tab.
-
-1. Click **Settings** next to the existing upstream requiring an update.
+1. Next to the existing upstream requiring an update, click the dropdown icon and then click **Edit settings**.
 
 1. In the **Repository credentials** section, click **Update credentials** (or **Add credentials** if none are set yet), enter the new credentials, then click **Save**.
 

--- a/src/source/content/guides/custom-upstream/07-switch-custom-upstream.md
+++ b/src/source/content/guides/custom-upstream/07-switch-custom-upstream.md
@@ -12,7 +12,7 @@ cms: [drupal, wordpress]
 audience: [development]
 product: [custom-upstreams]
 integration: [--]
-reviewed: "2022-12-13"
+reviewed: "2026-08-04"
 ---
 
 This section provides steps to switch an existing site's Custom Upstream to a different Custom Upstream.
@@ -20,6 +20,8 @@ This section provides steps to switch an existing site's Custom Upstream to a di
 <Alert title="Warning" type="danger">
 
 Switching the upstream of an existing site is risky. It is safer to create a new site from your Custom Upstream and migrate the contents. [Back up](/guides/backups) your site first and consider our documentation on [upstream merge conflicts](/core-updates/#apply-upstream-updates-manually-from-the-command-line-to-resolve-merge-conflicts) if you must switch upstreams.
+
+The destination Custom Upstream must **share Git history** with the one the site currently uses (for example, forked from or based on the same repository). A site cannot switch to an upstream with an unrelated commit history.
 
 </Alert>
 


### PR DESCRIPTION
## What

Updates the **Edit an Existing Custom Upstream** guide. Customers can now update a Custom Upstream's repository **access token** (GitHub personal access token or Bitbucket repository access token) directly from the Dashboard — previously the guide said repository details couldn't be modified at all.

## Details

- Split the section into **Repository Credentials** (now editable in-Dashboard, with steps) and **Repository URL** (still requires creating a new upstream).
- Corrected the credential wording: the flow uses an access token per provider (GitHub PAT / Bitbucket repository access token), not a username/password.
- Kept the existing `## Change Custom Upstream Repository URL or Password` heading so existing anchor links don't break.
- Fixed a stray lowercase "we" and bumped the `reviewed` date.

## Why

This reflects functionality shipped in the Dashboard (upstream settings → Repository credentials → Update credentials).