### PR TITLE
docs(release-notes): [SITE-6079] WP SAML Auth 2.3.4 security and packaging update

### DIFF
--- a/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
+++ b/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
@@ -1,6 +1,7 @@
 ---
 title: "WP SAML Auth 2.3.4 security and packaging update now available"
 published_date: "2026-08-13"
+published_at: "2026-08-13T12:56:24Z"
 categories: [wordpress, plugins, action-required, security]
 ---
 

--- a/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
+++ b/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
@@ -1,0 +1,30 @@
+---
+title: "WP SAML Auth 2.3.4 security and packaging update now available"
+published_date: "2026-08-13"
+categories: [wordpress, plugins, action-required, security]
+---
+
+Pantheon has released version 2.3.4 of the [WP SAML Auth WordPress plugin](https://wordpress.org/plugins/wp-saml-auth/).
+
+Version 2.3.3 was released on August 11, 2026 with a security fix for SAML user matching. The 2.3.3 package published to the WordPress Plugin Repository was missing its `vendor` directory, which includes the bundled `onelogin/php-saml` library, so sites that took that update could not authenticate through SAML. Version 2.3.4 was released the following day to correct the packaging, and it carries the 2.3.3 security fix as well. Both releases are one day apart, so a site may be on either version depending on when it last updated.
+
+<Alert title="Action required" type="warning">
+
+Update to 2.3.4 as soon as possible. Sites running 2.3.2 or earlier are missing a security fix, and sites that updated to 2.3.3 from the WordPress Plugin Repository may be unable to log in through SAML.
+
+</Alert>
+
+## What's new
+
+* **Security: user matching now accent-sensitive** — Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison. Originally released in 2.3.3 and included here ([#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)).
+* **Restores the bundled SAML library** — The `vendor` directory, which includes `onelogin/php-saml`, is included in the package again. Sites affected by 2.3.3 will be able to authenticate through SAML after updating ([#498](https://github.com/pantheon-systems/wp-saml-auth/issues/498)).
+
+## Who is affected
+
+* **Sites on 2.3.2 or earlier** are missing the security fix and should update to 2.3.4.
+* **Sites on 2.3.3 installed from the WordPress Plugin Repository**, using the WordPress dashboard, WP-CLI, or the direct download, have the security fix but may be unable to authenticate through SAML. Update to 2.3.4 to restore login.
+* **Sites that install the plugin with Composer** are unaffected by the packaging issue, because `onelogin/php-saml` is resolved as a dependency rather than from the bundled copy. These sites should still update to 2.3.4 if they are on 2.3.2 or earlier.
+
+Update to 2.3.4 from the WordPress dashboard under **Plugins > Installed Plugins**, or download it from the [WordPress Plugin Repository](https://wordpress.org/plugins/wp-saml-auth/).
+
+For more details, see the [plugin release notes](https://github.com/pantheon-systems/wp-saml-auth/releases/tag/2.3.4).

--- a/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
+++ b/src/source/releasenotes/2026-08-13-wp-saml-auth-2-3-4.md
@@ -17,8 +17,8 @@ Update to 2.3.4 as soon as possible. Sites running 2.3.2 or earlier are missing 
 
 ## What's new
 
-* **Security: user matching now accent-sensitive** — Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison. Originally released in 2.3.3 and included here ([#495](https://github.com/pantheon-systems/wp-saml-auth/pull/495)).
-* **Restores the bundled SAML library** — The `vendor` directory, which includes `onelogin/php-saml`, is included in the package again. Sites affected by 2.3.3 will be able to authenticate through SAML after updating ([#498](https://github.com/pantheon-systems/wp-saml-auth/issues/498)).
+* **Security: user matching now accent-sensitive** — Fixes an account takeover where an accent-insensitive database collation could match a SAML attribute to the wrong WordPress user. User lookup is now verified with a case-insensitive, accent-sensitive comparison. Originally released in 2.3.3.
+* **Restores the bundled SAML library** — The `vendor` directory, which includes `onelogin/php-saml`, is included in the package again. Sites affected by 2.3.3 will be able to authenticate through SAML after updating.
 
 ## Who is affected
 


### PR DESCRIPTION
## Summary

- Add a release note for WP SAML Auth 2.3.4, covering both the security fix originally shipped in 2.3.3 and the packaging fix that 2.3.4 delivers.

## Context

[SITE-6079](https://getpantheon.atlassian.net/browse/SITE-6079)

Two plugin releases went out a day apart:

- **2.3.3** (August 11) carried a security fix for SAML user matching, but the package published to WordPress.org was missing its `vendor` directory, including the bundled `onelogin/php-saml` library. Sites that took that update from WordPress.org could not authenticate through SAML.
- **2.3.4** (August 12) corrected the packaging and carries the 2.3.3 security fix forward.

No release note was published for 2.3.3, so the last version customers were told about is 2.3.2. This note is therefore written against a 2.3.2 baseline rather than a 2.3.3 one: it leads with the security fix, which affects everyone on 2.3.2 or earlier, then covers the packaging fix, which affects the narrower set who took 2.3.3 from WordPress.org. The `Who is affected` section splits guidance by the version a site is currently on, including Composer-managed sites that were never hit by the packaging issue but may still be missing the security fix.

## Verification

The fix is live and confirmed in the published package:

```
2.3.4 zip: 64 vendor entries, incl. wp-saml-auth/vendor/onelogin/php-saml/src/Saml2/Auth.php
2.3.3 zip: 0 vendor entries
```

`api.wordpress.org` reports `version: 2.3.4`, and the GitHub release was published 2026-08-12T19:58:18Z.

## Conventions

- Filename, frontmatter, and the "Pantheon has released version X" opener follow the existing plugin notes, most closely `2026-03-09-wp-saml-auth-2-3-1.md` and `2026-05-20-wp-saml-auth-2-3-2.md`.
- Categories are all valid slugs from `releaseNoteCategories.json`. `security` is added here; the 2.3.2 note omitted it despite being a security release.
- The security-first structure and explicit affected/not-affected framing follow `2026-05-20-drupal-core-security-update.md`.
- `Alert type="warning"` rather than `danger`, since `danger` is remapped to `warning` in `src/components/common/alert/index.tsx:18-19`.

## Reviewer notes

- The account takeover is described at the same level of detail as the public plugin changelog and the 2.3.3 GitHub release, both already public. Flagging it explicitly since a docs release note reaches a much wider audience than a changelog — please confirm this level of detail is intended for this channel.
- The plugin's own readme changelog entry for 2.3.4 links PR #499, which was superseded and never merged; the real PR is #500. That is inside the tagged readme and is not worth re-tagging over, so it will be corrected in the next release's changelog pass. This note links #495 and #498, both correct.

## References

- Jira: [SITE-6079](https://getpantheon.atlassian.net/browse/SITE-6079)
- Plugin release: [2.3.4](https://github.com/pantheon-systems/wp-saml-auth/releases/tag/2.3.4)
- Originating issue: pantheon-systems/wp-saml-auth#498
- Fix PR: pantheon-systems/wp-saml-auth#500


[SITE-6079]: https://getpantheon.atlassian.net/browse/SITE-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-6079]: https://getpantheon.atlassian.net/browse/SITE-6079?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ