### PR TITLE
Fix: contribute page describes docs as a Gatsby site; it's Next.js.

### DIFF
--- a/src/source/content/contribute.md
+++ b/src/source/content/contribute.md
@@ -17,7 +17,7 @@ Become one of our [contributors](/contributors)! Help us create relevant and use
 
 </Wistia>
 
-Pantheon's documentation is a static site built by [Gatsby](https://www.gatsbyjs.com/docs/glossary/static-site-generator/) from files maintained in a public [GitHub repository](https://github.com/pantheon-systems/documentation).
+Pantheon's documentation is a [Next.js](https://www.nextjs.org/) site, built from files maintained in a public [GitHub repository](https://github.com/pantheon-systems/documentation).
 
 Get involved by:
 


### PR DESCRIPTION
The Contribute page says that Pantheon's documentation is a static site built by Gatsby, but the Readme page says the site is built with Next.js. This looks like drift left over from a framework migration. 

The change: Pantheon's documentation is a [Next.js](https://nextjs.org/) site, built from files maintained in a public [GitHub repository](https://github.com/pantheon-systems/documentation).