### PR TITLE
docs(integrated-composer): [SITE-6176] add Composer plugins through a Custom Upstream

### DIFF
--- a/src/source/content/guides/integrated-composer/06-ic-upstreams.md
+++ b/src/source/content/guides/integrated-composer/06-ic-upstreams.md
@@ -33,6 +33,55 @@ Follow the steps to [Create a Custom Upstream](/guides/custom-upstream/create-cu
 
 <Partial file="upstream-management-dependencies.md" />
 
+## Add a Composer Plugin to Your Upstream
+
+Composer loads plugin code once, when Composer starts, from the `vendor` directory that is already on disk. A plugin that arrives in the same update that first needs it is not on disk yet, so it does not run.
+
+Add the plugin to your upstream and deploy it to every site first, then make the change that depends on it. This example uses [`mglaman/composer-drupal-lenient`](https://github.com/mglaman/composer-drupal-lenient), which relaxes a contributed module's published `drupal/core` constraint.
+
+1. In the **root** `composer.json` of your Custom Upstream, require the plugin and allow it to run:
+
+    ```json:title=composer.json
+    "require": {
+        "mglaman/composer-drupal-lenient": "^1.0"
+    },
+    "config": {
+        "allow-plugins": {
+            "mglaman/composer-drupal-lenient": true
+        }
+    }
+    ```
+
+1. Commit and push the upstream, then apply the update to your sites and let each one build.
+
+<Alert title="Note" type="info">
+
+`config` and `repositories` are root-only properties. Composer reads them from the root `composer.json` only, so a plugin added to `upstream-configuration/composer.json` has no effect.
+
+</Alert>
+
+1. Confirm the plugin is installed on a site before you rely on it. Over [SFTP](/guides/sftp), the plugin's directory is present under `code/vendor`:
+
+    ```bash{promptUser: user}
+    ls code/vendor/mglaman
+    ```
+
+1. Only after every site has the plugin, push the change that needs it as a second upstream commit. For `composer-drupal-lenient`, that is the module's `require` entry plus the `extra.drupal-lenient.allowed-list` entry naming it:
+
+    ```json:title=composer.json
+    "extra": {
+        "drupal-lenient": {
+            "allowed-list": ["drupal/module-name"]
+        }
+    }
+    ```
+
+<Alert title="Warning" type="danger">
+
+Changes to the root `composer.json` in an upstream overwrite edits that individual sites have made to their own root `composer.json`, without a merge conflict and without failing the build. Review your sites for local edits before you push. See [Changes Lost During Upstream Updates](/guides/integrated-composer/ic-troubleshooting#changes-lost-during-upstream-updates).
+
+</Alert>
+
 ## Maintain Your Integrated Composer Custom Upstream
 
  There are some special considerations to keep in mind if you intend to make modifications to your upstream based on this repository.

--- a/src/source/content/guides/integrated-composer/06-ic-upstreams.md
+++ b/src/source/content/guides/integrated-composer/06-ic-upstreams.md
@@ -4,7 +4,7 @@ subtitle: Custom Upstream Usage
 description: Learn how to use an Upstream with Integrated Composer.
 tags: [composer, workflow]
 contributors: [ari, edwardangert, jazzsequence]
-reviewed: "2026-07-28"
+reviewed: "2026-09-03"
 showtoc: true
 permalink: docs/guides/integrated-composer/ic-upstreams
 contenttype: [guide]
@@ -35,11 +35,17 @@ Follow the steps to [Create a Custom Upstream](/guides/custom-upstream/create-cu
 
 ## Add a Composer Plugin to Your Upstream
 
-Composer loads plugin code once, when Composer starts, from the `vendor` directory that is already on disk. A plugin that arrives in the same update that first needs it is not on disk yet, so it does not run.
+Composer loads plugin code once, when Composer starts, from the `vendor` directory that is on disk at that moment. A plugin that arrives in the same upstream update that first needs it is not installed yet, so it does not run.
 
-Add the plugin to your upstream and deploy it to every site first, then make the change that depends on it. This example uses [`mglaman/composer-drupal-lenient`](https://github.com/mglaman/composer-drupal-lenient), which relaxes a contributed module's published `drupal/core` constraint.
+Deploy the plugin to your sites in one upstream commit, then push the change that depends on it in a second commit. The example below uses [`mglaman/composer-drupal-lenient`](https://github.com/mglaman/composer-drupal-lenient), which relaxes a contributed module's published `drupal/core` constraint so that the module can install on a newer version of Drupal core.
 
-1. In the **root** `composer.json` of your Custom Upstream, require the plugin and allow it to run:
+<Alert title="Note" type="info">
+
+`config` and `repositories` are root-only properties. Composer reads them from the root `composer.json` and nowhere else, so a plugin added to `upstream-configuration/composer.json` has no effect.
+
+</Alert>
+
+1. In the root `composer.json` of your Custom Upstream, require the plugin and add it to the `allow-plugins` list:
 
     ```json:title=composer.json
     "require": {
@@ -52,21 +58,15 @@ Add the plugin to your upstream and deploy it to every site first, then make the
     }
     ```
 
-1. Commit and push the upstream, then apply the update to your sites and let each one build.
+1. Commit and push the change to your Custom Upstream, then [apply the upstream update](/core-updates) to each site and let the build finish.
 
-<Alert title="Note" type="info">
-
-`config` and `repositories` are root-only properties. Composer reads them from the root `composer.json` only, so a plugin added to `upstream-configuration/composer.json` has no effect.
-
-</Alert>
-
-1. Confirm the plugin is installed on a site before you rely on it. Over [SFTP](/guides/sftp), the plugin's directory is present under `code/vendor`:
+1. Confirm that the plugin is installed before you rely on it. Connect to an environment over [SFTP](/guides/sftp) and list the vendor directory:
 
     ```bash{promptUser: user}
     ls code/vendor/mglaman
     ```
 
-1. Only after every site has the plugin, push the change that needs it as a second upstream commit. For `composer-drupal-lenient`, that is the module's `require` entry plus the `extra.drupal-lenient.allowed-list` entry naming it:
+1. Push the change that depends on the plugin as a separate upstream commit. For `composer-drupal-lenient`, that is the module in `upstream-configuration/composer.json` and an `extra.drupal-lenient.allowed-list` entry in the root `composer.json` that names it:
 
     ```json:title=composer.json
     "extra": {
@@ -76,9 +76,11 @@ Add the plugin to your upstream and deploy it to every site first, then make the
     }
     ```
 
+1. Apply the upstream update to your sites again. Composer now loads the plugin from `vendor` and resolves the module.
+
 <Alert title="Warning" type="danger">
 
-Changes to the root `composer.json` in an upstream overwrite edits that individual sites have made to their own root `composer.json`, without a merge conflict and without failing the build. Review your sites for local edits before you push. See [Changes Lost During Upstream Updates](/guides/integrated-composer/ic-troubleshooting#changes-lost-during-upstream-updates).
+A change to the root `composer.json` in your Custom Upstream replaces edits that individual sites have made to their own root `composer.json`. This happens without a merge conflict and without failing the build. Review your sites for local changes before you push. For more information, see [Changes Lost During Upstream Updates](/guides/integrated-composer/ic-troubleshooting#changes-lost-during-upstream-updates).
 
 </Alert>
 
@@ -100,4 +102,5 @@ Changes to the root `composer.json` in an upstream overwrite edits that individu
 - [Pantheon YAML Configuration Files](/pantheon-yml)
 - [Best Practices for Maintaining Custom Upstreams](/guides/custom-upstream/maintain-custom-upstream)
 - [Composer Fundamentals and WebOps Workflows](/guides/composer)
+- [Integrated Composer Troubleshooting](/guides/integrated-composer/ic-troubleshooting)
 - [Create a Composer-managed WordPress Site with Bedrock](/guides/wordpress-composer/wordpress-composer-managed)

--- a/src/source/content/guides/integrated-composer/06-ic-upstreams.md
+++ b/src/source/content/guides/integrated-composer/06-ic-upstreams.md
@@ -66,7 +66,15 @@ Deploy the plugin to your sites in one upstream commit, then push the change tha
     ls code/vendor/mglaman
     ```
 
-1. Push the change that depends on the plugin as a separate upstream commit. For `composer-drupal-lenient`, that is the module in `upstream-configuration/composer.json` and an `extra.drupal-lenient.allowed-list` entry in the root `composer.json` that names it:
+1. Push the change that depends on the plugin as a separate upstream commit. For `composer-drupal-lenient`, that is the module itself in `upstream-configuration/composer.json`:
+
+    ```json:title=upstream-configuration/composer.json
+    "require": {
+        "drupal/module-name": "^2.0"
+    }
+    ```
+
+    Along with an `extra.drupal-lenient.allowed-list` entry in the root `composer.json` that names the same module:
 
     ```json:title=composer.json
     "extra": {

--- a/src/source/content/guides/integrated-composer/06-ic-upstreams.md
+++ b/src/source/content/guides/integrated-composer/06-ic-upstreams.md
@@ -37,7 +37,7 @@ Follow the steps to [Create a Custom Upstream](/guides/custom-upstream/create-cu
 
 Composer loads plugin code once, when Composer starts, from the `vendor` directory that is on disk at that moment. A plugin that arrives in the same upstream update that first needs it is not installed yet, so it does not run.
 
-Deploy the plugin to your sites in one upstream commit, then push the change that depends on it in a second commit. The example below uses [`mglaman/composer-drupal-lenient`](https://github.com/mglaman/composer-drupal-lenient), which relaxes a contributed module's published `drupal/core` constraint so that the module can install on a newer version of Drupal core.
+Add the plugin to your upstream in one release, then run an upstream update on all sites created from that upstream. Once the plugin is deployed everywhere, add the change that uses it in a later release. The example below uses [`mglaman/composer-drupal-lenient`](https://github.com/mglaman/composer-drupal-lenient), which relaxes a contributed module's published `drupal/core` constraint so that the module can install on a newer version of Drupal core.
 
 <Alert title="Note" type="info">
 
@@ -58,7 +58,7 @@ Deploy the plugin to your sites in one upstream commit, then push the change tha
     }
     ```
 
-1. Commit and push the change to your Custom Upstream, then [apply the upstream update](/core-updates) to each site and let the build finish.
+1. Commit and push this release to your Custom Upstream, then [apply the upstream update](/core-updates) to each site and let the build finish.
 
 1. Confirm that the plugin is installed before you rely on it. Connect to an environment over [SFTP](/guides/sftp) and list the vendor directory:
 
@@ -66,7 +66,7 @@ Deploy the plugin to your sites in one upstream commit, then push the change tha
     ls code/vendor/mglaman
     ```
 
-1. Push the change that depends on the plugin as a separate upstream commit. For `composer-drupal-lenient`, that is the module itself in `upstream-configuration/composer.json`:
+1. In a later upstream release, add the change that depends on the plugin. For `composer-drupal-lenient`, that is the module itself in `upstream-configuration/composer.json`:
 
     ```json:title=upstream-configuration/composer.json
     "require": {


### PR DESCRIPTION
## Summary

- New section in the Integrated Composer Custom Upstream guide covering how to add a Composer plugin, such as `mglaman/composer-drupal-lenient`, through a Custom Upstream.

## Context

[SITE-6176](https://getpantheon.atlassian.net/browse/SITE-6176)

Composer loads plugins once at startup from the vendor directory already on disk, so a plugin that arrives in the same upstream update that first needs it never runs. Customers hit this trying to relax a contrib module's `drupal/core` constraint for a Drupal 11 upgrade. The guide covered upstream dependencies but not plugins.

The section documents the two-commit ordering, the root-only `config` and `repositories` properties, and the silent overwrite of site-local root `composer.json` edits.

## Do not merge yet

The platform-side fix is site-job-scripts#173, which installs the locked dependencies before the upstream merge. Until that ships, the update path has no vendor directory at all and this workflow still fails.

## Test plan

- [ ] Preview renders both Alerts and the JSON blocks
- [ ] Links resolve: `/core-updates`, `/guides/sftp`, `/guides/integrated-composer/ic-troubleshooting#changes-lost-during-upstream-updates`
- [ ] Review of the customer-facing wording


[SITE-6176]: https://getpantheon.atlassian.net/browse/SITE-6176?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ