### PR TITLE
Add composer.lock exclude instructions to Custom Upstream dependency guide

### DIFF
--- a/src/source/content/partials/upstream-management-dependencies.md
+++ b/src/source/content/partials/upstream-management-dependencies.md
@@ -26,6 +26,14 @@ reviewed: ""
 
 1. Commit and push your changes to your `composer.json` file. **Remember to *not* commit the `composer.lock` file.**
 
+   The `composer.lock` file should not be added to your `.gitignore` file, since it must still be committed for individual sites created from your Custom Upstream. Instead, run the following command to prevent yourself from accidentally committing it while working directly in the Custom Upstream repository:
+
+```bash{promptUser: user}
+    echo /composer.lock >> .git/info/exclude
+```
+
+    This has the same effect as a `.gitignore` entry, but the exclusion isn't tracked in the repository itself. You'll need to re-run this command each time you make a new local clone of your Custom Upstream.
+
 ## Update Dependencies in Your Upstream
 
 You may need to pin specific versions of your dependencies in your Custom Upstream. This is normally done with the `composer.lock` file. However, including the `composer.lock` file in the root of the Custom Upstream causes merge conflicts with your downstream sites. You can use the `upstream:update-dependencies` composer command to solve this problem.


### PR DESCRIPTION
## What changed
Adds missing instructions for excluding `composer.lock` from a Custom Upstream repository, in `src/source/content/partials/upstream-management-dependencies.md`.

## Why
The guide already warned developers not to commit `composer.lock`, but didn't explain:
- Why it can't simply be added to `.gitignore` (it must still be committed for individual sites created from the Custom Upstream)
- How to reliably prevent accidental commits while working directly in the upstream repository

This matches the issue's reported symptom: confusion and inadvertent git conflicts.

## Approach
Equivalent guidance already exists for Integrated Composer upstreams (in `ic-upstream-structure.md`), but that version references Integrated-Composer-specific concepts (build artifacts, `upstream-configuration/`) that don't apply here. Rather than duplicating that content directly, this adds a scoped-down version using the `.git/info/exclude` technique, written for the plain Custom Upstream workflow this page documents.

## Fix
Inserted a short explanation and command directly under the existing "Remember to *not* commit the `composer.lock` file" step, so the guidance appears exactly where a developer would need it.

Closes #9884