### PR TITLE
EDRT-9457: announce new sites default to next-gen GCDN on Cloudflare

### DIFF
--- a/src/source/content/guides/global-cdn/07-global-cdn-faq.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-faq.md
@@ -149,7 +149,7 @@ Eligible sites will see a next-generation GCDN banner on the site dashboard. If 
 
 ### Are new sites created on the next-generation GCDN by default?
 
-Not yet. New sites are currently provisioned on the legacy GCDN and receive legacy GCDN IP addresses. The next-generation GCDN will become the default for new sites in a future phase, and a release note will be published when that change happens.
+Yes, as of September 10, 2026. New sites created on Pantheon are provisioned on the next-generation GCDN by default. Sites created before this date are not affected and remain eligible for migration through the normal [migration path](/guides/global-cdn/next-gen-global-cdn#setup). [Advanced Global CDN (AGCDN)](/guides/agcdn) customers are not affected by this change — if you have questions, [contact Pantheon Support](/guides/support/contact-support/).
 
 ### I have a Custom Certificate. Can I migrate?
 

--- a/src/source/content/guides/global-cdn/07-global-cdn-faq.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-faq.md
@@ -149,7 +149,7 @@ Eligible sites will see a next-generation GCDN banner on the site dashboard. If 
 
 ### Are new sites created on the next-generation GCDN by default?
 
-Yes, as of September 10, 2026. New sites created on Pantheon are provisioned on the next-generation GCDN by default. Sites created before this date are not affected and remain eligible for migration through the normal [migration path](/guides/global-cdn/next-gen-global-cdn#setup). [Advanced Global CDN (AGCDN)](/guides/agcdn) customers are not affected by this change — if you have questions, [contact Pantheon Support](/guides/support/contact-support/).
+Yes, as of September 10, 2026. New sites created on Pantheon are provisioned on the next-generation GCDN by default. Sites created before this date are not affected and remain eligible for migration through the normal [migration path](/guides/global-cdn/next-gen-global-cdn#setup). [Advanced Global CDN (AGCDN)](/guides/agcdn) customers are not affected by this change. If you have questions, [contact Pantheon Support](/guides/support/contact-support/).
 
 ### I have a Custom Certificate. Can I migrate?
 

--- a/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
+++ b/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
@@ -1,0 +1,15 @@
+---
+title: "New sites now provision on the next-generation Global CDN by default"
+published_date: "2026-09-10"
+published_at: "2026-09-10T16:00:00Z"
+categories: [infrastructure, new-feature]
+description: "Starting September 10, 2026, all new sites created on Pantheon are provisioned on the next-generation Global CDN, powered by Cloudflare, instead of the legacy Global CDN."
+---
+
+Starting September 10, 2026, new sites created on Pantheon are provisioned on the [next-generation Global CDN](/guides/global-cdn/next-gen-global-cdn), powered by Cloudflare, instead of the legacy Global CDN.
+
+This change applies to newly created sites only. Existing sites are not affected and remain eligible for migration through the normal [migration path](/guides/global-cdn/next-gen-global-cdn#setup).
+
+No action is required — the next-generation GCDN is provisioned automatically at site creation.
+
+[Advanced Global CDN (AGCDN)](/guides/agcdn) customers are not affected by this change. If you have any questions, [contact Pantheon Support](/guides/support/contact-support/).

--- a/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
+++ b/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
@@ -1,7 +1,7 @@
 ---
 title: "New sites now provision on the next-generation Global CDN by default"
 published_date: "2026-09-10"
-published_at: "2026-09-10T16:00:00Z"
+published_at: "2026-09-10T18:08:52Z"
 categories: [infrastructure, new-feature]
 description: "Starting September 10, 2026, all new sites created on Pantheon are provisioned on the next-generation Global CDN, powered by Cloudflare, instead of the legacy Global CDN."
 ---

--- a/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
+++ b/src/source/releasenotes/2026-09-10-new-sites-next-gen-gcdn-default.md
@@ -10,6 +10,6 @@ Starting September 10, 2026, new sites created on Pantheon are provisioned on th
 
 This change applies to newly created sites only. Existing sites are not affected and remain eligible for migration through the normal [migration path](/guides/global-cdn/next-gen-global-cdn#setup).
 
-No action is required — the next-generation GCDN is provisioned automatically at site creation.
+No action is required: the next-generation GCDN is provisioned automatically at site creation.
 
 [Advanced Global CDN (AGCDN)](/guides/agcdn) customers are not affected by this change. If you have any questions, [contact Pantheon Support](/guides/support/contact-support/).


### PR DESCRIPTION
## Summary

Fulfills the promise in the next-gen GCDN FAQ ("a release note will be published when that change happens") now that new sites provision on the next-generation Global CDN (Cloudflare) by default instead of the legacy GCDN.

## Changes

- New release note: `2026-09-10-new-sites-next-gen-gcdn-default.md`, publishing 2026-09-10 12 PM EDT alongside this week's other GCDN releases
- `guides/global-cdn/07-global-cdn-faq.md`: flips "Are new sites created on the next-generation GCDN by default?" from "Not yet" to "Yes, as of September 10, 2026"

Both note that existing sites are unaffected (still migrate through the normal path) and that AGCDN customers are unaffected, with a pointer to support for questions.

## Test plan

- [ ] Cyrus Kia reviews for accuracy per the GCDN Wednesday release plan
- [ ] Confirm publish timing lines up with the other 9/10 releases (HTTP-01 docs, Bot Bypass) for the combined #ask-cloudflare announcement