### PR TITLE
EDRT-9481: Bot bypass tokens for Next Generation GCDN — docs and release note

### DIFF
--- a/src/source/content/guides/global-cdn/06-next-gen-global-cdn.md
+++ b/src/source/content/guides/global-cdn/06-next-gen-global-cdn.md
@@ -28,11 +28,37 @@ Bot protection is enabled by default on all migrated sites. There is no addition
 - **Automated bot detection and scoring** — Incoming traffic is automatically evaluated and scored. Requests identified as malicious receive managed challenges.
 - **Verified bot identification** — Legitimate bots (such as Googlebot, Bingbot, and other search engine crawlers) are recognized and allowed through automatically. Unverified malicious bots are challenged.
 
-### Bot Exclusions
+### Bot Bypass Tokens
 
-If your site relies on a custom bot or automated service that is not on the verified bot list, it may be challenged or blocked. Contact Pantheon support to request an exclusion for your bot's user agent.
+If your site relies on automation that is not on the verified bot list, such as uptime monitors, CI/CD tools, feed importers, or custom API clients, bot protection may challenge or block it. You can exempt your own automation by generating a bot bypass token and sending it with your requests.
 
-After migrating to the next-generation GCDN, monitor your automated integrations (CI/CD tools, feed importers, monitoring services, API clients) to ensure they are not being blocked. If a service stops working, check whether its user agent is being challenged and contact support to add an exclusion.
+**1. Install the plugin and generate your site's token:**
+
+```
+terminus self:plugin:install pantheon-systems/terminus-gcdn-plugin
+terminus gcdn:bot-bypass <site>
+```
+
+Use `--format=json` if you're wiring this into CI or a monitoring config. The command prints two tokens for your site — a current token and a next token — each with its Valid From date, Expires date, and the header name to use. You must have access to the site in Pantheon to generate its tokens. The site argument accepts a name or UUID; one token pair covers every environment (dev, test, live, and multidevs).
+
+**2. Add the current token to your automation** as an HTTP request header:
+
+```
+x-pantheon-bot-bypass: <token>
+```
+
+For example, configure your uptime monitor or CI job to send this custom header on every request to your site.
+
+Requests that carry a valid token skip the standard challenge applied to automated traffic. Targeted protections, rate limiting, the managed WAF, and other platform-level security rules still apply to every request, with or without a token.
+
+Keep in mind:
+
+- **Tokens are valid for 6 months.** Each time you run the command you get the current token plus a next token that starts 3 months later; both are accepted during that overlap. Switch your automation to the next token on or after its Valid From date, and re-run the command each quarter to pick up the following pair.
+- **Treat the token like a credential.** Send it only from servers and services you control. Never expose it in client-side code, public repositories, or logs. If a token is leaked, contact Pantheon support to revoke it; a replacement token becomes available at the start of the following month.
+- **A missing token gets normal bot evaluation** — no penalty. **An incorrect token is rejected with a 403** on every request, so if your automation starts failing, check the header value first.
+- Verified bots (such as Googlebot and Bingbot) are allowed through automatically and do not need a token.
+
+After migrating to the next-generation GCDN, monitor your automated integrations (CI/CD tools, feed importers, monitoring services, API clients) to ensure they are not being blocked. If a service stops working, generate a bot bypass token and add it to that service's requests as described above. If the bypass token doesn't cover your situation, contact Pantheon support to request an exception.
 
 ### Custom Certificates
 

--- a/src/source/content/guides/global-cdn/07-global-cdn-faq.md
+++ b/src/source/content/guides/global-cdn/07-global-cdn-faq.md
@@ -185,7 +185,7 @@ Content Converter (Markdown for Agents) is a feature enabled on all next-generat
 
 ### My automated integration stopped working after migration. What do I do?
 
-Your bot or automated service may be receiving a managed challenge from bot protection. Check whether the service's user agent is being challenged by reviewing its error logs (look for 403 responses or HTML challenge pages). Contact Pantheon support to request a bot exclusion for your user agent.
+Check whether the service is receiving a managed challenge from bot protection (look for 403 responses or HTML challenge pages in its error logs). If so, generate a bot bypass token for your site with `terminus gcdn:bot-bypass <site>` and configure the service to send it in the `x-pantheon-bot-bypass` request header — see [Bot Bypass Tokens](/guides/global-cdn/next-gen-global-cdn#bot-bypass-tokens) for setup steps. If the token doesn't cover your situation, contact Pantheon support to request an exception.
 
 ### I have Cloudflare in front of my site. Is that supported?
 

--- a/src/source/releasenotes/2026-09-09-gcdn-bot-bypass-token.md
+++ b/src/source/releasenotes/2026-09-09-gcdn-bot-bypass-token.md
@@ -1,0 +1,21 @@
+---
+title: "Self-service bot bypass tokens for Next Generation GCDN"
+published_date: "2026-09-09"
+published_at: "2026-09-09T20:33:13Z"
+categories: [new-feature, tools-apis]
+description: "Generate a per-site token with Terminus to exempt your own trusted automation from Next Generation GCDN bot protection, without contacting support."
+---
+
+Sites on the [Next Generation GCDN](/guides/global-cdn/next-gen-global-cdn) can now exempt their own trusted automation from bot protection, without contacting support.
+
+Bot protection on the Next Generation GCDN automatically challenges traffic that looks automated. That is the right default for scrapers and attack tools, but it can also challenge automation you rely on: uptime monitors, CI/CD pipelines, feed importers, and custom API clients that are not on the verified bot list.
+
+You can now generate a bot bypass token for your site using Terminus and configure your automation to send it in the `x-pantheon-bot-bypass` request header. Requests carrying a valid token skip the standard challenge applied to automated traffic; targeted protections, rate limiting, and the managed WAF still apply to every request.
+
+Key details:
+
+- Tokens are scoped to a single site (all environments) and valid for 6 months. The command returns a current token and a next token that becomes valid 3 months later; both are accepted during the overlap. Send the current token now, switch to the next token on or after its start date, and re-run the command each quarter to pick up the following pair.
+- Treat the token like a credential. Send it only from trusted servers and services, and never expose it in client-side code. If a token is leaked, contact Pantheon support to revoke it; a replacement token becomes available at the start of the following month.
+- Requests without the header are evaluated by bot protection as usual. Requests with an incorrect token are rejected with a 403, so check the header value first if your automation starts failing.
+
+See [Bot Bypass Tokens](/guides/global-cdn/next-gen-global-cdn#bot-bypass-tokens) in the Next Generation GCDN guide for setup instructions.

--- a/src/source/releasenotes/2026-09-09-gcdn-bot-bypass-token.md
+++ b/src/source/releasenotes/2026-09-09-gcdn-bot-bypass-token.md
@@ -1,7 +1,7 @@
 ---
 title: "Self-service bot bypass tokens for Next Generation GCDN"
-published_date: "2026-09-09"
-published_at: "2026-09-09T20:33:13Z"
+published_date: "2026-09-10"
+published_at: "2026-09-10T15:36:09Z"
 categories: [new-feature, tools-apis]
 description: "Generate a per-site token with Terminus to exempt your own trusted automation from Next Generation GCDN bot protection, without contacting support."
 ---


### PR DESCRIPTION
## What

Replaces the "Bot Exclusions" section of the [Next Generation GCDN guide](https://docs.pantheon.io/guides/global-cdn/next-gen-global-cdn) with setup instructions for the new self-service bot bypass token, updates the matching FAQ entry, and adds the companion release note announcing the feature.

Bot bypass tokens let customers exempt their own trusted automation (uptime monitors, CI/CD, feed importers, API clients) from bot protection via a Terminus command, without contacting support.

## Product decision reflected here

Bot bypass tokens are the primary, self-service path. Customers who still need a manual exception (can't use the token, unusual constraint) are pointed at Pantheon support in both the guide and the FAQ.

## Follow-ups (not in this PR)

- Release note's `published_date`/`published_at` use today's date — update before merge if the actual announcement timing differs.

Refs EDRT-9481.