### PR TITLE
docs(release-notes): Add WordPress 7.1 release note

### DIFF
--- a/src/source/releasenotes/2026-08-19-wordpress-7-1.md
+++ b/src/source/releasenotes/2026-08-19-wordpress-7-1.md
@@ -1,7 +1,7 @@
 ---
 title: WordPress 7.1 release now available
 published_date: "2026-08-19"
-published_at: "2026-08-19T12:00:00Z"
+published_at: "2026-08-20T00:58:02Z"
 categories: [wordpress, action-required]
 ---
 

--- a/src/source/releasenotes/2026-08-19-wordpress-7-1.md
+++ b/src/source/releasenotes/2026-08-19-wordpress-7-1.md
@@ -1,0 +1,23 @@
+---
+title: WordPress 7.1 release now available
+published_date: "2026-08-19"
+published_at: "2026-08-19T12:00:00Z"
+categories: [wordpress, action-required]
+---
+
+The latest version of WordPress, [7.1](https://wordpress.org/download/releases/7-1/), is available on Pantheon as of August 19, 2026.
+
+### Action required
+Upgrade to WordPress 7.1 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).
+
+### Highlights
+
+* **Collaboration with Notes** — Inline notes with @mentions and rich text formatting, plus suggestion mode and emoji reactions for asynchronous feedback.
+* **Expanded styling controls** — Style blocks across screen sizes and style interactive states without writing custom CSS.
+* **Media improvements** — A free-form image cropper, support for more image formats, and more resilient client-side media handling.
+* **New blocks** — A Playlist block for collections of audio files with optional waveform visualization, and a Tabs block for organizing content into clickable panels.
+* **Site identity in the Site Editor** — Title, tagline, and site icon now live in their own labeled section.
+* **Accessibility** — A new accessible tooltips API, more predictable screen reader behavior, and improved labeling throughout the admin.
+* [...and more](https://wordpress.org/download/releases/7-1/)
+
+For full details about WordPress 7.1, see the [release notes](https://wordpress.org/documentation/wordpress-version/version-7-1/) or the [WordPress 7.1 Field Guide](https://make.wordpress.org/core/2026/08/05/wordpress-7-1-field-guide/).

--- a/src/source/releasenotes/2026-08-19-wordpress-7-1.md
+++ b/src/source/releasenotes/2026-08-19-wordpress-7-1.md
@@ -1,5 +1,5 @@
 ---
-title: WordPress 7.1 release now available
+title: WordPress 7.1 (Mary Lou) release now available
 published_date: "2026-08-19"
 published_at: "2026-08-20T00:58:02Z"
 categories: [wordpress, action-required]

--- a/src/source/releasenotes/2026-08-19-wordpress-7-1.md
+++ b/src/source/releasenotes/2026-08-19-wordpress-7-1.md
@@ -5,7 +5,7 @@ published_at: "2026-08-20T00:58:02Z"
 categories: [wordpress, action-required]
 ---
 
-The latest version of WordPress, [7.1](https://wordpress.org/download/releases/7-1/), is available on Pantheon as of August 19, 2026.
+The latest version of WordPress, [7.1](https://wordpress.org/news/2026/08/mary-lou/), is available on Pantheon as of August 19, 2026.
 
 ### Action required
 Upgrade to WordPress 7.1 right from your Pantheon dashboard or Terminus to access the latest features, fixes, and security enhancements. See [related documentation for how to apply core updates](/core-updates#apply-upstream-updates-via-the-site-dashboard).


### PR DESCRIPTION
## Summary

- Add release note announcing WordPress 7.1 availability on Pantheon (2026-08-19).

## Context

WordPress 7.1 ships today, timed with WordCamp US. Same format as the WordPress 7.0 note (`src/source/releasenotes/2026-05-20-wordpress-7-0.md`).

Highlights sourced from the 7.1 Field Guide, RC1 announcement, and the accessibility roundup on make.wordpress.org.

No ticket for this one.

## Notes for reviewers

- The wordpress.org GA post is not live yet, so the release codename is omitted from the title. Worth adding once it publishes.
- The version-7-1 documentation link should be re-checked after GA.

## Test plan

- [ ] Note renders on the release notes listing with the 2026-08-19 date
- [ ] External links resolve after the GA announcement is published
