### PR TITLE
clarify env vars take effect on next build

### DIFF
--- a/src/source/content/nextjs/environment-variables.md
+++ b/src/source/content/nextjs/environment-variables.md
@@ -44,6 +44,6 @@ terminus secret:site:set <site_name>.live  MY_VARIABLE my-variable-value-for-liv
 
 ## Reading environment variables in Next.js
 
-Once set, these environment variables can be read in your Next.js application code using `process.env.VARIABLE_NAME`.
+Newly set or updated environment variables take effect starting with your next build. Once that build runs, they are available during the build phase, and at runtime after the build completes successfully. In your Next.js application code, read them using `process.env.VARIABLE_NAME`.
 
 To learn more about using Secrets Manager to set environment variables, see [Managing Environment Variables with Secrets Manager](/guides/secrets).


### PR DESCRIPTION
## What

Reword the intro of "Reading environment variables in Next.js" to state when
newly set environment variables actually become available.

## Why

The previous wording — "Once set, these environment variables can be read in
your Next.js application code..." — implies a secret is readable as soon as it's
saved. In practice, changes take effect starting with the next build: available
during the build phase, and at runtime after that build succeeds.

This is a common source of confusion for anyone who sets a variable, sees
`undefined` in their running app, and assumes something is broken.

## Changes

- Lead with the build-timing behavior instead of "Once set"
- Keep the rest of the section unchanged

**Before**
> Once set, these environment variables can be read in your Next.js application code using `process.env.VARIABLE_NAME`.

**After**
> Newly set or updated environment variables take effect starting with your next build. Once that build runs, they are available during the build phase, and at runtime after the build completes successfully. In your Next.js application code, read them using `process.env.VARIABLE_NAME`.