### PR TITLE
Fix bold styling bug

### DIFF
--- a/src/components/common/addsearch.css
+++ b/src/components/common/addsearch.css
@@ -7,7 +7,7 @@
 .number-of-results {
   border-bottom: 1px solid var(--pds-color-border-default);
   font-size: var(--pds-typography-size-m);
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   padding-block: var(--pds-spacing-l);
 }
 
@@ -15,17 +15,17 @@
 .addsearch-searchresults .number-of-results,
 .addsearch-searchresults .number-of-results h2 {
   font-size: var(--pds-typography-size-m);
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-weight: var(--pds-typography-fw-regular);
   padding-block: var(--pds-spacing-l);
 }
 
 .addsearch-searchresults-no-results h2 em {
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
 }
 
 /* Individual results */
 .search-results__items .hit {
-  line-height: var(--pds-typography-line-height-l);
+  line-height: var(--pds-typography-lh-l);
   padding-block: var(--pds-spacing-xl);
 }
 
@@ -35,8 +35,8 @@
   color: var(--pds-color-tag-4-foreground);
   display: inline-flex;
   font-size: var(--pds-typography-size-s) !important;
-  font-weight: var(--pds-typography-font-weight-semibold);
-  line-height: var(--pds-typography-line-height-s);
+  font-weight: var(--pds-typography-fw-semibold);
+  line-height: var(--pds-typography-lh-s);
   margin-block-start: var(--pds-spacing-m);
   padding-block: var(--pds-spacing-4xs);
   padding-inline: var(--pds-spacing-2xs);
@@ -54,7 +54,7 @@
 .search-results__items .hit h2 a,
 .search-results__items .hit h3 a {
   font-size: var(--pds-typography-size-l);
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   text-decoration: none;
 }
 
@@ -69,12 +69,12 @@
 
 .search-results__items .hit .highlight em {
   background-color: #fff1a9;
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   padding-inline: var(--pds-spacing-4xs);
 }
 .addsWg--highlight em {
   background-color: #fff1a9;
-  font-weight: var(--pds-typography-font-weight-semibold) !important;
+  font-weight: var(--pds-typography-fw-semibold) !important;
   padding-inline: var(--pds-spacing-4xs);
   font-style: normal;
 }
@@ -89,8 +89,8 @@
   color: var(--pds-color-text-default);
   column-gap: var(--pds-spacing-3xs);
   display: flex;
-  font-family: var(--pds-typography-font-default);
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-family: var(--pds-typography-ff-default);
+  font-weight: var(--pds-typography-fw-semibold);
   justify-content: center;
   list-style-type: none;
 }
@@ -100,7 +100,7 @@
   border-radius: var(--pds-border-radius-default);
   color: var(--pds-color-text-default);
   display: flex;
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   justify-content: center;
   line-height: 1;
   min-width: var(--pds-spacing-2xl);

--- a/src/components/common/commands/style.module.css
+++ b/src/components/common/commands/style.module.css
@@ -6,6 +6,7 @@
   margin-block: var(--pds-spacing-xl) var(--pds-spacing-m);
 }
 
+
 .commandName {
   font-weight: var(--pds-typography-fw-bold);
   margin-block-end: var(--pds-spacing-s);

--- a/src/components/common/commands/style.module.css
+++ b/src/components/common/commands/style.module.css
@@ -7,7 +7,7 @@
 }
 
 .commandName {
-  font-weight: var(--pds-typography-font-weight-bold);
+  font-weight: var(--pds-typography-fw-bold);
   margin-block-end: var(--pds-spacing-s);
   display: block;
 }

--- a/src/components/common/navbar-item/style.css
+++ b/src/components/common/navbar-item/style.css
@@ -7,9 +7,9 @@
   color: var(--pds-color-menu-item-foreground);
   cursor: pointer;
   font-size: var(--pds-typography-size-m);
-  line-height: var(--pds-typography-line-height-s);
+  line-height: var(--pds-typography-lh-s);
   margin: 0;
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-weight: var(--pds-typography-fw-regular);
   padding: var(--pds-spacing-2xs) var(--pds-spacing-xs);
   margin-inline-start: calc(var(--pds-spacing-xs) * -1);
   text-decoration: none;

--- a/src/components/common/navbar/style.module.css
+++ b/src/components/common/navbar/style.module.css
@@ -28,7 +28,7 @@
 
   h2.manualGuideTocHeading {
     font-size: var(--pds-typography-size-l);
-    line-height: var(--pds-typography-line-height-m);
+    line-height: var(--pds-typography-lh-m);
     margin-block-end: var(--pds-spacing-s);
   }
 }

--- a/src/components/common/published-date/style.module.css
+++ b/src/components/common/published-date/style.module.css
@@ -1,5 +1,5 @@
 .docsPublishedDate {
   font-size: var(--pds-typography-size-m);
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   color: var(--pds-color-text-default-secondary);
 }

--- a/src/components/common/style-example/style.module.css
+++ b/src/components/common/style-example/style.module.css
@@ -10,8 +10,8 @@
 .source-code::after {
   color: var(--pds-color-text-default-secondary);
   font-size: var(--pds-typography-size-s);
-  font-weight: var(--pds-typography-font-weight-bold);
-  letter-spacing: var(--pds-typography-letter-spacing-s);
+  font-weight: var(--pds-typography-fw-bold);
+  letter-spacing: var(--pds-typography-ls-s);
   position: absolute;
   text-transform: uppercase;
 }

--- a/src/components/common/subtopic-group/style.module.css
+++ b/src/components/common/subtopic-group/style.module.css
@@ -9,7 +9,7 @@
 .subtopic__list {
   display: flex;
   flex-direction: column;
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-weight: var(--pds-typography-fw-regular);
   list-style-type: none;
   margin: 0;
   padding: 0;

--- a/src/components/footer/style.module.css
+++ b/src/components/footer/style.module.css
@@ -15,7 +15,7 @@
 }
 
 .ccLicenseLogoText {
-  line-height: var(--pds-typography-line-height-m);
+  line-height: var(--pds-typography-lh-m);
   padding-block-start: 0.5rem;
 }
 

--- a/src/styles/common.css
+++ b/src/styles/common.css
@@ -114,7 +114,7 @@ hr.landing-page__guides-separator {
 
 .landing-page__guides-title {
   font-size: var(--pds-typography-size-l);
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   padding-block-start: var(--pds-spacing-xl);
 }
 
@@ -201,11 +201,11 @@ a.individual-changelog-link:hover {
   border-radius: var(--pds-border-radius-default);
   box-shadow: none !important;
   color: var(--pds-color-button-primary-foreground-default) !important;
-  font-family: var(--pds-typography-font-default) !important;
+  font-family: var(--pds-typography-ff-default) !important;
   font-size: 1rem !important;
-  font-weight: var(--pds-typography-font-weight-semibold) !important;
+  font-weight: var(--pds-typography-fw-semibold) !important;
   height: 2.25rem;
-  letter-spacing: var(--pds-typography-letter-spacing-m);
+  letter-spacing: var(--pds-typography-ls-m);
   transition: var(--pds-animation-button-transition);
 }
 
@@ -335,7 +335,7 @@ article {
 }
 
 strong {
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
 }
 
 .pds-tag {
@@ -3127,7 +3127,7 @@ span.line-numbers-rows {
 
 code {
   background-color: #f0ecff;
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   margin-inline: var(--pds-spacing-6xs);
   padding: var(--pds-spacing-6xs) var(--pds-spacing-4xs);
 }
@@ -3135,7 +3135,7 @@ code {
 pre > code {
   background-color: inherit;
   color: #ffffff;
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-weight: var(--pds-typography-fw-regular);
 }
 
 .gatsby-highlight {

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -134,8 +134,8 @@ a.pds-skiplink:focus {
 
 .toc-container {
   border-left: 1px solid var(--pds-color-border-default);
-  font-family: var(--pds-typography-font-default);
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-family: var(--pds-typography-ff-default);
+  font-weight: var(--pds-typography-fw-regular);
   margin-block-start: var(--pds-spacing-xl);
   overflow: auto;
   position: sticky;
@@ -157,7 +157,7 @@ a.pds-skiplink:focus {
 
 #toc-nav {
   font-size: 1.44rem;
-  font-weight: var(--pds-typography-font-weight-semibold);
+  font-weight: var(--pds-typography-fw-semibold);
   margin-block-end: var(--pds-spacing-l);
   padding-inline-start: var(--pds-spacing-xl);
 }
@@ -198,11 +198,11 @@ ul.toc-list ul li {
 }
 
 .tocify-item {
-  line-height: var(--pds-typography-line-height-s);
+  line-height: var(--pds-typography-lh-s);
 }
 
 .tocify-item.is-active-li a {
-  font-weight: var(--pds-typography-font-weight-regular);
+  font-weight: var(--pds-typography-fw-regular);
 }
 
 pre {
@@ -230,8 +230,8 @@ pre {
 .source-code::after {
   color: var(--pds-color-text-default-secondary);
   font-size: var(--pds-typography-size-s);
-  font-weight: var(--pds-typography-font-weight-bold);
-  letter-spacing: var(--pds-typography-letter-spacing-s);
+  font-weight: var(--pds-typography-fw-bold);
+  letter-spacing: var(--pds-typography-ls-s);
   position: absolute;
   text-transform: uppercase;
 }

--- a/src/templates/landing.tsx
+++ b/src/templates/landing.tsx
@@ -160,7 +160,7 @@ export const LandingTemplate = ({ topic }: { topic: Landing }) => {
                           url={link.url}
                           image={link.image || ""}
                         />
-                      )
+                      ),
                     )}
                 </div>
               </Container>
@@ -215,8 +215,7 @@ export const LandingTemplate = ({ topic }: { topic: Landing }) => {
                         <Link
                           style={{
                             color: "var(--pds-color-interactive-link-default)",
-                            fontWeight:
-                              "var(--pds-typography-font-weight-regular)",
+                            fontWeight: "var(--pds-typography-fw-regular)",
                           }}
                           href={link.url ?? "#"}
                         >


### PR DESCRIPTION
After updating pds-toolkit to 1.20.0, bold styling stopped working

This fix renames all 36 references for typography tokens that were renamed. 

`--pds-typography-font-weight-*` → `--pds-typography-fw-*`, plus `line-height-*` → `lh-*`, `letter-spacing-*` → `ls-*`, `font-default` → `ff-default`.  


## Before
<img width="1107" height="769" alt="Screenshot 2026-08-31 at 1 54 01 PM" src="https://github.com/user-attachments/assets/c7b7b3fa-f20d-4266-98b7-5ff96b1b99e4" />

## After 

<img width="1095" height="769" alt="Screenshot 2026-08-31 at 1 53 43 PM" src="https://github.com/user-attachments/assets/938d4fc0-ad66-4fb4-b13f-bce3f466a40a" />
