### PR TITLE
[SITE-5208] Add PHP 8.5 plugin/module compatibility release note

### DIFF
--- a/src/source/content/guides/wordpress-configurations/02-plugins.md
+++ b/src/source/content/guides/wordpress-configurations/02-plugins.md
@@ -11,7 +11,7 @@ product: [--]
 integration: [--]
 tags: [wordpress, webops]
 contributors: [whitneymeredith]
-reviewed: "2025-02-05"
+reviewed: "2026-08-14"
 showtoc: true
 permalink: docs/guides/wordpress-configurations/plugins
 ---
@@ -51,6 +51,9 @@ add_filter('pantheon_should_add_terms', 'custom_should_add_terms', 10, 2);
 ```
 
 For additional details, refer to the [plugin README file](https://github.com/pantheon-systems/pantheon-advanced-page-cache#140).
+
+## Pantheon Content Publisher
+Use the [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) plugin to publish content to WordPress directly from Google Docs. For details, see [related documentation](https://docs.content.pantheon.io/wordpress-overview).
 
 ## Pantheon HUD
 

--- a/src/source/content/modules.md
+++ b/src/source/content/modules.md
@@ -3,7 +3,7 @@ title: Pantheon Modules
 description: Details on specific Drupal modules developed and maintained for the Pantheon Website Management Platform workflow.
 contributors: [eabquina]
 tags: [cache, libraries, modules, site]
-reviewed: "2022-04-01"
+reviewed: "2026-08-14"
 contenttype: [doc]
 innav: [true]
 categories: [cache]
@@ -24,24 +24,31 @@ WordPress users should review [Pantheon Plugins](/guides/wordpress-configuration
 
 The Advanced Page Cache module attaches [Drupal's cache metadata](https://www.drupal.org/docs/8/api/cache-api/cache-api) to a response so that Pantheon's [Global CDN](/guides/global-cdn) edge service can granularly clear new content as it is saved. The Global CDN can detect when underlying data changes, such as nodes and taxonomy terms, then clear pages containing that entity. For details, see [this blog post](https://pantheon.io/blog/pantheon-advanced-page-cache-drupal-cache-metadata-global-cdn).
 
+## [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets)
+Provides Drupal integration with [Pantheon Secrets](/guides/secrets/drupal) in the form of a Key Provider plugin for the Key module.
+
+## [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher)
+Integrates your Drupal site with Pantheon's Content Cloud, allowing you to draft, preview, and publish content straight from Google Docs. For details, see [related documentation](https://docs.content.pantheon.io/drupal-overview).
+
+## [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon)
+
+This module is meant to simplify the usage of [Search API](https://www.drupal.org/project/search_api) and [Search API Solr](https://www.drupal.org/project/search_api_solr) on Pantheon. Search API Solr provides the ability to connect to any Solr server by providing numerous configuration options. This module automatically sets the Solr connection options by extending the plugin from Search API Solr. The module also changes the connection information between Pantheon environments, eliminating the need to do extra work setting up Solr servers for each environment.
+
+## [Site Audit](https://www.drupal.org/project/site_audit)
+Static site analysis is a service for Drupal sites that makes best practice recommendations on site configurations. These reports are found in the Site Dashboard under the Status tab and are accessible by site team members. For more details, visit [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check).
+
+
 ## [Generate Errors (Drupal 7)](https://www.drupal.org/project/generate_errors)
 
 Interface which allows you to generate various errors to test system behaviors like custom errors and server responses.
 
-## [Login](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_login)
+## [Login (Drupal 7)](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_login)
 
 Provides login integration between Drupal and the Pantheon Site Dashboard.
 
-## [Search API Pantheon (Drupal)](https://www.drupal.org/project/search_api_pantheon)
-
-This module is meant to simplify the usage of [Search API](https://www.drupal.org/project/search_api) and [Search API Solr](https://www.drupal.org/project/search_api_solr) on Pantheon. Search API Solr provides the ability to connect to any Solr server by providing numerous configuration options. This module automatically sets the Solr connection options by extending the plugin from Search API Solr. The module also changes the connection information between Pantheon environments, eliminating the need to do extra work setting up Solr servers for each environment.
-
-### [Apache Solr](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr)
+## [Apache Solr (Drupal 7)](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon/pantheon_apachesolr)
 
 This module facilitates and debugs communication between Drupal and Pantheon's Apache Solr service, indexing and searching site content. For more details, visit [Pantheon Search](/solr).
-
-## [Site Audit](https://www.drupal.org/project/site_audit)
-Static site analysis is a service for Drupal sites that makes best practice recommendations on site configurations. These reports are found in the Site Dashboard under the Status tab and are accessible by site team members. For more details, visit [Launch Check - Drupal Performance and Configuration Analysis](/drupal-launch-check).
 
 ## [Pantheon Module (Drupal 7)](https://github.com/pantheon-systems/drops-7/tree/master/modules/pantheon)
 
@@ -49,7 +56,7 @@ This module provides general methods your site needs to access aspects of the in
 
 The code for the API module is available within our upstream repositories, in the `modules/pantheon` directory. The functionality of this module is provided in three parts: Apache Solr, Pantheon Platform API, and Login.
 
-## [Pantheon Platform API (Drupal 7)](https://github.com/pantheon-systems/drops-7/blob/master/modules/pantheon/pantheon_api/pantheon_api.info) (Drupal 7)
+## [Pantheon Platform API (Drupal 7)](https://github.com/pantheon-systems/drops-7/blob/master/modules/pantheon/pantheon_api/pantheon_api.info)
 
 This module provides general methods your site needs to access aspects of the internal Pantheon API. This is necessary for clearing caches and other common workflows on the platform in Drupal 7.
 

--- a/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
@@ -10,20 +10,20 @@ All Pantheon-maintained Drupal modules and WordPress plugins have been confirmed
 
 ## Drupal modules
 
-- [Pantheon Advanced Page Cache 2.4.0](https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.4.0)
-- [Pantheon Secrets 1.1.0](https://www.drupal.org/project/pantheon_secrets/releases/1.1.0)
-- [Search API Pantheon 8.5.0](https://www.drupal.org/project/search_api_pantheon/releases/8.5.0)
-- [Pantheon Content Publisher 1.0.5](https://www.drupal.org/project/pantheon_content_publisher/releases/1.0.5)
-- [Pantheon Domain Masking 2.2.0](https://github.com/pantheon-systems/pantheon-domain-masking/releases/tag/2.2.0)
+- [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.4.0) 2.4.0
+- [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets/releases/1.1.0) 1.1.0
+- [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon/releases/8.5.0) 8.5.0
+- [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher/releases/1.0.5) 1.0.5
+- [Pantheon Domain Masking](https://github.com/pantheon-systems/pantheon-domain-masking/releases/tag/2.2.0) 2.2.0
 
 ## WordPress plugins
 
-- [Pantheon Advanced Page Cache 2.1.2](https://wordpress.org/plugins/pantheon-advanced-page-cache/)
-- [WP Redis 1.4.7](https://wordpress.org/plugins/wp-redis/)
-- [WP Native PHP Sessions 1.4.5](https://wordpress.org/plugins/wp-native-php-sessions/)
-- [Pantheon HUD 0.4.5](https://wordpress.org/plugins/pantheon-hud/)
-- [WP SAML Auth 2.3.4](https://wordpress.org/plugins/wp-saml-auth/)
-- [Pantheon Content Publisher 1.3.6](https://wordpress.org/plugins/pantheon-content-publisher/)
-- [Pantheon MU Plugin 1.5.7](https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.5.7)
+- [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) 2.1.2
+- [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7
+- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
+- [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
+- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.4
+- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.6
+- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.5.7) 1.5.7
 
 To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).

--- a/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
@@ -3,31 +3,27 @@ title: "Pantheon-maintained plugins and modules are now compatible with PHP 8.5"
 published_date: "2026-08-14"
 published_at: "2026-08-14T12:00:00Z"
 categories: [drupal, wordpress]
-description: "All Pantheon-maintained Drupal modules and WordPress plugins now support PHP 8.5, available on the platform."
+description: "All Pantheon-maintained Drupal modules and WordPress plugins are confirmed compatible with PHP 8.5."
 ---
 
-All Pantheon-maintained Drupal modules and WordPress plugins have been updated to support [PHP 8.5](/guides/php), which is available on the Pantheon platform.
+All Pantheon-maintained Drupal modules and WordPress plugins have been confirmed compatible with [PHP 8.5](/guides/php). Some required code updates and received new releases; others were already compatible.
 
 ## Drupal modules
 
-The following Drupal modules have been updated for PHP 8.5 compatibility:
-
-- [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache) 2.4.0
-- [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets) 1.1.0
-- [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon) 8.5.0
-- [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher) 1.0.5
-- [Pantheon Domain Masking](https://github.com/pantheon-systems/pantheon-domain-masking) 2.2.0
+- [Pantheon Advanced Page Cache 2.4.0](https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.4.0)
+- [Pantheon Secrets 1.1.0](https://www.drupal.org/project/pantheon_secrets/releases/1.1.0)
+- [Search API Pantheon 8.5.0](https://www.drupal.org/project/search_api_pantheon/releases/8.5.0)
+- [Pantheon Content Publisher 1.0.5](https://www.drupal.org/project/pantheon_content_publisher/releases/1.0.5)
+- [Pantheon Domain Masking 2.2.0](https://github.com/pantheon-systems/pantheon-domain-masking/releases/tag/2.2.0)
 
 ## WordPress plugins
 
-The following WordPress plugins have been updated for PHP 8.5 compatibility:
-
-- [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) 2.1.2
-- [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7
-- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
-- [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
-- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.4
-- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.6
-- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) 1.5.7
+- [Pantheon Advanced Page Cache 2.1.2](https://wordpress.org/plugins/pantheon-advanced-page-cache/)
+- [WP Redis 1.4.7](https://wordpress.org/plugins/wp-redis/)
+- [WP Native PHP Sessions 1.4.5](https://wordpress.org/plugins/wp-native-php-sessions/)
+- [Pantheon HUD 0.4.5](https://wordpress.org/plugins/pantheon-hud/)
+- [WP SAML Auth 2.3.4](https://wordpress.org/plugins/wp-saml-auth/)
+- [Pantheon Content Publisher 1.3.6](https://wordpress.org/plugins/pantheon-content-publisher/)
+- [Pantheon MU Plugin 1.5.7](https://github.com/pantheon-systems/pantheon-mu-plugin/releases/tag/1.5.7)
 
 To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).

--- a/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
@@ -1,0 +1,33 @@
+---
+title: "Pantheon-maintained plugins and modules are now compatible with PHP 8.5"
+published_date: "2026-08-14"
+published_at: "2026-08-14T12:00:00Z"
+categories: [drupal, wordpress]
+description: "All Pantheon-maintained Drupal modules and WordPress plugins now support PHP 8.5, available on the platform."
+---
+
+All Pantheon-maintained Drupal modules and WordPress plugins have been updated to support [PHP 8.5](/guides/php), which is available on the Pantheon platform.
+
+## Drupal modules
+
+The following Drupal modules have been updated for PHP 8.5 compatibility:
+
+- [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache) 2.4.0
+- [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets) 1.1.0
+- [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon) 8.5.0
+- [Pantheon Content Publisher](https://www.drupal.org/project/pantheon_content_publisher) 1.0.5
+- [Pantheon Domain Masking](https://github.com/pantheon-systems/pantheon-domain-masking) 2.2.0
+
+## WordPress plugins
+
+The following WordPress plugins have been updated for PHP 8.5 compatibility:
+
+- [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) 2.1.2
+- [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7
+- [WP Native PHP Sessions](https://wordpress.org/plugins/wp-native-php-sessions/) 1.4.5
+- [Pantheon HUD](https://wordpress.org/plugins/pantheon-hud/) 0.4.5
+- [WP SAML Auth](https://wordpress.org/plugins/wp-saml-auth/) 2.3.4
+- [Pantheon Content Publisher](https://wordpress.org/plugins/pantheon-content-publisher/) 1.3.6
+- [Pantheon MU Plugin](https://github.com/pantheon-systems/pantheon-mu-plugin) 1.5.7
+
+To switch your site to PHP 8.5, see [Upgrade PHP Versions](/guides/php/php-versions).

--- a/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
+++ b/src/source/releasenotes/2026-08-14-php85-plugin-module-compatibility.md
@@ -1,7 +1,7 @@
 ---
 title: "Pantheon-maintained plugins and modules are now compatible with PHP 8.5"
 published_date: "2026-08-14"
-published_at: "2026-08-14T12:00:00Z"
+published_at: "2026-08-14T16:55:23Z"
 categories: [drupal, wordpress]
 description: "All Pantheon-maintained Drupal modules and WordPress plugins are confirmed compatible with PHP 8.5."
 ---
@@ -10,6 +10,8 @@ All Pantheon-maintained Drupal modules and WordPress plugins have been confirmed
 
 ## Drupal modules
 
+The following Drupal modules have been updated for PHP 8.5 compatibility:
+
 - [Pantheon Advanced Page Cache](https://www.drupal.org/project/pantheon_advanced_page_cache/releases/2.4.0) 2.4.0
 - [Pantheon Secrets](https://www.drupal.org/project/pantheon_secrets/releases/1.1.0) 1.1.0
 - [Search API Pantheon](https://www.drupal.org/project/search_api_pantheon/releases/8.5.0) 8.5.0
@@ -17,6 +19,8 @@ All Pantheon-maintained Drupal modules and WordPress plugins have been confirmed
 - [Pantheon Domain Masking](https://github.com/pantheon-systems/pantheon-domain-masking/releases/tag/2.2.0) 2.2.0
 
 ## WordPress plugins
+
+The following WordPress plugins have been updated for PHP 8.5 compatibility:
 
 - [Pantheon Advanced Page Cache](https://wordpress.org/plugins/pantheon-advanced-page-cache/) 2.1.2
 - [WP Redis](https://wordpress.org/plugins/wp-redis/) 1.4.7


### PR DESCRIPTION
## Summary

Adds release note announcing PHP 8.5 compatibility across all 12 Pantheon-maintained Drupal modules and WordPress plugins.

## Context

[SITE-5208](https://getpantheon.atlassian.net/browse/SITE-5208)

PHP 8.5 is available on the Pantheon platform. Epic [SITE-5195](https://getpantheon.atlassian.net/browse/SITE-5195) tracked compatibility work across all Pantheon-maintained plugins and modules. Some required code updates and received new releases; others were already compatible without changes.

Supersedes #10179.

[SITE-5208]: https://getpantheon.atlassian.net/browse/SITE-5208?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5195]: https://getpantheon.atlassian.net/browse/SITE-5195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ