### PR TITLE
Integrated Composer allow-plugins symfony/runtime 

### DIFF
--- a/src/source/content/guides/external-repositories/04-setup-drupal.md
+++ b/src/source/content/guides/external-repositories/04-setup-drupal.md
@@ -86,6 +86,7 @@ This is the most important file. It configures Pantheon-specific dependencies, i
 | Quicksilver installer path | Not present | Maps `type:quicksilver-script` to `web/private/scripts/quicksilver/` |
 | `config.platform.php` | Not set or varies | Must match `php_version` in `pantheon.upstream.yml` |
 | `cweagans/composer-patches` | Not present | Included for patching support |
+| `symfony/runtime` | Not present | Must be added in allow-plugins for the build process for Pantheon `composer config --no-plugins allow-plugins.symfony/runtime true` |
 
 It is expected that you will update this file from the original and Pantheon does not maintain it for you.
 


### PR DESCRIPTION
During the creation of the site on the default drupal-composer-managed upstream `Pantheon Automation`, this is being run and changes the composer.json:
```
composer config --no-plugins allow-plugins.symfony/runtime true
```

However, this does not seem to apply to a custom upstream. If this is not enabled, Integrated Composer will return the error:
```
symfony/runtime contains a Composer plugin which is blocked by your allow-p
lugins config. You may add it to the list if you consider it safe.         
You can run "composer config --no-plugins allow-plugins.symfony/runtime [tr
ue|false]" to enable it (true) or disable it explicitly and suppress this e
xception (false)                                                           
See https://getcomposer.org/allow-plugins 
```

They need to make sure that it is enabled to ensure that the Integrated Composer works during code sync.