### PR TITLE
Performance fixes for mobile speed

### DIFF
--- a/src/components/ui/mdx-wrapper/default-components.tsx
+++ b/src/components/ui/mdx-wrapper/default-components.tsx
@@ -68,7 +68,11 @@ const ImageRenderer = async ({ src = "", alt }: any) => {
         loading="lazy"
         width={image.default.width}
         height={image.default.height}
-        style={{ objectFit: "contain" }}
+        style={{ 
+          maxWidth: "1032px",
+          height: "auto",
+          width: "100%",
+        }}
       />
     </span>
   );

--- a/src/components/ui/mdx-wrapper/default-components.tsx
+++ b/src/components/ui/mdx-wrapper/default-components.tsx
@@ -28,6 +28,7 @@ import Card from "@/components/common/card";
 import { Popover } from "@/components/common/popover";
 import { Wistia } from "@/components/common/wistia";
 import Enablement from "@/components/common/enablement";
+import Image from "next/image";
 
 export type MdxWrapperProps = ComponentProps<typeof ArticleRenderer>;
 
@@ -61,10 +62,13 @@ const ImageRenderer = async ({ src = "", alt }: any) => {
 
   return (
     <span className="next-resp-image-container">
-      <img
+      <Image
         src={image.default.src} // You may copy your images to `public/images` in build step
         alt={alt || ""}
-        style={{ maxWidth: "100%", height: "auto" }}
+        loading="lazy"
+        width={image.default.width}
+        height={image.default.height}
+        style={{ objectFit: "contain" }}
       />
     </span>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -4,7 +4,6 @@
 @import "@pantheon-systems/pds-toolkit-react/css/pds-layouts.css";
 @import "@pantheon-systems/pds-toolkit-react/css/pds-components.css";
 @import "tocbot/dist/tocbot.css";
-@import "./stoplight-elements-modified.css";
 
 /* custom typefaces */
 @import "prismjs/themes/prism-okaidia.css";


### PR DESCRIPTION
* **A 472KB dead stylesheet is loaded on every single page.** 
`src/styles/globals.css` `@imports` `stoplight-elements-modified.css` (23,083 lines, 472KB), which is a copy of Stoplight Elements' CSS meant for the standalone API reference page at `public/openapi/index.html`. That page already loads Stoplight via CDN script and inlines its own copy of this exact CSS — neither `@stoplight/elements` nor `redoc` (also in `package.json`) is imported anywhere in `src`. So this is pure dead weight, yet it's bundled into the global stylesheet the root layout loads for every guide, release note, and landing page on the site. This is very likely a big chunk of that ~1MB CSS payload seen live. 
  * **Fix:** drop the import from `globals.css` (delete the file if truly unused, or keep it only inlined in the static openapi/index.html).
* **Content images bypass Next's image optimization entirely.** 
`ImageRenderer` in `src/components/ui/mdx-wrapper/default-components.tsx` does a Next-optimized static import of each markdown image (which gives it width, height, and blur data for free), then throws all of that away and renders a bare `<img src={image.default.src}>` with no `width`/`height`/`loading` attributes. Confirmed live: on `/guides/multidev`, the doc screenshots (`multidev-flow.png`, `multidev-workflow.png`) have no dimensions and load eagerly, while the site-chrome logo and hamburger icon — which correctly go through `next/image` — have explicit width/height and `loading="lazy"`. Since virtually every guide has embedded screenshots, this means no responsive `srcset`, no WebP/AVIF conversion, and layout shift (CLS) risk on essentially every content page. 
  * **Fix:** swap the raw `<img>` for `next/image`'s `<Image>`, passing through the width/height already available on the imported `image.default` object.