### PR TITLE
Fix copy-paste error: binary logs step incorrectly referenced Slow Query logs

### DIFF
--- a/src/source/content/guides/mariadb-mysql/10-mariadb-mysql-faq.md
+++ b/src/source/content/guides/mariadb-mysql/10-mariadb-mysql-faq.md
@@ -39,7 +39,7 @@ To access [MySQL binary logs](https://dev.mysql.com/doc/internals/en/binary-log-
 
 1. Replace the word `appserver` with `dbserver` in the connection string.
 
-1. Navigate to the `data` subdirectory to view the MySQL Slow Query logs.
+1. Navigate to the `data` subdirectory to view the MySQL binary logs.
 
 ### Are table prefixes supported?
 


### PR DESCRIPTION
## What changed
Corrects a copy-paste error in the MariaDB and MySQL FAQ. Under "How can I access MySQL Binary Logs?", step 3 said to navigate to the `data` subdirectory to view "MySQL Slow Query logs" — but that step is under the Binary Logs section, and the Slow Query Logs section above it already correctly points to the `logs` subdirectory.

## Why
The wrong log type was almost certainly left over from copying the Slow Query Logs steps as a template for the Binary Logs steps, and never updated. This could confuse anyone trying to actually locate binlogs on the platform.

## Fix
Changed "MySQL Slow Query logs" to "MySQL binary logs" in that one step. No other content changed.

Closes #9652