### PR TITLE
WP SAML Auth 2.3.4 release note

### DIFF
--- a/src/source/releasenotes/2026-08-12-wp-saml-auth-2-3-4.md
+++ b/src/source/releasenotes/2026-08-12-wp-saml-auth-2-3-4.md
@@ -1,0 +1,11 @@
+---
+title: "WP SAML Auth 2.3.4 update now available"
+published_date: "2026-08-12"
+published_at: "2026-08-12T22:50:00Z"
+categories: [wordpress, plugins, action-required]
+description: "WP SAML Auth 2.3.4 restores the vendor directory that was missing from the 2.3.3 WordPress.org package."
+---
+
+Pantheon has released version 2.3.4 of the [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/). This restores the `vendor` directory to the WordPress.org package, which was missing from 2.3.3 and affected SAML login on sites installed from the WordPress Plugin Repository. See [#500](https://github.com/pantheon-systems/wp-saml-auth/pull/500) for details.
+
+Sites on 2.3.3 should update to 2.3.4. Update from the WordPress dashboard under **Plugins > Installed Plugins**, or download it from the [WordPress Plugin Repository](https://wordpress.org/plugins/wp-saml-auth/).

--- a/src/source/releasenotes/2026-08-12-wp-saml-auth-2-3-4.md
+++ b/src/source/releasenotes/2026-08-12-wp-saml-auth-2-3-4.md
@@ -6,6 +6,6 @@ categories: [wordpress, plugins, action-required]
 description: "WP SAML Auth 2.3.4 restores the vendor directory that was missing from the 2.3.3 WordPress.org package."
 ---
 
-Pantheon has released version 2.3.4 of the [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/). This restores the `vendor` directory to the WordPress.org package, which was missing from 2.3.3 and affected SAML login on sites installed from the WordPress Plugin Repository. See [#500](https://github.com/pantheon-systems/wp-saml-auth/pull/500) for details.
+Pantheon has released version 2.3.4 of the [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/). This restores the `vendor` directory to the WordPress.org package, which was missing from 2.3.3 and affected SAML login on sites installed from the WordPress Plugin Repository.
 
 Sites on 2.3.3 should update to 2.3.4. Update from the WordPress dashboard under **Plugins > Installed Plugins**, or download it from the [WordPress Plugin Repository](https://wordpress.org/plugins/wp-saml-auth/).


### PR DESCRIPTION
## Summary

- Adds release note for WP SAML Auth 2.3.4, which restores the `vendor` directory missing from the 2.3.3 WordPress.org package (broke SAML login on sites installed from the WordPress Plugin Repository)
- Reference: https://github.com/pantheon-systems/wp-saml-auth/pull/500