### PR TITLE
docs: clarify update-notice controls ship in mu-plugin 1.5.7

### DIFF
--- a/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
+++ b/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
@@ -6,7 +6,7 @@ categories: [new-feature, wordpress]
 description: "The Pantheon WordPress core update notice can now be dismissed per user, or hidden site-wide with CSS, a filter, or a constant."
 ---
 
-The Pantheon [WordPress core update notice](/core-updates#suppress-wordpress-admin-notice) ("A new WordPress update is available!") can now be dismissed or hidden.
+Pantheon MU-Plugin 1.5.7 adds dismiss and hide controls for the Pantheon [WordPress core update notice](/core-updates#suppress-wordpress-admin-notice) ("A new WordPress update is available!"). This version is delivered automatically as an upstream update; no action is required to receive it.
 
 ## Dismiss the notice
 

--- a/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
+++ b/src/source/releasenotes/2026-08-18-wordpress-update-notice-controls.md
@@ -6,7 +6,7 @@ categories: [new-feature, wordpress]
 description: "The Pantheon WordPress core update notice can now be dismissed per user, or hidden site-wide with CSS, a filter, or a constant."
 ---
 
-Pantheon MU-Plugin 1.5.7 adds dismiss and hide controls for the Pantheon [WordPress core update notice](/core-updates#suppress-wordpress-admin-notice) ("A new WordPress update is available!"). This version is delivered automatically as an upstream update; no action is required to receive it.
+Pantheon MU-Plugin 1.5.7 adds dismiss and hide controls for the Pantheon [WordPress core update notice](/core-updates#suppress-wordpress-admin-notice) ("A new WordPress update is available!"). [Apply upstream updates](/core-updates#apply-upstream-updates-via-the-site-dashboard) to get this version of the mu-plugin.
 
 ## Dismiss the notice
 


### PR DESCRIPTION
## Summary
- Clarifies that the WordPress core update-notice dismiss/hide controls announced in the 2026-08-18 release note ship as part of Pantheon mu-plugin 1.5.7, delivered automatically via upstream update.