### PR TITLE
docs(release-notes): WordPress 7.0.3 security release

### DIFF
--- a/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
+++ b/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
@@ -22,4 +22,4 @@ This update resolves a number of security vulnerabilities, including:
 
 The RCE vulnerability is serious, but unlike wp2shell it requires specific targeting of a user to be effective. However, it is present on all versions of WordPress going back to 4.7. We will provide a list of backport patches shortly for customers on older branches of WordPress.
 
-For more information on this release, please visit the [HelpHub site](https://wordpress.org/documentation/wordpress-version/version-7-0-3/).
+For more information on this release, please see the [WordPress documentation](https://wordpress.org/documentation/wordpress-version/version-7-0-3/).

--- a/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
+++ b/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
@@ -5,7 +5,7 @@ published_at: "2026-08-06T19:00:00Z"
 categories: [wordpress, action-required, security]
 ---
 
-The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon as of 5:15pm ET on August 6, 2026.
+The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon.
 
 ### Action required
 

--- a/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
+++ b/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
@@ -1,0 +1,25 @@
+---
+title: WordPress 7.0.3 Security Release now available
+published_date: "2026-08-06"
+published_at: "2026-08-06T19:00:00Z"
+categories: [wordpress, action-required, security]
+---
+
+The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon as of 3pm ET on August 6, 2026.
+
+### Action required
+
+Because this is a security update, we recommend all users upgrade to WordPress 7.0.3 as soon as possible from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+Pantheon has pre-deployed platform-wide mitigations (virtual patching via our routing network) against external abuse of the vulnerability, and are actively monitoring those rules. However, customers need to update their sites as soon as possible.
+
+### Highlights
+
+This update resolves a number of security vulnerabilities, including:
+
+* A [pre-authentication reflected XSS attack](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-52p2-r8wf-jcrf) that can lead to remote code execution
+* Several other XSS issues that require an authenticated user
+
+The RCE vulnerability is serious, but unlike wp2shell it requires specific targeting of a user to be effective. However, it is present on all versions of WordPress going back to 4.7. We will provide a list of backport patches shortly for customers on older branches of WordPress.
+
+For more information on this release, please visit the [HelpHub site](https://wordpress.org/documentation/wordpress-version/version-7-0-3/).

--- a/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
+++ b/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
@@ -1,8 +1,9 @@
 ---
 title: WordPress 7.0.3 Security Release now available
 published_date: "2026-08-06"
-published_at: "2026-08-06T19:00:00Z"
+published_at: "2026-08-06T22:01:45Z"
 categories: [wordpress, action-required, security]
+description: "The latest security release for WordPress, 7.0.3, is available on Pantheon."
 ---
 
 The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon.

--- a/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
+++ b/src/source/releasenotes/2026-08-06-wordpress-7-0-3.md
@@ -5,7 +5,7 @@ published_at: "2026-08-06T19:00:00Z"
 categories: [wordpress, action-required, security]
 ---
 
-The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon as of 3pm ET on August 6, 2026.
+The latest security release for WordPress, [7.0.3](https://wordpress.org/news/2026/08/wordpress-7-0-3-release/), is available on Pantheon as of 5:15pm ET on August 6, 2026.
 
 ### Action required
 


### PR DESCRIPTION
Re-push of #10202 so that @pwtyler can approve and merge (he authored the original and is the only docs approver online). Commits are cherry-picked from `wordpress-7-0-3-release-note` with original authorship preserved; content is byte-identical to #10202, rebased onto current `main`.

Original #10202 left open — close whichever is redundant once this merges.

---

Adds a release note for the WordPress 7.0.3 security release, available on Pantheon as of 3pm ET August 6, 2026.

Content sourced from the [release announcement draft doc](https://docs.google.com/document/d/1WhCP7ckdl9t3464sAfK5ztq2LrR-F0SVITye85jI3cE/edit).

Covers:
- Action required: upgrade via dashboard/Terminus; platform-wide virtual patching is in place but sites still need to update
- Pre-auth reflected XSS (GHSA-52p2-r8wf-jcrf) that can lead to RCE, plus several authenticated XSS fixes
- Note that backport patches for older WordPress branches are forthcoming

🤖
