### PR TITLE
Simplify WordPress Multisite access routing to Support

### DIFF
--- a/src/source/content/guides/multisite/01-introduction.md
+++ b/src/source/content/guides/multisite/01-introduction.md
@@ -41,7 +41,7 @@ We do not support uses of WordPress Multisite that run functionally-different or
 ## Request a WordPress Multisite
 WordPress Multisite requires a special configuration that is only available to select customers. Access to WordPress Multisite requires a Gold, Platinum, or Diamond level [Workspace plan](https://pantheon.io/plans/pricing).
 
-Pantheon employees must enable a WordPress Multisite custom upstream on your behalf so your team can create new Multisites self-serve in your professional workspace. This is because WordPress Multisites use the `wordpress_network` [framework](/glossary/#framework), which includes Multisite specific Nginx configurations and differs from the default `wordpress` framework. Reach out to your account manager to get started, or if you don't have an account manager, you can [contact sales](https://pantheon.io/contact-us).
+Pantheon employees must enable a WordPress Multisite custom upstream on your behalf so your team can create new Multisites self-serve in your professional workspace. This is because WordPress Multisites use the `wordpress_network` [framework](/glossary/#framework), which includes Multisite specific Nginx configurations and differs from the default `wordpress` framework. Gold, Platinum, and Diamond plans include WordPress Multisite access. If you are on one of these plans, please contact Support to enable this feature for your site.
 
 
 Existing WordPress sites cannot be converted to WordPress Multisites (since they are different frameworks), however you can spin up a new WordPress Multisite and then [manually migrate](/migrate-manual) the code, database and files from your existing site. 


### PR DESCRIPTION
Removes the account manager / sales routing step for Gold, Platinum, and Diamond plan customers, since these plans already include WordPress Multisite access per their plan tier. Directs customers straight to Support instead, cutting the routing loop between departments.

Closes #9895