### PR TITLE
Update 01-scope.md

### DIFF
--- a/src/source/content/guides/support/01-scope.md
+++ b/src/source/content/guides/support/01-scope.md
@@ -17,7 +17,7 @@ editpath: support/01-scope.md
 reviewed: "2026-08-24"
 ---
 
-![Screenshot of the Support Tab](../../../images/dashboard/new-dashboard/2024/support-tab.png)
+![Select Support from the Workspace's Dashboard](../../../images/dashboard/workspace-support.png)
 
 ## Support Features and Response Times
 

--- a/src/source/content/guides/support/01-scope.md
+++ b/src/source/content/guides/support/01-scope.md
@@ -14,7 +14,7 @@ type: guide
 showtoc: true
 permalink: docs/guides/support/
 editpath: support/01-scope.md
-reviewed: "2026-08-24"
+reviewed: "2026-08-31"
 ---
 
 ![Select Support from the Workspace's Dashboard](../../../images/dashboard/workspace-support.png)


### PR DESCRIPTION
Updating the image on the Scope of Support page so that it shows the current UI, instead of the one from 3 years ago

Impacted page: https://docs.pantheon.io/guides/support. The following patch changes the image, to use the same one shown on the [contact support page](https://docs.pantheon.io/guides/support/contact-support), which is updated correctly.

<img width="1461" height="809" alt="Screenshot 2026-08-27 at 4 19 29 PM" src="https://github.com/user-attachments/assets/ec8480da-6be9-4a82-aced-5f2d5cd29633" />
