### PR TITLE
release note: update custom upstream credentials in the dashboard

### DIFF
--- a/src/source/releasenotes/2026-08-03-update-custom-upstream-credentials.md
+++ b/src/source/releasenotes/2026-08-03-update-custom-upstream-credentials.md
@@ -5,7 +5,7 @@ published_at: "2026-08-03T00:00:00Z"
 categories: [new-feature]
 ---
 
-You can now update the credentials for a Custom Upstream directly from the Pantheon Dashboard, without recreating the upstream. Previously, changing a private repository's access token required creating a new Custom Upstream and switching each site over to it.
+You can now update the credentials for a Custom Upstream directly from the Pantheon Dashboard — no support ticket or new upstream required. Previously, changing a private repository's access token meant either creating a new Custom Upstream and switching each site over to it, or contacting Pantheon Support.
 
 ## What's new
 

--- a/src/source/releasenotes/2026-08-03-update-custom-upstream-credentials.md
+++ b/src/source/releasenotes/2026-08-03-update-custom-upstream-credentials.md
@@ -1,0 +1,17 @@
+---
+title: "Update Custom Upstream credentials in the Dashboard"
+published_date: "2026-08-03"
+published_at: "2026-08-03T00:00:00Z"
+categories: [new-feature]
+---
+
+You can now update the credentials for a Custom Upstream directly from the Pantheon Dashboard, without recreating the upstream. Previously, changing a private repository's access token required creating a new Custom Upstream and switching each site over to it.
+
+## What's new
+
+- The upstream **Settings** page now has a **Repository credentials** section that shows whether credentials are set and lets you update them — a GitHub personal access token or a Bitbucket repository access token.
+- The stored credential is masked and never displayed back in the Dashboard.
+
+Changing the repository **URL** still requires creating a new Custom Upstream.
+
+For steps, see [Edit an Existing Custom Upstream](/guides/custom-upstream/edit-custom-upstream).

--- a/src/source/releasenotes/2026-08-07-update-custom-upstream-credentials.md
+++ b/src/source/releasenotes/2026-08-07-update-custom-upstream-credentials.md
@@ -1,8 +1,9 @@
 ---
 title: "Update Custom Upstream credentials in the Dashboard"
-published_date: "2026-08-03"
-published_at: "2026-08-03T00:00:00Z"
-categories: [new-feature]
+published_date: "2026-08-07"
+published_at: "2026-08-07T22:01:45Z"
+categories: [new-feature, user-interface]
+description: “You can now update the credentials for a Custom Upstream directly from the Pantheon Dashboard — no support ticket or new upstream required.”
 ---
 
 You can now update the credentials for a Custom Upstream directly from the Pantheon Dashboard — no support ticket or new upstream required. Previously, changing a private repository's access token meant either creating a new Custom Upstream and switching each site over to it, or contacting Pantheon Support.


### PR DESCRIPTION
Adds a release note announcing that customers can now update Custom Upstream repository credentials (a GitHub personal access token or Bitbucket repository access token) directly from the Dashboard, without recreating the upstream.

Pairs with the guide update in #10192.

- Category: `new-feature`
- Published date: 2026-08-03