### PR TITLE
docs: add release note for Drupal 7.106 LTS security backport

### DIFF
--- a/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
+++ b/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
@@ -1,0 +1,19 @@
+---
+title: Drupal 7 LTS security update now available (Drupal 7.106)
+published_date: "2026-08-19"
+categories: [drupal, action-required, security]
+---
+
+As part of [Pantheon's Long-Term Support (LTS) for Drupal 7](https://pantheon.io/drupal-7), Drupal 7.106 is now available with a backported security patch.
+
+This release backports the fix for [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010), an information disclosure vulnerability in the Image module. Insufficient access verification for image style derivatives could expose access-restricted images when served through non-private file streams.
+
+### Action required
+
+Apply the latest upstream update to your Drupal 7 site to receive this fix. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### About Drupal 7 Long-Term Support
+
+Pantheon has partnered with Tag1 Consulting to deliver security updates and maintenance for Drupal 7 sites. This extended support is included at no additional cost.
+
+For configuration guidance and detailed information, visit our [related documentation](/supported-drupal/#drupal-7-long-term-support).

--- a/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
+++ b/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
@@ -1,6 +1,7 @@
 ---
 title: Drupal 7 LTS security update now available (Drupal 7.106)
 published_date: "2026-08-19"
+published_at: "2026-08-19T00:00:00Z"
 categories: [drupal, action-required, security]
 ---
 

--- a/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
+++ b/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
@@ -1,7 +1,7 @@
 ---
 title: Drupal 7 LTS security update now available (Drupal 7.106)
 published_date: "2026-08-19"
-published_at: "2026-08-19T00:00:00Z"
+published_at: "2026-08-19T18:24:02Z"
 categories: [drupal, action-required, security]
 ---
 

--- a/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
+++ b/src/source/releasenotes/2026-08-19-drupal-7-106-security-update.md
@@ -7,7 +7,7 @@ categories: [drupal, action-required, security]
 
 As part of [Pantheon's Long-Term Support (LTS) for Drupal 7](https://pantheon.io/drupal-7), Drupal 7.106 is now available with a backported security patch.
 
-This release backports the fix for [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010), an information disclosure vulnerability in the Image module. Insufficient access verification for image style derivatives could expose access-restricted images when served through non-private file streams.
+This release backports the fix for [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010), an information disclosure vulnerability in the Image module. Image style derivatives stored on file schemes other than the core private scheme could be served without the access checks intended for access-restricted images.
 
 ### Action required
 


### PR DESCRIPTION
## Summary
- Adds a release note announcing Drupal 7.106, a Tag1 LTS backport of the fix for [SA-CORE-2026-010](https://www.drupal.org/sa-core-2026-010) (information disclosure in the Image module)