### PR TITLE
docs(release-notes): [SITE-6162] PHP 8.4.25 and 8.5.10 patch releases

### DIFF
--- a/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
@@ -1,0 +1,8 @@
+---
+title: "PHP 8.4 and 8.5 updated to their latest patch releases"
+published_date: "2026-08-31"
+categories: [infrastructure]
+description: "PHP versions 8.4.25 and 8.5.10 are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability."
+---
+PHP versions [8.4.25](https://www.php.net/ChangeLog-8.php#8.4.25) and [8.5.10](https://www.php.net/ChangeLog-8.php#8.5.10) are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability.
+Updates will be applied automatically over the next few days, so no manual action is required.

--- a/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
@@ -1,7 +1,7 @@
 ---
 title: "PHP 8.4 and 8.5 updated to their latest patch releases"
 published_date: "2026-08-31"
-published_at: "2026-08-31T14:03:05Z"
+published_at: "2026-08-31T15:18:30Z"
 categories: [infrastructure]
 description: "PHP versions 8.4.25 and 8.5.10 are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability."
 ---

--- a/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
@@ -1,6 +1,7 @@
 ---
 title: "PHP 8.4 and 8.5 updated to their latest patch releases"
 published_date: "2026-08-31"
+published_at: "2026-08-31T14:03:05Z"
 categories: [infrastructure]
 description: "PHP versions 8.4.25 and 8.5.10 are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability."
 ---

--- a/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
+++ b/src/source/releasenotes/2026-08-31-php-84-85-patch-updates.md
@@ -1,7 +1,7 @@
 ---
 title: "PHP 8.4 and 8.5 updated to their latest patch releases"
 published_date: "2026-08-31"
-published_at: "2026-08-31T15:18:30Z"
+published_at: "2026-08-31T18:12:07Z"
 categories: [infrastructure]
 description: "PHP versions 8.4.25 and 8.5.10 are now available on the platform. These updates include bug fixes and enhancements that improve performance and stability."
 ---


### PR DESCRIPTION
## Summary

- Add a release note announcing PHP 8.4.25 and 8.5.10.

## Context

[SITE-6162](https://getpantheon.atlassian.net/browse/SITE-6162)

Both versions were released upstream on 27 Aug 2026. Neither changelog entry lists a CVE or a Security section, so this is a bug fix patch round rather than a security round. The note follows the format of the previous patch round, `2026-05-04-php-84-85-patch-updates.md`, with `categories: [infrastructure]` and no security wording.

## Test plan

- [ ] Confirm the publish date matches the day the versions are actually available on the platform, and rename the file if it moves
- [ ] Preview renders correctly in the release notes listing

## References

- [PHP 8.4.25 changelog](https://www.php.net/ChangeLog-8.php#8.4.25)
- [PHP 8.5.10 changelog](https://www.php.net/ChangeLog-8.php#8.5.10)


[SITE-6162]: https://getpantheon.atlassian.net/browse/SITE-6162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ