### PR TITLE
Update documentation site URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 # Pantheon Documentation
 
-This repository contains the Next.js source code and the content of [Pantheon's Documentation site](https://newdocs.pantheon.io/).
+This repository contains the Next.js source code and the content of [Pantheon's Documentation site](https://docs.pantheon.io/).
 
 ## Contributing documentation changes
 


### PR DESCRIPTION
Updated [newdocs.pantheon.io](https://newdocs.pantheon.io) to [docs.pantheon.io](https://docs.pantheon.io/)