### PR TITLE
Add WordPress 7.0.4 security release note

### DIFF
--- a/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
+++ b/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
@@ -20,6 +20,6 @@ This update resolves a security vulnerability:
 
 * An [authenticated Author+ remote code execution via malicious file upload](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-8vr3-7mxf-gx8w) (CVE-2026-65640) on sites utilizing Imagick and Ghostscript
 
-The RCE vulnerability requires Author-level permissions or higher to upload files. However, certain setups that allow unauthenticated file uploads — such as forms with attachment uploads (e.g., Gravity Forms) — could extend the attack surface beyond the WordPress core standard. The vulnerability is present on all versions of WordPress going back to 4.7.
+The RCE vulnerability requires Author-level permissions or higher to upload files. However, certain setups that allow unauthenticated file uploads — such as forms with attachment uploads (e.g., Gravity Forms) — could extend the attack surface beyond the WordPress core standard.
 
 For more information on this release, please see the [WordPress documentation](https://wordpress.org/documentation/wordpress-version/version-7-0-4/).

--- a/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
+++ b/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
@@ -18,6 +18,6 @@ Pantheon has pre-deployed platform-wide mitigations (virtual patching via our ro
 
 This update resolves a security vulnerability:
 
-* An [authenticated Author+ remote code execution via malicious file upload](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-8vr3-7mxf-gx8w) (CVE-2026-65640) on sites utilizing Imagick and Ghostscript
+* An [authenticated Author+ remote code execution via malicious file upload](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-8vr3-7mxf-gx8w) (CVE-2026-65640).
 
 For more information on this release, please see the [WordPress documentation](https://wordpress.org/documentation/wordpress-version/version-7-0-4/).

--- a/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
+++ b/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
@@ -12,7 +12,7 @@ The latest security release for WordPress, [7.0.4](https://wordpress.org/news/20
 
 Because this is a security update, we recommend all users upgrade to WordPress 7.0.4 as soon as possible from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
 
-Pantheon has pre-deployed platform-wide mitigations (virtual patching via our routing network) against external abuse of the vulnerability, and are actively monitoring those rules. WAF rules are actively blocking scanning attempts with 0 false positives observed. However, customers need to update their sites as soon as possible.
+Pantheon has pre-deployed platform-wide mitigations (virtual patching via our routing network) against external abuse of the vulnerability, and are actively monitoring those rules. However, customers need to update their sites as soon as possible.
 
 ### Highlights
 

--- a/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
+++ b/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
@@ -1,0 +1,25 @@
+---
+title: WordPress 7.0.4 Security Release now available
+published_date: "2026-08-12"
+published_at: "2026-08-12T16:00:00Z"
+categories: [wordpress, action-required, security]
+description: "The latest security release for WordPress, 7.0.4, is available on Pantheon."
+---
+
+The latest security release for WordPress, [7.0.4](https://wordpress.org/news/2026/08/wordpress-7-0-4-release/), is available on Pantheon.
+
+### Action required
+
+Because this is a security update, we recommend all users upgrade to WordPress 7.0.4 as soon as possible from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+Pantheon has pre-deployed platform-wide mitigations (virtual patching via our routing network) against external abuse of the vulnerability, and are actively monitoring those rules. WAF rules are actively blocking scanning attempts with 0 false positives observed. However, customers need to update their sites as soon as possible.
+
+### Highlights
+
+This update resolves a security vulnerability:
+
+* An [authenticated Author+ remote code execution via malicious file upload](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-8vr3-7mxf-gx8w) (CVE-2026-65640) on sites utilizing Imagick and Ghostscript
+
+The RCE vulnerability requires Author-level permissions or higher to upload files. However, certain setups that allow unauthenticated file uploads — such as forms with attachment uploads (e.g., Gravity Forms) — could extend the attack surface beyond the WordPress core standard. The vulnerability is present on all versions of WordPress going back to 4.7.
+
+For more information on this release, please see the [WordPress documentation](https://wordpress.org/documentation/wordpress-version/version-7-0-4/).

--- a/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
+++ b/src/source/releasenotes/2026-08-12-wordpress-7-0-4.md
@@ -20,6 +20,4 @@ This update resolves a security vulnerability:
 
 * An [authenticated Author+ remote code execution via malicious file upload](https://github.com/WordPress/wordpress-develop/security/advisories/GHSA-8vr3-7mxf-gx8w) (CVE-2026-65640) on sites utilizing Imagick and Ghostscript
 
-The RCE vulnerability requires Author-level permissions or higher to upload files. However, certain setups that allow unauthenticated file uploads — such as forms with attachment uploads (e.g., Gravity Forms) — could extend the attack surface beyond the WordPress core standard.
-
 For more information on this release, please see the [WordPress documentation](https://wordpress.org/documentation/wordpress-version/version-7-0-4/).


### PR DESCRIPTION
## Summary
- Adds release note for WordPress 7.0.4 security release (CVE-2026-65640, Ghostscript RCE)
- Backports section to be added once backport tags are published on `pantheon-systems/WordPress`

## Test plan
- [ ] Verify release note renders correctly
- [ ] Confirm security advisory link resolves
- [ ] Add backports section when tags are available