### PR TITLE
Add release notes for Site Administrator role

### DIFF
--- a/src/source/releasenotes/2026-08-31-site-admin-role.md
+++ b/src/source/releasenotes/2026-08-31-site-admin-role.md
@@ -20,6 +20,5 @@ Organizations had to either grant broad workspace-level admin access just to man
 
 ## What you need to do
 The Site Administrator role is additive. No existing permissions change. Assign the role when you're ready to delegate site team management. 
-**One change to note:** as part of this update, the default role for newly invited site team members is now **Developer.**
 
 For the full permissions matrix and step-by-step assignment instructions, see [related documentation](/https://docs.pantheon.io/guides/account-mgmt/workspace-sites-teams/teams)

--- a/src/source/releasenotes/2026-08-31-site-admin-role.md
+++ b/src/source/releasenotes/2026-08-31-site-admin-role.md
@@ -1,7 +1,7 @@
 ---
 title: "Introducing the Site Administrator role"
 published_date: "2026-08-31"
-published_at: "2026-08-31T16:00:00Z"
+published_at: "2026-08-31T20:03:06Z"
 categories: [acccount-management]
 description: "You can now delegate site team management with a new site-level role. Site Administrator gives a trusted person full control over a single site's team, without workspace-level access or the ability to change billing or site plans."
 ---

--- a/src/source/releasenotes/2026-08-31-site-admin-role.md
+++ b/src/source/releasenotes/2026-08-31-site-admin-role.md
@@ -1,0 +1,25 @@
+---
+title: "Introducing the Site Administrator role"
+published_date: "2026-08-31"
+published_at: "2026-08-31T16:00:00Z"
+categories: [acccount-management]
+description: "You can now delegate site team management with a new site-level role. Site Administrator gives a trusted person full control over a single site's team, without workspace-level access or the ability to change billing or site plans."
+---
+
+You can now delegate site team management with a new site-level role: Site Administrator. 
+It lets you give a trusted person full control over a single site's team - inviting members, changing their roles, and managing Supporting Workspaces - without also granting workspace-level access, or the ability to change billing or site plans.
+
+Previously, there was no role between Workspace Administrator and Site Team Member that could manage a site's team. 
+Organizations had to either grant broad workspace-level admin access just to manage one site, or route every team change through a Workspace Administrator. Site Administrator closes that gap, making it easy for organizations to hand off a site to a lead (or leads) to manage site-level teams.
+
+## What's new
+- **A new role** - Site Administrator appears on the Team tab of the Site Dashboard, visible only to Workspace Administrators and Site Owners — the only roles that can assign it.
+- **Delegated team management** - Site Administrators can invite and remove Team Members and Developers, change their roles, and add and remove Supporting Workspaces for the site.
+- **Everything a Team Member can do** - Site Administrators inherit all Team Member permissions, including deploying to Test and Live, managing custom domains, and uploading files.
+- **Boundary on billing and deletion** - Site Administrators cannot access billing, change the site's plan, transfer ownership, or delete the site. 
+
+## What you need to do
+The Site Administrator role is additive. No existing permissions change. Assign the role when you're ready to delegate site team management. 
+**One change to note:** as part of this update, the default role for newly invited site team members is now **Developer.**
+
+For the full permissions matrix and step-by-step assignment instructions, see [related documentation](/https://docs.pantheon.io/guides/account-mgmt/workspace-sites-teams/teams)

--- a/src/source/releasenotes/2026-08-31-site-admin-role.md
+++ b/src/source/releasenotes/2026-08-31-site-admin-role.md
@@ -21,4 +21,4 @@ Organizations had to either grant broad workspace-level admin access just to man
 ## What you need to do
 The Site Administrator role is additive. No existing permissions change. Assign the role when you're ready to delegate site team management. 
 
-For the full permissions matrix and step-by-step assignment instructions, see [related documentation](/https://docs.pantheon.io/guides/account-mgmt/workspace-sites-teams/teams)
+For the full permissions matrix and step-by-step assignment instructions, see [related documentation](/guides/account-mgmt/workspace-sites-teams/teams)


### PR DESCRIPTION
Introduces the Site Administrator role for delegated site team management, allowing control over a single site's team without workspace-level access.